### PR TITLE
Stabilize toolbar status layout

### DIFF
--- a/docs-ai/046-toolbar-status-layout-stability/000-plan.md
+++ b/docs-ai/046-toolbar-status-layout-stability/000-plan.md
@@ -1,0 +1,77 @@
+# 046 — Toolbar Status Layout Stability: Plan
+
+| | |
+| --- | --- |
+| **Status** | Planned |
+| **Anchor date** | 2026-07-13 |
+| **Primary PRs** | TBD |
+| **Related** | [024-canvas-interaction-evolution](../024-canvas-interaction-evolution/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [033-ui-refresh-2026-05](../033-ui-refresh-2026-05/000-plan.md), [002-custom-commands](../002-custom-commands/000-plan.md), issue #471, `docs/components/canvas.md` |
+
+## Background
+
+`ToolbarStatusView` is the `.principal` toolbar item in both Normal and Canvas
+views. Its intrinsic width currently changes whenever the view switches between a
+time hint, a pull-request/check summary, and a transient toast. AppKit consequently
+re-measures the toolbar and nearby controls shift horizontally.
+
+Issue #471 also reports constrained space for custom command buttons. That is only
+partly related: Normal view intentionally shows at most three command buttons and
+places the remainder in an overflow menu. The fix must not alter that command policy.
+
+An earlier width-measurement and animation experiment (`4c73b76b`) was reverted by
+`09443b3f` because the transition introduced more visual churn than a direct snap.
+
+## Goals
+
+- Reserve a stable, bounded ideal width for the center status area in Normal and
+  Canvas views.
+- Allow the status area to compress when a narrow toolbar needs the space.
+- Keep transient toast messages readable through hover and accessibility when their
+  visual text truncates.
+- Preserve compact PR identity and CI-state signals, with the existing PR popover
+  remaining the source for full details.
+- Add a regression test for the view's width and single-line contract.
+
+### Non-goals
+
+- Do not reintroduce status-width measurement or width animation.
+- Do not change the three-inline-custom-command overflow policy.
+- Do not replace textual toast or PR semantics with color-only indicators.
+- Do not alter PR refresh, check classification, or command execution behavior.
+
+## Design / Approach
+
+1. Make `ToolbarStatusView` own its status-slot layout so both existing call sites
+   inherit the same behavior. After its horizontal padding, apply a 280-point ideal
+   and maximum width without a minimum width; an unconstrained toolbar therefore
+   keeps a stable reservation, while AppKit may propose a smaller width in a narrow
+   window.
+2. Apply one-line tail truncation to status text. Attach full toast text as the
+   hover help and accessibility label. PR status keeps its badge and check ring;
+   its existing hover popover continues to expose the complete title and checks.
+3. Add a macOS Swift Testing regression using `NSHostingView.fittingSize` for short
+   and long toast content. It will prove the common ideal width, the upper bound,
+   and single-line behavior under a constrained proposal.
+4. Update the Canvas and Custom Commands manual only to document the bounded status
+   area and the unchanged overflow behavior, then refresh the docs sync baseline.
+
+## Alternatives & decisions
+
+| Alternative | Decision |
+| --- | --- |
+| A fixed `.frame(width:)` slot | Rejected. It cannot yield space on narrow toolbars. |
+| `maxWidth` alone | Rejected. Short states retain their intrinsic width and still cause layout movement. |
+| Width measurement or animation | Rejected. Historical implementation was intentionally reverted for visual churn. |
+| Color/count-only PR state | Rejected. It loses meaningful toast and PR semantics; badge, ring, tooltip, accessibility, and popover already provide layered information. |
+| Ideal + maximum width, no minimum | Chosen. It makes normal-state allocation stable while retaining compression under toolbar pressure. |
+
+## Verification
+
+- Run the focused `ToolbarStatusViewTests` case with `xcodebuild`.
+- Run changed-file formatting and repository checks.
+- Build the Debug app with `make build-app`.
+- Launch a dedicated self-verify Prowl instance and inspect a narrow normal/canvas
+  toolbar screenshot; clean up the temporary app and socket afterward.
+
+## Amendments
+

--- a/docs-ai/046-toolbar-status-layout-stability/000-plan.md
+++ b/docs-ai/046-toolbar-status-layout-stability/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
+| **Status** | Implemented |
 | **Anchor date** | 2026-07-13 |
 | **Primary PRs** | TBD |
 | **Related** | [024-canvas-interaction-evolution](../024-canvas-interaction-evolution/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [033-ui-refresh-2026-05](../033-ui-refresh-2026-05/000-plan.md), [002-custom-commands](../002-custom-commands/000-plan.md), issue #471, `docs/components/canvas.md` |
@@ -74,4 +74,3 @@ An earlier width-measurement and animation experiment (`4c73b76b`) was reverted 
   toolbar screenshot; clean up the temporary app and socket afterward.
 
 ## Amendments
-

--- a/docs-ai/046-toolbar-status-layout-stability/001-action.md
+++ b/docs-ai/046-toolbar-status-layout-stability/001-action.md
@@ -1,0 +1,52 @@
+# 046 — Toolbar Status Layout Stability: Action Log
+
+## Timeline
+
+| Date | Change | Ref |
+| --- | --- | --- |
+| 2026-07-13 | Added a bounded, compressible status slot, one-line truncation, accessibility help, focused regression tests, and manual updates. | `8d44fdf1` |
+| 2026-07-13 | Verified the docs sync range and refreshed the manual baseline. | This record |
+
+## Outcome & current state (as of 2026-07-13)
+
+- `supacode/Features/Repositories/Views/ToolbarStatusView.swift` owns a 280-point
+  ideal and maximum width after horizontal padding. The absence of a minimum width
+  leaves a narrow toolbar free to propose a smaller size.
+- All status text is single-line and tail-truncates. Toasts expose their original
+  full text through hover help and accessibility labels.
+- `supacode/Features/Repositories/Views/PullRequestStatusButton.swift` keeps the
+  PR badge and check ring while allowing its textual summary to tail-truncate. The
+  existing PR hover popover remains the detailed PR and check view.
+- `supacode/Features/Repositories/Views/WorktreeDetailView.swift` consumes the
+  shared layout in Normal and Canvas modes without duplicate outer padding.
+- `supacodeTests/ToolbarStatusViewTests.swift` measures `ToolbarStatusView` through
+  `NSHostingView`; it locks the stable ideal width and one-line behavior under a
+  constrained width.
+- `docs/components/canvas.md` and `docs/components/custom-actions.md` document the
+  bounded status area and the existing three-inline-command overflow policy.
+- A dedicated debug Prowl instance was driven with `./.build/debug/prowl` on a
+  temporary socket. It opened this worktree, created a temporary tab, captured a
+  `SELF_VERIFY_TOOLBAR_STATUS` terminal marker, and was fully cleaned up.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| Focused `ToolbarStatusViewTests` | Passed after the implementation; both assertions failed against the pre-change view. |
+| `make check` | Passed. |
+| `make build-app` | Passed. |
+| `make test` | 1,788 passed and 1 failed: `ExternalDiffToolTests.snapshotPairIncludesModifiedAndUntrackedFiles()`. The test's temporary Git commit was rejected by the host's `oc-git-id` hook, independently reproduced outside the test. |
+| Debug app CLI round-trip | Passed; screenshot capture was unavailable because the current session lacked Screen Recording permission. |
+
+## Deviations from plan
+
+No implementation deviations. The planned screenshot inspection could not run
+because macOS rejected window capture for the current session; the unit test and
+dedicated-app CLI scenario supplied the remaining verification evidence.
+
+## Open questions
+
+The external-diff test should be rechecked in CI or an environment without the
+host-specific `oc-git-id` template hook. The shared status-view width and
+truncation contract is covered by the focused regression test; actual NSToolbar
+visual inspection remains unavailable in this session.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -92,3 +92,4 @@ behavior (`docs/` is the agent-facing manual for that).
 | 043 | [canvas-tile-layout](043-canvas-tile-layout/000-plan.md) | 2026-06-24 | Tile layout + default-layout setting |
 | 044 | [foundation-model-branch-names](044-foundation-model-branch-names/000-plan.md) | 2026-06-27 | On-device FM branch-name suggestions |
 | 045 | [native-agent-session-detection](045-native-agent-session-detection/000-plan.md) | 2026-07-12 | Native agent session identity (successor to 030's heuristics) |
+| 046 | [toolbar-status-layout-stability](046-toolbar-status-layout-stability/000-plan.md) | 2026-07-13 | Bounded adaptive toolbar status layout; truncation and accessibility policy |

--- a/docs/.sync-meta.json
+++ b/docs/.sync-meta.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Metadata for the docs/ manual. The last_synced_commit is the commit at which docs/ was last verified against the implementation; the sync-docs skill (.claude/skills/sync-docs/SKILL.md) diffs HEAD against it and updates this file. Committed to git on purpose so the baseline persists across sessions and machines. A dotfile + .json so a future docs website does not render it as a page.",
-  "last_synced_commit": "168d8e9c8e61655f57dcb8411092b0af9263e7e0",
-  "last_synced_date": "2026-07-10",
-  "note": "Release prep. All user-facing changes in range were doc-synced in their own PRs (#545 sound picker, #546 mute viewed surface, #542 editor additions, #543 TERM_PROGRAM, #541 gh hardening); #544 symlink-preserving writes and PR tri-state fixes need no doc changes."
+  "last_synced_commit": "8d44fdf131963dd217a667e46a5a16336fade331",
+  "last_synced_date": "2026-07-13",
+  "note": "Verified the source range through #580. Existing agent, CLI, settings, updates, terminal, and repository manuals remained accurate; documented the bounded toolbar status area and Custom Command overflow behavior."
 }

--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -80,6 +80,11 @@ Script / Custom Command buttons run against the focused card's worktree. `⌘⌃
 (`open_pull_request`, "Open on Code Host") opens that card's PR when it has one,
 or the repository page otherwise.
 
+The center status area has a bounded, compressible width so its content does not
+shift nearby toolbar controls. Long PR/check text tail-truncates; hover the PR
+summary for its full title and check details. Toasts retain their complete text in
+their hover help.
+
 ## Visual cues
 
 - **Focused card:** bright accent border. **Selected (multi-select):** medium

--- a/docs/components/custom-actions.md
+++ b/docs/components/custom-actions.md
@@ -71,6 +71,9 @@ detected when you record the key, and you choose Replace / Cancel.
 [Command Palette](command-palette.md). Custom Commands are also stored per repo,
 in `~/.prowl/repo/<repo-name>/prowl.onevcat.json`.
 
+The toolbar shows the first three Custom Commands inline. Additional commands stay
+available through the More Custom Commands overflow menu.
+
 ## Example uses
 
 - `swift build` on `⌘B` (shell script).

--- a/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
+++ b/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
@@ -34,6 +34,7 @@ struct PullRequestStatusButton: View {
             .lineLimit(1)
         }
       }
+      .truncationMode(.tail)
     }
     .font(.caption)
   }

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -4,6 +4,7 @@ struct ToolbarStatusView: View {
   let toast: RepositoriesFeature.StatusToast?
   let pullRequest: GithubPullRequest?
   let codeHost: CodeHost
+  private static let idealWidth: CGFloat = 280
 
   var body: some View {
     Group {
@@ -16,6 +17,8 @@ struct ToolbarStatusView: View {
             .font(.footnote)
             .foregroundStyle(.secondary)
         }
+        .help(message)
+        .accessibilityLabel(message)
         .transition(.opacity)
       case .success(let message):
         HStack(spacing: 6) {
@@ -26,6 +29,8 @@ struct ToolbarStatusView: View {
             .font(.footnote)
             .foregroundStyle(.secondary)
         }
+        .help(message)
+        .accessibilityLabel(message)
         .transition(.opacity)
       case .warning(let message):
         HStack(spacing: 6) {
@@ -36,6 +41,8 @@ struct ToolbarStatusView: View {
             .font(.footnote)
             .foregroundStyle(.secondary)
         }
+        .help(message)
+        .accessibilityLabel(message)
         .transition(.opacity)
       case nil:
         if let model = PullRequestStatusModel(pullRequest: pullRequest) {
@@ -47,6 +54,10 @@ struct ToolbarStatusView: View {
         }
       }
     }
+    .lineLimit(1)
+    .truncationMode(.tail)
+    .padding(.horizontal)
+    .frame(idealWidth: Self.idealWidth, maxWidth: Self.idealWidth)
     .animation(.easeInOut(duration: 0.2), value: toast)
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -242,7 +242,6 @@ struct WorktreeDetailView: View {
         pullRequest: state.pullRequest,
         codeHost: state.codeHost
       )
-      .padding(.horizontal)
     }
 
     ToolbarItemGroup(placement: .primaryAction) {
@@ -853,7 +852,6 @@ struct WorktreeDetailView: View {
           pullRequest: toolbarState.pullRequest,
           codeHost: toolbarState.codeHost
         )
-        .padding(.horizontal)
       }
 
       ToolbarItemGroup {

--- a/supacodeTests/ToolbarStatusViewTests.swift
+++ b/supacodeTests/ToolbarStatusViewTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ToolbarStatusViewTests {
+  @Test func statusSlotKeepsStableIdealWidthAcrossToastLengths() {
+    let shortToastSize = fittingSize(for: .success("Saved"))
+    let longToastSize = fittingSize(for: .success(String(repeating: "Long toolbar status ", count: 40)))
+
+    #expect(abs(shortToastSize.width - 280) < 0.5)
+    #expect(abs(longToastSize.width - 280) < 0.5)
+  }
+
+  @Test func longToastRemainsSingleLineWhenToolbarIsConstrained() {
+    let shortToastSize = fittingSize(for: .success("Saved"), constrainedTo: 180)
+    let longToastSize = fittingSize(
+      for: .success(String(repeating: "Long toolbar status ", count: 40)),
+      constrainedTo: 180
+    )
+
+    #expect(longToastSize.width <= 180.5)
+    #expect(abs(longToastSize.height - shortToastSize.height) < 0.5)
+  }
+
+  private func fittingSize(
+    for toast: RepositoriesFeature.StatusToast,
+    constrainedTo width: CGFloat? = nil
+  ) -> CGSize {
+    let statusView = ToolbarStatusView(toast: toast, pullRequest: nil, codeHost: .github)
+    let rootView =
+      if let width {
+        AnyView(statusView.frame(width: width))
+      } else {
+        AnyView(statusView)
+      }
+    return NSHostingView(rootView: rootView).fittingSize
+  }
+}


### PR DESCRIPTION
## What

- Reserve a bounded, compressible layout slot for the principal toolbar status area.
- Tail-truncate long status and PR/check summaries while preserving toast help and accessibility text.
- Add regression coverage for stable status width and single-line behavior under constrained width.

## Why

The principal status view previously used its intrinsic content width, causing toolbar remeasurement and visible layout shifts when switching between idle hints, PR summaries, and toasts.

Fixes #471

## How tested

- `make check`
- `make build-app`
- Focused `ToolbarStatusViewTests` (2 passing tests)
- `make test` (1,788 passing; one unrelated local `ExternalDiffToolTests` failure is blocked by a host Git identity hook)

— PR prepared by onevclaw on behalf of @onevcat