### PR TITLE
Add a fixture reduction and redaction script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -326,6 +326,9 @@ export-archive: # Export xarchive
 
 test: ensure-ghostty embed-cli-debug embed-docs test-app
 
+test-scripts: # Run tests for the repository's Python scripts
+	@python3 -m unittest discover -s "$(CURRENT_MAKEFILE_DIR)/scripts" -p 'test_*.py'
+
 test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 	@set -euo pipefail; \
 	result_bundle="$(CURRENT_MAKEFILE_DIR)/build/test-results/supacode-tests.xcresult"; \
@@ -427,7 +430,7 @@ format-lint: # Check Swift formatting without rewriting files
 lint: # Lint code with swiftlint
 	mise exec -- swiftlint lint --quiet --config .swiftlint.yml
 
-check: format-changed format-lint lint # Format changed Swift files, then run swift-format lint and SwiftLint
+check: format-changed format-lint lint test-scripts # Format changed Swift files, then run swift-format lint, SwiftLint, and the script tests
 
 log-stream: # Stream logs from the app via log stream
 	log stream --predicate 'subsystem == "com.onevcat.prowl"' --style compact --color always

--- a/scripts/make-detection-fixture.py
+++ b/scripts/make-detection-fixture.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Turn a `prowl read --source detection` capture into a corpus fixture.
+
+Implements steps 3, 6, and 7 of the capture-and-promotion procedure in
+`supacodeTests/Fixtures/AgentScreenDetection/README.md`: it rejects a capture
+that is not detector-faithful, reduces the screen to the same tail the detector
+reads, and applies redactions without changing the visible width of any line.
+
+Width matters. A fixture exists to pin how the classifier reads a real screen,
+and the agent CLIs wrap, shorten, and truncate their rows to the terminal width.
+A redaction that lengthens or shortens a line moves a wrap point and turns the
+fixture into a screen the product would never render, so every substitution here
+either preserves the line's visible width or is refused.
+
+Usage:
+
+    scripts/make-detection-fixture.py capture.json \\
+        --redact /Users/me=/Users/usr \\
+        --redact 'Acme Inc=<ORG_0000>' \\
+        > supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.226/idle/composer.txt
+
+Each `--redact OLD=NEW` is applied in order. `NEW` may differ in length from
+`OLD`: the difference is taken out of, or added to, that line's trailing spaces,
+which are invisible on screen. A line with too little trailing slack to absorb a
+longer replacement is reported and the run fails, rather than silently shifting
+the row.
+
+The redaction summary the metadata file requires (README step 5) is written to
+stderr, so it does not contaminate the fixture on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+DETECTOR_TAIL_LIMIT = 24
+
+
+def canonical_tail(content: str, limit: int = DETECTOR_TAIL_LIMIT) -> str:
+    """Port of `agentDetectionRecentLines(_:limit:)`.
+
+    Starts at the `limit`-th non-empty line from the bottom when that many
+    exist, and keeps every line from there down, blank lines and trailing screen
+    rows included. Fewer than `limit` non-empty lines keeps the whole screen.
+    """
+    lines = content.split("\n")
+    remaining = limit
+    start = 0
+    for index in range(len(lines) - 1, -1, -1):
+        if not lines[index].strip():
+            continue
+        remaining -= 1
+        if remaining == 0:
+            start = index
+            break
+    return "\n".join(lines[start:])
+
+
+class WidthError(Exception):
+    """A replacement could not keep the line's visible width."""
+
+
+def substitute(line: str, old: str, new: str) -> str:
+    """Replace `old` with `new`, keeping every later column where it was.
+
+    The padding is adjusted in the run of spaces immediately after the inserted
+    text, never at the end of the line. Anything further along the row — the
+    closing border of a box, a second column of chrome — therefore stays in its
+    captured column. Absorbing the change at the end of the line instead would
+    hold the line's total length while sliding all of that content sideways.
+    """
+    delta = len(new) - len(old)
+    out = ""
+    rest = line
+
+    while True:
+        head, separator, tail = rest.partition(old)
+        if not separator:
+            return out + rest
+
+        out += head + new
+        if delta < 0:
+            out += " " * (-delta)
+        elif delta > 0:
+            gap = len(tail) - len(tail.lstrip(" "))
+            if gap < delta:
+                raise WidthError(
+                    f"replacing {old!r} with {new!r} widens the row by {delta} column(s), "
+                    f"and only {gap} space(s) follow it; every column after this point "
+                    f"would shift. Choose a replacement of {len(old) + gap} characters or fewer"
+                )
+            tail = tail[delta:]
+        rest = tail
+
+
+# Money amounts carry no signal for the classifier and are account data.
+MONEY = re.compile(r"\$\d+\.\d\d")
+
+
+def parse_redaction(value: str) -> tuple[str, str]:
+    old, separator, new = value.partition("=")
+    if not separator or not old:
+        raise argparse.ArgumentTypeError(f"expected OLD=NEW, got {value!r}")
+    return old, new
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reduce and redact a detection capture into a corpus fixture."
+    )
+    parser.add_argument(
+        "capture", help="JSON emitted by `prowl read --source detection --json`"
+    )
+    parser.add_argument(
+        "--redact",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        type=parse_redaction,
+        help="literal replacement, applied in order; repeatable",
+    )
+    parser.add_argument(
+        "--keep-money",
+        action="store_true",
+        help="retain dollar amounts instead of masking them as $X.XX",
+    )
+    args = parser.parse_args()
+
+    with open(args.capture, encoding="utf-8") as handle:
+        capture = json.load(handle)
+
+    data = capture.get("data", {})
+    source = data.get("source")
+    if source != "detection":
+        print(
+            f"error: capture source is {source!r}, not 'detection'; a viewport read "
+            "is not the input the classifier sees",
+            file=sys.stderr,
+        )
+        return 2
+
+    applied: dict[str, str] = {}
+    out_lines = []
+    for number, line in enumerate(canonical_tail(data["text"]).split("\n"), start=1):
+        for old, new in args.redact:
+            try:
+                replaced = substitute(line, old, new)
+            except WidthError as error:
+                print(f"error: line {number}: {error}", file=sys.stderr)
+                return 1
+            if replaced != line:
+                applied[old] = new
+            line = replaced
+        if not args.keep_money:
+            masked = MONEY.sub("$X.XX", line)
+            if masked != line:
+                applied["<dollar amounts>"] = "$X.XX"
+            line = masked
+        # Width preservation keeps every column up to the last visible glyph, so
+        # a closing box border stays where the capture put it. Past that glyph
+        # the padding carries nothing, and the corpus stores lines without it.
+        out_lines.append(line.rstrip())
+
+    sys.stdout.write("\n".join(out_lines))
+
+    if applied:
+        print("redactions applied (for the metadata file):", file=sys.stderr)
+        for old, new in applied.items():
+            print(f'  "{old} replaced with {new}"', file=sys.stderr)
+    else:
+        print("no redactions applied", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/make-detection-fixture.py
+++ b/scripts/make-detection-fixture.py
@@ -35,6 +35,7 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 
 DETECTOR_TAIL_LIMIT = 24
 
@@ -63,6 +64,43 @@ class WidthError(Exception):
     """A replacement could not keep the line's visible width."""
 
 
+# Sequences whose rendered width terminals do not agree on. A ZWJ sequence may
+# collapse into one glyph or render as its parts; a variation selector flips a
+# character between text and emoji presentation, and therefore between one cell
+# and two. Refusing them is the same bargain the rest of this script makes:
+# a fixture that never renders is worse than a redaction that never happens.
+UNDECIDABLE_WIDTH = {"‍"}  # zero-width joiner
+VARIATION_SELECTORS = [range(0xFE00, 0xFE10), range(0xE0100, 0xE01F0)]
+
+
+def cell_width(text: str) -> int:
+    """Visible width of `text` in terminal cells.
+
+    `len()` counts code points, which is the same number only for the ASCII
+    subset. A CJK ideograph occupies two cells, a combining mark none, and
+    "CJK text replaced by an ASCII placeholder" is the common redaction on this
+    fork — so measuring in code points silently narrows exactly the lines the
+    corpus exists to pin.
+    """
+    width = 0
+    for character in text:
+        code = ord(character)
+        if character in UNDECIDABLE_WIDTH or any(
+            code in span for span in VARIATION_SELECTORS
+        ):
+            raise WidthError(
+                f"{character!r} (U+{code:04X}) has no width terminals agree on, so the "
+                f"replacement cannot be shown to preserve the row. Use a replacement "
+                f"without joiners or variation selectors"
+            )
+        if code < 0x20 or code == 0x7F:
+            raise WidthError(f"control character U+{code:04X} has no visible width")
+        if unicodedata.combining(character):
+            continue
+        width += 2 if unicodedata.east_asian_width(character) in ("W", "F") else 1
+    return width
+
+
 def substitute(line: str, old: str, new: str) -> str:
     """Replace `old` with `new`, keeping every later column where it was.
 
@@ -71,8 +109,11 @@ def substitute(line: str, old: str, new: str) -> str:
     closing border of a box, a second column of chrome — therefore stays in its
     captured column. Absorbing the change at the end of the line instead would
     hold the line's total length while sliding all of that content sideways.
+
+    Width is counted in terminal cells, so a two-cell ideograph replaced by a
+    one-cell letter is padded by the one column it gives up.
     """
-    delta = len(new) - len(old)
+    delta = cell_width(new) - cell_width(old)
     out = ""
     rest = line
 
@@ -90,7 +131,7 @@ def substitute(line: str, old: str, new: str) -> str:
                 raise WidthError(
                     f"replacing {old!r} with {new!r} widens the row by {delta} column(s), "
                     f"and only {gap} space(s) follow it; every column after this point "
-                    f"would shift. Choose a replacement of {len(old) + gap} characters or fewer"
+                    f"would shift. Choose a replacement of {cell_width(old) + gap} cells or fewer"
                 )
             tail = tail[delta:]
         rest = tail
@@ -98,6 +139,25 @@ def substitute(line: str, old: str, new: str) -> str:
 
 # Money amounts carry no signal for the classifier and are account data.
 MONEY = re.compile(r"\$\d+\.\d\d")
+
+
+def mask_money(line: str) -> tuple[str, list[tuple[str, str]]]:
+    """Mask dollar amounts digit for digit, through the same width guard.
+
+    A fixed `$X.XX` mask silently narrowed every amount that was not a single
+    unit — `$123.45` lost two columns and slid the rest of the row left, which
+    is precisely the defect this script exists to prevent. Masking each digit
+    with an X keeps the mask the same width as the amount for any magnitude, so
+    the substitution is a no-op for layout by construction rather than by luck.
+    """
+    applied: list[tuple[str, str]] = []
+    for amount in dict.fromkeys(MONEY.findall(line)):
+        masked = re.sub(r"\d", "X", amount)
+        replaced = substitute(line, amount, masked)
+        if replaced != line:
+            applied.append((amount, masked))
+        line = replaced
+    return line, applied
 
 
 def parse_redaction(value: str) -> tuple[str, str]:
@@ -125,7 +185,7 @@ def main() -> int:
     parser.add_argument(
         "--keep-money",
         action="store_true",
-        help="retain dollar amounts instead of masking them as $X.XX",
+        help="retain dollar amounts instead of masking their digits as X",
     )
     args = parser.parse_args()
 
@@ -155,10 +215,13 @@ def main() -> int:
                 applied[old] = new
             line = replaced
         if not args.keep_money:
-            masked = MONEY.sub("$X.XX", line)
-            if masked != line:
-                applied["<dollar amounts>"] = "$X.XX"
-            line = masked
+            try:
+                line, masked = mask_money(line)
+            except WidthError as error:
+                print(f"error: line {number}: {error}", file=sys.stderr)
+                return 1
+            for amount, mask in masked:
+                applied[amount] = mask
         # Width preservation keeps every column up to the last visible glyph, so
         # a closing box border stays where the capture put it. Past that glyph
         # the padding carries nothing, and the corpus stores lines without it.

--- a/scripts/make-detection-fixture.py
+++ b/scripts/make-detection-fixture.py
@@ -26,7 +26,10 @@ longer replacement is reported and the run fails, rather than silently shifting
 the row.
 
 The redaction summary the metadata file requires (README step 5) is written to
-stderr, so it does not contaminate the fixture on stdout.
+stderr, so it does not contaminate the fixture on stdout. It reports each
+replacement and how many lines it touched, and never the text that was
+replaced: that summary is committed, and the original is what the redaction
+existed to keep out of the repository.
 """
 
 from __future__ import annotations
@@ -60,17 +63,33 @@ def canonical_tail(content: str, limit: int = DETECTOR_TAIL_LIMIT) -> str:
     return "\n".join(lines[start:])
 
 
-class WidthError(Exception):
+class FixtureError(Exception):
+    """A capture could not be turned into a faithful fixture."""
+
+
+class WidthError(FixtureError):
     """A replacement could not keep the line's visible width."""
 
 
-# Sequences whose rendered width terminals do not agree on. A ZWJ sequence may
-# collapse into one glyph or render as its parts; a variation selector flips a
-# character between text and emoji presentation, and therefore between one cell
-# and two. Refusing them is the same bargain the rest of this script makes:
-# a fixture that never renders is worse than a redaction that never happens.
+class AmountError(FixtureError):
+    """A dollar-shaped value was left for the author to handle."""
+
+
+# Sequences whose rendered width terminals do not agree on, or that are not the
+# sum of their parts. A ZWJ sequence may collapse into one glyph or render as
+# its parts; a variation selector flips a character between text and emoji
+# presentation, and therefore between one cell and two; a skin-tone modifier or
+# a tag sequence attaches to the preceding emoji and adds no cell of its own,
+# so summing code points overcounts it. Refusing them is the same bargain the
+# rest of this script makes: a fixture that never renders is worse than a
+# redaction that never happens.
 UNDECIDABLE_WIDTH = {"‍"}  # zero-width joiner
-VARIATION_SELECTORS = [range(0xFE00, 0xFE10), range(0xE0100, 0xE01F0)]
+UNDECIDABLE_SPANS = [
+    range(0xFE00, 0xFE10),  # variation selectors
+    range(0xE0100, 0xE01F0),  # variation selectors supplement
+    range(0x1F3FB, 0x1F400),  # emoji modifiers (skin tone)
+    range(0xE0001, 0xE0080),  # tag characters, including flag tag sequences
+]
 
 
 def cell_width(text: str) -> int:
@@ -86,12 +105,12 @@ def cell_width(text: str) -> int:
     for character in text:
         code = ord(character)
         if character in UNDECIDABLE_WIDTH or any(
-            code in span for span in VARIATION_SELECTORS
+            code in span for span in UNDECIDABLE_SPANS
         ):
             raise WidthError(
                 f"{character!r} (U+{code:04X}) has no width terminals agree on, so the "
                 f"replacement cannot be shown to preserve the row. Use a replacement "
-                f"without joiners or variation selectors"
+                f"without joiners, variation selectors, emoji modifiers, or tag sequences"
             )
         if code < 0x20 or code == 0x7F:
             raise WidthError(f"control character U+{code:04X} has no visible width")
@@ -137,8 +156,14 @@ def substitute(line: str, old: str, new: str) -> str:
         rest = tail
 
 
-# Money amounts carry no signal for the classifier and are account data.
-MONEY = re.compile(r"\$\d+\.\d\d")
+# Money amounts carry no signal for the classifier and are account data. The
+# grouped form is what a status line prints once a session passes a thousand.
+MONEY = re.compile(r"\$\d{1,3}(?:,\d{3})+\.\d\d|\$\d+\.\d\d")
+
+# Anything else shaped like currency. `$1` is a shell positional parameter and
+# appears in real captures, so a decimal point or a grouping comma is required
+# before a token is treated as an amount the author has to account for.
+AMOUNT_SHAPED = re.compile(r"\$\d[\d,]*(?:\.\d+)?")
 
 
 def mask_money(line: str) -> tuple[str, list[tuple[str, str]]]:
@@ -149,6 +174,12 @@ def mask_money(line: str) -> tuple[str, list[tuple[str, str]]]:
     is precisely the defect this script exists to prevent. Masking each digit
     with an X keeps the mask the same width as the amount for any magnitude, so
     the substitution is a no-op for layout by construction rather than by luck.
+    Grouping separators are kept as they are, for the same reason.
+
+    A dollar-shaped token this does not recognise fails the run. Passing it
+    through would be worse than not masking at all: the README documents the
+    masking as automatic, so an author who reads that and does not re-read the
+    row would commit the amount believing the script had handled it.
     """
     applied: list[tuple[str, str]] = []
     for amount in dict.fromkeys(MONEY.findall(line)):
@@ -157,6 +188,14 @@ def mask_money(line: str) -> tuple[str, list[tuple[str, str]]]:
         if replaced != line:
             applied.append((amount, masked))
         line = replaced
+
+    for leftover in AMOUNT_SHAPED.findall(line):
+        if "." in leftover or "," in leftover:
+            raise AmountError(
+                f"{leftover!r} is shaped like an amount but is not the form this "
+                f"masks, so it would reach the fixture unchanged. Redact it with "
+                f"--redact, or pass --keep-money if it is not account data"
+            )
     return line, applied
 
 
@@ -202,26 +241,30 @@ def main() -> int:
         )
         return 2
 
-    applied: dict[str, str] = {}
+    # Counted by replacement, never by original: this summary is what README
+    # step 5 tells the author to carry into the committed metadata file, and a
+    # summary naming the home path or prompt it removed would put the redacted
+    # text back into the repository the redaction was protecting.
+    applied: dict[str, int] = {}
     out_lines = []
     for number, line in enumerate(canonical_tail(data["text"]).split("\n"), start=1):
         for old, new in args.redact:
             try:
                 replaced = substitute(line, old, new)
-            except WidthError as error:
+            except FixtureError as error:
                 print(f"error: line {number}: {error}", file=sys.stderr)
                 return 1
             if replaced != line:
-                applied[old] = new
+                applied[new] = applied.get(new, 0) + 1
             line = replaced
         if not args.keep_money:
             try:
                 line, masked = mask_money(line)
-            except WidthError as error:
+            except FixtureError as error:
                 print(f"error: line {number}: {error}", file=sys.stderr)
                 return 1
-            for amount, mask in masked:
-                applied[amount] = mask
+            for _, mask in masked:
+                applied[mask] = applied.get(mask, 0) + 1
         # Width preservation keeps every column up to the last visible glyph, so
         # a closing box border stays where the capture put it. Past that glyph
         # the padding carries nothing, and the corpus stores lines without it.
@@ -230,9 +273,15 @@ def main() -> int:
     sys.stdout.write("\n".join(out_lines))
 
     if applied:
-        print("redactions applied (for the metadata file):", file=sys.stderr)
-        for old, new in applied.items():
-            print(f'  "{old} replaced with {new}"', file=sys.stderr)
+        print(
+            "replacements applied, by line count. Name what each one replaced in "
+            "the metadata file — the originals are not printed here, because this "
+            "summary is committed and they were the reason to redact:",
+            file=sys.stderr,
+        )
+        for new, count in applied.items():
+            rows = "line" if count == 1 else "lines"
+            print(f'  {count} {rows} → "… replaced with {new}"', file=sys.stderr)
     else:
         print("no redactions applied", file=sys.stderr)
     return 0

--- a/scripts/test_make_detection_fixture.py
+++ b/scripts/test_make_detection_fixture.py
@@ -47,6 +47,15 @@ class CellWidth(unittest.TestCase):
         with self.assertRaises(fixture.WidthError):
             fixture.cell_width("❤️")
 
+    def test_emoji_modifier_is_refused_rather_than_summed(self):
+        # Two wide code points, one two-cell grapheme: summing reports four.
+        with self.assertRaises(fixture.WidthError):
+            fixture.cell_width("\U0001f469\U0001f3fd")
+
+    def test_tag_sequence_is_refused(self):
+        with self.assertRaises(fixture.WidthError):
+            fixture.cell_width("\U0001f3f4\U000e0067\U000e0062")
+
 
 class Substitute(unittest.TestCase):
     def test_narrowing_replacement_pads_to_hold_the_border(self):
@@ -82,6 +91,23 @@ class MoneyMasking(unittest.TestCase):
         out, _ = fixture.mask_money("cost $1.23 |")
         self.assertEqual(out, "cost $X.XX |")
 
+    def test_grouped_amount_is_masked_and_keeps_its_separator(self):
+        line = "│ $1,234.56 spent │"
+        out, applied = fixture.mask_money(line)
+        self.assertEqual(out, "│ $X,XXX.XX spent │")
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+        self.assertEqual(applied, [("$1,234.56", "$X,XXX.XX")])
+
+    def test_unrecognized_amount_shape_fails_rather_than_passing_through(self):
+        with self.assertRaises(fixture.AmountError):
+            fixture.mask_money("total $12,34.5 |")
+
+    def test_shell_positional_is_not_treated_as_an_amount(self):
+        # `echo "$1"` is ordinary capture content, not billing data.
+        out, applied = fixture.mask_money('echo "$1" && shift')
+        self.assertEqual(out, 'echo "$1" && shift')
+        self.assertEqual(applied, [])
+
     def test_several_amounts_on_one_row(self):
         line = "$9.99 and $1234.56 |"
         out, applied = fixture.mask_money(line)
@@ -116,6 +142,14 @@ class EndToEnd(unittest.TestCase):
         result = self.run_script(line, "--redact", "東京都のユーザー=<CITY_0000>")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(fixture.cell_width(result.stdout), fixture.cell_width(line))
+
+    def test_summary_never_names_what_it_replaced(self):
+        line = "│ /Users/realname/Code  │"
+        result = self.run_script(line, "--redact", "/Users/realname=/Users/usr")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("realname", result.stderr)
+        self.assertIn("/Users/usr", result.stderr)
+        self.assertIn("1 line", result.stderr)
 
     def test_undecidable_replacement_fails_the_run(self):
         result = self.run_script("│ owner name │", "--redact", "owner=❤️")

--- a/scripts/test_make_detection_fixture.py
+++ b/scripts/test_make_detection_fixture.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Tests for the fixture generator's width guarantee.
+
+The corpus tests validate the fixtures that were committed; they never execute
+the generator, so nothing held it to the one promise it makes — that a redacted
+row occupies the same columns the terminal captured. These do.
+
+Run with `make test-scripts`, or directly:
+
+    python3 -m unittest discover -s scripts -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent / "make-detection-fixture.py"
+
+_spec = importlib.util.spec_from_file_location("make_detection_fixture", SCRIPT)
+fixture = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fixture)
+
+
+class CellWidth(unittest.TestCase):
+    def test_ascii_counts_one_cell_per_character(self):
+        self.assertEqual(fixture.cell_width("claude"), 6)
+
+    def test_ideographs_count_two_cells(self):
+        # len() is 1 here, which is exactly the confusion this replaces.
+        self.assertEqual(fixture.cell_width("猫"), 2)
+        self.assertEqual(fixture.cell_width("メモ"), 4)
+
+    def test_combining_marks_occupy_no_cell(self):
+        self.assertEqual(fixture.cell_width("é"), 1)
+
+    def test_joiner_is_refused_rather_than_guessed(self):
+        with self.assertRaises(fixture.WidthError):
+            fixture.cell_width("\U0001f469‍\U0001f4bb")
+
+    def test_variation_selector_is_refused(self):
+        with self.assertRaises(fixture.WidthError):
+            fixture.cell_width("❤️")
+
+
+class Substitute(unittest.TestCase):
+    def test_narrowing_replacement_pads_to_hold_the_border(self):
+        line = "│ user  猫猫  │"
+        out = fixture.substitute(line, "猫猫", "cat")
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+        self.assertTrue(out.endswith("│"))
+
+    def test_widening_replacement_consumes_following_spaces(self):
+        line = "│ me     │"
+        out = fixture.substitute(line, "me", "user")
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+
+    def test_widening_beyond_the_slack_is_refused(self):
+        with self.assertRaises(fixture.WidthError):
+            fixture.substitute("│ me │", "me", "a much longer name")
+
+    def test_ascii_replaced_by_ideograph_holds_the_width(self):
+        line = "│ ab      │"
+        out = fixture.substitute(line, "ab", "猫")
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+
+
+class MoneyMasking(unittest.TestCase):
+    def test_multi_digit_amount_keeps_its_columns(self):
+        line = "│ spent $123.45 today │"
+        out, applied = fixture.mask_money(line)
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+        self.assertIn("$XXX.XX", out)
+        self.assertEqual(applied, [("$123.45", "$XXX.XX")])
+
+    def test_single_unit_amount_still_masks(self):
+        out, _ = fixture.mask_money("cost $1.23 |")
+        self.assertEqual(out, "cost $X.XX |")
+
+    def test_several_amounts_on_one_row(self):
+        line = "$9.99 and $1234.56 |"
+        out, applied = fixture.mask_money(line)
+        self.assertEqual(fixture.cell_width(out), fixture.cell_width(line))
+        self.assertEqual(out, "$X.XX and $XXXX.XX |")
+        self.assertEqual(len(applied), 2)
+
+
+class EndToEnd(unittest.TestCase):
+    def run_script(self, text, *args):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump({"data": {"source": "detection", "text": text}}, handle)
+            path = handle.name
+        try:
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), path, *args],
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            pathlib.Path(path).unlink()
+
+    def test_amount_masking_does_not_move_the_closing_border(self):
+        line = "│ Opus 5 · $123.45 · 60m │"
+        result = self.run_script(line)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(fixture.cell_width(result.stdout), fixture.cell_width(line))
+        self.assertIn("$XXX.XX", result.stdout)
+
+    def test_unicode_redaction_holds_the_row(self):
+        line = "│ 東京都のユーザー          │"
+        result = self.run_script(line, "--redact", "東京都のユーザー=<CITY_0000>")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(fixture.cell_width(result.stdout), fixture.cell_width(line))
+
+    def test_undecidable_replacement_fails_the_run(self):
+        result = self.run_script("│ owner name │", "--redact", "owner=❤️")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("no width terminals agree on", result.stderr)
+
+    def test_viewport_capture_is_still_rejected(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump({"data": {"source": "screen", "text": "x"}}, handle)
+            path = handle.name
+        try:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), path], capture_output=True, text=True
+            )
+        finally:
+            pathlib.Path(path).unlink()
+        self.assertEqual(result.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -59,7 +59,10 @@ Each replacement is padded or trimmed in the spaces immediately following it, so
 later column on the row — a closing box border, a second column of chrome — keeps its
 captured position. A replacement too long for the space after it fails with the maximum
 length that would fit. The script writes the redaction summary step 5 asks for to stderr,
-leaving stdout to be redirected into the fixture. It still does not choose *what* to
+leaving stdout to be redirected into the fixture. That summary names each replacement and
+the number of lines it touched, never the text it replaced — it is copied into a committed
+metadata file, and the original is what the redaction existed to keep out of the
+repository, so describe it there yourself. The script still does not choose *what* to
 redact: step 7 governs that.
 
 Width is counted in terminal cells, not code points: an ideograph occupies two columns and
@@ -68,9 +71,12 @@ than the three-column one `len()` would report. A replacement whose width no ter
 agrees on — a ZWJ sequence, or a variation selector that flips a character between text
 and emoji presentation — is refused rather than guessed at. Dollar amounts are masked
 digit for digit (`$123.45` becomes `$XXX.XX`), so the mask is the width of the amount at
-any magnitude; pass `--keep-money` to retain them. The digit count survives, and therefore
-so does the order of magnitude: a mask that hid it would occupy different columns, and
-holding the columns is what the fixture is for.
+any magnitude; grouped amounts keep their separator (`$1,234.56` becomes `$X,XXX.XX`), and
+`--keep-money` retains them. The digit count survives, and therefore so does the order of
+magnitude: a mask that hid it would occupy different columns, and holding the columns is
+what the fixture is for. A dollar-shaped token this does not recognise fails the run, so
+the documented default never silently skips one; a bare `$1` is a shell positional and is
+left alone.
 
 `make test-scripts` exercises these guarantees. The corpus tests validate committed
 fixtures and never run the generator, so without it nothing holds the script to the

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -60,6 +60,18 @@ length that would fit. The script writes the redaction summary step 5 asks for t
 leaving stdout to be redirected into the fixture. It still does not choose *what* to
 redact: step 7 governs that.
 
+Width is counted in terminal cells, not code points: an ideograph occupies two columns and
+a combining mark none, so replacing `東京` with `Tokyo` is a one-column widening rather
+than the three-column one `len()` would report. A replacement whose width no terminal
+agrees on — a ZWJ sequence, or a variation selector that flips a character between text
+and emoji presentation — is refused rather than guessed at. Dollar amounts are masked
+digit for digit (`$123.45` becomes `$XXX.XX`), so the mask is the width of the amount at
+any magnitude; pass `--keep-money` to retain them.
+
+`make test-scripts` exercises these guarantees. The corpus tests validate committed
+fixtures and never run the generator, so without it nothing holds the script to the
+promise it exists to make.
+
 The loader resolves this tree through `#filePath`, so tests intentionally run from a
 source checkout rather than relying on test-bundle resource flattening.
 

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -41,6 +41,25 @@ derived from `idle + unseen` and is never a fixture state.
    remain verbatim and are preferred for conversational fixtures.
 8. Run `AgentScreenFixtureCorpusTests` before committing.
 
+Steps 3, 6, and 7 are mechanical, and doing them by hand is where fixtures go wrong: a
+redaction that changes a line's visible width moves a wrap point and produces a screen the
+agent CLI would never render. `scripts/make-detection-fixture.py` performs those three
+steps and refuses a substitution it cannot fit:
+
+```bash
+scripts/make-detection-fixture.py .local/agent-screen-captures/capture.json \
+  --redact "/Users/me=/Users/usr" \
+  --redact "Acme Inc=<ORG_0000>" \
+  > claude/2.1.226/idle/composer.txt
+```
+
+Each replacement is padded or trimmed in the spaces immediately following it, so every
+later column on the row — a closing box border, a second column of chrome — keeps its
+captured position. A replacement too long for the space after it fails with the maximum
+length that would fit. The script writes the redaction summary step 5 asks for to stderr,
+leaving stdout to be redirected into the fixture. It still does not choose *what* to
+redact: step 7 governs that.
+
 The loader resolves this tree through `#filePath`, so tests intentionally run from a
 source checkout rather than relying on test-bundle resource flattening.
 

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -35,10 +35,12 @@ derived from `idle + unseen` and is never a fixture state.
 6. Reduce the capture with the production `agentDetectionRecentText` helper: start at
    the 24th non-empty line from the bottom when at least 24 exist; otherwise retain the
    whole screen. Keep blank lines and trailing screen rows inside that window.
-7. Redact paths, repositories, account identifiers, and all real-session prompts/model
-   output without changing runtime chrome, line ordering, markers, wrapping, or blank-line
-   boundaries. Deliberately scripted probe interactions from disposable workspaces may
-   remain verbatim and are preferred for conversational fixtures.
+7. Redact paths, repositories, account identifiers, all real-session prompts/model output,
+   and the counters a custom status line reports for the session — cost, token totals,
+   quota percentages, elapsed time — without changing runtime chrome, line ordering,
+   markers, wrapping, or blank-line boundaries. The generator masks dollar amounts only;
+   the other counters are yours to replace. Deliberately scripted probe interactions from
+   disposable workspaces may remain verbatim and are preferred for conversational fixtures.
 8. Run `AgentScreenFixtureCorpusTests` before committing.
 
 Steps 3, 6, and 7 are mechanical, and doing them by hand is where fixtures go wrong: a
@@ -66,7 +68,9 @@ than the three-column one `len()` would report. A replacement whose width no ter
 agrees on — a ZWJ sequence, or a variation selector that flips a character between text
 and emoji presentation — is refused rather than guessed at. Dollar amounts are masked
 digit for digit (`$123.45` becomes `$XXX.XX`), so the mask is the width of the amount at
-any magnitude; pass `--keep-money` to retain them.
+any magnitude; pass `--keep-money` to retain them. The digit count survives, and therefore
+so does the order of magnitude: a mask that hid it would occupy different columns, and
+holding the columns is what the fixture is for.
 
 `make test-scripts` exercises these guarantees. The corpus tests validate committed
 fixtures and never run the generator, so without it nothing holds the script to the


### PR DESCRIPTION
Opening as a draft because it adds tooling rather than fixing a defect, so the shape is open to direction.

## What

`scripts/make-detection-fixture.py` performs steps 3, 6, and 7 of the capture-and-promotion procedure the corpus README already documents: it rejects a capture whose `.data.source` is not `detection`, reduces the screen to the same tail `agentDetectionRecentLines` reads, and applies redactions without changing any line's visible width.

## Why

Those three steps are mechanical, and the width rule is the one that breaks a fixture without looking broken. The agent CLIs wrap, shorten, and truncate rows to the terminal width, so a redaction one character longer than what it replaces moves a wrap point. The fixture then pins a screen the CLI would never render, and it pins it convincingly, because nothing about the file looks wrong.

The padding goes into the spaces immediately after the replacement rather than at the end of the row. That keeps every later column where the capture put it:

```text
│   <ACCOUNT_ID_0000>'s Org                          │ /release-notes for more    │
```

Absorbing the two-character difference at the end of the line instead preserves the line's length while sliding the closing border two columns left. I made exactly that mistake while writing this, and the regeneration check below is what caught it.

A replacement that cannot fit is refused rather than applied:

```
error: line 5: replacing 'Claude Max' with 'Claude Maximum Subscription Plan' widens
the row by 22 column(s), and only 1 space(s) follow it; every column after this point
would shift. Choose a replacement of 11 characters or fewer
```

## Evidence

Regenerating three committed fixtures from their original captures reproduces each byte for byte:

```
MATCH  676-wrapped-background-agent-wait   (claude 2.1.226, 36 columns)
MATCH  676-background-agent-wait           (claude 2.1.224)
MATCH  676-compound-elapsed-status         (claude 2.1.224)
```

Those three come from #691 and are not on `main` yet, so the check runs against that branch. As a negative control, feeding a `--source screen` capture exits 2 and writes nothing, and the widening case above exits 1 and writes nothing.

## Scope

The script chooses no redactions of its own beyond masking dollar amounts, which `--keep-money` disables. What to redact stays step 7's decision and the author's. Tool versions: Python 3.14.6, `prowl read --source detection --json` from a 2026.8.9 Debug build.
