### PR TITLE
Group notification update controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Reducer ← .terminalEvent(Event) ← AsyncStream<Event>
 - Use `@ObservableState` for TCA feature state; use `@Observable` for non-TCA shared stores; never `ObservableObject`
 - Always mark `@Observable` classes with `@MainActor`
 - Modern SwiftUI only: `foregroundStyle()`, `NavigationStack`, `Button` over `onTapGesture()`
+- Before changing a window toolbar control, its grouping, or Liquid Glass, read `docs-ai/061-native-toolbar-controls/toolbar-controls.md` and perform a Debug visual verification.
 - When a new logic changes in the Reducer, always add tests
 - In unit tests, never use `Task.sleep`; use `TestClock` (or an injected clock) and drive time with `advance`.
 - Prefer Swift-native APIs over Foundation where they exist (e.g., `replacing()` not `replacingOccurrences()`)

--- a/docs-ai/058-unified-toolbar-layout/000-plan.md
+++ b/docs-ai/058-unified-toolbar-layout/000-plan.md
@@ -113,3 +113,5 @@ direction while hardening its implementation:
 - Remove the notifications style branch and share leading-control metrics between Agents and Bell.
 - Restore rename prompt submit/tooltip semantics and advertise the configurable shortcut from the context menu.
 - Verify the reported first-focus timing risk at runtime before changing it; do not add speculative focus workarounds.
+
+- Updated 2026-08-17: Grouped the conditional update indicator with Bell in the leading cluster — see [002-notification-update-group.md](002-notification-update-group.md).

--- a/docs-ai/058-unified-toolbar-layout/001-action.md
+++ b/docs-ai/058-unified-toolbar-layout/001-action.md
@@ -17,13 +17,15 @@
   `.toolbar(removing: .title)`, preserving `WindowTitle.compute(...)` for window identity
   without rendering a toolbar title. `AgentNotificationsToolbarContent` is the shared
   leading composition for all three view modes.
-- Agents and Quick Launch remain a native shared-glass group. The bell follows in a
-  separate `.navigation` item with `.sharedBackgroundVisibility(.hidden)` so it keeps the
-  visual gap that previously separated Agents from the branch title.
-- `supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift` now has
-  one unconditional standalone-capsule presentation. Agents, Quick Launch, and Bell share
-  `LeadingToolbarControlMetrics`; the dead style branch and duplicated label metrics are
-  gone. Notification count, hover, click, and read-state behavior are unchanged.
+- Agents and Quick Launch remain a native shared-glass group. Bell and the conditional update
+  indicator follow in a separate leading capsule, preserving the visual gap that previously
+  separated Agents from the branch title. The implementation is centralized in
+  `AgentNotificationsToolbarContent`; see [002-notification-update-group.md](002-notification-update-group.md).
+- `supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift` and
+  `ToolbarUpdateButton.swift` retain their original button-owned tint, tooltip, accessibility,
+  and interaction behavior. The isolated owner supplies the shared capsule; see
+  [061 Native Toolbar Controls](../061-native-toolbar-controls/toolbar-controls.md) for the
+  documented macOS 26 exception and review standard.
 - Normal, Shelf, and Canvas receive one assembled `ToolbarSharedState`; only their documented
   `ToolbarContent` structure differs. Canvas resolves the Agents capsule and profile launcher
   from the focused card. With no focused card, Quick Launch/profile rows are omitted instead
@@ -57,7 +59,7 @@
 - `make check`: changed-file formatting, strict `swift-format` lint, and SwiftLint passed.
 - `make build-app`: Debug build passed with zero errors and zero warnings.
 - Live Debug app inspection:
-  - Normal: no branch item; Agents + Quick Launch and Bell render as separate capsules.
+  - Normal: no branch item; Agents + Quick Launch render separately from the Bell + update capsule.
   - Canvas: no visible `Canvas` title; the same leading controls render against the
     focused-card toolbar.
   - Shelf: the same leading order and separation are retained.
@@ -72,8 +74,8 @@
 ## Deviations from plan
 
 - The initial shared-layout implementation placed Bell inside the Agents shared-glass
-  group. During live review, the desired separation was clarified: Bell now uses a
-  standalone glass capsule with the same gap as the removed branch item.
+  group. During live review, the desired separation was clarified: Bell and the conditional
+  update indicator now share a standalone capsule with the same gap as the removed branch item.
 - Removing the toolbar anchor required the rename form to move from a popover to an
   app-level sheet. The form and reducer request model remain intact.
 - Adding Agents to Canvas exposed that Hand Off still resolved only

