### PR TITLE
Detect two live Claude states the typed profile still reports idle

### DIFF
--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -142,3 +142,7 @@ the failed attempt to extend the first signal to plain commands is
   history-search viewer chrome was fixed from captured evidence, and the third-runtime
   adoption gate stopped further migration — see
   [012-claude-screen-profile.md](012-claude-screen-profile.md)
+- Updated 2026-08-08: a captured failing screen supports the subagent-wait rule that
+  012 deferred; adding it exposed that every row rule read one physical line, which
+  misses Claude's wrapped rows on narrow panes — see
+  [013-background-agent-wait-and-wrapped-rows.md](013-background-agent-wait-and-wrapped-rows.md)

--- a/docs-ai/030-agent-status-detection/013-background-agent-wait-and-wrapped-rows.md
+++ b/docs-ai/030-agent-status-detection/013-background-agent-wait-and-wrapped-rows.md
@@ -1,0 +1,92 @@
+# 013 — Background-agent wait rule and wrapped status rows
+
+Amends [012-claude-screen-profile.md](012-claude-screen-profile.md), which states that
+"No subagent-wait rule was added because no captured failing screen supports one." A
+failing screen now exists, and adding the rule exposed a second defect that affects every
+row-based rule in the Claude profile.
+
+## The failing screen
+
+Captured with `prowl read --source detection` against Claude Code 2.1.224, sampling
+`prowl agents --json` at the same instant as the read:
+
+```text
+● Perusing… (1m 38s · ↓ 187 tokens)          ->  agents: done
+✻ Waiting for 1 background agent to finish   ->  agents: done
+```
+
+The corpus subagent fixtures retain a live spinner because Claude was still working
+alongside the subagent. The failing state is the one *after* its own turn ends: the
+spinner is replaced by the wait row, which carries a spinner glyph but no `…`, so
+`hasSpinnerActivity` rejects it.
+
+The second row is a separate defect. `hasElapsedStatusLine` required a one-word label and
+a single `<digits><unit>` token, so a correctly shaped row detected for 59 seconds and
+then reported idle for the rest of the turn.
+
+## Why the profile migration preserved both
+
+Neither rule had a captured witness. `claude.elapsedStatus` and `claude.backgroundWork`
+were exercised only by inline synthetic screens, and those screens were written from the
+same assumptions as the predicates they test — a single-word label with a single elapsed
+token, and a row containing the literal `agents done`. A test that restates its
+implementation cannot falsify it.
+
+Meanwhile every captured Claude working fixture retains a spinner, so `claude.spinner`
+returns first and shadows `claude.elapsedStatus` before it can be observed being wrong.
+
+`AgentScreenRuleCoverageTests` now asserts that every typed rule is fired by at least one
+non-quarantined captured fixture. It would have flagged both rules on the day the corpus
+landed.
+
+## The switcher block is not a liveness signal
+
+The `⏺ main` plus `◯` block below the prompt is the obvious way to detect background
+agents, and it is wrong. A subagent that returns control while it still awaits collection
+keeps its row, with the elapsed value frozen at the moment it stopped:
+
+```text
+⏺ Agent "Sleep 300 then reply" finished · 1m 54s
+...
+  ⏺ main
+  ◯ general-purpose  Sleep 300 then reply    1m 54s · ↓ 23.0k tokens
+```
+
+Observed live on 2.1.224. A single frame cannot separate that from a running agent, so
+matching the row shape holds the pane at working after the work has stopped — a worse
+failure than the one being fixed, because it is wrong in the direction that hides real
+idleness. The rule keys on the wait row instead, and the retained-row case is pinned by
+`ClaudeBackgroundAgentDetectionTests.retainedAgentRowAloneDoesNotReportWorking`.
+
+## Wrapped rows
+
+Every rule in the profile read one physical line. Claude wraps a row too wide for the pane
+onto continuation lines indented two spaces. Observed at 40 columns on 2.1.225:
+
+```text
+✻ Waiting for 1 background agent to
+  finish
+```
+
+Narrow split panes are ordinary in Prowl, so both rules missed their own captured screens
+at realistic widths. Rows are now assembled into logical rows before matching: an adjacent
+line indented past its head and starting with ordinary text is a continuation, while a
+line opening with its own marker starts a new row. That bound keeps continuation joining
+from stitching together rows that were never on screen.
+
+Two related shapes came out of the same narrow-terminal session and are covered by tests:
+
+- At 32 columns Claude *shortens* the row instead of wrapping it, dropping the detail
+  segments entirely and leaving `● Razzle-dazzling… (1m 7s)` — an elapsed terminated by
+  the closing paren with no `" · "` at all.
+- The label is free text and contains parentheses, so the elapsed segment is located from
+  the end of the row. Anchoring at the first `(` reads `focused)… (1m 38s` as the elapsed
+  and rejects `● Running tests (focused)… (1m 38s · ↓ 187 tokens)`.
+
+## Result
+
+`claude.backgroundWork` matches the wait row in the live status region, keeping the
+existing below-prompt `agents done` workflow marker. `claude.elapsedStatus` accepts a
+free-text label and a compound elapsed segment, located from the end of the logical row.
+Both read logical rows rather than physical lines. Two captured fixtures under
+`claude/2.1.224/working/` witness the rules, and a narrow capture covers the wrapped shape.

--- a/docs-ai/030-agent-status-detection/013-background-agent-wait-and-wrapped-rows.md
+++ b/docs-ai/030-agent-status-detection/013-background-agent-wait-and-wrapped-rows.md
@@ -83,10 +83,21 @@ Two related shapes came out of the same narrow-terminal session and are covered 
   the end of the row. Anchoring at the first `(` reads `focused)… (1m 38s` as the elapsed
   and rejects `● Running tests (focused)… (1m 38s · ↓ 187 tokens)`.
 
+Assembling rows is not enough on its own, because the region that selects which rows the
+rules see was still counted in physical lines. `ClaudeScreenRegions.liveStatus` took the
+last three non-blank lines above the box and only then handed them to the row assembler,
+so a row wrapping onto three or more continuations pushed its own head out of the window.
+The head is what carries the `●` or the spinner, so the reconstructed row could not match
+and the pane reported idle. Surfaces that narrow are reachable, and the shape is not
+exotic: `✻ Waiting for 1 background agent to finish` needs only about twenty columns to
+wrap that far. The region is now assembled into logical rows first and limited to the last
+three of those, which is the same three rows whenever nothing wraps.
+
 ## Result
 
 `claude.backgroundWork` matches the wait row in the live status region, keeping the
 existing below-prompt `agents done` workflow marker. `claude.elapsedStatus` accepts a
 free-text label and a compound elapsed segment, located from the end of the logical row.
