### PR TITLE
Fix dynamic terminal tab color resolution

### DIFF
--- a/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
@@ -30,13 +30,14 @@ enum TerminalTabBarColors {
 
   /// Resolves to `dark` under Dark Aqua and `light` otherwise, wrapped in a
   /// dynamic `NSColor` so callers stay appearance-agnostic.
-  private static func adaptiveFill(
-    dark: @escaping () -> NSColor,
-    light: @escaping () -> NSColor
+  private nonisolated static func adaptiveFill(
+    dark: @escaping @MainActor () -> NSColor,
+    light: @escaping @MainActor () -> NSColor
   ) -> Color {
-    Color(
+    let resolver = TerminalTabBarAdaptiveFillResolver(dark: dark, light: light)
+    return Color(
       nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark() : light()
+        resolver.resolve(for: appearance)
       }
     )
   }
@@ -59,5 +60,50 @@ enum TerminalTabBarColors {
 
   static var dirtyIndicator: Color {
     Color(nsColor: .labelColor).opacity(0.6)
+  }
+}
+
+// `NSAppearance` is read-only here and lives only through the synchronous main-queue handoff.
+private nonisolated struct TerminalTabBarAppearanceBox: @unchecked Sendable {
+  let appearance: NSAppearance
+}
+
+// The stored closures are immutable and invoked only from `resolvedColor(for:)` on the main actor.
+private nonisolated final class TerminalTabBarAdaptiveFillResolver: @unchecked Sendable {
+  private let dark: @MainActor () -> NSColor
+  private let light: @MainActor () -> NSColor
+
+  init(
+    dark: @escaping @MainActor () -> NSColor,
+    light: @escaping @MainActor () -> NSColor
+  ) {
+    self.dark = dark
+    self.light = light
+  }
+
+  func resolve(for appearance: NSAppearance) -> NSColor {
+    let appearanceBox = TerminalTabBarAppearanceBox(appearance: appearance)
+    if Thread.isMainThread {
+      return MainActor.assumeIsolated {
+        resolvedColor(for: appearanceBox.appearance)
+      }
+    }
+    return DispatchQueue.main.sync {
+      MainActor.assumeIsolated {
+        resolvedColor(for: appearanceBox.appearance)
+      }
+    }
+  }
+
+  @MainActor
+  private func resolvedColor(for appearance: NSAppearance) -> NSColor {
+    var color: NSColor?
+    appearance.performAsCurrentDrawingAppearance {
+      color = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark() : light()
+    }
+    guard let color else {
+      preconditionFailure("NSAppearance did not resolve a terminal tab bar color")
+    }
+    return color
   }
 }

--- a/supacodeTests/TerminalTabBarColorsTests.swift
+++ b/supacodeTests/TerminalTabBarColorsTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct TerminalTabBarColorsTests {
+  @Test
+  func adaptiveFillsResolveOffMainThread() async {
+    for color in [
+      TerminalTabBarColors.barBackground,
+      TerminalTabBarColors.activeTabBackground,
+      TerminalTabBarColors.hoveredTabBackground,
+    ] {
+      let resolved = await resolveOffMain(color)
+      #expect(resolved)
+    }
+  }
+
+  private func resolveOffMain(_ color: Color) async -> Bool {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        continuation.resume(returning: NSColor(color).usingColorSpace(.sRGB) != nil)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Resolve dynamic terminal tab colors on the main actor when SwiftUI renders them asynchronously.
- Preserve the provider-supplied `NSAppearance`, keeping the existing dark/light brightness ladder unchanged.
- Add a regression test that resolves every adaptive tab fill off the main thread.

## Testing
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:"supacodeTests/TerminalTabBarColorsTests/adaptiveFillsResolveOffMainThread()" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app`