--- a/docs-ai/058-unified-toolbar-layout/002-notification-update-group.md
+++ b/docs-ai/058-unified-toolbar-layout/002-notification-update-group.md
@@ -1,0 +1,25 @@
+# 058.002 — Notification and Update Group
+
+## Context
+
+Moving the notification bell into the leading orchestration cluster left the background-update
+indicator in the trailing toolbar. The two related controls no longer read as a group.
+
+## Change
+
+`WorktreeDetailView.AgentNotificationsToolbarContent` now keeps Bell and the conditional
+`ToolbarUpdateButton` together immediately after the Agents + Quick Launch group in Normal,
+Shelf, and Canvas. The original button views retain their own tint, tooltip, accessibility, and
+popover behavior.
+
+Adjacent native navigation groups merge on macOS 26, so the bell/update pair is one isolated
+navigation item: it hides the shared toolbar background and owns one outer glass capsule. This
+keeps the pair together while retaining the visual gap after Agents. The durable implementation
+and review standard live in
+[061 Native Toolbar Controls](../061-native-toolbar-controls/toolbar-controls.md).
+
+## Current state
+
+The Command Palette Debug action **[Debug] Simulate Update Found** exposes the update indicator
+for visual verification without contacting Sparkle. `docs/components/updates.md` and
+`docs/components/notifications.md` describe the current leading toolbar behavior.