-Both read logical rows rather than physical lines. Two captured fixtures under
+Both read logical rows rather than physical lines, and so does the live status region that
+feeds them. Two captured fixtures under
 `claude/2.1.224/working/` witness the rules, and a narrow capture covers the wrapped shape.

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -48,10 +48,18 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    Other agent families keep their own patterns (including Oh My Pi's
    `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
    hexagons, Kimi's moon phases, etc.).
-   For Claude, a running **background workflow** keeps a status line *below* the
-   input box (e.g. `3/5 agents done · 7m 29s · ↓ 288.5k tokens`) after the turn has
-   ended; Prowl reads that footer as **Working**, so a churning workflow isn't
-   mistaken for idle.
+   Claude's live status row (`● <label>… (<elapsed> · …)`) accepts a multi-word
+   label and a compound elapsed segment such as `28m 34s` or `1h 4m 2s`, so a turn
+   keeps reporting **Working** after it passes a minute.
+   For Claude, **background agents** end the main turn while they run, leaving
+   `✻ Waiting for 1 background agent to finish` above the input box — a spinner
+   glyph with no ellipsis, which the spinner pattern alone rejects. Prowl reads
+   that wait row as **Working**, along with the older background-workflow footer
+   (`3/5 agents done · 7m 29s · ↓ 288.5k tokens`) below the box.
+   The agent switcher block below the box (`⏺ main` plus one `◯` row per agent) is
+   deliberately *not* read as activity: a subagent that returns control while it
+   still awaits collection keeps its row with the elapsed frozen, so the rows
+   cannot distinguish running work from finished work on a single frame.
 
 For diagnostics and sanitized regression captures, `prowl read --source detection`
 returns the exact active-screen buffer used by stage 2. It is explicitly requested
@@ -81,12 +89,12 @@ showing their chrome keep the last trusted state instead of forcing idle.
 
 **Display states** (what you see):
 
-| Display | Derived from | Meaning |
-|---------|--------------|---------|
-| **Working** | raw `working` | actively processing |
-| **Blocked** | raw `blocked` | waiting for the user (a prompt) |
-| **Done** | raw `idle` + **unseen** | just finished; you haven't looked yet |
-| **Idle** | raw `idle` + **seen** | nothing running |
+| Display     | Derived from            | Meaning                               |
+| ----------- | ----------------------- | ------------------------------------- |
+| **Working** | raw `working`           | actively processing                   |
+| **Blocked** | raw `blocked`           | waiting for the user (a prompt)       |
+| **Done**    | raw `idle` + **unseen** | just finished; you haven't looked yet |
+| **Idle**    | raw `idle` + **seen**   | nothing running                       |
 
 A **Done** pane becomes **Idle** the moment you focus it.
 
@@ -116,11 +124,11 @@ The sidebar worktree row spinner and `prowl list`'s `task.status` report
 
 - a terminal command reports progress (OSC 9;4 / ConEmu-style, e.g. a long shell
   command), **or**
-- a detected agent is **Working** or **Blocked** — including Claude running a
-  background **workflow**, detected from its below-prompt `… agents done …` status
-  line even while the input box looks idle.
+- a detected agent is **Working** or **Blocked** — including Claude waiting on
+  **background agents**, detected from the `✻ Waiting for … background agent …`
+  row even while the input box looks idle.
 
-It's a single coarse running/idle bit (it can't distinguish a background workflow
+It's a single coarse running/idle bit (it can't distinguish background agents
 from a long command). For the agent's finer state use the
 [Active Agents panel](active-agents.md) or [`prowl agents`](cli.md). Expect up to
 ~2 s before it lights on a warm pane, and the ~3 s working-hold before it clears.

--- a/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
@@ -114,7 +114,7 @@ enum ClaudeScreenProfile {
   // elapsed segment wins. Anchoring at the first "(" instead would read
   // "focused)… (1m 38s" as the elapsed and reject a live row.
   nonisolated private static func hasElapsedStatusLine(_ content: String) -> Bool {
-    logicalRows(content).contains { row in
+    claudeLogicalRows(content).contains { row in
       guard row.first == "●" else { return false }
       let body = row.dropFirst().trimmingCharacters(in: .whitespaces)
 
@@ -127,50 +127,6 @@ enum ClaudeScreenProfile {
       }
       return false
     }
-  }
-
-  // Claude wraps a row too wide for the pane onto indented continuation lines —
-  // observed at 40 columns on 2.1.225:
-  //
-  //   "✻ Waiting for 1 background agent to"
-  //   "  finish"
-  //
-  // Narrow split panes are ordinary, so every rule that reads a row has to see the
-  // logical row rather than the first physical one. Only an adjacent line indented
-  // past its head and starting with ordinary text is a continuation: a line opening
-  // with its own marker starts a new row, which keeps this from swallowing the
-  // whole region and inventing rows that were never on screen.
-  nonisolated private static func logicalRows(_ content: String) -> [String] {
-    var rows: [String] = []
-    var current: String?
-    var headIndent = 0
-
-    for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
-      let trimmed = line.trimmingCharacters(in: .whitespaces)
-      guard !trimmed.isEmpty else {
-        if let row = current { rows.append(row) }
-        current = nil
-        continue
-      }
-      let indent = line.prefix(while: { $0 == " " }).count
-
-      if current != nil, indent > headIndent, !startsNewRow(trimmed) {
-        current?.append(" ")
-        current?.append(trimmed)
-        continue
-      }
-      if let row = current { rows.append(row) }
-      current = trimmed
-      headIndent = indent
-    }
-    if let row = current { rows.append(row) }
-    return rows
-  }
-
-  nonisolated private static func startsNewRow(_ trimmed: String) -> Bool {
-    guard let first = trimmed.unicodeScalars.first else { return false }
-    if isAgentSpinnerScalar(first) { return true }
-    return "●⏺◯⎿❯─-".unicodeScalars.contains(first)
   }
 
   // One or more "<digits><unit>" tokens separated by single spaces, terminated by
@@ -209,7 +165,7 @@ enum ClaudeScreenProfile {
   // and it is scoped to the live status region so a transcript quoting it cannot
   // trip the rule.
   nonisolated private static func hasBackgroundAgentWait(_ liveStatus: String) -> Bool {
-    logicalRows(liveStatus).contains { row in
+    claudeLogicalRows(liveStatus).contains { row in
       guard let first = row.unicodeScalars.first, isAgentSpinnerScalar(first) else {
         return false
       }
@@ -237,10 +193,15 @@ private struct ClaudeScreenRegions: Sendable {
     )
     self.currentInteractionLines = currentInteractionLines
     self.currentInteractionLower = currentInteractionLines.joined(separator: "\n").lowercased()
-    self.liveStatus = agentDetectionRecentLines(
-      Self.contentAbovePrompt(screenLines: lines, promptIndex: promptIndex),
-      limit: 3
+    // Reconstruct rows before limiting the region. Counting the limit in physical
+    // lines drops the head of any row that wraps onto three or more continuations,
+    // and the head is what carries the "●" or spinner glyph the rules key on.
+    // Widths that narrow are reachable: a surface can be as few as five columns.
+    self.liveStatus = claudeLogicalRows(
+      Self.contentAbovePrompt(screenLines: lines, promptIndex: promptIndex)
     )
+    .suffix(3)
+    .joined(separator: "\n")
     self.belowPromptLines = Self.contentBelowPrompt(screenLines: lines, promptIndex: promptIndex)
       .split(separator: "\n", omittingEmptySubsequences: false)
       .map(String.init)
@@ -296,6 +257,54 @@ private struct ClaudeScreenRegions: Sendable {
     return isBoxBorderLine(screenLines[screenLines.index(before: promptIndex)])
       && isBoxBorderLine(screenLines[nextIndex])
   }
+}
+
+// Claude wraps a row too wide for the pane onto indented continuation lines —
+// observed at 40 columns on 2.1.225:
+//
+//   "✻ Waiting for 1 background agent to"
+//   "  finish"
+//
+// Narrow split panes are ordinary, so every rule that reads a row has to see the
+// logical row rather than the first physical one, and so does the region that
+// selects which rows the rules see. Only an adjacent line indented past its head
+// and starting with ordinary text is a continuation: a line opening with its own
+// marker starts a new row, which keeps this from swallowing the whole region and
+// inventing rows that were never on screen.
+//
+// Rows arrive already trimmed and unindented, so running this over its own output
+// returns that output unchanged.
+nonisolated private func claudeLogicalRows(_ content: String) -> [String] {
+  var rows: [String] = []
+  var current: String?
+  var headIndent = 0
+
+  for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else {
+      if let row = current { rows.append(row) }
+      current = nil
+      continue
+    }
+    let indent = line.prefix(while: { $0 == " " }).count
+
+    if current != nil, indent > headIndent, !claudeRowStartsNewRow(trimmed) {
+      current?.append(" ")
+      current?.append(trimmed)
+      continue
+    }
+    if let row = current { rows.append(row) }
+    current = trimmed
+    headIndent = indent
+  }
+  if let row = current { rows.append(row) }
+  return rows
+}
+
+nonisolated private func claudeRowStartsNewRow(_ trimmed: String) -> Bool {
+  guard let first = trimmed.unicodeScalars.first else { return false }
+  if isAgentSpinnerScalar(first) { return true }
+  return "●⏺◯⎿❯─-".unicodeScalars.contains(first)
 }
 
 nonisolated private func isClaudeNumberedSelectionLine(_ line: String) -> Bool {

--- a/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
@@ -108,18 +108,69 @@ enum ClaudeScreenProfile {
   // tokens once it passes a minute: "45s", "28m 34s", "1h 4m 2s". Both parts stay
   // strict about completeness so transcript prose such as "(1st attempt)" or
   // "(10seconds)" still cannot pass as a live status row.
+  // Free-text labels contain parentheses — "Running tests (focused)…" — so the
+  // elapsed segment is located from the END of the row. Candidate openings are
+  // tried right to left, and the first one whose contents parse as a complete
+  // elapsed segment wins. Anchoring at the first "(" instead would read
+  // "focused)… (1m 38s" as the elapsed and reject a live row.
   nonisolated private static func hasElapsedStatusLine(_ content: String) -> Bool {
-    content.split(separator: "\n").contains { line in
-      let trimmed = line.trimmingCharacters(in: .whitespaces)
-      guard trimmed.first == "●" else { return false }
-      let body = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
-      guard let open = body.firstIndex(of: "(") else { return false }
+    logicalRows(content).contains { row in
+      guard row.first == "●" else { return false }
+      let body = row.dropFirst().trimmingCharacters(in: .whitespaces)
 
-      let label = body[..<open].trimmingCharacters(in: .whitespaces)
-      guard label.hasSuffix("…") else { return false }
-
-      return hasCompleteElapsedSegment(body[body.index(after: open)...])
+      for open in body.indices.reversed() where body[open] == "(" {
+        let label = body[..<open].trimmingCharacters(in: .whitespaces)
+        guard label.hasSuffix("…") else { continue }
+        if hasCompleteElapsedSegment(body[body.index(after: open)...]) {
+          return true
+        }
+      }
+      return false
     }
+  }
+
+  // Claude wraps a row too wide for the pane onto indented continuation lines —
+  // observed at 40 columns on 2.1.225:
+  //
+  //   "✻ Waiting for 1 background agent to"
+  //   "  finish"
+  //
+  // Narrow split panes are ordinary, so every rule that reads a row has to see the
+  // logical row rather than the first physical one. Only an adjacent line indented
+  // past its head and starting with ordinary text is a continuation: a line opening
+  // with its own marker starts a new row, which keeps this from swallowing the
+  // whole region and inventing rows that were never on screen.
+  nonisolated private static func logicalRows(_ content: String) -> [String] {
+    var rows: [String] = []
+    var current: String?
+    var headIndent = 0
+
+    for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      guard !trimmed.isEmpty else {
+        if let row = current { rows.append(row) }
+        current = nil
+        continue
+      }
+      let indent = line.prefix(while: { $0 == " " }).count
+
+      if current != nil, indent > headIndent, !startsNewRow(trimmed) {
+        current?.append(" ")
+        current?.append(trimmed)
+        continue
+      }
+      if let row = current { rows.append(row) }
+      current = trimmed
+      headIndent = indent
+    }
+    if let row = current { rows.append(row) }
+    return rows
+  }
+
+  nonisolated private static func startsNewRow(_ trimmed: String) -> Bool {
+    guard let first = trimmed.unicodeScalars.first else { return false }
+    if isAgentSpinnerScalar(first) { return true }
+    return "●⏺◯⎿❯─-".unicodeScalars.contains(first)
   }
 
   // One or more "<digits><unit>" tokens separated by single spaces, terminated by
@@ -158,12 +209,11 @@ enum ClaudeScreenProfile {
   // and it is scoped to the live status region so a transcript quoting it cannot
   // trip the rule.
   nonisolated private static func hasBackgroundAgentWait(_ liveStatus: String) -> Bool {
-    liveStatus.split(separator: "\n").contains { line in
-      let trimmed = line.trimmingCharacters(in: .whitespaces)
-      guard let first = trimmed.unicodeScalars.first, isAgentSpinnerScalar(first) else {
+    logicalRows(liveStatus).contains { row in
+      guard let first = row.unicodeScalars.first, isAgentSpinnerScalar(first) else {
         return false
       }
-      let lower = trimmed.lowercased()
+      let lower = row.lowercased()
       return lower.contains("waiting for") && lower.contains("background agent")
     }
   }

--- a/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
@@ -35,7 +35,9 @@ enum ClaudeScreenProfile {
     if hasElapsedStatusLine(regions.liveStatus) {
       return AgentScreenDetection(state: .working, reason: .matched(RuleID.elapsedStatus))
     }
-    if regions.belowPromptLower.contains("agents done") {
+    if hasBackgroundAgentWait(regions.liveStatus)
+      || regions.belowPromptLines.joined(separator: "\n").lowercased().contains("agents done")
+    {
       return AgentScreenDetection(state: .working, reason: .matched(RuleID.backgroundWork))
     }
     if regions.hasIdleComposer {
@@ -99,6 +101,13 @@ enum ClaudeScreenProfile {
     }
   }
 
+  // Claude's live status row is "● <label>… (<elapsed> · <detail>)". The label is
+  // free text and is not always a single word — "Running gates and merge
+  // lifecycle…" is as common as "Forging…" — so only the trailing ellipsis is
+  // structural. The elapsed segment grows with the turn and becomes several
+  // tokens once it passes a minute: "45s", "28m 34s", "1h 4m 2s". Both parts stay
+  // strict about completeness so transcript prose such as "(1st attempt)" or
+  // "(10seconds)" still cannot pass as a live status row.
   nonisolated private static func hasElapsedStatusLine(_ content: String) -> Bool {
     content.split(separator: "\n").contains { line in
       let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -107,19 +116,55 @@ enum ClaudeScreenProfile {
       guard let open = body.firstIndex(of: "(") else { return false }
 
       let label = body[..<open].trimmingCharacters(in: .whitespaces)
-      guard label.hasSuffix("…"), label.split(whereSeparator: { $0.isWhitespace }).count == 1 else {
-        return false
-      }
+      guard label.hasSuffix("…") else { return false }
 
-      let elapsed = body[body.index(after: open)...]
-      let digits = elapsed.prefix(while: \.isNumber)
-      guard !digits.isEmpty else { return false }
-      let afterDigits = elapsed.dropFirst(digits.count)
-      guard let unit = afterDigits.first, unit == "s" || unit == "m" || unit == "h" else {
+      return hasCompleteElapsedSegment(body[body.index(after: open)...])
+    }
+  }
+
+  // One or more "<digits><unit>" tokens separated by single spaces, terminated by
+  // the closing paren or by the " · " that separates elapsed from the rest of the
+  // row. A partial token ("10seconds", "1st") fails the terminator check.
+  nonisolated private static func hasCompleteElapsedSegment(_ elapsed: Substring) -> Bool {
+    var remainder = elapsed
+    var tokenCount = 0
+
+    while true {
+      let digits = remainder.prefix(while: \.isNumber)
+      guard !digits.isEmpty else { break }
+      let afterDigits = remainder.dropFirst(digits.count)
+      guard let unit = afterDigits.first, unit == "s" || unit == "m" || unit == "h" else { break }
+      tokenCount += 1
+      remainder = afterDigits.dropFirst()
+      guard remainder.hasPrefix(" "), remainder.dropFirst().first?.isNumber == true else { break }
+      remainder = remainder.dropFirst()
+    }
+
+    guard tokenCount > 0 else { return false }
+    return remainder.hasPrefix(")") || remainder.hasPrefix(" · ")
+  }
+
+  // When Claude delegates to a background agent, its own turn ends first: the
+  // spinner above the prompt is replaced by "✻ Waiting for 1 background agent to
+  // finish". That row carries a spinner glyph but no "…", so hasSpinnerActivity
+  // rejects it and the pane reports finished while the agent is still running.
+  //
+  // The agent switcher block below the input box ("⏺ main" plus one "◯" row per
+  // agent) looks like a better signal but is not one. A subagent that returns
+  // control while still awaiting collection keeps its row, with the elapsed value
+  // frozen — a single screen cannot separate that from a running agent, so
+  // matching the row shape would hold the pane at working after the work stopped.
+  // The wait row is only painted while Claude is genuinely blocked on an agent,
+  // and it is scoped to the live status region so a transcript quoting it cannot
+  // trip the rule.
+  nonisolated private static func hasBackgroundAgentWait(_ liveStatus: String) -> Bool {
+    liveStatus.split(separator: "\n").contains { line in
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      guard let first = trimmed.unicodeScalars.first, isAgentSpinnerScalar(first) else {
         return false
       }
-      let trailing = afterDigits.dropFirst()
-      return trailing.hasPrefix(")") || trailing.hasPrefix(" · ")
+      let lower = trimmed.lowercased()
+      return lower.contains("waiting for") && lower.contains("background agent")
     }
   }
 }
@@ -128,7 +173,7 @@ private struct ClaudeScreenRegions: Sendable {
   let currentInteractionLines: [String]
   let currentInteractionLower: String
   let liveStatus: String
-  let belowPromptLower: String
+  let belowPromptLines: [String]
   let bottomChromeLines: [String]
   let bottomViewerLines: [String]
   let hasIdleComposer: Bool
@@ -146,8 +191,9 @@ private struct ClaudeScreenRegions: Sendable {
       Self.contentAbovePrompt(screenLines: lines, promptIndex: promptIndex),
       limit: 3
     )
-    self.belowPromptLower = Self.contentBelowPrompt(screenLines: lines, promptIndex: promptIndex)
-      .lowercased()
+    self.belowPromptLines = Self.contentBelowPrompt(screenLines: lines, promptIndex: promptIndex)
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .map(String.init)
 
     let nonEmptyLines = lines.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
     self.bottomChromeLines = Array(nonEmptyLines.suffix(3))

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -353,17 +353,22 @@ nonisolated private func hasInterruptPattern(_ lower: String) -> Bool {
     || (lower.contains("esc") && lower.contains("interrupt"))
 }
 
+private nonisolated let agentSpinnerScalars: Set<UnicodeScalar> = [
+  "·", "✱", "✲", "✳", "✴", "✵", "✶", "✷", "✸", "✹", "✺", "✻", "✼", "✽", "✾", "✿",
+  "❀", "❁", "❂", "❃", "❇", "❈", "❉", "❊", "❋", "✢", "✣", "✤", "✥", "✦", "✧", "✨",
+  "⊛", "⊕", "⊙", "◉", "◎", "◍", "⁂", "⁕", "※", "⍟", "☼", "★", "☆",
+]
+
+nonisolated func isAgentSpinnerScalar(_ scalar: UnicodeScalar) -> Bool {
+  agentSpinnerScalars.contains(scalar)
+}
+
 nonisolated func hasSpinnerActivity(_ content: String) -> Bool {
-  let spinnerScalars: Set<UnicodeScalar> = [
-    "·", "✱", "✲", "✳", "✴", "✵", "✶", "✷", "✸", "✹", "✺", "✻", "✼", "✽", "✾", "✿",
-    "❀", "❁", "❂", "❃", "❇", "❈", "❉", "❊", "❋", "✢", "✣", "✤", "✥", "✦", "✧", "✨",
-    "⊛", "⊕", "⊙", "◉", "◎", "◍", "⁂", "⁕", "※", "⍟", "☼", "★", "☆",
-  ]
-  return content.split(separator: "\n").contains { line in
+  content.split(separator: "\n").contains { line in
     let trimmed = line.trimmingCharacters(in: .whitespaces)
     guard let first = trimmed.unicodeScalars.first else { return false }
     let rest = String(trimmed.unicodeScalars.dropFirst())
-    return spinnerScalars.contains(first)
+    return isAgentSpinnerScalar(first)
       && rest.hasPrefix(" ")
       && rest.contains("…")
       && rest.contains(where: \.isLetter)

--- a/supacodeTests/AgentScreenRuleCoverageTests.swift
+++ b/supacodeTests/AgentScreenRuleCoverageTests.swift
@@ -1,0 +1,61 @@
+import Testing
+
+@testable import supacode
+
+/// Every typed rule must be witnessed by a captured screen.
+///
+/// `ClaudeScreenProfileTests` and `CodexScreenProfileTests` already assert that
+/// each rule ID is unique and runtime-prefixed, and inline synthetic screens
+/// exercise the predicates. Synthetic screens are written from the same mental
+/// model as the predicate they test, so they cannot falsify that model — only a
+/// capture can. This test makes the corpus an obligation rather than a sample:
+/// a rule with no captured witness is a rule whose shape has never been checked
+/// against a real agent.
+///
+/// Quarantined fixtures do not count. They document a state the detector gets
+/// wrong, so the rule they currently fire is the wrong one.
+struct AgentScreenRuleCoverageTests {
+  /// Rules that no captured screen reaches yet. Shrink this list by capturing the
+  /// missing screen; never grow it to make a red test green.
+  ///
+  /// - `codex.confirmationChoices`: not merely uncaptured — possibly unreachable.
+  ///   The captured command-permission screen satisfies this rule's structure
+  ///   (numbered selection, "Would you like…", Yes and No options) but ends with
+  ///   "Press enter to confirm or esc to cancel", so `codex.confirmationFooter`
+  ///   matches first and this rule never runs. Deleting that one footer line from
+  ///   the fixture flips the reason to `codex.confirmationChoices`, which is how
+  ///   the shadowing was confirmed. Reaching it needs a Codex confirmation whose
+  ///   last three lines after the selection carry none of the five footer markers,
+  ///   and no such screen has been seen on 0.146.1. If none exists, the rule is
+  ///   dead and should be removed rather than witnessed.
+  private static let knownUnwitnessed: Set<String> = [
+    "codex.confirmationChoices"
+  ]
+
+  @Test func everyTypedRuleHasACapturedWitness() throws {
+    let witnessed = Set(
+      try AgentScreenFixtureCorpus.load()
+        .filter { !$0.isQuarantined }
+        .map { $0.agent.detectScreen(in: $0.text).reason.identifier }
+    )
+
+    let typedRules =
+      ClaudeScreenProfile.RuleID.all.map(\.rawValue)
+      + CodexScreenProfile.RuleID.all.map(\.rawValue)
+
+    let unwitnessed = Set(typedRules.filter { !witnessed.contains($0) })
+
+    let regressed = unwitnessed.subtracting(Self.knownUnwitnessed).sorted()
+    #expect(
+      regressed.isEmpty,
+      """
+      Typed rules that lost their captured witness: \(regressed).
+      Capture a screen that fires each one with `prowl read --source detection`,
+      or quarantine it under known-misdetection if the detector gets it wrong.
+      """
+    )
+
+    let stale = Self.knownUnwitnessed.subtracting(unwitnessed).sorted()
+    #expect(stale.isEmpty, "These rules are witnessed now; drop them from knownUnwitnessed: \(stale)")
+  }
+}

--- a/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
+++ b/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
@@ -122,11 +122,94 @@ struct ClaudeBackgroundAgentDetectionTests {
     }
   }
 
+  @Test func wrappedRowsAreReadAsOneLogicalRow() {
+    // Claude Code 2.1.225 at 40 columns. Both shapes were observed on a real
+    // narrow pane; the continuation is indented two spaces.
+    let wrappedWait = detect(
+      """
+      ⏺ The subagent is running; waiting for its reply.
+
+      ✻ Waiting for 1 background agent to
+        finish
+      ────────
+      ❯
+      ────────
+      """
+    )
+    #expect(wrappedWait.state == .working)
+    #expect(wrappedWait.reason == .matched(ClaudeScreenProfile.RuleID.backgroundWork))
+
+    let wrappedElapsed = detect(
+      """
+      ● Running gates and merge lifecycle…
+        (1m 38s · ↓ 187 tokens)
+      ────────
+      ❯
+      ────────
+      """
+    )
+    #expect(wrappedElapsed.state == .working)
+    #expect(wrappedElapsed.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
+  }
+
+  @Test func continuationJoiningDoesNotInventRows() {
+    // A following line that carries its own marker starts a new row rather than
+    // continuing the previous one, so nothing is stitched into a status row that
+    // was never on screen.
+    let detection = detect(
+      """
+      ⏺ Wrote the report.
+        ⎿  Waiting for 1 background agent to finish is what it said earlier
+      ⏺ Nothing is running now.
+      ────────
+      ❯
+      ────────
+      """
+    )
+
+    #expect(detection.state == .idle)
+  }
+
+  @Test func labelContainingParenthesesStillParses() {
+    // The label is free text, so the elapsed segment is located from the end of
+    // the row. Anchoring at the first "(" reads "focused)… (1m 38s" as elapsed.
+    let detection = detect(
+      """
+      ● Running tests (focused)… (1m 38s · ↓ 187 tokens)
+      ────────
+      ❯
+      ────────
+      """
+    )
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
+  }
+
+  @Test func narrowPaneDropsDetailSegmentsAndStillParses() {
+    // At 32 columns Claude shortens the row rather than wrapping it, leaving the
+    // elapsed terminated by the closing paren with no " · " detail at all.
+    let detection = detect(
+      """
+      ● Razzle-dazzling… (1m 7s)
+      ────────
+      ❯
+      ────────
+      """
+    )
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
+  }
+
   @Test func incompleteElapsedSegmentsStayIdle() {
     let notWorking = [
       "● Retrying the merge lifecycle… (1st attempt)",
       "● Actioning… (10seconds · ↓ 47.7k tokens)",
       "● Actioning… (28m 34 · ↓ 47.7k tokens)",
+      // Incomplete elapsed carried across a wrapped row stays incomplete.
+      "● Running gates and merge lifecycle…\n  (1st attempt)",
+      "● Running tests (focused)…\n  (10seconds · ↓ 187 tokens)",
     ]
     for row in notWorking {
       let detection = detect(

--- a/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
+++ b/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
@@ -152,6 +152,47 @@ struct ClaudeBackgroundAgentDetectionTests {
     #expect(wrappedElapsed.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
   }
 
+  @Test func rowWrappedPastTheRegionLimitKeepsItsHead() {
+    // The live status region is the last three rows above the box. A row narrow
+    // enough to wrap onto four or more physical lines pushes its own head out of
+    // a window counted in physical lines, and the head carries the glyph every
+    // rule keys on. The region is therefore reconstructed into logical rows
+    // before the limit applies.
+    let wrappedWait = detect(
+      """
+      ⏺ Launched it.
+
+      ✻ Waiting
+        for 1
+        background
+        agent to
+        finish
+      ────
+      ❯
+      ────
+      """
+    )
+    #expect(wrappedWait.state == .working)
+    #expect(wrappedWait.reason == .matched(ClaudeScreenProfile.RuleID.backgroundWork))
+
+    let wrappedElapsed = detect(
+      """
+      ⏺ Started.
+
+      ● Running
+        gates…
+        (1m 38s ·
+        ↓ 187
+        tokens)
+      ────
+      ❯
+      ────
+      """
+    )
+    #expect(wrappedElapsed.state == .working)
+    #expect(wrappedElapsed.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
+  }
+
   @Test func continuationJoiningDoesNotInventRows() {
     // A following line that carries its own marker starts a new row rather than
     // continuing the previous one, so nothing is stitched into a status row that

--- a/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
+++ b/supacodeTests/ClaudeBackgroundAgentDetectionTests.swift
@@ -1,0 +1,143 @@
+import Testing
+
+@testable import supacode
+
+/// Reconstructed screens for the background-agent lifecycle.
+///
+/// The captured evidence lives in the fixture corpus; these are the synthetic
+/// boundary cases around it, kept inline per the corpus README.
+struct ClaudeBackgroundAgentDetectionTests {
+  private func detect(_ screen: String) -> AgentScreenDetection {
+    DetectedAgent.claude.detectScreen(in: screen)
+  }
+
+  @Test func waitRowReportsWorkingWithoutASpinnerEllipsis() {
+    // Claude Code 2.1.224. The turn has ended, so the only live marker is the wait
+    // row. It carries a spinner glyph but no "…", which hasSpinnerActivity requires.
+    let detection = detect(
+      """
+      ⏺ Subagent launched in the background, running sleep 300.
+
+      ✻ Waiting for 1 background agent to finish
+      ─────────
+      ❯
+      ─────────
+        ⏵⏵ auto mode on · 1 shell
+
+        ⏺ main
+        ◯ general-purpose  Sleep 300 then reply    1m 5s · ↓ 21.4k tokens
+      """
+    )
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.backgroundWork))
+  }
+
+  @Test func retainedAgentRowAloneDoesNotReportWorking() {
+    // Claude Code 2.1.224, observed live. A subagent that returned control but is
+    // still awaiting collection keeps its switcher row, with the elapsed value
+    // frozen at the moment it stopped. Nothing is running, so the pane must not
+    // report working — matching the "◯" row shape alone would pin it there.
+    let detection = detect(
+      """
+      ⏺ Agent "Sleep 300 then reply" finished · 1m 54s
+
+        Ran 3 shell commands
+
+      ✻ Churned for 2m 49s · 2 shells still running
+      ─────────
+      ❯
+      ─────────
+        ⏵⏵ auto mode on · 2 shells
+
+        ⏺ main
+        ◯ general-purpose  Sleep 300 then reply    1m 54s · ↓ 23.0k tokens
+      """
+    )
+
+    #expect(detection.state == .idle)
+  }
+
+  @Test func waitRowQuotedEarlierInTheTranscriptDoesNotReportWorking() {
+    // The rule reads the live status region, which is the last three non-blank
+    // lines above the prompt box. A wait row quoted further back in the
+    // transcript falls outside that window and stays idle.
+    //
+    // A quote inside the window is indistinguishable from live chrome on a single
+    // screen and does report working; the same limit applies to every rule scoped
+    // this way, including the pre-existing spinner rule.
+    let detection = detect(
+      """
+      ⏺ Earlier the screen showed:
+
+        ✻ Waiting for 1 background agent to finish
+
+      ⏺ That row is the one the detector keys on.
+      ⏺ It is quoted here, four lines above the box.
+      ⏺ Nothing is running now.
+      ─────────
+      ❯
+      ─────────
+        ⏵⏵ auto mode on (shift+tab to cycle)
+      """
+    )
+
+    #expect(detection.state == .idle)
+  }
+
+  @Test func workflowFooterVariantStillReportsWorking() {
+    // The pre-existing "agents done" workflow row keeps its behaviour and reason.
+    let detection = detect(
+      """
+      Task complete.
+      ─────────
+      ❯
+      ─────────
+      ◯ scout  Map idle detection  3/5 agents done · 7m 29s
+      """
+    )
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.backgroundWork))
+  }
+
+  @Test func elapsedStatusAcceptsMultiWordLabelsAndCompoundElapsed() {
+    let working = [
+      "● Running gates and merge lifecycle… (45s · ↓ 13.2k tokens)",
+      "● Actioning… (28m 34s · ↓ 47.7k tokens)",
+      "● Actioning… (1h 4m 2s · ↓ 47.7k tokens)",
+      "● Perusing… (3s · ↓ 77 tokens)",
+    ]
+    for row in working {
+      let detection = detect(
+        """
+        \(row)
+        ─────────
+        ❯
+        ─────────
+        """
+      )
+      #expect(detection.state == .working, "expected working for: \(row)")
+      #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.elapsedStatus))
+    }
+  }
+
+  @Test func incompleteElapsedSegmentsStayIdle() {
+    let notWorking = [
+      "● Retrying the merge lifecycle… (1st attempt)",
+      "● Actioning… (10seconds · ↓ 47.7k tokens)",
+      "● Actioning… (28m 34 · ↓ 47.7k tokens)",
+    ]
+    for row in notWorking {
+      let detection = detect(
+        """
+        \(row)
+        ─────────
+        ❯
+        ─────────
+        """
+      )
+      #expect(detection.state == .idle, "expected idle for: \(row)")
+    }
+  }
+}

--- a/supacodeTests/ClaudeScreenProfileTests.swift
+++ b/supacodeTests/ClaudeScreenProfileTests.swift
@@ -34,6 +34,12 @@ struct ClaudeScreenProfileTests {
       "claude/2.1.223/working/subagent-active.txt": .matched(
         ClaudeScreenProfile.RuleID.spinner
       ),
+      "claude/2.1.224/working/676-background-agent-wait.txt": .matched(
+        ClaudeScreenProfile.RuleID.backgroundWork
+      ),
+      "claude/2.1.224/working/676-compound-elapsed-status.txt": .matched(
+        ClaudeScreenProfile.RuleID.elapsedStatus
+      ),
     ]
     let fixtures = try AgentScreenFixtureCorpus.load().filter { $0.agent == .claude }
 

--- a/supacodeTests/ClaudeScreenProfileTests.swift
+++ b/supacodeTests/ClaudeScreenProfileTests.swift
@@ -40,6 +40,9 @@ struct ClaudeScreenProfileTests {
       "claude/2.1.224/working/676-compound-elapsed-status.txt": .matched(
         ClaudeScreenProfile.RuleID.elapsedStatus
       ),
+      "claude/2.1.226/working/676-wrapped-background-agent-wait.txt": .matched(
+        ClaudeScreenProfile.RuleID.backgroundWork
+      ),
     ]
     let fixtures = try AgentScreenFixtureCorpus.load().filter { $0.agent == .claude }
 

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-background-agent-wait.metadata.json
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-background-agent-wait.metadata.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-07T09:30:00Z",
+  "cli_version": "2.1.224",
+  "capture_source": "prowl-read-detection",
+  "terminal": {
+    "columns": 195,
+    "rows": 63
+  },
+  "redactions": [
+    "account and organization identifiers replaced with synthetic values",
+    "usage balances and plan labels replaced with placeholders",
+    "terminal right-edge padding removed without changing line wrapping"
+  ],
+  "issue": null
+}

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-background-agent-wait.txt
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-background-agent-wait.txt
@@ -1,0 +1,59 @@
+│                                                    │ ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── │
+│                       ▐▛███▜▌                      │ What's new                                                                                                                                 │
+│                      ▝▜█████▛▘                     │ Added self-hosted environments: `claude self-hosted-runner` turns your own machines or containers into a place Claude Code web, mobile, a… │
+│                        ▘▘ ▝▝                       │ Added `archive` plugin source: install plugins from a zip over HTTPS without git or npm, with optional SHA-256 pinning                     │
+│   Opus 5 (1M context) with high… · Claude XXX ·    │ Added a cancel-and-confirm step when removing an unavailable paste changes a command's text                                                │
+│   <ACCOUNT_ID_0000>'s Org                          │ /release-notes for more                                                                                                                    │
+│              /…/scratchpad/fixture-ws              │                                                                                                                                            │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+❯ Launch exactly one general-purpose subagent whose only job is to run the shell command `sleep 300` and then reply DONE. Run that subagent in the background. Then wait for it to finish and
+  report its reply. Do nothing else at all while waiting.
+
+⏺ I'll launch the subagent now.
+
+⏺ Agent(Sleep 300 then reply)
+  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)
+  ⎿  Allowed by auto mode classifier
+
+⏺ Subagent launched in the background, running sleep 300. Waiting for its completion notification.
+
+✻ Waiting for 1 background agent to finish
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ⚠ Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker · restart with CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 to keep future transcripts
+  [Opus 5 (1M context)] | --------------------  3% | $X.XX | ⏱️ 0m 54s | 🟢                                                                                                             /rc active
+  ⏵⏵ auto mode on · 1 shell
+
+  ⏺ main
+  ◯ general-purpose  Sleep 300 then reply                                                                                                                                    1m 5s · ↓ 21.4k tokens

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-compound-elapsed-status.metadata.json
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-compound-elapsed-status.metadata.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-07T09:50:00Z",
+  "cli_version": "2.1.224",
+  "capture_source": "prowl-read-detection",
+  "terminal": {
+    "columns": 167,
+    "rows": 47
+  },
+  "redactions": [
+    "capture root and account path segments replaced with equal-width synthetic values",
+    "usage balances and plan labels replaced with placeholders",
+    "terminal right-edge padding removed without changing line wrapping"
+  ],
+  "issue": null
+}

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-compound-elapsed-status.txt
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.224/working/676-compound-elapsed-status.txt
@@ -1,0 +1,35 @@
+  281–290: 1823(3)1831(3)1847(3)1861(1)1867(3)1871(3)1873(1)1877(1)1879(3)1889(1)
+  291–300: 1901(1)1907(3)1913(1)1931(3)1933(1)1949(1)1951(3)1973(1)1979(3)1987(3)
+
+  Tally: 145 primes ≡ 1 (mod 4), 154 ≡ 3 (mod 4), plus 2. The 3-mod-4 lead through the whole range is Chebyshev's bias; the race first favors 1 mod 4 at 26861, well
+  past this list.
+
+  Generated from memory without computation tools, so the arithmetic carries no independent check.
+
+✻ Worked for 2m 5s
+
+❯ Run the script ./spin.sh in the foreground with a 200 second timeout and wait for it to finish. Reply DONE with its output. Use exactly one tool call and emit no
+  text before it.
+
+  Ran 1 shell command
+
+⏺ ./spin.sh does not exist in /Users/usr/Code/fixtureco/prowl/prowl (exit 127). Give me the correct path and I'll run it.
+
+✻ Churned for 6s
+
+❯ Run this exact command in the foreground with a 200 second timeout, using exactly one tool call and no text before it: bash
+  /private/tmp/claude-502/-Users-usr-Code-fixtureco-prowl-prowl/00000000-0000-0000-0000-000000000000/scratchpad/fixture-ws/spin.sh
+
+  Running 1 shell command · 1m 35s…
+  ⎿  $ bash /private/tmp/claude-502/-Users-usr-Code-fixtureco-prowl-prowl/00000000-0000-0000-0000-000000000000/scratchpad/fixture-ws/spin.sh (1m 32s)
+     (ctrl+b to run in background)
+
+● Perusing… (1m 38s · ↓ 187 tokens)
+  ⎿  Tip: Dynamic workflows let Claude write a script that orchestrates many agents for you. Mention the keyword ultracode or ask Claude to use a workflow directly.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ⚠ Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker · restart with CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 to keep future transcripts
+  [Opus 5 (1M context)] | #-------------------  6% | $X.XX | ⏱️ 16m 23s | 🟢                                                                                /rc active
+  ⏵⏵ auto mode on (shift+tab to cycle)

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.226/working/676-wrapped-background-agent-wait.metadata.json
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.226/working/676-wrapped-background-agent-wait.metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-08T12:32:00Z",
+  "cli_version": "2.1.226",
+  "capture_source": "prowl-read-detection",
+  "terminal": {
+    "columns": 36,
+    "rows": 83
+  },
+  "redactions": [
+    "terminal right-edge padding removed without changing line wrapping"
+  ],
+  "issue": null
+}

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.226/working/676-wrapped-background-agent-wait.txt
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.226/working/676-wrapped-background-agent-wait.txt
@@ -1,0 +1,70 @@
+╰──────────────────────────────────╯
+
+
+❯ Launch exactly one
+  general-purpose subagent whose
+  only job is to run bash spin.sh
+  and reply DONE. Background it,
+  then wait for it and report its
+  reply. Do nothing else while
+  waiting.
+
+⏺ I'll launch the subagent now.
+
+⏺ Agent(Run spin.sh script)
+  ⎿  Backgrounded agent (↓ to
+  ⎿  Allowed by auto mode
+
+⏺ Agent is running. Waiting for its
+  reply.
+
+✻ Waiting for 1 background agent to
+  finish
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────
+❯
+────────────────────────────────────
+  ⚠ Transcript saving is off — inhe…
+  [Opus 5 (1M context)] | --------…
+  ⏵⏵ auto mode on (shift+tab to
+
+  ⏺ main
+  ◯ general-purpose 55s · ↓ 15.0k


### PR DESCRIPTION
Follow-up to #676, and a direct answer to the open question in [this comment](https://github.com/onevcat/Prowl/issues/676#issuecomment-5208734315):

> No subagent-wait rule was added: the captured subagent screens retained a real spinner, and there is still no failing long-wait screen to justify another heuristic.

Here is that screen, plus a second one. Both captured against `5d449690` with `prowl read --source detection`, Claude Code 2.1.224, sampling `prowl agents --json` at the same instant as the read.

## Two live states report idle

```
● Perusing… (1m 38s · ↓ 187 tokens)          ->  agents: done
✻ Waiting for 1 background agent to finish   ->  agents: done
```

**Elapsed status.** `hasElapsedStatusLine` requires the label to be exactly one word and the elapsed segment to be exactly one `<digits><unit>` token. Claude satisfies neither reliably: labels are free text, and elapsed grows to several tokens past a minute. A correctly shaped row therefore detects for 59 seconds and then flips to idle for the rest of the turn. The label is now free text ending in an ellipsis, and the elapsed segment accepts a sequence of complete tokens terminated by `)` or `" · "` — so `(1st attempt)` and `(10seconds)` still stay idle.

**Background agents.** When Claude delegates, its own turn ends first and the spinner above the prompt is replaced by `✻ Waiting for 1 background agent to finish`. That row carries a spinner glyph but no `…`, which `hasSpinnerActivity` requires, and the existing marker matched the literal `agents done` that only the workflow variant of the row prints. The captured subagent fixtures in the corpus retain a live spinner because Claude was still working alongside the subagent; this is the state after its own turn has ended.

## The switcher block is not a liveness signal

Worth recording, because it is the obvious fix and it is wrong. The `⏺ main` + `◯` block below the prompt looks like a per-agent liveness list. It isn't: a subagent that returns control while still awaiting collection keeps its row, with the elapsed value **frozen** at the moment it stopped.

```
⏺ Agent "Sleep 300 then reply" finished · 1m 54s
...
  ⏺ main
  ◯ general-purpose  Sleep 300 then reply    1m 54s · ↓ 23.0k tokens     <- nothing running
