### PR TITLE
Add outgoing changes diff view for pull requests

### DIFF
--- a/docs-ai/003-diff-window/000-plan.md
+++ b/docs-ai/003-diff-window/000-plan.md
@@ -95,3 +95,5 @@ cut the embedded asset from 9.3 MB to 2.7 MB (−7 MB on the .app) (#45).
   (#529/#536/#537) — see [003-render-pipeline-hardening.md](003-render-pipeline-hardening.md)
 - Updated 2026-07-08: diff window follows app appearance instead of system
   (#540) — see [004-appearance-follows-app.md](004-appearance-follows-app.md)
+- Updated 2026-07-14: built-in outgoing changes for an identified pull request,
+  using its target remote and merge-base semantics — see [005-outgoing-changes.md](005-outgoing-changes.md)

--- a/docs-ai/003-diff-window/005-outgoing-changes.md
+++ b/docs-ai/003-diff-window/005-outgoing-changes.md
@@ -1,0 +1,68 @@
+# 003.005 — Outgoing Changes
+
+## Context
+
+`Show Diff` deliberately compares the working directory with `HEAD`; it cannot
+review commits that the current worktree would contribute to a pull request.
+Fork issue #510 requested that distinct review surface. The comparison needs a
+reliable base: assuming `origin/main` is incorrect for forks, multiple remotes,
+and stacked pull requests.
+
+## Change
+
+Fork issue #510 is implemented as a built-in `Outgoing Changes` action in the
+View menu and Command Palette. `Show Diff` and the line-change badge remain
+working-tree views.
+
+- The action requires the selected worktree's cached pull request URL and base
+  ref. It maps the pull request target repository to exactly one local remote,
+  then resolves `<remote>/<baseRef>` and its merge base with `HEAD`.
+- The file list and document contents come from `<merge-base>` and `HEAD`, which
+  implements `git diff <base>...HEAD`. Staged, unstaged, and untracked files are
+  deliberately excluded.
+- Refreshing the window resolves a fresh base/`HEAD` comparison before loading
+  files, so an advanced base or a new commit cannot leave a stale snapshot open.
+- Missing PR data, an ambiguous or unfetched target remote, and no common
+  ancestor produce an actionable error. There is no implicit default-branch
+  fallback.
+- The action always uses the built-in diff window. Configurable external tools
+  continue to receive only `HEAD`-versus-working-directory snapshots.
+
+## Alternatives & decisions
+
+- **PR-derived base with explicit failure, not `origin/main` fallback** — chosen
+  for correctness in forks and stacked branches. A base picker for worktrees
+  without a PR is deferred; it needs a dedicated selection UI and persistent
+  semantics rather than a hidden heuristic.
+- **Reuse the built-in Diff window, not external tools** — it already renders
+  per-file YiTong documents, while the external integrations have incompatible
+  snapshot inputs.
+- **Merge-base left tree, not the current base tip** — a base branch can advance
+  after the feature branch is created. Reading `<base>:path` would disagree with
+  GitHub's three-dot pull-request comparison.
+
+## Refs
+
+- Fork issue #510. Files: `GitClient.swift`, `OutgoingChangesClient.swift`,
+  `DiffWindowState.swift`, `DiffWindowManager.swift`, `DiffWindowContentView.swift`,
+  the AppFeature and Command Palette routes, and their focused tests.
+
+## Current state
+
+Outgoing Changes is available for a selected worktree through View and the
+Command Palette. It can compare a pull request aimed at a fork upstream, an
+Enterprise-style repository host, or a remote using a custom SSH port, provided
+that Prowl can identify one matching local remote.
+
+## Verification
+
+- Focused `xcodebuild test` coverage passed 10 tests, including target-remote
+  resolution, merge-base contents after the base advanced, uncommitted-file
+  exclusion, refresh behavior, copied files, and AppFeature/Command Palette
+  routing.
+- `make test` passed 1,807 tests; `make check` and `make build-app` completed
+  successfully.
+- An isolated debug Prowl instance was exercised through its dedicated socket:
+  open the worktree, create a tab, send and read a terminal marker, close both
+  tabs, and terminate only the debug process. The menu/reducer route is covered
+  by the focused tests because the CLI does not expose app menu commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | [`components/active-agents.md`](components/active-agents.md) | The Active Agents panel: a live list of every running agent and its status, with one-click jump-to-agent. |
 | [`components/agent-detection.md`](components/agent-detection.md) | How Prowl knows an agent is Working / Blocked / Idle / Done, which agents it recognizes, and how the status indicator works. |
 | [`components/notifications.md`](components/notifications.md) | Agent-finished reminders, command-finished notifications, the bell/unread indicators, and Dock badge/bounce. |
-| [`components/diff-view.md`](components/diff-view.md) | The Diff window (`⌘⇧Y`): working-tree changes vs HEAD, split/unified modes, line-change badges. |
+| [`components/diff-view.md`](components/diff-view.md) | Show Diff (`⌘⇧Y`) for working-tree changes vs HEAD, plus Outgoing Changes for pull-request branch diffs. |
 | [`components/github-pull-requests.md`](components/github-pull-requests.md) | GitHub PR integration via `gh`: PR status, CI checks, merge/close/re-run actions from the command palette. |
 | [`components/custom-actions.md`](components/custom-actions.md) | Run Script (`⌘R`/`⌘.`), Setup & Archive scripts, and per-repo Custom Commands with their own buttons & hotkeys. Injected env vars. |
 | [`components/settings.md`](components/settings.md) | The Settings window (`⌘,`): every tab and what it controls. |

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -30,8 +30,8 @@ The available actions depend on context (e.g. PR actions appear only when the
 selected worktree has a pull request).
 
 - **View / layout:** Toggle Sidebar, Toggle Active Agents Panel, Toggle Canvas,
-  Toggle Shelf, Show Diff, and Canvas actions (Expand/Arrange/Organize/Select-All
-  cards).
+  Toggle Shelf, Show Diff, Outgoing Changes, and Canvas actions
+  (Expand/Arrange/Organize/Select-All cards).
 - **Navigation:** Reveal in Finder, Copy Path, Reveal in Sidebar, Jump to Latest
   Unread, and select-a-specific-worktree entries.
 - **Worktree:** New Worktree, Refresh Worktrees, View Archived Worktrees, Run
@@ -52,6 +52,9 @@ selected worktree has a pull request).
   suggestions.
 - PR and Canvas entries appear/disappear as state changes (PR present, Canvas
   active, etc.).
+- Outgoing Changes compares committed work against the selected worktree's pull
+  request base; it reports an error rather than guessing when Prowl cannot
+  resolve that base.
 - In Canvas, worktree-scoped actions use the focused card as their context.
 - There are no user settings for the palette; ranking is automatic.
 

--- a/docs/components/diff-view.md
+++ b/docs/components/diff-view.md
@@ -3,7 +3,7 @@
 > A dedicated window showing what changed in a worktree vs HEAD — review an
 > agent's work before you commit.
 
-**Keywords:** diff, diff view, changes, review, working tree, HEAD, split, unified, line changes, ⌘⇧Y, show diff
+**Keywords:** diff, diff view, outgoing changes, changes, review, working tree, HEAD, split, unified, line changes, ⌘⇧Y, show diff
 
 **Related:** [repositories-and-worktrees](repositories-and-worktrees.md) · [github-pull-requests](github-pull-requests.md) · [command-palette](command-palette.md)
 
@@ -16,8 +16,26 @@ fast way to review before committing or merging.
 **Open:** click a worktree's diff badge, press `⌘⇧Y` (`show_diff`), or use
 Command Palette → "Show Diff".
 
-By default Prowl opens its built-in YiTong-based diff window. In Settings →
-General → Diff Tool, you can choose an external tool instead:
+## Outgoing Changes
+
+**Outgoing Changes** is a separate built-in view for the committed changes a
+selected worktree contributes to its pull request. It does not change the
+working-tree semantics of Show Diff or its line-change badge.
+
+**Open:** View → Outgoing Changes, or Command Palette → "Outgoing Changes".
+
+Prowl uses the pull request's target repository and base branch to find its
+matching local remote, then compares `git diff <base>...HEAD`. It reads the
+merge-base and `HEAD` snapshots, so staged, unstaged, and untracked files are
+excluded. On each focus refresh it captures a new consistent comparison.
+
+Outgoing Changes requires a pull request with a resolvable, fetched target
+base. If Prowl cannot determine one, it shows an error instead of guessing a
+default branch. It always uses the built-in window; the external Diff Tool
+setting applies only to Show Diff.
+
+For **Show Diff**, Prowl opens its built-in YiTong-based diff window by default.
+In Settings → General → Diff Tool, you can choose an external tool instead:
 
 - **Built-in** — opens Prowl's diff window. The window is a persistent singleton
   (remembers size/position) and auto-refreshes when it regains focus. `⌘W`
@@ -32,7 +50,7 @@ General → Diff Tool, you can choose an external tool instead:
 
 Tools that are not installed on the Mac are shown disabled in the Diff Tool menu.
 
-## What the built-in window shows
+## What Show Diff shows
 
 - A **file list** sidebar of changed files, each with a colored status badge:
   - **M** Modified (orange) · **A** Added/untracked (green) · **D** Deleted (red) ·
@@ -49,7 +67,8 @@ Tools that are not installed on the Mac are shown disabled in the Diff Tool menu
   picker.
 - Click a file in the list to view its diff. Rapid switching is debounced: the
   first selection renders immediately, files flicked through are skipped.
-- Auto-refresh on focus keeps it current as the agent keeps working.
+- Auto-refresh on focus keeps the active comparison current as the agent keeps
+  working or commits.
 - If a render fails, **re-selecting the file** (or any refresh) retries it.
 
 ## Line-change badges elsewhere
@@ -66,8 +85,8 @@ Diff is a **git-only** feature — it's unavailable for plain (non-git) folders.
 
 - The diff is **working-tree vs HEAD**, not vs the base branch — it reflects
   uncommitted changes in that worktree.
+- Outgoing Changes is **merge-base vs HEAD** for an identified pull request;
+  it excludes all uncommitted files and does not guess a base branch.
 - External GUI tools receive snapshot folders so untracked files are included
   without changing the git index.
 - The Hunk integration runs in a terminal tab because Hunk is terminal-native.
-- For changes already in a pull request (vs the base branch, with CI), see
-  [github-pull-requests](github-pull-requests.md).

--- a/supacode/Clients/ExternalDiff/OutgoingChangesClient.swift
+++ b/supacode/Clients/ExternalDiff/OutgoingChangesClient.swift
@@ -1,0 +1,67 @@
+import ComposableArchitecture
+import Foundation
+
+nonisolated struct OutgoingChangesClient: Sendable {
+  var open:
+    @MainActor @Sendable (
+      _ worktree: Worktree,
+      _ pullRequestURL: String,
+      _ baseRefName: String,
+      _ resolvedKeybindings: ResolvedKeybindingMap,
+      _ onError: @escaping @MainActor @Sendable (OpenActionError) -> Void
+    ) async -> Void
+}
+
+extension OutgoingChangesClient: DependencyKey {
+  static let liveValue = OutgoingChangesClient { worktree, pullRequestURL, baseRefName, resolvedKeybindings, onError in
+    let gitClient = GitClient()
+    guard
+      let baseRef = await gitClient.outgoingChangesBaseRef(
+        pullRequestURL: pullRequestURL,
+        baseRefName: baseRefName,
+        in: worktree.workingDirectory
+      )
+    else {
+      onError(
+        OpenActionError(
+          title: "Unable to show outgoing changes",
+          message:
+            "Prowl could not resolve the pull request base in a local remote. Fetch the target remote and try again."
+        )
+      )
+      return
+    }
+
+    do {
+      let revisions = try await gitClient.outgoingChangesComparison(from: baseRef, at: worktree.workingDirectory)
+      @Shared(.settingsFile) var settingsFile
+      DiffWindowManager.shared.show(
+        worktreeURL: worktree.workingDirectory,
+        branchName: worktree.name,
+        comparison: .outgoing(revisions),
+        resolvedKeybindings: resolvedKeybindings,
+        colorScheme: settingsFile.global.appearanceMode.colorScheme
+      )
+    } catch {
+      onError(
+        OpenActionError(
+          title: "Unable to show outgoing changes",
+          message: [
+            "Prowl could not compare this branch with \(baseRef).",
+            "Fetch the base branch and try again.",
+            error.localizedDescription,
+          ].joined(separator: "\n\n")
+        )
+      )
+    }
+  }
+
+  static let testValue = OutgoingChangesClient { _, _, _, _, _ in }
+}
+
+extension DependencyValues {
+  var outgoingChangesClient: OutgoingChangesClient {
+    get { self[OutgoingChangesClient.self] }
+    set { self[OutgoingChangesClient.self] = newValue }
+  }
+}

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -563,6 +563,82 @@ struct GitClient {
     }
   }
 
+  /// Resolves the local remote-tracking ref that represents an identified pull
+  /// request's base. A nil result is intentionally ambiguous to callers: Prowl
+  /// must ask the user to fix the remote/base state rather than guessing origin.
+  nonisolated func outgoingChangesBaseRef(
+    pullRequestURL: String,
+    baseRefName: String,
+    in worktreeURL: URL
+  ) async -> String? {
+    let normalizedBaseRefName = baseRefName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedBaseRefName.isEmpty,
+      let pullRequestRepository = Self.pullRequestRepositoryWebInfo(pullRequestURL)
+    else {
+      return nil
+    }
+    let matchingRemotes = await remoteWebCandidates(for: worktreeURL)
+      .filter { Self.matches($0.info, pullRequestRepository) }
+      .map(\.name)
+    guard matchingRemotes.count == 1, let remote = matchingRemotes.first else {
+      return nil
+    }
+    let baseRef = "\(remote)/\(normalizedBaseRefName)"
+    guard await refExists(baseRef, repoRoot: worktreeURL) else {
+      return nil
+    }
+    return baseRef
+  }
+
+  /// Captures the immutable Git revisions used by a three-dot pull request
+  /// comparison. The merge base is the left side; the current HEAD is the
+  /// right side. Capturing both keeps the file list and all file documents
+  /// internally consistent even if refs move while the window is loading.
+  nonisolated func outgoingChangesComparison(
+    from baseRef: String,
+    at worktreeURL: URL
+  ) async throws -> GitOutgoingChangesComparison {
+    let path = worktreeURL.path(percentEncoded: false)
+    let head = try await runGit(
+      operation: .outgoingChangesComparison,
+      arguments: ["-C", path, "rev-parse", "--verify", "HEAD"]
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !head.isEmpty else {
+      throw GitClientError.commandFailed(command: "git rev-parse --verify HEAD", message: "Empty output")
+    }
+    let mergeBase = try await runGit(
+      operation: .outgoingChangesComparison,
+      arguments: ["-C", path, "merge-base", baseRef, head]
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !mergeBase.isEmpty else {
+      throw GitClientError.commandFailed(command: "git merge-base \(baseRef) \(head)", message: "Empty output")
+    }
+    return GitOutgoingChangesComparison(baseRef: baseRef, mergeBase: mergeBase, head: head)
+  }
+
+  /// Lists committed files in a captured pull-request comparison. Unlike
+  /// `diffNameStatus(at:)`, errors deliberately propagate so callers never
+  /// mistake a missing base for an empty outgoing diff.
+  nonisolated func outgoingDiffNameStatus(
+    for comparison: GitOutgoingChangesComparison,
+    at worktreeURL: URL
+  ) async throws -> String {
+    let path = worktreeURL.path(percentEncoded: false)
+    return try await runGit(
+      operation: .outgoingDiffNameStatus,
+      arguments: [
+        "-C",
+        path,
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-status",
+        comparison.mergeBase,
+        comparison.head,
+      ]
+    )
+  }
+
   nonisolated func untrackedFilePaths(at worktreeURL: URL) async -> [String] {
     let path = worktreeURL.path(percentEncoded: false)
     do {
@@ -581,11 +657,15 @@ struct GitClient {
   }
 
   nonisolated func showFileAtHEAD(_ relativePath: String, in worktreeURL: URL) async -> String? {
+    await showFile(relativePath, at: "HEAD", in: worktreeURL)
+  }
+
+  nonisolated func showFile(_ relativePath: String, at revision: String, in worktreeURL: URL) async -> String? {
     let path = worktreeURL.path(percentEncoded: false)
     do {
       return try await runGit(
         operation: .showFile,
-        arguments: ["-C", path, "show", "HEAD:\(relativePath)"]
+        arguments: ["-C", path, "show", "\(revision):\(relativePath)"]
       )
     } catch {
       return nil
@@ -663,6 +743,30 @@ struct GitClient {
       return candidates
     }
     return candidates.filter { $0.name == "origin" } + candidates.filter { $0.name != "origin" }
+  }
+
+  nonisolated private static func pullRequestRepositoryWebInfo(_ pullRequestURL: String) -> GitRemoteWebInfo? {
+    guard let pullRequestInfo = parseRepositoryWebInfo(pullRequestURL) else {
+      return nil
+    }
+    let components = pullRequestInfo.repositoryPath.split(separator: "/", omittingEmptySubsequences: true)
+    guard components.count >= 4,
+      components[2].caseInsensitiveCompare("pull") == .orderedSame
+    else {
+      return nil
+    }
+    return GitRemoteWebInfo(
+      host: pullRequestInfo.host,
+      repositoryPath: "\(components[0])/\(components[1])",
+      port: pullRequestInfo.port
+    )
+  }
+
+  nonisolated private static func matches(_ lhs: GitRemoteWebInfo, _ rhs: GitRemoteWebInfo) -> Bool {
+    // Pull request URLs use the web transport while remotes commonly use SSH;
+    // their ports do not identify different repositories.
+    lhs.host.caseInsensitiveCompare(rhs.host) == .orderedSame
+      && lhs.repositoryPath.caseInsensitiveCompare(rhs.repositoryPath) == .orderedSame
   }
 
   nonisolated static func prioritizedGithubRemoteInfos(

--- a/supacode/Clients/Git/GitClientTypes.swift
+++ b/supacode/Clients/Git/GitClientTypes.swift
@@ -18,6 +18,8 @@ enum GitOperation: String {
   case branchDelete = "branch_delete"
   case lineChanges = "line_changes"
   case diffNameStatus = "diff_name_status"
+  case outgoingChangesComparison = "outgoing_changes_comparison"
+  case outgoingDiffNameStatus = "outgoing_diff_name_status"
   case untrackedFilePaths = "untracked_file_paths"
   case showFile = "show_file"
   case remoteInfo = "remote_info"
@@ -125,6 +127,12 @@ nonisolated struct GitBranchRefOption: Codable, Equatable, Hashable, Sendable, I
     self.ref = ref
     self.kind = kind
   }
+}
+
+nonisolated struct GitOutgoingChangesComparison: Equatable, Sendable {
+  let baseRef: String
+  let mergeBase: String
+  let head: String
 }
 
 nonisolated struct GitRemoteBranchRefs: Equatable, Sendable {

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -77,6 +77,11 @@ struct SidebarCommands: Commands {
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.showDiff)))
       .help(helpText(title: "Show Diff", commandID: AppShortcuts.CommandID.showDiff))
       .disabled(store.repositories.selectedWorktreeID == nil)
+      Button("Outgoing Changes", systemImage: "arrow.up.right") {
+        store.send(.showSelectedWorktreeOutgoingChanges)
+      }
+      .help("Show committed changes relative to this worktree's pull request base")
+      .disabled(store.repositories.selectedWorktreeID == nil)
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -162,6 +162,9 @@ extension AppFeature {
     case .showDiff:
       return openSelectedWorktreeDiffEffect(state: state)
 
+    case .showOutgoingChanges:
+      return openSelectedWorktreeOutgoingChangesEffect(state: state)
+
     case .revealInFinder:
       return .send(.openWorktree(.finder))
 
@@ -212,6 +215,34 @@ extension AppFeature {
       return .none
     }
     return openDiffEffect(worktree: worktree, resolvedKeybindings: state.resolvedKeybindings)
+  }
+
+  func openSelectedWorktreeOutgoingChangesEffect(state: State) -> Effect<Action> {
+    guard let worktreeID = state.repositories.selectedWorktreeID,
+      let worktree = state.repositories.worktree(for: worktreeID),
+      let pullRequest = state.repositories.worktreeInfo(for: worktreeID)?.pullRequest,
+      let baseRefName = pullRequest.baseRefName?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !baseRefName.isEmpty
+    else {
+      return .send(
+        .openWorktreeFailed(
+          OpenActionError(
+            title: "Outgoing changes unavailable",
+            message: [
+              "Outgoing Changes requires a pull request with a known base branch.",
+              "Create or refresh the pull request and try again.",
+            ].joined(separator: " ")
+          )
+        )
+      )
+    }
+    let pullRequestURL = pullRequest.url
+    let resolvedKeybindings = state.resolvedKeybindings
+    return .run { send in
+      await outgoingChangesClient.open(worktree, pullRequestURL, baseRefName, resolvedKeybindings) { error in
+        send(.openWorktreeFailed(error))
+      }
+    }
   }
 
   func reduceCommandPaletteWorktreeActionDelegate(

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -58,6 +58,7 @@ struct AppFeature {
     case worktreeUserSettingsLoaded(UserRepositorySettings, worktreeID: Worktree.ID)
     case openSelectedWorktree
     case showSelectedWorktreeDiff
+    case showSelectedWorktreeOutgoingChanges
     case openWorktree(OpenWorktreeAction)
     case openWorktreeFailed(OpenActionError)
     case requestQuit
@@ -104,6 +105,7 @@ struct AppFeature {
   @Dependency(WorktreeInfoWatcherClient.self) var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) var customShortcutRegistryClient
   @Dependency(ExternalDiffToolClient.self) var externalDiffToolClient
+  @Dependency(OutgoingChangesClient.self) var outgoingChangesClient
 
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
@@ -552,6 +554,9 @@ struct AppFeature {
 
       case .showSelectedWorktreeDiff:
         return openSelectedWorktreeDiffEffect(state: state)
+
+      case .showSelectedWorktreeOutgoingChanges:
+        return openSelectedWorktreeOutgoingChangesEffect(state: state)
 
       case .openWorktree(let action):
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -72,6 +72,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case selectAllCanvasCards
     case toggleShelf
     case showDiff
+    case outgoingChanges
     case revealInFinder
     case copyPath
     case revealInSidebar
@@ -164,6 +165,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .revealInFinder,
       .copyPath,
       .togglePinWorktree,
+      .outgoingChanges,
       .deleteWorktree,
       .openRepositorySettings,
       .runCustomCommand:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -62,6 +62,7 @@ struct CommandPaletteFeature {
     case selectAllCanvasCards
     case toggleShelf
     case showDiff
+    case showOutgoingChanges
     case revealInFinder
     case copyPath
     case revealInSidebar
@@ -238,15 +239,7 @@ struct CommandPaletteFeature {
     }
     let worktreeActionTargetID = actionTargetWorktreeID ?? repositories.selectedWorktreeID
     if repositories.selectedWorktreeID != nil {
-      items.append(
-        .appShortcut(
-          id: CommandPaletteItemID.globalShowDiff,
-          title: "Show Diff",
-          category: .view,
-          kind: .showDiff,
-          keywords: ["diff", "changes", "git"]
-        )
-      )
+      items.append(contentsOf: selectedWorktreeViewCommandItems())
       items.append(contentsOf: worktreeNavigationCommandItems())
       items.append(
         contentsOf: worktreeActionCommandItems(
@@ -572,6 +565,27 @@ private func worktreeNavigationCommandItems() -> [CommandPaletteItem] {
       category: .navigation,
       kind: .revealInSidebar,
       keywords: ["reveal", "locate", "find worktree"]
+    ),
+  ]
+}
+
+private func selectedWorktreeViewCommandItems() -> [CommandPaletteItem] {
+  [
+    .appShortcut(
+      id: CommandPaletteItemID.globalShowDiff,
+      title: "Show Diff",
+      category: .view,
+      kind: .showDiff,
+      keywords: ["diff", "changes", "git"]
+    ),
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalOutgoingChanges,
+      title: "Outgoing Changes",
+      subtitle: nil,
+      kind: .outgoingChanges,
+      category: .view,
+      defaultSuggestion: true,
+      keywords: ["diff", "changes", "pull request", "git"]
     ),
   ]
 }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
@@ -22,6 +22,7 @@ enum CommandPaletteItemID {
   static let globalSelectAllCanvasCards = "global.select-all-canvas-cards"
   static let globalToggleShelf = "global.toggle-shelf"
   static let globalShowDiff = "global.show-diff"
+  static let globalOutgoingChanges = "global.outgoing-changes"
   static let globalRevealInFinder = "global.reveal-in-finder"
   static let globalCopyPath = "global.copy-path"
   static let globalRevealInSidebar = "global.reveal-in-sidebar"
@@ -59,6 +60,7 @@ enum CommandPaletteItemID {
       globalSelectAllCanvasCards,
       globalToggleShelf,
       globalShowDiff,
+      globalOutgoingChanges,
       globalRevealInFinder,
       globalCopyPath,
       globalRevealInSidebar,
@@ -196,6 +198,7 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     .selectAllCanvasCards,
     .toggleShelf,
     .showDiff,
+    .outgoingChanges,
     .revealInFinder,
     .copyPath,
     .revealInSidebar,
@@ -278,6 +281,8 @@ func viewDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeat
     return .toggleShelf
   case .showDiff:
     return .showDiff
+  case .outgoingChanges:
+    return .showOutgoingChanges
   default:
     return nil
   }
@@ -326,6 +331,7 @@ func pullRequestDelegateAction(
     .selectAllCanvasCards,
     .toggleShelf,
     .showDiff,
+    .outgoingChanges,
     .revealInFinder,
     .copyPath,
     .revealInSidebar,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -523,7 +523,7 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
       .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
-      .toggleShelf, .showDiff,
+      .toggleShelf, .showDiff, .outgoingChanges,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings, .runCustomCommand:
@@ -599,6 +599,8 @@ private struct CommandPaletteRowView: View {
       return "books.vertical"
     case .showDiff:
       return "plusminus.circle"
+    case .outgoingChanges:
+      return "arrow.up.right"
     case .revealInFinder:
       return "folder"
     case .copyPath:
@@ -640,7 +642,7 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
       .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
-      .toggleShelf, .showDiff,
+      .toggleShelf, .showDiff, .outgoingChanges,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings,
@@ -786,6 +788,8 @@ private struct CommandPaletteRowView: View {
       base = "Toggle Shelf"
     case .showDiff:
       base = "Show Diff"
+    case .outgoingChanges:
+      base = "Show committed changes relative to the pull request base"
     case .revealInFinder:
       base = "Reveal in Finder"
     case .copyPath:

--- a/supacode/Features/DiffView/DiffWindowContentView.swift
+++ b/supacode/Features/DiffView/DiffWindowContentView.swift
@@ -14,6 +14,15 @@ struct DiffWindowContentView: View {
     DiffStyle(rawValue: diffStyleRaw) ?? .split
   }
 
+  private var emptyState: (title: String, description: String) {
+    switch state.comparison {
+    case .workingTree:
+      ("No Changes", "Working directory is clean")
+    case .outgoing:
+      ("No Outgoing Changes", "This branch has no committed changes relative to its pull request base")
+    }
+  }
+
   private var resolvedDiffAppearance: DiffAppearance {
     switch settingsFile.global.appearanceMode {
     case .system: colorScheme == .dark ? .dark : .light
@@ -97,11 +106,17 @@ struct DiffWindowContentView: View {
     .overlay {
       if state.isLoadingFiles && state.changedFiles.isEmpty {
         ProgressView()
+      } else if let loadError = state.loadError {
+        ContentUnavailableView(
+          "Unable to Load Changes",
+          systemImage: "exclamationmark.triangle",
+          description: Text(loadError),
+        )
       } else if !state.isLoadingFiles && state.changedFiles.isEmpty {
         ContentUnavailableView(
-          "No Changes",
+          emptyState.title,
           systemImage: "checkmark.circle",
-          description: Text("Working directory is clean"),
+          description: Text(emptyState.description),
         )
       }
     }
@@ -159,6 +174,12 @@ struct DiffWindowContentView: View {
           }
         }
         .animation(.easeInOut(duration: 0.15), value: state.renderState)
+      } else if let loadError = state.loadError {
+        ContentUnavailableView(
+          "Unable to Load Changes",
+          systemImage: "exclamationmark.triangle",
+          description: Text(loadError),
+        )
       } else if state.isLoadingFiles {
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/supacode/Features/DiffView/DiffWindowManager.swift
+++ b/supacode/Features/DiffView/DiffWindowManager.swift
@@ -15,10 +15,11 @@ final class DiffWindowManager {
   func show(
     worktreeURL: URL,
     branchName: String,
+    comparison: DiffComparison = .workingTree,
     resolvedKeybindings: ResolvedKeybindingMap = .appDefaults,
     colorScheme: ColorScheme? = nil
   ) {
-    state.load(worktreeURL: worktreeURL, branchName: branchName)
+    state.load(worktreeURL: worktreeURL, branchName: branchName, comparison: comparison)
     skipNextFocusRefresh = true
     let rootView = AnyView(
       DiffWindowContentView(state: state)
@@ -31,7 +32,7 @@ final class DiffWindowManager {
       if let hostingController = existingWindow.contentViewController as? NSHostingController<AnyView> {
         hostingController.rootView = rootView
       }
-      existingWindow.title = windowTitle(branchName: branchName)
+      existingWindow.title = windowTitle(branchName: branchName, comparison: comparison)
       existingWindow.appearance = appearance
       if existingWindow.isMiniaturized {
         existingWindow.deminiaturize(nil)
@@ -43,7 +44,7 @@ final class DiffWindowManager {
     let hostingController = NSHostingController(rootView: rootView)
 
     let newWindow = NSWindow(contentViewController: hostingController)
-    newWindow.title = windowTitle(branchName: branchName)
+    newWindow.title = windowTitle(branchName: branchName, comparison: comparison)
     newWindow.identifier = NSUserInterfaceItemIdentifier("diff")
     newWindow.styleMask = [.titled, .closable, .miniaturizable, .resizable]
     newWindow.tabbingMode = .disallowed
@@ -86,8 +87,13 @@ final class DiffWindowManager {
     !state.changedFiles.isEmpty || state.isLoadingFiles
   }
 
-  private func windowTitle(branchName: String) -> String {
-    "Changes — \(branchName)"
+  private func windowTitle(branchName: String, comparison: DiffComparison) -> String {
+    switch comparison {
+    case .workingTree:
+      "Changes — \(branchName)"
+    case .outgoing:
+      "Outgoing Changes — \(branchName)"
+    }
   }
 
   @objc private func windowDidBecomeKey(_ notification: Notification) {

--- a/supacode/Features/DiffView/DiffWindowState.swift
+++ b/supacode/Features/DiffView/DiffWindowState.swift
@@ -1,6 +1,11 @@
 import Foundation
 import YiTong
 
+nonisolated enum DiffComparison: Equatable, Sendable {
+  case workingTree
+  case outgoing(GitOutgoingChangesComparison)
+}
+
 @Observable
 @MainActor
 final class DiffWindowState {
@@ -21,10 +26,12 @@ final class DiffWindowState {
 
   var worktreeURL: URL?
   var branchName: String = ""
+  var comparison: DiffComparison = .workingTree
   var changedFiles: [DiffChangedFile] = []
   var selectedFile: DiffChangedFile?
   var diffDocument: DiffDocument?
   var isLoadingFiles = false
+  var loadError: String?
   var renderState: RenderState = .idle
   /// Identity for the hosted `DiffView` (used as `.id()` by the view). YiTong
   /// skips re-rendering a value-equal document, so after a render failure the
@@ -36,38 +43,80 @@ final class DiffWindowState {
   private var loadTask: Task<Void, Never>?
   private let selectDebouncer: Debouncer
 
-  private let fetchChangedFiles: @Sendable (URL) async -> [DiffChangedFile]
-  private let loadDiffDocument: @Sendable (DiffChangedFile, URL) async -> DiffDocument
+  private let fetchChangedFiles: @Sendable (URL, DiffComparison) async throws -> [DiffChangedFile]
+  private let loadDiffDocument: @Sendable (DiffChangedFile, URL, DiffComparison) async -> DiffDocument
+  private let refreshComparison: @Sendable (URL, DiffComparison) async throws -> DiffComparison
 
   init(
-    fetchChangedFiles: @escaping @Sendable (URL) async -> [DiffChangedFile] = DiffWindowState.liveFetchChangedFiles,
-    loadDiffDocument: @escaping @Sendable (DiffChangedFile, URL) async -> DiffDocument = DiffWindowState
+    fetchChangedFiles: @escaping @Sendable (URL, DiffComparison) async throws -> [DiffChangedFile] =
+      DiffWindowState.liveFetchChangedFiles,
+    loadDiffDocument: @escaping @Sendable (DiffChangedFile, URL, DiffComparison) async -> DiffDocument = DiffWindowState
       .liveLoadDocument,
+    refreshComparison: @escaping @Sendable (URL, DiffComparison) async throws -> DiffComparison =
+      DiffWindowState.liveRefreshComparison,
     selectDebounceInterval: Duration = .milliseconds(150),
     clock: any Clock<Duration> = ContinuousClock()
   ) {
     self.fetchChangedFiles = fetchChangedFiles
     self.loadDiffDocument = loadDiffDocument
+    self.refreshComparison = refreshComparison
     self.selectDebouncer = Debouncer(interval: selectDebounceInterval, clock: clock)
   }
 
-  func load(worktreeURL: URL, branchName: String) {
+  convenience init(
+    fetchChangedFiles: @escaping @Sendable (URL) async -> [DiffChangedFile],
+    loadDiffDocument: @escaping @Sendable (DiffChangedFile, URL) async -> DiffDocument,
+    selectDebounceInterval: Duration = .milliseconds(150),
+    clock: any Clock<Duration> = ContinuousClock()
+  ) {
+    self.init(
+      fetchChangedFiles: { worktreeURL, _ in await fetchChangedFiles(worktreeURL) },
+      loadDiffDocument: { file, worktreeURL, _ in await loadDiffDocument(file, worktreeURL) },
+      refreshComparison: { _, comparison in comparison },
+      selectDebounceInterval: selectDebounceInterval,
+      clock: clock
+    )
+  }
+
+  func load(worktreeURL: URL, branchName: String, comparison: DiffComparison = .workingTree) {
     self.worktreeURL = worktreeURL
     self.branchName = branchName
+    self.comparison = comparison
     changedFiles = []
     selectedFile = nil
     diffDocument = nil
+    loadError = nil
     documentCache = [:]
     selectDebouncer.cancel()
     loadTask?.cancel()
-    loadTask = Task { await loadAllFiles(worktreeURL: worktreeURL) }
+    loadTask = Task { await loadAllFiles(worktreeURL: worktreeURL, comparison: comparison) }
   }
 
   func refresh() {
     guard let worktreeURL else { return }
     // Keep cache intact so file switching remains responsive during refresh
     loadTask?.cancel()
-    loadTask = Task { await loadAllFiles(worktreeURL: worktreeURL) }
+    let currentComparison = comparison
+    let resolveRefreshedComparison = refreshComparison
+    isLoadingFiles = true
+    loadError = nil
+    loadTask = Task { [weak self] in
+      do {
+        let refreshedComparison = try await resolveRefreshedComparison(worktreeURL, currentComparison)
+        guard !Task.isCancelled, let self else { return }
+        self.comparison = refreshedComparison
+        await self.loadAllFiles(worktreeURL: worktreeURL, comparison: refreshedComparison)
+      } catch {
+        guard !Task.isCancelled, let self else { return }
+        self.changedFiles = []
+        self.selectedFile = nil
+        self.diffDocument = nil
+        self.documentCache = [:]
+        self.renderState = .idle
+        self.isLoadingFiles = false
+        self.loadError = error.localizedDescription
+      }
+    }
   }
 
   func selectFile(_ file: DiffChangedFile) {
@@ -151,9 +200,24 @@ final class DiffWindowState {
 
   /// Exposed (not private) so tests can drive it directly with injected fakes,
   /// bypassing the `Task` scheduling used by `load()`/`refresh()`.
-  func loadAllFiles(worktreeURL: URL) async {
+  func loadAllFiles(worktreeURL: URL, comparison: DiffComparison? = nil) async {
+    let comparison = comparison ?? self.comparison
     isLoadingFiles = true
-    let files = await fetchChangedFiles(worktreeURL)
+    loadError = nil
+    let files: [DiffChangedFile]
+    do {
+      files = try await fetchChangedFiles(worktreeURL, comparison)
+    } catch {
+      guard !Task.isCancelled else { return }
+      changedFiles = []
+      selectedFile = nil
+      diffDocument = nil
+      documentCache = [:]
+      renderState = .idle
+      isLoadingFiles = false
+      loadError = error.localizedDescription
+      return
+    }
 
     guard !Task.isCancelled else { return }
 
@@ -167,7 +231,7 @@ final class DiffWindowState {
     await withTaskGroup(of: (String, DiffDocument).self) { [loadDiffDocument] group in
       for file in files {
         group.addTask {
-          let doc = await loadDiffDocument(file, worktreeURL)
+          let doc = await loadDiffDocument(file, worktreeURL, comparison)
           return (file.id, doc)
         }
       }
@@ -190,39 +254,82 @@ final class DiffWindowState {
 
   // MARK: - Live Git integration
 
-  private nonisolated static func liveFetchChangedFiles(worktreeURL: URL) async -> [DiffChangedFile] {
+  private nonisolated static func liveFetchChangedFiles(
+    worktreeURL: URL,
+    comparison: DiffComparison
+  ) async throws -> [DiffChangedFile] {
     let gitClient = GitClient()
-    async let trackedOutput = gitClient.diffNameStatus(at: worktreeURL)
-    async let untrackedPaths = gitClient.untrackedFilePaths(at: worktreeURL)
-    let trackedFiles = DiffChangedFile.parseNameStatus(await trackedOutput)
-    let untrackedFiles = await untrackedPaths.map {
-      DiffChangedFile(status: .added, oldPath: nil, newPath: $0)
+    switch comparison {
+    case .workingTree:
+      async let trackedOutput = gitClient.diffNameStatus(at: worktreeURL)
+      async let untrackedPaths = gitClient.untrackedFilePaths(at: worktreeURL)
+      let trackedFiles = DiffChangedFile.parseNameStatus(await trackedOutput)
+      let untrackedFiles = await untrackedPaths.map {
+        DiffChangedFile(status: .added, oldPath: nil, newPath: $0)
+      }
+      return trackedFiles + untrackedFiles
+
+    case .outgoing(let revisions):
+      let output = try await gitClient.outgoingDiffNameStatus(for: revisions, at: worktreeURL)
+      return DiffChangedFile.parseNameStatus(output)
     }
-    return trackedFiles + untrackedFiles
+  }
+
+  private nonisolated static func liveRefreshComparison(
+    worktreeURL: URL,
+    comparison: DiffComparison
+  ) async throws -> DiffComparison {
+    switch comparison {
+    case .workingTree:
+      .workingTree
+    case .outgoing(let revisions):
+      .outgoing(try await GitClient().outgoingChangesComparison(from: revisions.baseRef, at: worktreeURL))
+    }
   }
 
   private nonisolated static func liveLoadDocument(
     for file: DiffChangedFile,
-    worktreeURL: URL
+    worktreeURL: URL,
+    comparison: DiffComparison
   ) async -> DiffDocument {
     let gitClient = GitClient()
     let oldContents: String
     let newContents: String
 
-    switch file.status {
-    case .added:
-      oldContents = ""
-      newContents = readFile(worktreeURL.appending(path: file.displayPath))
-    case .deleted:
-      oldContents = await gitClient.showFileAtHEAD(file.oldPath ?? "", in: worktreeURL) ?? ""
-      newContents = ""
-    case .renamed:
-      oldContents = await gitClient.showFileAtHEAD(file.oldPath ?? "", in: worktreeURL) ?? ""
-      newContents = readFile(worktreeURL.appending(path: file.newPath ?? ""))
-    default:
-      let path = file.displayPath
-      oldContents = await gitClient.showFileAtHEAD(path, in: worktreeURL) ?? ""
-      newContents = readFile(worktreeURL.appending(path: path))
+    switch comparison {
+    case .workingTree:
+      switch file.status {
+      case .added:
+        oldContents = ""
+        newContents = readFile(worktreeURL.appending(path: file.displayPath))
+      case .deleted:
+        oldContents = await gitClient.showFileAtHEAD(file.oldPath ?? "", in: worktreeURL) ?? ""
+        newContents = ""
+      case .renamed:
+        oldContents = await gitClient.showFileAtHEAD(file.oldPath ?? "", in: worktreeURL) ?? ""
+        newContents = readFile(worktreeURL.appending(path: file.newPath ?? ""))
+      default:
+        let path = file.displayPath
+        oldContents = await gitClient.showFileAtHEAD(path, in: worktreeURL) ?? ""
+        newContents = readFile(worktreeURL.appending(path: path))
+      }
+
+    case .outgoing(let revisions):
+      switch file.status {
+      case .added:
+        oldContents = ""
+        newContents = await gitClient.showFile(file.newPath ?? "", at: revisions.head, in: worktreeURL) ?? ""
+      case .deleted:
+        oldContents = await gitClient.showFile(file.oldPath ?? "", at: revisions.mergeBase, in: worktreeURL) ?? ""
+        newContents = ""
+      case .renamed, .copied:
+        oldContents = await gitClient.showFile(file.oldPath ?? "", at: revisions.mergeBase, in: worktreeURL) ?? ""
+        newContents = await gitClient.showFile(file.newPath ?? "", at: revisions.head, in: worktreeURL) ?? ""
+      default:
+        let path = file.displayPath
+        oldContents = await gitClient.showFile(path, at: revisions.mergeBase, in: worktreeURL) ?? ""
+        newContents = await gitClient.showFile(path, at: revisions.head, in: worktreeURL) ?? ""
+      }
     }
 
     let diffFile = DiffFile(

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -926,6 +926,107 @@ struct AppFeatureCommandPaletteTests {
     #expect(launched.value.map(\.1) == [worktree])
   }
 
+  @Test(.dependencies) func outgoingChangesAlwaysUsesBuiltInClient() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-outgoing/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-outgoing"
+    )
+    let repository = makeRepository(id: "/tmp/repo-outgoing", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: GithubPullRequest(
+        number: 42,
+        title: "Outgoing Changes",
+        state: "OPEN",
+        additions: 1,
+        deletions: 0,
+        isDraft: false,
+        reviewDecision: nil,
+        mergeable: nil,
+        mergeStateStatus: nil,
+        updatedAt: nil,
+        url: "https://github.com/upstream/project/pull/42",
+        headRefName: worktree.name,
+        baseRefName: "main",
+        commitsCount: 1,
+        authorLogin: "onevcat",
+        statusCheckRollup: nil
+      )
+    )
+    #expect(
+      CommandPaletteFeature.commandPaletteItems(from: repositoriesState).contains { $0.kind == .outgoingChanges }
+    )
+    let outgoingRequests = LockIsolated<[OutgoingChangesRequest]>([])
+    let externalRequests = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.outgoingChangesClient.open = { worktree, pullRequestURL, baseRefName, _, _ in
+        outgoingRequests.withValue {
+          $0.append(
+            OutgoingChangesRequest(
+              worktree: worktree,
+              pullRequestURL: pullRequestURL,
+              baseRefName: baseRefName
+            )
+          )
+        }
+      }
+      $0.externalDiffToolClient.open = { _, _, _, _ in
+        externalRequests.withValue { $0 += 1 }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.showOutgoingChanges)))
+    await store.send(.showSelectedWorktreeOutgoingChanges)
+    await store.finish()
+
+    let requests = outgoingRequests.value
+    #expect(requests.count == 2)
+    for request in requests {
+      #expect(request.worktree == worktree)
+      #expect(request.pullRequestURL == "https://github.com/upstream/project/pull/42")
+      #expect(request.baseRefName == "main")
+    }
+    #expect(externalRequests.value == 0)
+  }
+
+  @Test(.dependencies) func outgoingChangesWithoutPullRequestShowsAnAlert() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-outgoing-no-pr/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-outgoing-no-pr"
+    )
+    let repository = makeRepository(id: "/tmp/repo-outgoing-no-pr", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.showSelectedWorktreeOutgoingChanges)
+    await store.receive(\.openWorktreeFailed)
+
+    #expect(store.state.alert != nil)
+  }
+
   @Test(.dependencies) func closePullRequestDispatchesAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
@@ -967,6 +1068,12 @@ struct AppFeatureCommandPaletteTests {
     }
   }
 
+}
+
+private struct OutgoingChangesRequest: Equatable {
+  let worktree: Worktree
+  let pullRequestURL: String
+  let baseRefName: String
 }
 
 private func makeWorktree(id: String, name: String, repoRoot: String = "/tmp/repo") -> Worktree {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1676,6 +1676,30 @@ struct CommandPaletteFeatureTests {
     }
     await store.receive(.delegate(.ghosttyCommand("goto_split:right")))
   }
+
+  @Test func activateOutgoingChangesDispatchesDelegate() async {
+    let now = Date(timeIntervalSince1970: 7_654_322)
+    let item = makeItem(
+      id: CommandPaletteItemID.globalOutgoingChanges,
+      title: "Outgoing Changes",
+      subtitle: nil,
+      kind: .outgoingChanges
+    )
+    var state = CommandPaletteFeature.State()
+    state.isPresented = true
+    let store = TestStore(initialState: state) {
+      CommandPaletteFeature()
+    }
+    store.dependencies.date = .constant(now)
+
+    await store.send(.activateItem(item)) {
+      $0.isPresented = false
+      $0.query = ""
+      $0.selectedIndex = nil
+      $0.recencyByItemID[item.id] = now.timeIntervalSince1970
+    }
+    await store.receive(.delegate(.showOutgoingChanges))
+  }
 }
 
 private func makeWorktree(
@@ -1750,7 +1774,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     return .terminal
   case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
     .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
-    .toggleShelf, .showDiff:
+    .toggleShelf, .showDiff, .outgoingChanges:
     return .view
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
@@ -1767,7 +1791,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
     .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
     .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
-    .toggleShelf, .showDiff,
+    .toggleShelf, .showDiff, .outgoingChanges,
     .revealInFinder, .copyPath, .revealInSidebar,
     .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
     .openRepositorySettings:

--- a/supacodeTests/DiffWindowStateTests.swift
+++ b/supacodeTests/DiffWindowStateTests.swift
@@ -81,6 +81,103 @@ struct DiffWindowStateTests {
     #expect(!state.isLoadingFiles)
   }
 
+  @Test func outgoingComparisonFlowsToFileAndDocumentLoaders() async {
+    let file = DiffChangedFile(status: .modified, oldPath: "tracked.swift", newPath: "tracked.swift")
+    let document = DiffDocument(files: [], title: "tracked")
+    let comparison = DiffComparison.outgoing(
+      GitOutgoingChangesComparison(baseRef: "upstream/main", mergeBase: "base", head: "head")
+    )
+    let state = DiffWindowState(
+      fetchChangedFiles: { _, receivedComparison in
+        #expect(receivedComparison == comparison)
+        return [file]
+      },
+      loadDiffDocument: { receivedFile, _, receivedComparison in
+        #expect(receivedFile == file)
+        #expect(receivedComparison == comparison)
+        return document
+      }
+    )
+
+    await state.loadAllFiles(worktreeURL: URL(fileURLWithPath: "/tmp"), comparison: comparison)
+
+    #expect(state.changedFiles == [file])
+    #expect(state.diffDocument == document)
+    #expect(state.loadError == nil)
+  }
+
+  @Test func refreshRecapturesOutgoingComparisonBeforeLoading() async {
+    let file = DiffChangedFile(status: .modified, oldPath: "tracked.swift", newPath: "tracked.swift")
+    let initial = GitOutgoingChangesComparison(baseRef: "upstream/main", mergeBase: "old-base", head: "old-head")
+    let refreshed = GitOutgoingChangesComparison(baseRef: "upstream/main", mergeBase: "new-base", head: "new-head")
+    let state = DiffWindowState(
+      fetchChangedFiles: { _, comparison in
+        #expect(comparison == .outgoing(refreshed))
+        return [file]
+      },
+      loadDiffDocument: { _, _, comparison in
+        #expect(comparison == .outgoing(refreshed))
+        return DiffDocument(files: [], title: "tracked")
+      },
+      refreshComparison: { _, comparison in
+        #expect(comparison == .outgoing(initial))
+        return .outgoing(refreshed)
+      }
+    )
+    state.worktreeURL = URL(fileURLWithPath: "/tmp")
+    state.comparison = .outgoing(initial)
+
+    state.refresh()
+    await waitForDiffWindowState { !state.isLoadingFiles }
+
+    #expect(state.comparison == .outgoing(refreshed))
+    #expect(state.changedFiles == [file])
+    #expect(state.loadError == nil)
+  }
+
+  @Test func outgoingCopyLoadsTheSourcePathFromTheMergeBase() async throws {
+    let repositoryURL = FileManager.default.temporaryDirectory.appending(
+      path: "prowl-outgoing-copy-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    defer { try? FileManager.default.removeItem(at: repositoryURL) }
+
+    try runDiffWindowStateGit(["init", repositoryURL.path(percentEncoded: false)])
+    try runDiffWindowStateGit([
+      "-C", repositoryURL.path(percentEncoded: false), "config", "user.email", "test@example.com",
+    ])
+    try runDiffWindowStateGit([
+      "-C", repositoryURL.path(percentEncoded: false), "config", "user.name", "Test User",
+    ])
+    try "source\n".write(
+      to: repositoryURL.appending(path: "source.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "add", "source.txt"])
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "commit", "-m", "base"])
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "branch", "-M", "main"])
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "checkout", "-b", "feature"])
+    try "source\n".write(
+      to: repositoryURL.appending(path: "copy.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "add", "copy.txt"])
+    try runDiffWindowStateGit(["-C", repositoryURL.path(percentEncoded: false), "commit", "-m", "copy"])
+
+    let comparison = try await GitClient().outgoingChangesComparison(from: "main", at: repositoryURL)
+    let copiedFile = DiffChangedFile(status: .copied, oldPath: "source.txt", newPath: "copy.txt")
+    let state = DiffWindowState(fetchChangedFiles: { _, _ in [copiedFile] })
+
+    await state.loadAllFiles(worktreeURL: repositoryURL, comparison: .outgoing(comparison))
+
+    let document = try #require(state.diffDocument)
+    let diffFile = try #require(document.files?.first)
+    #expect(diffFile.oldContents == "source")
+    #expect(diffFile.newContents == "source")
+  }
+
   @Test func loadAllFilesPreservesSelectionWhenStillPresent() async {
     let fileA = DiffChangedFile(status: .modified, oldPath: "a.swift", newPath: "a.swift")
     let fileB = DiffChangedFile(status: .modified, oldPath: "b.swift", newPath: "b.swift")
@@ -407,4 +504,40 @@ private func advanceSelectDebounce(_ clock: TestClock<Duration>, by duration: Du
   await Task.yield()
   await clock.advance(by: duration)
   await Task.yield()
+}
+
+private struct DiffWindowStateGitCommandError: Error {
+  let output: String
+}
+
+private func runDiffWindowStateGit(_ arguments: [String]) throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+  process.arguments = arguments
+  var environment = ProcessInfo.processInfo.environment
+  environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+  environment["GIT_CONFIG_NOSYSTEM"] = "1"
+  process.environment = environment
+  let pipe = Pipe()
+  process.standardOutput = pipe
+  process.standardError = pipe
+  try process.run()
+  process.waitUntilExit()
+  let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+  guard process.terminationStatus == 0 else {
+    throw DiffWindowStateGitCommandError(output: output)
+  }
+}
+
+@MainActor
+private func waitForDiffWindowState(
+  _ condition: @MainActor @escaping () -> Bool,
+  maxIterations: Int = 500
+) async {
+  for _ in 0..<maxIterations {
+    if condition() {
+      return
+    }
+    await Task.yield()
+  }
 }

--- a/supacodeTests/GitOutgoingChangesTests.swift
+++ b/supacodeTests/GitOutgoingChangesTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+actor OutgoingChangesShellCallStore {
+  private(set) var calls: [[String]] = []
+
+  func record(_ arguments: [String]) {
+    calls.append(arguments)
+  }
+}
+
+struct GitOutgoingChangesTests {
+  @Test func baseRefUsesPullRequestTargetRemoteIncludingEnterpriseHostAndSSHPort() async {
+    let store = OutgoingChangesShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        if arguments.contains("get-url") {
+          switch arguments.last {
+          case "origin":
+            return ShellOutput(stdout: "git@ghe.example:fork/project.git\n", stderr: "", exitCode: 0)
+          case "upstream":
+            return ShellOutput(
+              stdout: "ssh://git@ghe.example:2222/target/project.git\n",
+              stderr: "",
+              exitCode: 0
+            )
+          default:
+            return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+          }
+        }
+        if arguments.contains("remote") {
+          return ShellOutput(stdout: "origin\nupstream\n", stderr: "", exitCode: 0)
+        }
+        if arguments.contains("rev-parse") {
+          return ShellOutput(stdout: "0123456789abcdef\n", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let baseRef = await client.outgoingChangesBaseRef(
+      pullRequestURL: "https://ghe.example/target/project/pull/42",
+      baseRefName: "main",
+      in: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    #expect(baseRef == "upstream/main")
+    let calls = await store.calls
+    #expect(calls.contains { $0.last == "origin" })
+    #expect(calls.contains { $0.last == "upstream" })
+    #expect(calls.contains { $0.contains("upstream/main") })
+  }
+
+  @Test func baseRefDoesNotFallBackToOriginWhenTargetRemoteDoesNotMatch() async {
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        if arguments.contains("get-url") {
+          return ShellOutput(stdout: "git@github.com:fork/project.git\n", stderr: "", exitCode: 0)
+        }
+        if arguments.contains("remote") {
+          return ShellOutput(stdout: "origin\n", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let baseRef = await client.outgoingChangesBaseRef(
+      pullRequestURL: "https://github.com/upstream/project/pull/42",
+      baseRefName: "main",
+      in: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    #expect(baseRef == nil)
+  }
+
+  @Test func outgoingDiffNameStatusUsesCapturedRevisionsAndPreservesUnicodePaths() async throws {
+    let store = OutgoingChangesShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        return ShellOutput(stdout: "M\t中文.swift\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let comparison = GitOutgoingChangesComparison(
+      baseRef: "upstream/main",
+      mergeBase: "merge-base-oid",
+      head: "head-oid"
+    )
+
+    let output = try await client.outgoingDiffNameStatus(
+      for: comparison,
+      at: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    #expect(output.contains("中文.swift"))
+    let calls = await store.calls
+    #expect(calls.count == 1)
+    let arguments = calls[0]
+    #expect(arguments.contains("core.quotePath=false"))
+    #expect(arguments.contains("merge-base-oid"))
+    #expect(arguments.contains("head-oid"))
+  }
+
+  @Test func outgoingComparisonUsesMergeBaseAndHeadAndExcludesWorkingTreeChanges() async throws {
+    let repositoryURL = FileManager.default.temporaryDirectory.appending(
+      path: "prowl-outgoing-changes-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    defer { try? FileManager.default.removeItem(at: repositoryURL) }
+
+    try runOutgoingChangesGit(["init", repositoryURL.path(percentEncoded: false)])
+    try runOutgoingChangesGit([
+      "-C", repositoryURL.path(percentEncoded: false), "config", "user.email", "test@example.com",
+    ])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "config", "user.name", "Test User"])
+
+    let trackedURL = repositoryURL.appending(path: "tracked.txt")
+    try "base\n".write(to: trackedURL, atomically: true, encoding: .utf8)
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "add", "tracked.txt"])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "commit", "-m", "base"])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "branch", "-M", "main"])
+
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "checkout", "-b", "feature"])
+    try "feature\n".write(to: trackedURL, atomically: true, encoding: .utf8)
+    try "feature only\n".write(
+      to: repositoryURL.appending(path: "feature-only.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try runOutgoingChangesGit([
+      "-C", repositoryURL.path(percentEncoded: false), "add", "tracked.txt", "feature-only.txt",
+    ])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "commit", "-m", "feature"])
+
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "checkout", "main"])
+    try "main advanced\n".write(to: trackedURL, atomically: true, encoding: .utf8)
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "add", "tracked.txt"])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "commit", "-m", "main advanced"])
+    try runOutgoingChangesGit(["-C", repositoryURL.path(percentEncoded: false), "checkout", "feature"])
+
+    try "uncommitted\n".write(to: trackedURL, atomically: true, encoding: .utf8)
+    try "untracked\n".write(
+      to: repositoryURL.appending(path: "untracked.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let client = GitClient()
+    let comparison = try await client.outgoingChangesComparison(from: "main", at: repositoryURL)
+    let files = DiffChangedFile.parseNameStatus(
+      try await client.outgoingDiffNameStatus(for: comparison, at: repositoryURL)
+    )
+    let oldContents = await client.showFile("tracked.txt", at: comparison.mergeBase, in: repositoryURL)
+    let newContents = await client.showFile("tracked.txt", at: comparison.head, in: repositoryURL)
+
+    #expect(comparison.baseRef == "main")
+    #expect(files.map(\.displayPath).sorted() == ["feature-only.txt", "tracked.txt"])
+    #expect(!files.contains { $0.displayPath == "untracked.txt" })
+    #expect(oldContents == "base")
+    #expect(newContents == "feature")
+  }
+}
+
+private struct OutgoingChangesGitCommandError: Error {
+  let output: String
+}
+
+@discardableResult
+private func runOutgoingChangesGit(_ arguments: [String]) throws -> String {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+  process.arguments = arguments
+  var environment = ProcessInfo.processInfo.environment
+  environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+  process.environment = environment
+  let pipe = Pipe()
+  process.standardOutput = pipe
+  process.standardError = pipe
+  try process.run()
+  process.waitUntilExit()
+  let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+  guard process.terminationStatus == 0 else {
+    throw OutgoingChangesGitCommandError(output: output)
+  }
+  return output
+}


### PR DESCRIPTION
## What

Add a built-in Outgoing Changes action to the View menu and Command Palette. It resolves the selected worktree's pull request target remote and base branch, then renders `git diff <base>...HEAD` from captured merge-base and HEAD snapshots.

## Why

Show Diff intentionally displays uncommitted working-tree changes. This adds a separate review surface for committed changes that would be included in a pull request, without guessing `origin/main` for forks or stacked branches.

## How tested

- Focused outgoing changes regression tests
- `make test`
- `make check`
- `make build-app`
- Isolated debug-app terminal lifecycle verification

Fixes #510

— PR prepared by onevpaw on behalf of @onevcat