### PR TITLE
Feed Claude detection the full active screen

### DIFF
--- a/docs-ai/030-agent-status-detection/009-captured-screen-fixture-corpus.md
+++ b/docs-ai/030-agent-status-detection/009-captured-screen-fixture-corpus.md
@@ -1,5 +1,9 @@
 # 030.009 — Captured Screen Fixture Corpus and Baseline
 
+> Amended by [014-claude-full-screen-live-block.md](014-claude-full-screen-live-block.md):
+> the canonical-tail reduction below now applies to non-Claude fixtures only. Claude
+> fixtures are committed as full active screens, bounded by the captured terminal rows.
+
 | | |
 | --- | --- |
 | **Status** | Implemented |

--- a/docs-ai/030-agent-status-detection/012-claude-screen-profile.md
+++ b/docs-ai/030-agent-status-detection/012-claude-screen-profile.md
@@ -1,5 +1,10 @@
 # 030.012 — Claude Screen Profile: Action
 
+> Amended by [014-claude-full-screen-live-block.md](014-claude-full-screen-live-block.md):
+> Claude now consumes the full active screen and the live status region is bounded by
+> row shape instead of `suffix(3)`; the canonical-tail contract and the Debug
+> canonical-tail assert described below no longer apply to Claude.
+
 | | |
 | --- | --- |
 | **Status** | Implemented |

--- a/docs-ai/030-agent-status-detection/014-claude-full-screen-live-block.md
+++ b/docs-ai/030-agent-status-detection/014-claude-full-screen-live-block.md
@@ -1,0 +1,64 @@
+# 014 — Claude full-screen input and the shape-bounded live status block
+
+Amends [009-captured-screen-fixture-corpus.md](009-captured-screen-fixture-corpus.md) and
+[012-claude-screen-profile.md](012-claude-screen-profile.md): the "canonical 24-line
+detector tail" contract those records describe now applies to **non-Claude agents
+only**. Claude detection consumes the full active screen, and the Debug canonical-tail
+assert on `AgentScreenSnapshot` was replaced by a single production construction seam.
+
+## Problem
+
+Two bottom-measured budgets could each cut the live signal off:
+
+1. The shared detector tail (`agentDetectionRecentText`, 24 non-empty lines from the
+   bottom). On a Claude screen the bottom is fixed chrome — composer, multi-line
+   statusline — plus the todo block under the spinner row. Past ~16 todo lines the
+   spinner fell out of the window and a working agent read as idle
+   (`claude.idleComposer`).
+2. The live status region itself, previously `claudeLogicalRows(above prompt).suffix(3)`.
+   The committed 2.1.223 `foreground-spinner` fixture already had zero slack (spinner,
+   queued `❯` message, `◉ xhigh · /effort`): one more queued message or `⎿ Tip:` row
+   displaced the spinner even with the tail removed.
+
+Both are the same defect: bounding a region the TUI sizes dynamically by a fixed count
+measured from the bottom.
+
+## Fix
+
+- `DetectedAgent.detectionScreenText(from:)` forks the slice policy: Claude gets the
+  full active screen (naturally bounded by terminal height via `GHOSTTY_POINT_ACTIVE`);
+  every other agent keeps the bounded tail as its guard against transcript history.
+- `DetectedAgent.detectionSnapshot(from:)` is the one production entry point for
+  building a profile snapshot, so state detection and blocker extraction always read
+  the same slice (`detectScreen` and the `agents read` CLI path both go through it).
+- The Claude live status region is bounded by **shape, not count**
+  (`ClaudeScreenRegions.liveStatusBlock`): logical rows above the composer are taken
+  bottom-up while they look like live chrome — spinner-scalar heads, `●` status rows,
+  `⎿` attachments, queued `❯` messages, todo checkboxes — and the scan stops at the
+  first transcript-shaped row (`⏺` blocks, `◯` rows, prose, borders).
+
+The stop condition is what replaces the tail's false-positive guard: a status row
+quoted inside a `⏺` block or prose sits above a non-chrome row, so the walk never
+reaches it. Known residual (accepted, present in every prior version too): a quoted
+status row that is itself the bottom-most logical row above the composer — with only
+chrome-shaped rows below it — still reads as live. Rules stay strict (`…` + complete
+elapsed segment), so completed rows like `✻ Crunched for 7s` never match.
+
+## Codex
+
+Codex's structured profile is region-anchored like Claude's and shares the
+bounded-bottom exposure in principle (its working footer has zero slack; a ~17-line
+approval dialog can push the question out of the tail). It keeps the tail until its
+regions are bounded by shape the same way; the `detectionScreenText` doc comment
+records this, and `detectionScreenTextSlicesPerAgent` pins the current asymmetry.
+
+## Corpus contract
+
+- Claude fixtures are full active screens: commit captures as read, never trimmed
+  (trimming can delete the row above the window that reproduces the bug). The corpus
+  check enforces the one mechanical invariant — line count ≤ captured terminal rows.
+- Non-Claude fixtures remain exact `agentDetectionRecentText` tails, checked as before.
+- The existing 2.1.22x Claude fixtures predate this change and are tail-shaped; they
+  stay valid as detector inputs (the detector accepts any screen) but new Claude
+  captures must be full screens. Capture step 6 in the fixture README describes the
+  per-agent reduction.

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -33,11 +33,17 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
 1. **Process probe.** Prowl reads the pane's foreground process group and matches
    process names / argv against known agent executables, scoring argv[0] highest,
    then process name, then command-line tokens.