```

A single frame cannot separate that from a running agent, so matching the row shape pins the pane at working after the work stopped. Observed live; `ClaudeBackgroundAgentDetectionTests.retainedAgentRowAloneDoesNotReportWorking` pins it.

## Why both survived the profile migration

Neither rule has a captured witness. `claude.elapsedStatus` and `claude.backgroundWork` are exercised only by inline synthetic screens, and those screens were written from the same assumptions as the predicates they test — a single-word label with a single elapsed token, and a row containing the literal `agents done` — so they cannot falsify them. Meanwhile every captured Claude working fixture retains a spinner, so `claude.spinner` returns first and `claude.elapsedStatus` is shadowed before it can be observed being wrong.

`AgentScreenRuleCoverageTests` closes that: every typed rule must be fired by at least one non-quarantined captured fixture. It would have flagged both rules the day the corpus landed.

It also surfaced something separate. `codex.confirmationChoices` has no witness either, and cannot get one from any screen seen on 0.146.1 — the captured command-permission screen satisfies its structure but ends with `Press enter to confirm or esc to cancel`, so `codex.confirmationFooter` matches first. Deleting only that line from the fixture flips the reason to `codex.confirmationChoices`, which is how the shadowing was confirmed. It is carried in an explicit `knownUnwitnessed` list with that note; if no Codex screen can reach it, the rule is dead and should be removed rather than witnessed.

## Contents

- Two fixtures under `claude/2.1.224/working/`, with provenance metadata and width-preserving redactions.
- `AgentScreenRuleCoverageTests` — the coverage obligation, plus the documented Codex exception.
- `ClaudeBackgroundAgentDetectionTests` — the wait row, the retained-row negative control, a wait row quoted earlier in the transcript, the preserved `agents done` variant, and the elapsed cases including the `(1st attempt)` / `(10seconds)` negatives.
- `docs/components/agent-detection.md` updated, including why the switcher rows are deliberately not read.
- `hasSpinnerActivity`'s scalar set extracted to `isAgentSpinnerScalar` so the wait rule shares it.

`ClaudeScreenProfileTests.capturedFixturesHaveStableReasonsIncludingViewerFix` gains the two new entries; every other existing test is unchanged and passing.

Validation: the detection suites (`ClaudeScreenProfileTests`, `CodexScreenProfileTests`, `AgentScreenFixtureCorpusTests`, `AgentScreenRuleCoverageTests`, `AgentScreenDetectionTests`, `ScreenHeuristicsTests`, `PaneAgentStateTests`, `ClaudeBackgroundAgentDetectionTests`) all pass; `swift-format lint --strict --recursive` and `swiftlint --strict` are clean.

Happy to reshape any of this — split the coverage test out, drop the Codex note, or re-capture at a narrower terminal width to match the 2.1.223 set.