--- a/docs-ai/061-native-toolbar-controls/000-plan.md
+++ b/docs-ai/061-native-toolbar-controls/000-plan.md
@@ -1,0 +1,87 @@
+# 061 — Native Toolbar Controls: Plan
+
+| | |
+| --- | --- |
+| **Status** | Implemented |
+| **Anchor date** | 2026-08-17 |
+| **Primary PRs** | Pending |
+| **Related** | [049-agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [058-unified-toolbar-layout](../058-unified-toolbar-layout/000-plan.md), [`AGENTS.md`](../../AGENTS.md) |
+
+## Background
+
+Moving the update indicator into the leading notification cluster exposed a recurring
+failure mode in Prowl's macOS 26 toolbar work: visual grouping, placement, and Liquid
+Glass are coupled by SwiftUI's toolbar bridge, but their interactions are not obvious from
+individual view code. Iterations that substituted `ControlGroup`, restyled existing buttons,
+or attached glass to the wrong owner lost placement, colors, or the native surface.
+
+The app already contains deliberate toolbar exceptions: the shared Normal/Shelf/Canvas
+leading cluster must keep Agents separate from the notification/update cluster, and Canvas
+keeps its dynamic command controls inside one toolbar item to avoid NSToolbar insert/remove
+animation. These decisions need one current reference rather than scattered comments and
+git archaeology.
+
+## Goals
+
+- Audit every current window-toolbar control and record whether its grouping is native or a
+  deliberate exception.
+- Document the verified native SwiftUI model, including official Apple references and the
+  macOS 26 SDK API boundary.
+- Record the notification/update leading-cluster implementation and the failed approaches
+  that must not be retried.
+- Establish a short, actionable implementation and review standard for future toolbar work.
+- Make the reference mandatory before changes to toolbar controls, grouping, or Liquid Glass.
+- Correct stale toolbar comments discovered during the audit without changing verified UI
+  behavior.
+
+### Non-goals
+
+- Redesigning existing toolbar controls, their actions, or their visual hierarchy.
+- Replacing SwiftUI toolbar APIs with AppKit toolbar management.
+- General documentation for non-toolbar `glassEffect` surfaces such as HUDs, popovers, or
+  terminal tabs.
+
+## Design / Approach
+
+Create a living guide at
+`docs-ai/061-native-toolbar-controls/toolbar-controls.md` with four durable sections:
+
+1. **Official model** — `ToolbarItem`, `ToolbarItemGroup`, `ToolbarSpacer(.fixed)`, and
+   `sharedBackgroundVisibility(_:)`, linked to Apple documentation and WWDC25 guidance.
+2. **Prowl audit** — the Main, Canvas, Diff, Sidebar, and Archived Worktrees toolbars,
+   including the reason for every non-default composition.
+3. **Implementation standard** — native grouping by default; a narrowly scoped leading
+   notification/update exception that preserves the original button views and applies one
+   outer glass surface only after opting out of shared background.
+4. **Review checklist** — visual state matrix, placement/grouping checks, and explicit
+   prohibitions against replacing toolbar grouping with `ControlGroup`, nested glass, or
+   incidental button restyling.
+
+Add a focused `AGENTS.md` instruction that routes toolbar changes to the guide. Keep the
+Normal/Shelf/Canvas composition centralized in
+`WorktreeDetailView.AgentNotificationsToolbarContent`; do not create mode-specific copies.
+
+## Alternatives & decisions
+
+- **Rely only on comments in `WorktreeDetailView.swift`:** rejected. They cannot capture the
+  full audit, official API boundary, historical failure modes, and review matrix.
+- **Use `ControlGroup` as a universal replacement for `ToolbarItemGroup`:** rejected. It is a
+  view container, not toolbar content; in the observed leading-cluster case it altered
+  placement, shared surface, and label-color behavior.
+- **Use `glassEffect` for every related toolbar button:** rejected. Native toolbar grouping is
+  the default; manually layered glass is reserved for the verified isolated composite where
+  a shared toolbar group cannot remain separate from Agents.
+- **Move all toolbar composition into AppKit:** rejected. SwiftUI's native toolbar APIs cover
+  the app's current needs, and the documented exceptions are smaller and safer.
+
+## Verification
+
+- Confirm the audit covers every `ToolbarItem`, `ToolbarItemGroup`, `ToolbarSpacer`, and
+  toolbar-owned `glassEffect` in the app source.
+- Confirm the guide's Apple API claims against both official Apple documentation and the
+  installed macOS 26 SwiftUI interface.
+- Run `make check` and `make build-app`.
+- Live-inspect the Debug app's leading cluster with update simulated: Agents is separate;
+  bell and update share one capsule; unread and update accent colors remain visible.
+
+## Amendments

--- a/docs-ai/061-native-toolbar-controls/001-action.md
+++ b/docs-ai/061-native-toolbar-controls/001-action.md
@@ -1,0 +1,52 @@
+# 061 — Native Toolbar Controls: Action Log
+
+## Timeline
+
+| Date | Change | Ref |
+| --- | --- | --- |
+| 2026-08-17 | Audited every window-toolbar primitive and identified the leading notification/update and Canvas dynamic-command exceptions | Current source tree |
+| 2026-08-17 | Compared the implementation with Apple toolbar guidance and the installed macOS 26 SwiftUI interface | Apple docs / Xcode 26.6 SDK |
+| 2026-08-17 | Added the living native-toolbar control guide and required it from `AGENTS.md` | This record |
+| 2026-08-17 | Updated the leading-cluster implementation comments and corrected stale Canvas trailing-update references | `WorktreeDetailView.swift` |
+| 2026-08-17 | Amended the unified-toolbar record and user docs for the Bell + update capsule | [058.002](../058-unified-toolbar-layout/002-notification-update-group.md) |
+
+## Outcome & current state (as of 2026-08-17)
+
+- `docs-ai/061-native-toolbar-controls/toolbar-controls.md` is the normative implementation
+  map for Prowl window toolbars. It records the official SwiftUI primitives, Prowl's source
+  audit, approved exceptions, rejected approaches, and a review matrix.
+- `AGENTS.md` requires the guide and a Debug visual verification before changes to a window
+  toolbar control, its grouping, or Liquid Glass.
+- `WorktreeDetailView.AgentNotificationsToolbarContent` remains the one shared leading
+  composition for Normal, Shelf, and Canvas. Agents + Quick Launch use native
+  `ToolbarItemGroup`; the isolated Bell + conditional update capsule preserves the original
+  button views' color and behavior while remaining separate from Agents.
+- The Canvas Run/custom-command cluster remains one dynamic `ToolbarItem`; its source comment
+  now accurately describes the animation/overflow constraint without referring to a trailing
+  update control.
+- `docs-ai/058-unified-toolbar-layout` now records the current Bell + update behavior, and
+  `docs/components/notifications.md` describes the visible grouped indicator.
+
+## Verification
+
+- Source audit covered every `ToolbarItem`, `ToolbarItemGroup`, `ToolbarSpacer`,
+  `sharedBackgroundVisibility`, and toolbar-owned `glassEffect` under `supacode/Features/`.
+- Apple documentation confirmed `ToolbarItemGroup` for logical toolbar grouping,
+  `ToolbarSpacer(.fixed)` for group separation, and `sharedBackgroundVisibility(_:)` for
+  shared Liquid Glass ownership. The installed Xcode 26.6 macOS 26.5 SwiftUI interface
+  declares `ToolbarContent.sharedBackgroundVisibility(_:)` as available on macOS 26.
+- Debug visual review confirmed the final leading arrangement: Agents stays separate; Bell and
+  update share one capsule; their unread and update-accent colors remain visible.
+- `make check` and `make build-app` are run for the final change set.
+
+## Deviations from plan
+
+The leading Bell + update capsule cannot be expressed as two adjacent native navigation groups:
+the macOS 26 toolbar bridge merges those groups with Agents. The implementation therefore keeps
+the original button views inside one isolated owner with one outer glass surface. This is a
+narrow, documented exception rather than a replacement for `ToolbarItemGroup`.
+
+## Open questions
+
+- Re-verify the leading-cluster exception when upgrading the Xcode/macOS SDK: a future toolbar
+  bridge may honor a fixed navigation spacer or provide a native separate-group API.

--- a/docs-ai/061-native-toolbar-controls/toolbar-controls.md
+++ b/docs-ai/061-native-toolbar-controls/toolbar-controls.md
@@ -1,0 +1,120 @@
+# Native Toolbar Controls Guide
+
+This is the implementation and review reference for Prowl's macOS window toolbars. Read it
+before changing a toolbar button, placement, control group, `ToolbarSpacer`,
+`sharedBackgroundVisibility`, or toolbar-owned `glassEffect`.
+
+## 1. The native model
+
+| API | Owns | Standard use |
+| --- | --- | --- |
+| `ToolbarItem` | One semantic toolbar item and its placement | A single action, picker, or intentionally stable composite view. |
+| `ToolbarItemGroup` | Related toolbar items | Native group surface, per-item behavior, overflow semantics, and platform spacing. This is the default for related toolbar actions. |
+| `ToolbarSpacer(.fixed)` | Separation between unrelated toolbar groups | Use in placements where the toolbar honors it, especially trailing action clusters. |
+| `sharedBackgroundVisibility(_:)` | Whether toolbar content participates in an adjacent shared glass surface | Use `.hidden` only when the content must not merge with its neighbors. It removes the system-provided shared background. |
+| `glassEffect` | A custom view's own material | Not a replacement for `ToolbarItemGroup`. Use only when one isolated `ToolbarItem` must own a composite visual surface that native toolbar grouping cannot express. |
+
+### Official references
+
+- [Apple: ToolbarItemGroup](https://developer.apple.com/documentation/swiftui/toolbaritemgroup)
+- [Apple: sharedBackgroundVisibility(_:)](https://developer.apple.com/documentation/swiftui/toolbarcontent/sharedbackgroundvisibility(_:))
+- [Apple: Refining the system-provided Liquid Glass effect in toolbars](https://developer.apple.com/documentation/swiftui/landmarks-refining-the-system-provided-glass-effect-in-toolbars)
+- [WWDC25: Build a SwiftUI app with the new design](https://developer.apple.com/videos/play/wwdc2025/323/) — fixed toolbar spacers and hiding shared glass background
+
+The installed macOS 26 SwiftUI interface declares `ToolbarItemGroup` as `ToolbarContent` and
+exposes `ToolbarContent.sharedBackgroundVisibility(_:)` only on macOS 26+. The app's macOS
+26 deployment target satisfies that availability requirement.
+
+## 2. Prowl toolbar audit
+
+| Surface | Source | Current composition | Assessment |
+| --- | --- | --- | --- |
+| Main leading cluster (Normal, Shelf, Canvas) | `supacode/Features/Repositories/Views/WorktreeDetailView.swift` | Agents + Quick Launch use `ToolbarItemGroup(placement: .navigation)`. Bell + update use one isolated `ToolbarItem(placement: .navigation)`. | Native Agents group; verified composite exception for bell/update. |
+| Main principal status | `supacode/Features/Repositories/Views/WorktreeDetailView.swift`, `ToolbarStatusView.swift` | One `.principal` status projection. | Correct: display-only content is not an action group. |
+| Normal/Shelf trailing actions | `supacode/Features/Repositories/Views/WorktreeDetailView.swift`, `WorktreeDetailToolbarViews.swift` | Open action group, fixed spacers, Run item, inline custom-command group, overflow item. | Correct: semantic actions retain native toolbar ownership. |
+| Canvas trailing actions | `supacode/Features/Repositories/Views/WorktreeDetailView.swift` | One `.primaryAction` item with a dynamic Run/custom-command `HStack`. | Approved stability exception: changing the number of toolbar items causes NSToolbar insert/remove animation and visible overflow. |
+| Diff window | `supacode/Features/DiffView/DiffWindowContentView.swift` | Navigation sidebar toggle; principal and primary segmented pickers. | Correct native items; no custom glass. |
+| Sidebar | `supacode/Features/Repositories/Views/SidebarListView.swift` | Automatic Add Repository/Workspace item. | Correct single action. |
+| Archived Worktrees | `supacode/Features/Repositories/Views/ArchivedWorktreesDetailView.swift` | Automatic destructive Delete Selected item. | Correct single action. |
+
+`HandoffHudOverlayView`, `CommandPaletteOverlayView`, and terminal tab backgrounds use
+`glassEffect`, but are not window-toolbar content and are deliberately outside this guide.
+
+## 3. The leading notification/update exception
+
+### Required visible result
+
+```
+[ Agents | Quick Launch ]    [ Bell | Update ]
+```
+
+- Agents and Quick Launch remain one native shared-glass group.
+- Bell and update form a second capsule immediately after it.
+- The two capsules are separate.
+- Bell retains its `.orange` unread state and `.secondary` idle state.
+- Update retains `Color("ProwlAccent")`.
+
+### Why it is an exception
+
+Adjacent `.navigation` toolbar groups merge into one native shared-glass surface. A fixed
+`ToolbarSpacer` does not split that leading cluster in the observed macOS 26 toolbar bridge.
+Hiding the bell/update owner's shared background keeps it independent, but also removes the
+system surface. Therefore `AgentNotificationsToolbarContent` uses exactly one isolated
+`ToolbarItem` with all of the following:
+
+1. `.sharedBackgroundVisibility(.hidden)` on that `ToolbarItem`;
+2. an `HStack(spacing: 0)` containing the existing
+   `ToolbarNotificationsPopoverButton` and conditional `ToolbarUpdateButton` unchanged;
+3. one outer `.glassEffect(.regular.interactive(), in: Capsule())`.
+
+This is an ownership boundary, not a new style system. Do not add a divider, child glass,
+child padding, child frame, `buttonStyle(.plain)`, or a new color while moving these controls.
+The original button views own their labels, tint, tooltip, accessibility label, and popover
+behavior.
+
+### Explicitly rejected approaches
+
+| Approach | Observed failure | Do instead |
+| --- | --- | --- |
+| Put Agents, Bell, and update in adjacent `.navigation` `ToolbarItemGroup`s | The toolbar merges all controls into one shared glass surface. | Keep bell/update in the isolated composite owner. |
+| Use `ControlGroup` as a `ToolbarItemGroup` substitute | It changed the leading controls' surface/placement behavior and unified label rendering, losing bell and update colors. | Preserve the original button views in the approved isolated `HStack`. |
+| Add glass, padding, frames, dividers, or plain button styles to bell/update children | The native proportions, accent colors, and interaction appearance drift. | Apply one glass surface only to the composite owner. |
+| Move update separately to `.primaryAction` | Update appears detached from its related bell. | Keep it conditional inside the bell/update owner. |
+| Duplicate this composition by mode | Normal, Shelf, and Canvas drift. | Use `AgentNotificationsToolbarContent` in every mode. |
+
+## 4. Implementation standard
+
+1. Start with semantic relationship, then choose the native toolbar primitive:
+   - one action → `ToolbarItem`;
+   - related independent actions → `ToolbarItemGroup`;
+   - unrelated trailing groups → `ToolbarSpacer(.fixed)`;
+   - status/display → placement-specific `ToolbarItem`.
+2. Let the toolbar supply button material, hover behavior, padding, separators, and overflow
+   behavior by default.
+3. Treat `.sharedBackgroundVisibility(.hidden)` as an ownership boundary. Verify the resulting
+   background; it may need a documented owner-drawn surface such as the leading
+   notification/update exception.
+4. Keep dynamic Canvas command controls in their existing single `ToolbarItem` until a live
+   regression demonstrates that a multi-item structure no longer animates or overflows.
+5. Centralize shared toolbar content. Do not copy it into Normal, Shelf, and Canvas paths.
+6. Update this guide and the relevant `docs-ai` record when a new verified exception is added,
+   removed, or its rendering changes.
+
+## 5. Review checklist
+
+Before committing a toolbar change:
+
+- [ ] The chosen primitive matches the controls' semantic relationship.
+- [ ] A native `ToolbarItemGroup` is used unless this guide documents the exception.
+- [ ] Each `sharedBackgroundVisibility(.hidden)` has an explicit owner and visual reason.
+- [ ] Existing toolbar button views have not gained incidental padding, sizing, tint, or button
+      styles merely because their placement changed.
+- [ ] All affected modes render the same intended order.
+- [ ] The Debug build has been manually checked at normal width and a constrained width.
+- [ ] For the leading cluster: generic/detected Agents, no update/update available, unread
+      notification, and downloaded-update-ready states retain grouping and color.
+- [ ] Tooltips, accessibility labels, menus, popovers, and shortcuts remain available.
+- [ ] `make check` and `make build-app` pass.
+
+For visual verification, use the Debug Command Palette action **[Debug] Simulate Update Found**
+to expose the update control without querying Sparkle.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -112,3 +112,4 @@ agent-facing manual for that).
 | 058 | [unified-toolbar-layout](058-unified-toolbar-layout/000-plan.md) | 2026-08-07 | Remove redundant branch/title toolbar items and align the Agents + notifications cluster across Normal, Shelf, and Canvas |
 | 059 | [agent-transcript-snapshots](059-agent-transcript-snapshots/000-plan.md) | 2026-08-11 | Immediate Codex/Claude agent snapshots with trustworthy transcript results and actionable blocker text |
 | 060 | [prowl-cli-targeting-and-contract-governance](060-prowl-cli-targeting-and-contract-governance/000-plan.md) | 2026-08-16 | Unified target grammar, CLI contract rebaseline, and durable documentation governance |
+| 061 | [native-toolbar-controls](061-native-toolbar-controls/000-plan.md) | 2026-08-17 | Native macOS toolbar grouping, Liquid Glass ownership, and review standards |

--- a/docs/components/notifications.md
+++ b/docs/components/notifications.md
@@ -41,8 +41,9 @@ sound.
 
 - **Sidebar:** an orange bell next to a worktree with unseen notifications.
 - **Toolbar:** a bell button follows the Agents control in the leading area in
-  Normal, Shelf, and Canvas. Its badge shows the unread count; opening the
-  popover marks items read.
+  Normal, Shelf, and Canvas. When an app update is available, its indicator
+  appears in the same control immediately after the bell. The bell badge shows
+  the unread count; opening the popover marks items read.
 - **Shelf:** orange highlight on the relevant tab slot + a dot on the spine.
 - **Canvas:** the card's title bar turns orange.
 - **Dock:** an optional numeric badge (count of worktrees with unseen

--- a/docs/components/updates.md
+++ b/docs/components/updates.md
@@ -14,8 +14,8 @@ Prowl uses the **Sparkle** framework for auto-updates. Releases are notarized.
   Updates", or Settings → Updates → "Check for Updates Now".
 - **Background checks:** if `updatesAutomaticallyCheckForUpdates` is on, Prowl
   checks periodically (roughly hourly). When a background check finds an update, a
-  badge appears on the notification bell; clicking it opens the standard Sparkle
-  dialog.
+  badge appears immediately after the notification bell in the same toolbar control;
+  clicking it opens the standard Sparkle dialog.
 - **On quit with a downloaded update:** Prowl offers to install or defer.
 - **Install confirmation:** installing and relaunching always requires an
   explicit confirmation. When an update is ready (or a user-initiated check finds

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -4,8 +4,6 @@ enum LeadingToolbarControlMetrics {
   static let labelSpacing: CGFloat = 6
   static let iconSize: CGFloat = 20
   static let font: Font = .title3.weight(.medium)
-  static let standaloneHorizontalPadding: CGFloat = 10
-  static let standaloneVerticalPadding: CGFloat = 8
 }
 
 /// What the Agents capsule shows for the selected pane's detected agent.
@@ -50,9 +48,10 @@ struct AgentsLauncherItem: Equatable, Identifiable {
 /// the popover is the durable container here.
 ///
 /// The button carries no background of its own: it sits in a shared-glass
-/// toolbar group next to `AgentsQuickLaunchButton`. Notifications follow as
-/// a separate capsule, preserving the visual gap previously occupied by the
-/// branch item. Normal, Shelf, and Canvas share this leading structure.
+/// toolbar group next to `AgentsQuickLaunchButton`. Notifications and update
+/// status follow in an isolated glass capsule because adjacent navigation
+/// groups merge on macOS 26. See docs-ai 061 before changing that composition.
+/// Normal, Shelf, and Canvas share this leading structure.
 struct AgentsToolbarButton: View {
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]

--- a/supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift
+++ b/supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift
@@ -21,66 +21,53 @@ struct ToolbarNotificationsPopoverButton: View {
   }
 
   var body: some View {
-    button
-      .buttonStyle(.plain)
-      .glassEffect(.regular.interactive(), in: Capsule())
-      .help("Notifications. Hover or click to show all notifications.")
-      .accessibilityLabel("Notifications")
-      .onHover { hovering in
-        isHoveringButton = hovering
-        updatePresentation()
-      }
-      .popover(isPresented: $isPresented) {
-        ToolbarNotificationsPopoverView(
-          groups: groups,
-          onSelectNotification: { worktreeID, notification in
-            onSelectNotification(worktreeID, notification)
-            closePopover()
-          },
-          onDismissAll: {
-            onDismissAll()
-            closePopover()
-          }
-        )
-        .onHover { hovering in
-          isHoveringPopover = hovering
-          updatePresentation()
-        }
-        .onDisappear {
-          isHoveringPopover = false
-          isPinnedOpen = false
-        }
-      }
-      .onChange(of: groups) { _, newValue in
-        if newValue.isEmpty {
-          closePopover()
-        }
-      }
-      .onDisappear {
-        closeTask?.cancel()
-      }
-  }
-
-  private var button: some View {
     Button {
       togglePresentation()
     } label: {
-      HStack(spacing: LeadingToolbarControlMetrics.labelSpacing) {
+      HStack(spacing: 6) {
         Image(systemName: unseenWorktreeCount > 0 ? "bell.badge.fill" : "bell.fill")
           .foregroundStyle(unseenWorktreeCount > 0 ? .orange : .secondary)
           .accessibilityHidden(true)
-          .frame(
-            width: LeadingToolbarControlMetrics.iconSize,
-            height: LeadingToolbarControlMetrics.iconSize
-          )
         if notificationCount > 0 {
           Text(notificationCount, format: .number)
             .font(.caption.monospacedDigit())
         }
       }
-      .font(LeadingToolbarControlMetrics.font)
-      .padding(.horizontal, LeadingToolbarControlMetrics.standaloneHorizontalPadding)
-      .padding(.vertical, LeadingToolbarControlMetrics.standaloneVerticalPadding)
+    }
+    .help("Notifications. Hover or click to show all notifications.")
+    .accessibilityLabel("Notifications")
+    .onHover { hovering in
+      isHoveringButton = hovering
+      updatePresentation()
+    }
+    .popover(isPresented: $isPresented) {
+      ToolbarNotificationsPopoverView(
+        groups: groups,
+        onSelectNotification: { worktreeID, notification in
+          onSelectNotification(worktreeID, notification)
+          closePopover()
+        },
+        onDismissAll: {
+          onDismissAll()
+          closePopover()
+        }
+      )
+      .onHover { hovering in
+        isHoveringPopover = hovering
+        updatePresentation()
+      }
+      .onDisappear {
+        isHoveringPopover = false
+        isPinnedOpen = false
+      }
+    }
+    .onChange(of: groups) { _, newValue in
+      if newValue.isEmpty {
+        closePopover()
+      }
+    }
+    .onDisappear {
+      closeTask?.cancel()
     }
   }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -346,7 +346,11 @@ private struct CanvasToolbarPreview: View {
             onLaunchProfile: { _ in },
             onManageProfiles: {},
             onSelectNotification: { _, _ in },
-            onDismissAllNotifications: {}
+            onDismissAllNotifications: {},
+            isUpdateAvailable: true,
+            isUpdateReadyToInstall: false,
+            availableUpdateVersion: "2026.5.1",
+            onActivateUpdateButton: {}
           )
         }
     }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -197,7 +197,11 @@ struct WorktreeDetailView: View {
       onSelectNotification: selectToolbarNotification,
       onDismissAllNotifications: {
         dismissAllToolbarNotifications(in: state.notificationGroups)
-      }
+      },
+      isUpdateAvailable: state.isUpdateAvailable,
+      isUpdateReadyToInstall: state.isUpdateReadyToInstall,
+      availableUpdateVersion: state.availableUpdateVersion,
+      onActivateUpdateButton: { store.send(.updates(.activateUpdateButton)) }
     )
 
     ToolbarItem(placement: .principal) {
@@ -209,24 +213,13 @@ struct WorktreeDetailView: View {
       .padding(.horizontal)
     }
 
-    if state.isUpdateAvailable {
-      ToolbarItem(placement: .primaryAction) {
-        ToolbarUpdateButton(
-          availableVersion: state.availableUpdateVersion,
-          isReadyToInstall: state.isUpdateReadyToInstall
-        ) {
-          store.send(.updates(.activateUpdateButton))
-        }
-      }
-    }
-
     let showRunButton =
       state.showRunButtonInToolbar
       && (state.runScriptIsRunning || state.runScriptEnabled)
     let inlineCommands = Array(state.customCommands.enumerated().prefix(3))
     let overflowCommands = Array(state.customCommands.enumerated().dropFirst(3))
-    // A fixed separator keeps the Run + Custom Command cluster distinct from
-    // the trailing update control, mirroring the Normal toolbar.
+    // A fixed separator keeps the dynamic Run + Custom Command cluster distinct
+    // from other trailing actions, mirroring the Normal toolbar spacing.
     //
     // INTENTIONAL DIVERGENCE FROM THE NORMAL TOOLBAR: the whole cluster is a
     // single `ToolbarItem` (an HStack) here, whereas `commandToolbarItems`
@@ -814,8 +807,8 @@ struct WorktreeDetailView: View {
   }
 
   /// Shared leading toolbar cluster for Normal, Shelf, and Canvas. Agents and
-  /// Quick Launch share one native group; the notifications button stays in a
-  /// separate capsule with the same gap the former branch item used.
+  /// Quick Launch share one native group; notifications and update status share
+  /// the trailing group that replaces the former branch item.
   struct AgentNotificationsToolbarContent: ToolbarContent {
     let agentsCapsule: AgentsCapsuleState?
     let agentsLauncherItems: [AgentsLauncherItem]
@@ -826,6 +819,10 @@ struct WorktreeDetailView: View {
     let onManageProfiles: () -> Void
     let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
     let onDismissAllNotifications: () -> Void
+    let isUpdateAvailable: Bool
+    let isUpdateReadyToInstall: Bool
+    let availableUpdateVersion: String?
+    let onActivateUpdateButton: () -> Void
 
     var body: some ToolbarContent {
       ToolbarItemGroup(placement: .navigation) {
@@ -841,13 +838,25 @@ struct WorktreeDetailView: View {
         }
       }
 
+      // Adjacent navigation groups merge on macOS 26. This isolated item owns
+      // the second capsule; see docs-ai 061 before changing its structure.
       ToolbarItem(placement: .navigation) {
-        ToolbarNotificationsPopoverButton(
-          groups: notificationGroups,
-          unseenWorktreeCount: unseenNotificationWorktreeCount,
-          onSelectNotification: onSelectNotification,
-          onDismissAll: onDismissAllNotifications
-        )
+        HStack(spacing: 0) {
+          ToolbarNotificationsPopoverButton(
+            groups: notificationGroups,
+            unseenWorktreeCount: unseenNotificationWorktreeCount,
+            onSelectNotification: onSelectNotification,
+            onDismissAll: onDismissAllNotifications
+          )
+          if isUpdateAvailable {
+            ToolbarUpdateButton(
+              availableVersion: availableUpdateVersion,
+              isReadyToInstall: isUpdateReadyToInstall,
+              onActivate: onActivateUpdateButton
+            )
+          }
+        }
+        .glassEffect(.regular.interactive(), in: Capsule())
       }
       .sharedBackgroundVisibility(.hidden)
     }
@@ -880,7 +889,11 @@ struct WorktreeDetailView: View {
         onLaunchProfile: onLaunchProfile,
         onManageProfiles: onManageProfiles,
         onSelectNotification: onSelectNotification,
-        onDismissAllNotifications: onDismissAllNotifications
+        onDismissAllNotifications: onDismissAllNotifications,
+        isUpdateAvailable: toolbarState.shared.isUpdateAvailable,
+        isUpdateReadyToInstall: toolbarState.shared.isUpdateReadyToInstall,
+        availableUpdateVersion: toolbarState.shared.availableUpdateVersion,
+        onActivateUpdateButton: onActivateUpdateButton
       )
 
       ToolbarItem(placement: .principal) {
@@ -890,16 +903,6 @@ struct WorktreeDetailView: View {
           codeHost: toolbarState.shared.codeHost
         )
         .padding(.horizontal)
-      }
-
-      if toolbarState.shared.isUpdateAvailable {
-        ToolbarItem(placement: .primaryAction) {
-          ToolbarUpdateButton(
-            availableVersion: toolbarState.shared.availableUpdateVersion,
-            isReadyToInstall: toolbarState.shared.isUpdateReadyToInstall,
-            onActivate: onActivateUpdateButton
-          )
-        }
       }
 
       if toolbarState.showDefaultEditorInToolbar {
@@ -994,8 +997,8 @@ struct WorktreeDetailView: View {
       let overflowEntries = Array(entries.dropFirst(3))
 
       // One fixed separator in front of the whole Run + Custom Command cluster
-      // keeps it distinct from the Open Editor / update controls no matter which
-      // items are hidden. Run and the custom commands share one group (no spacer
+      // keeps it distinct from preceding trailing actions no matter which items
+      // are hidden. Run and the custom commands share one group (no spacer
       // between them), matching the grouping before the toolbar toggles.
       if showRunButton || !inlineEntries.isEmpty || !overflowEntries.isEmpty {
         ToolbarSpacer(.fixed)


### PR DESCRIPTION
## Summary
- Group the update indicator with the leading notifications control while keeping Agents separate.
- Preserve native button behavior, colors, and accessibility across Normal, Shelf, and Canvas.
- Document native toolbar grouping, Liquid Glass ownership, review rules, and verified exceptions.

## Validation
- `make check`
- `make build-app`