-2. **Screen heuristics.** It starts from the last ~24 non-blank lines, then selects
+2. **Screen heuristics.** Claude detection consumes the full active screen (bounded
+   by the terminal height); every other agent starts from the last ~24 non-blank
+   lines as a guard against transcript history. The classifier then selects
    agent-specific live UI regions rather than treating every transcript line as current
    state. Structured confirmation/permission chrome is **Blocked**; status rows and
-   spinners are **Working**. Claude working rows are scoped to the lines immediately above
-   its prompt box, while confirmation text is consulted only around a current numbered
+   spinners are **Working**. Claude working rows come from a live status block walked
+   bottom-up from its prompt box by row shape — the spinner or `●` status row, `⎿`
+   attachments such as todo lists and tips, queued `❯` messages, and right-aligned
+   chrome — stopping at the first transcript-shaped row, so a long todo list cannot
+   push the live row out of view and a status row quoted inside a `⏺` block cannot
+   read as live. Confirmation text is consulted only around a current numbered
    selection row such as `❯ 1. Yes`; a bare input prompt cuts off the preceding transcript.
    Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to interrupt)` footer
    fallback. Its confirmation detector requires a numbered selected row such as `› 1. Yes`

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -589,11 +589,11 @@ struct SupacodeApp: App {
     }
 
     let detection = detectedAgent.detectScreen(in: activeText)
-    let canonicalScreen = AgentScreenSnapshot(text: detectedAgent.detectionScreenText(from: activeText))
+    let detectorScreen = detectedAgent.detectionSnapshot(from: activeText)
     let blockerText: String? =
       switch detectedAgent {
-      case .codex: CodexScreenProfile.blockerText(in: canonicalScreen)
-      case .claude: ClaudeScreenProfile.blockerText(in: canonicalScreen)
+      case .codex: CodexScreenProfile.blockerText(in: detectorScreen)
+      case .claude: ClaudeScreenProfile.blockerText(in: detectorScreen)
       default: nil
       }
     if detection.state == .blocked, blockerText == nil {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -589,7 +589,7 @@ struct SupacodeApp: App {
     }
 
     let detection = detectedAgent.detectScreen(in: activeText)
-    let canonicalScreen = AgentScreenSnapshot(canonicalText: agentDetectionRecentText(activeText))
+    let canonicalScreen = AgentScreenSnapshot(text: detectedAgent.detectionScreenText(from: activeText))
     let blockerText: String? =
       switch detectedAgent {
       case .codex: CodexScreenProfile.blockerText(in: canonicalScreen)

--- a/supacode/Domain/AgentDetection/AgentScreenSnapshot.swift
+++ b/supacode/Domain/AgentDetection/AgentScreenSnapshot.swift
@@ -3,8 +3,10 @@ struct AgentScreenSnapshot: Equatable, Sendable {
   let lines: [String]
 
   /// `text` must be the exact detector input for the agent consuming this
-  /// snapshot — produce it with `DetectedAgent.detectionScreenText(from:)` so
-  /// state detection and blocker extraction always read the same screen.
+  /// snapshot. Production call sites go through
+  /// `DetectedAgent.detectionSnapshot(from:)` so state detection and blocker
+  /// extraction always read the same slice; constructing one directly is for
+  /// tests feeding already-sliced synthetic screens.
   nonisolated init(text: String) {
     self.text = text
     self.lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)

--- a/supacode/Domain/AgentDetection/AgentScreenSnapshot.swift
+++ b/supacode/Domain/AgentDetection/AgentScreenSnapshot.swift
@@ -2,12 +2,11 @@ struct AgentScreenSnapshot: Equatable, Sendable {
   let text: String
   let lines: [String]
 
-  nonisolated init(canonicalText: String) {
-    assert(
-      canonicalText == agentDetectionRecentText(canonicalText),
-      "AgentScreenSnapshot requires canonical detector-tail text."
-    )
-    self.text = canonicalText
-    self.lines = canonicalText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  /// `text` must be the exact detector input for the agent consuming this
+  /// snapshot — produce it with `DetectedAgent.detectionScreenText(from:)` so
+  /// state detection and blocker extraction always read the same screen.
+  nonisolated init(text: String) {
+    self.text = text
+    self.lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
   }
 }

--- a/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
@@ -203,14 +203,22 @@ private struct ClaudeScreenRegions: Sendable {
     )
     self.currentInteractionLines = currentInteractionLines
     self.currentInteractionLower = currentInteractionLines.joined(separator: "\n").lowercased()
-    // Reconstruct rows before limiting the region. Counting the limit in physical
-    // lines drops the head of any row that wraps onto three or more continuations,
+    // Reconstruct rows before selecting the region. Counting in physical lines
+    // drops the head of any row that wraps onto three or more continuations,
     // and the head is what carries the "●" or spinner glyph the rules key on.
     // Widths that narrow are reachable: a surface can be as few as five columns.
-    self.liveStatus = claudeLogicalRows(
-      Self.contentAbovePrompt(screenLines: lines, promptIndex: promptIndex)
+    //
+    // The block is then bounded by shape, not by count. The TUI paints live
+    // status as a trailing run of chrome-headed rows directly above the
+    // composer, so rows are taken bottom-up while they keep that shape. A
+    // fixed row count put an upper bound on the block — one extra queued "❯"
+    // message or "⎿" tip row displaced the live spinner and a working agent
+    // read as idle — while stopping at the first transcript-shaped row keeps
+    // a status row quoted inside a "⏺" block or prose from matching now that
+    // Claude detection reads the full active screen.
+    self.liveStatus = Self.liveStatusBlock(
+      claudeLogicalRows(Self.contentAbovePrompt(screenLines: lines, promptIndex: promptIndex))
     )
-    .suffix(3)
     .joined(separator: "\n")
     self.belowPromptLines = Self.contentBelowPrompt(screenLines: lines, promptIndex: promptIndex)
       .split(separator: "\n", omittingEmptySubsequences: false)
@@ -220,6 +228,14 @@ private struct ClaudeScreenRegions: Sendable {
     self.bottomChromeLines = Array(nonEmptyLines.suffix(3))
     self.bottomViewerLines = Array(nonEmptyLines.suffix(5))
     self.hasIdleComposer = Self.hasIdleComposer(screenLines: lines, promptIndex: promptIndex)
+  }
+
+  nonisolated private static func liveStatusBlock(_ rows: [String]) -> ArraySlice<String> {
+    var start = rows.endIndex
+    while start > rows.startIndex, isClaudeLiveChromeRow(rows[start - 1]) {
+      start -= 1
+    }
+    return rows[start...]
   }
 
   nonisolated private static func currentInteractionLines(
@@ -315,6 +331,18 @@ nonisolated private func claudeRowStartsNewRow(_ trimmed: String) -> Bool {
   guard let first = trimmed.unicodeScalars.first else { return false }
   if isAgentSpinnerScalar(first) { return true }
   return "●⏺◯⎿❯─-".unicodeScalars.contains(first)
+}
+
+// Rows the TUI paints below the transcript while a turn is live: the spinner
+// or "●" status row, "⎿" attachments (todo lists, tips), queued "❯" messages,
+// todo checkboxes when they surface as their own rows, and right-aligned
+// chrome such as "◉ xhigh · /effort" (whose head is a spinner scalar). "⏺"
+// transcript blocks, "◯" agent-switcher rows, prose, and borders end the live
+// block: everything above them is history, however status-shaped it looks.
+nonisolated private func isClaudeLiveChromeRow(_ row: String) -> Bool {
+  guard let first = row.unicodeScalars.first else { return false }
+  if isAgentSpinnerScalar(first) { return true }
+  return "●⎿❯◻☐✔✘".unicodeScalars.contains(first)
 }
 
 nonisolated private func isClaudeNumberedSelectionLine(_ line: String) -> Bool {

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -7,8 +7,21 @@ extension DetectedAgent {
     detectScreen(in: screen).state
   }
 
+  /// The slice of the active screen this agent's detector consumes.
+  ///
+  /// Claude reads the full active screen: its rules are all region-anchored
+  /// (live status from the last rows above the composer, blockers from around
+  /// the prompt, chrome from the bottom lines), while the shared recent-line
+  /// tail is measured from the bottom — a long todo list plus a multi-line
+  /// status line pushes the live spinner row past the limit and a working
+  /// agent reads as idle. Every other detector matches with whole-text scans,
+  /// so the bounded tail stays on as their guard against transcript history.
+  nonisolated func detectionScreenText(from screen: String) -> String {
+    self == .claude ? screen : agentDetectionRecentText(screen)
+  }
+
   nonisolated func detectScreen(in screen: String) -> AgentScreenDetection {
-    let text = agentDetectionRecentText(screen)
+    let text = detectionScreenText(from: screen)
     let state: AgentRawState
     switch self {
     case .pi:
@@ -16,9 +29,9 @@ extension DetectedAgent {
     case .omp:
       state = detectOMP(text)
     case .claude:
-      return ClaudeScreenProfile.detect(in: AgentScreenSnapshot(canonicalText: text))
+      return ClaudeScreenProfile.detect(in: AgentScreenSnapshot(text: text))
     case .codex:
-      return CodexScreenProfile.detect(in: AgentScreenSnapshot(canonicalText: text))
+      return CodexScreenProfile.detect(in: AgentScreenSnapshot(text: text))
     case .gemini:
       state = detectGemini(text)
     case .cursor:

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -9,15 +9,28 @@ extension DetectedAgent {
 
   /// The slice of the active screen this agent's detector consumes.
   ///
-  /// Claude reads the full active screen: its rules are all region-anchored
-  /// (live status from the last rows above the composer, blockers from around
-  /// the prompt, chrome from the bottom lines), while the shared recent-line
-  /// tail is measured from the bottom — a long todo list plus a multi-line
-  /// status line pushes the live spinner row past the limit and a working
-  /// agent reads as idle. Every other detector matches with whole-text scans,
-  /// so the bounded tail stays on as their guard against transcript history.
+  /// Claude reads the full active screen: its rules are region-anchored (the
+  /// live status block is walked bottom-up from the composer by row shape,
+  /// blockers around the prompt, viewer chrome from the bottom lines), so a
+  /// bottom-measured line budget added no false-positive guard — it only cut
+  /// the live signal off when a long todo list plus a multi-line status line
+  /// pushed the spinner row past the limit and a working agent read as idle.
+  ///
+  /// Every other detector keeps the bounded tail as its guard against
+  /// transcript history. For the legacy scanners the tail is load-bearing —
+  /// they match with whole-text scans. Codex's structured profile anchors
+  /// its windows inside the tail instead; it shares Claude's bounded-bottom
+  /// exposure in principle and keeps the tail until its regions are bounded
+  /// by shape the same way.
   nonisolated func detectionScreenText(from screen: String) -> String {
     self == .claude ? screen : agentDetectionRecentText(screen)
+  }
+
+  /// The one production entry point for building a profile snapshot. State
+  /// detection and blocker extraction must read the same slice; going through
+  /// this keeps a call site from pairing a profile with the wrong one.
+  nonisolated func detectionSnapshot(from screen: String) -> AgentScreenSnapshot {
+    AgentScreenSnapshot(text: detectionScreenText(from: screen))
   }
 
   nonisolated func detectScreen(in screen: String) -> AgentScreenDetection {

--- a/supacodeTests/AgentScreenFixtureCorpusTests.swift
+++ b/supacodeTests/AgentScreenFixtureCorpusTests.swift
@@ -67,8 +67,8 @@ struct AgentScreenFixtureCorpusTests {
     #expect(!fixtures.isEmpty, "The captured screen corpus must not be empty.")
     for fixture in fixtures {
       #expect(
-        fixture.text == AgentScreenFixtureCorpus.canonicalTail(fixture.text),
-        "Fixture is not the canonical 24-non-empty-line detector tail: \(fixture.relativePath)"
+        fixture.text == fixture.agent.detectionScreenText(from: fixture.text),
+        "Fixture is not the exact detector input for its agent: \(fixture.relativePath)"
       )
 
       let actualState = fixture.agent.detectState(in: fixture.text)
@@ -146,10 +146,6 @@ enum AgentScreenFixtureCorpus {
       )
     }
     return fixtures
-  }
-
-  static func canonicalTail(_ content: String) -> String {
-    agentDetectionRecentText(content)
   }
 
   private static func loadFixture(at screenURL: URL, root: URL) throws -> AgentScreenFixture {

--- a/supacodeTests/AgentScreenFixtureCorpusTests.swift
+++ b/supacodeTests/AgentScreenFixtureCorpusTests.swift
@@ -66,10 +66,24 @@ struct AgentScreenFixtureCorpusTests {
 
     #expect(!fixtures.isEmpty, "The captured screen corpus must not be empty.")
     for fixture in fixtures {
-      #expect(
-        fixture.text == fixture.agent.detectionScreenText(from: fixture.text),
-        "Fixture is not the exact detector input for its agent: \(fixture.relativePath)"
-      )
+      // The corpus must hold exact production detector inputs. For agents
+      // that consume the bounded tail this is checkable directly; for Claude
+      // the tail check is x == x, so the enforceable invariant is that a
+      // full-active-screen capture cannot exceed the captured viewport.
+      if fixture.agent == .claude {
+        let lineCount = fixture.text
+          .split(separator: "\n", omittingEmptySubsequences: false)
+          .count
+        #expect(
+          lineCount <= fixture.metadata.terminal.rows,
+          "Claude fixtures are full screens and cannot exceed the captured terminal rows: \(fixture.relativePath)"
+        )
+      } else {
+        #expect(
+          fixture.text == fixture.agent.detectionScreenText(from: fixture.text),
+          "Fixture is not the exact detector input for its agent: \(fixture.relativePath)"
+        )
+      }
 
       let actualState = fixture.agent.detectState(in: fixture.text)
       let mismatchMessage =

--- a/supacodeTests/ClaudeScreenProfileTests.swift
+++ b/supacodeTests/ClaudeScreenProfileTests.swift
@@ -114,15 +114,16 @@ struct ClaudeScreenProfileTests {
   }
 
   @Test func spinnerAboveLongTodoListStaysWorking() {
-    // Regression: the shared recent-line tail is measured from the bottom of the
-    // screen, so a long todo list plus the composer and a multi-line status line
-    // pushed the live spinner row out of the detector window and a working agent
-    // was reported idle (via the idle-composer rule).
+    // Regression: a bottom-measured line budget (the shared recent-line tail)
+    // let a long todo list plus the composer and a multi-line status line push
+    // the live spinner row out of the detector window, so a working agent was
+    // reported idle via the idle-composer rule. The todo block is sized from
+    // the tail limit so this screen keeps overflowing it if the limit moves.
     var lines = [
       "✻ Implementing hybridTopK… (5m 5s · ↓ 21.1k tokens)",
       "  ⎿ \u{00A0}✔ Write failing tests for hybridTopK and per-scope pickCandidates",
     ]
-    for index in 2...16 {
+    for index in 2...(agentDetectionRecentLineLimit + 2) {
       lines.append("     ◻ Todo item number \(index) still pending")
     }
     lines.append(
@@ -137,11 +138,66 @@ struct ClaudeScreenProfileTests {
         "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents",
       ]
     )
+    let nonBlankCount = lines.count { $0.contains { !$0.isWhitespace } }
+    #expect(nonBlankCount > agentDetectionRecentLineLimit)
 
     let detection = DetectedAgent.claude.detectScreen(in: lines.joined(separator: "\n"))
 
     #expect(detection.state == .working)
     #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.spinner))
+  }
+
+  @Test func spinnerAboveQueuedMessagesAndTipStaysWorking() {
+    // The live status block is bounded by row shape, not by a fixed row
+    // count: a "⎿" tip attachment, queued "❯" messages, and the right-aligned
+    // effort chrome all belong to the block and must not displace the spinner.
+    let text = """
+      ⏺ Running 1 shell command…
+        ⎿  $ touch permission-probe.txt
+
+      ✻ Slithering… (16s · ↓ 21.1k tokens)
+        ⎿  Tip: Use ctrl+v to paste images from your clipboard
+
+        ❯ Run the shell command `sleep 8`, then reply exactly DONE.
+        ❯ Then summarize the diff in one line.
+                                                        ◉ xhigh · /effort
+      ──────────────────────────────────────────
+      ❯ Press up to edit queued messages
+      ──────────────────────────────────────────
+      """
+
+    let detection = DetectedAgent.claude.detectScreen(in: text)
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.spinner))
+  }
+
+  @Test func spinnerQuotedAboveTranscriptBlockStaysIdle() {
+    // A status row quoted in the transcript sits above a "⏺" block head. The
+    // live block scan stops at that head, so reading the full active screen
+    // must not resurrect the quoted spinner as live activity.
+    var lines = [
+      "✻ Tempering… (12s · esc to interrupt)",
+      "",
+      "⏺ Here is the analysis:",
+    ]
+    lines.append(contentsOf: (1...20).map { "    analysis detail line \($0)" })
+    lines.append(
+      contentsOf: [
+        "",
+        "✻ Crunched for 7s",
+        "",
+        "──────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────",
+        "  ⏸ manual mode on · ← for agents",
+      ]
+    )
+
+    let detection = DetectedAgent.claude.detectScreen(in: lines.joined(separator: "\n"))
+
+    #expect(detection.state == .idle)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.idleComposer))
   }
 
   @Test func unstructuredScreenUsesExplicitFallback() {

--- a/supacodeTests/ClaudeScreenProfileTests.swift
+++ b/supacodeTests/ClaudeScreenProfileTests.swift
@@ -57,7 +57,7 @@ struct ClaudeScreenProfileTests {
   @Test func elapsedAndBackgroundWorkHaveDistinctReasons() {
     let elapsed = ClaudeScreenProfile.detect(
       in: AgentScreenSnapshot(
-        canonicalText: """
+        text: """
             ● Forging… (10s · thinking with high effort)
             ─────────
             ❯
@@ -70,7 +70,7 @@ struct ClaudeScreenProfileTests {
 
     let background = ClaudeScreenProfile.detect(
       in: AgentScreenSnapshot(
-        canonicalText: """
+        text: """
             Task complete.
             ─────────
             ❯
@@ -86,7 +86,7 @@ struct ClaudeScreenProfileTests {
   @Test func blockerOutranksRetainedSpinner() {
     let detection = ClaudeScreenProfile.detect(
       in: AgentScreenSnapshot(
-        canonicalText: """
+        text: """
             ✻ Tempering… (12s · esc to interrupt)
             Do you want to proceed?
             ❯ 1. Yes
@@ -105,7 +105,7 @@ struct ClaudeScreenProfileTests {
       .first { $0.relativePath == "claude/2.1.223/blocked/command-permission.txt" }
     let text = try #require(fixture).text
 
-    let blocker = ClaudeScreenProfile.blockerText(in: AgentScreenSnapshot(canonicalText: text))
+    let blocker = ClaudeScreenProfile.blockerText(in: AgentScreenSnapshot(text: text))
 
     #expect(blocker?.contains("Do you want to proceed?") == true)
     #expect(blocker?.contains("❯ 1. Yes") == true)
@@ -113,9 +113,40 @@ struct ClaudeScreenProfileTests {
     #expect(blocker?.contains("Esc to cancel · Tab to amend · ctrl+e to explain") == true)
   }
 
+  @Test func spinnerAboveLongTodoListStaysWorking() {
+    // Regression: the shared recent-line tail is measured from the bottom of the
+    // screen, so a long todo list plus the composer and a multi-line status line
+    // pushed the live spinner row out of the detector window and a working agent
+    // was reported idle (via the idle-composer rule).
+    var lines = [
+      "✻ Implementing hybridTopK… (5m 5s · ↓ 21.1k tokens)",
+      "  ⎿ \u{00A0}✔ Write failing tests for hybridTopK and per-scope pickCandidates",
+    ]
+    for index in 2...16 {
+      lines.append("     ◻ Todo item number \(index) still pending")
+    }
+    lines.append(
+      contentsOf: [
+        "──────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────",
+        "  [Fable 5 | Enterprise] ██░░░░░░░░ 16% | will git:(master*)",
+        "  ███░░░░░░░ 34% (4h 3m / 5h) | ███░░░░░░░ 29% (4d 19h / 7d)",
+        "  ✓ Bash ×7 | ✓ Read ×6 | ✓ Edit ×5",
+        "  ▸ Implement hybridTopK in similarity.ts (2/16)",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents",
+      ]
+    )
+
+    let detection = DetectedAgent.claude.detectScreen(in: lines.joined(separator: "\n"))
+
+    #expect(detection.state == .working)
+    #expect(detection.reason == .matched(ClaudeScreenProfile.RuleID.spinner))
+  }
+
   @Test func unstructuredScreenUsesExplicitFallback() {
     let detection = ClaudeScreenProfile.detect(
-      in: AgentScreenSnapshot(canonicalText: "screen without live Claude chrome")
+      in: AgentScreenSnapshot(text: "screen without live Claude chrome")
     )
 
     #expect(detection.state == .idle)

--- a/supacodeTests/CodexScreenProfileTests.swift
+++ b/supacodeTests/CodexScreenProfileTests.swift
@@ -58,7 +58,7 @@ struct CodexScreenProfileTests {
 
     for fixture in fixtures {
       let blocker = CodexScreenProfile.blockerText(
-        in: AgentScreenSnapshot(text: agentDetectionRecentText(fixture.text))
+        in: DetectedAgent.codex.detectionSnapshot(from: fixture.text)
       )
 
       #expect(blocker != nil)
@@ -75,7 +75,7 @@ struct CodexScreenProfileTests {
     )
 
     let blocker = CodexScreenProfile.blockerText(
-      in: AgentScreenSnapshot(text: agentDetectionRecentText(fixture.text))
+      in: DetectedAgent.codex.detectionSnapshot(from: fixture.text)
     )
 
     #expect(blocker == nil)
@@ -83,9 +83,8 @@ struct CodexScreenProfileTests {
 
   @Test func blockerTextKeepsQuestionAboveLongWrappedInteraction() {
     let filler = (1...14).map { "  wrapped command detail \($0)" }.joined(separator: "\n")
-    let snapshot = AgentScreenSnapshot(
-      text: agentDetectionRecentText(
-        """
+    let snapshot = DetectedAgent.codex.detectionSnapshot(
+      from: """
         Historical output that must not be returned.
 
           Would you like to run the following command?
@@ -95,7 +94,6 @@ struct CodexScreenProfileTests {
 
           Press enter to confirm or esc to cancel
         """
-      )
     )
 
     let blocker = CodexScreenProfile.blockerText(in: snapshot)
@@ -110,7 +108,7 @@ struct CodexScreenProfileTests {
       .first { $0.relativePath == "codex/0.146.1/blocked/command-permission.txt" }
     let text = try #require(fixture).text
 
-    let blocker = CodexScreenProfile.blockerText(in: AgentScreenSnapshot(text: text))
+    let blocker = CodexScreenProfile.blockerText(in: DetectedAgent.codex.detectionSnapshot(from: text))
 
     #expect(blocker?.contains("Would you like to run the following command?") == true)
     #expect(blocker?.contains("Environment: local") == true)

--- a/supacodeTests/CodexScreenProfileTests.swift
+++ b/supacodeTests/CodexScreenProfileTests.swift
@@ -39,7 +39,7 @@ struct CodexScreenProfileTests {
   @Test func structuredChoicesExplainBlockedWithoutAFooter() {
     let detection = CodexScreenProfile.detect(
       in: AgentScreenSnapshot(
-        canonicalText: """
+        text: """
             Would you like to run the following command?
           › 1. Yes, proceed
             2. No, cancel
@@ -58,7 +58,7 @@ struct CodexScreenProfileTests {
 
     for fixture in fixtures {
       let blocker = CodexScreenProfile.blockerText(
-        in: AgentScreenSnapshot(canonicalText: agentDetectionRecentText(fixture.text))
+        in: AgentScreenSnapshot(text: agentDetectionRecentText(fixture.text))
       )
 
       #expect(blocker != nil)
@@ -75,7 +75,7 @@ struct CodexScreenProfileTests {
     )
 
     let blocker = CodexScreenProfile.blockerText(
-      in: AgentScreenSnapshot(canonicalText: agentDetectionRecentText(fixture.text))
+      in: AgentScreenSnapshot(text: agentDetectionRecentText(fixture.text))
     )
 
     #expect(blocker == nil)
@@ -84,7 +84,7 @@ struct CodexScreenProfileTests {
   @Test func blockerTextKeepsQuestionAboveLongWrappedInteraction() {
     let filler = (1...14).map { "  wrapped command detail \($0)" }.joined(separator: "\n")
     let snapshot = AgentScreenSnapshot(
-      canonicalText: agentDetectionRecentText(
+      text: agentDetectionRecentText(
         """
         Historical output that must not be returned.
 
@@ -110,7 +110,7 @@ struct CodexScreenProfileTests {
       .first { $0.relativePath == "codex/0.146.1/blocked/command-permission.txt" }
     let text = try #require(fixture).text
 
-    let blocker = CodexScreenProfile.blockerText(in: AgentScreenSnapshot(canonicalText: text))
+    let blocker = CodexScreenProfile.blockerText(in: AgentScreenSnapshot(text: text))
 
     #expect(blocker?.contains("Would you like to run the following command?") == true)
     #expect(blocker?.contains("Environment: local") == true)

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -32,9 +32,15 @@ derived from `idle + unseen` and is never a fixture state.
 4. Keep the raw response under the ignored `.local/agent-screen-captures/` directory.
 5. Record exact CLI version, capture timestamp, terminal rows/columns, and the redaction
    summary in a same-basename metadata file.
-6. Reduce the capture with the production `agentDetectionRecentText` helper: start at
-   the 24th non-empty line from the bottom when at least 24 exist; otherwise retain the
-   whole screen. Keep blank lines and trailing screen rows inside that window.
+6. Reduce the capture to the exact production detector input for the agent
+   (`DetectedAgent.detectionScreenText(from:)`):
+   - `claude` consumes the full active screen. Commit the capture as read, without
+     trimming; it must not exceed the terminal rows recorded in metadata. Trimming a
+     Claude capture can delete the very row above the window that reproduces a bug.
+   - Every other agent consumes the bounded tail produced by the production
+     `agentDetectionRecentText` helper: start at the 24th non-empty line from the
+     bottom when at least 24 exist; otherwise retain the whole screen. Keep blank
+     lines and trailing screen rows inside that window.
 7. Redact paths, repositories, account identifiers, and all real-session prompts/model
    output without changing runtime chrome, line ordering, markers, wrapping, or blank-line
    boundaries. Deliberately scripted probe interactions from disposable workspaces may

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -8,6 +8,18 @@ struct ScreenHeuristicsTests {
     #expect(agent?.detectState(in: "Working...") ?? .unknown == .unknown)
   }
 
+  @Test func detectionScreenTextSlicesPerAgent() {
+    // Pin the slice asymmetry: Claude consumes the full active screen, every
+    // other detector consumes the bounded tail. Widening the full-screen
+    // branch to a whole-text scanner must fail here, not ship silently.
+    let screen = (1...(agentDetectionRecentLineLimit * 2)).map { "line \($0)" }.joined(separator: "\n")
+
+    #expect(DetectedAgent.claude.detectionScreenText(from: screen) == screen)
+    #expect(DetectedAgent.codex.detectionScreenText(from: screen) == agentDetectionRecentText(screen))
+    #expect(DetectedAgent.codex.detectionScreenText(from: screen) != screen)
+    #expect(DetectedAgent.gemini.detectionScreenText(from: screen) == agentDetectionRecentText(screen))
+  }
+
   @Test func piDetection() {
     #expect(DetectedAgent.pi.detectState(in: "Working...") == .working)
     #expect(DetectedAgent.pi.detectState(in: "⠹ Working...") == .working)


### PR DESCRIPTION
## Problem

A Claude session showing a strong working signal (a live `✻ Implementing…` spinner row) can be reported as **Idle**.

The shared detector tail (`agentDetectionRecentText`) keeps only the last 24 non-empty screen lines, measured from the bottom. On a Claude screen the bottom is occupied by fixed chrome — the composer (3 lines) and a multi-line statusline (e.g. claude-hud, 5 lines) — plus the todo list rendered under the spinner row. Once the todo block grows past ~16 lines, the spinner row falls out of the window, no working rule can see it, and the idle-composer rule wins: a working agent reads as idle until the todo block shrinks.

This is the remaining sibling of the family fixed by d4caf058 ("Assemble live status rows before limiting the region"): that commit fixed the inner 3-row live-status window against todo blocks; the outer 24-line pre-truncation had the same failure mode left.

## Fix

Make the detector tail per-agent (`DetectedAgent.detectionScreenText(from:)`):

- **Claude** consumes the full active screen. Its rules are all region-anchored — live status from the last logical rows above the composer, blockers from around the prompt, viewer chrome from the bottom lines — so the bounded tail added no false-positive protection there, only the risk of cutting the live signal off. The active screen is naturally bounded by the terminal height.
- **Every other detector** keeps the bounded 24-line tail: they match with whole-text scans, where the tail is the guard against transcript history.

`AgentScreenSnapshot` now takes the exact detector input (`init(text:)`) instead of asserting the global 24-line canonical form, and the `agents read` snapshot path uses the same per-agent entry point so state detection and blocker extraction always read the same screen.

## Verification

- New regression test `spinnerAboveLongTodoListStaysWorking` (red before the fix: reported `idle/claude.idleComposer`; green after).
- All agent-detection suites pass: ClaudeScreenProfileTests, CodexScreenProfileTests, AgentScreenFixtureCorpusTests, AgentScreenDetectionTests, AgentScreenRuleCoverageTests, AgentScreenScanCacheTests, ClaudeBackgroundAgentDetectionTests, DetectedAgentTests, PaneAgentStateTests.
- Verified against a real captured screen: the reported sample stays `working/claude.spinner`, 16+-item todo variants flip from `idle/claude.idleComposer` to `working/claude.spinner`, and a genuinely finished session still reads `idle`.
- `make check` and `make build-app` pass.
