### PR TITLE
Sign the Debug build so folder-access grants survive rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ make build-ghostty-xcframework  # Rebuild GhosttyKit from Zig source (requires m
 make build-app                   # Build macOS app (Debug) via xcodebuild
 make run-app                     # Build and launch Debug app
 make install-dev-build           # Build and copy to /Applications (Debug)
+make sign-debug-app              # Sign the built Debug app (runs from build-app; PROWL_CODESIGN_IDENTITY overrides)
 make install-release             # Build Release, sign locally, install to /Applications
 make format-changed              # Run swift-format on changed Swift files only
 make format                      # Run full-tree swift-format cleanup

--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,9 @@ sign-debug-app: # Sign the built Debug app so TCC grants survive rebuilds
 		exit 1; \
 	fi; \
 	codesign --force --sign "$$identity" --preserve-metadata=entitlements "$$app"; \
-	codesign --verify --verbose=4 "$$app" >/dev/null 2>&1 || { \
+	codesign --verify --deep --strict --verbose=4 "$$app" >/dev/null 2>&1 || { \
 		echo "error: '$$app' failed code-signature verification." >&2; \
-		codesign --verify --verbose=4 "$$app" >&2 || true; \
+		codesign --verify --deep --strict --verbose=4 "$$app" >&2 || true; \
 		exit 1; \
 	}; \
 	dr="$$(codesign --display --requirements - "$$app" 2>&1)"; \

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ FORMAT_BASE_REF ?= origin/main
 BUILD_SETTINGS_CACHE := $(CURRENT_MAKEFILE_DIR)/.build_settings_cache.json
 PBXPROJ_PATH := $(CURRENT_MAKEFILE_DIR)/supacode.xcodeproj/project.pbxproj
 
-# Code-signing identity for the Debug bundle. Empty auto-selects one that carries
-# a Team ID; "-" opts out and keeps xcodebuild's ad-hoc signature. See sign-debug-app.
+# Code-signing identity for local Debug products, the app and the test host alike.
+# Empty auto-selects one that carries a Team ID; "-" opts out and keeps the ad-hoc
+# signature. See scripts/resolve-codesign-identity.sh.
 PROWL_CODESIGN_IDENTITY ?=
+CODESIGN_IDENTITY_SCRIPT := $(CURRENT_MAKEFILE_DIR)/scripts/resolve-codesign-identity.sh
 
 # Release-only analytics/crash credentials. Included from Config/Secrets.env if present,
 # or overridable from the environment (e.g. CI). Debug builds skip SDK init regardless.
@@ -143,36 +145,14 @@ endef
 # agents running in panes trip them. A named identity yields a cdhash-free
 # requirement, and the answers survive rebuilds.
 #
-# Precedence: an explicit PROWL_CODESIGN_IDENTITY wins, with "-" opting out;
-# otherwise auto-select an identity carrying a Team ID. When none exists the
-# bundle keeps its ad-hoc signature and the reason is announced rather than
-# silently accepted, because the prompts would otherwise look like a Prowl bug.
+# Precedence lives in scripts/resolve-codesign-identity.sh, which the test host
+# resolves through as well so both products carry the same requirement and share
+# one grant.
 sign-debug-app: # Sign the built Debug app so TCC grants survive rebuilds
 	@set -euo pipefail; \
-	if [ "$$(uname -s)" != "Darwin" ]; then \
-		exit 0; \
-	fi; \
-	identity="$(PROWL_CODESIGN_IDENTITY)"; \
-	if [ "$$identity" = "-" ]; then \
-		echo "code-signing opted out (PROWL_CODESIGN_IDENTITY=-): keeping the ad-hoc signature." >&2; \
-		exit 0; \
-	fi; \
+	identity="$$(bash "$(CODESIGN_IDENTITY_SCRIPT)")"; \
 	if [ -z "$$identity" ]; then \
-		identity="$$(security find-identity -v -p codesigning 2>/dev/null \
-			| grep -oE '"(Apple Development|Apple Distribution|Developer ID Application): [^"]*"' \
-			| sed 's/^"//; s/"$$//' | head -n1 || true)"; \
-	fi; \
-	if [ -z "$$identity" ]; then \
-		echo "note: no Team-ID signing identity found; leaving the ad-hoc signature." >&2; \
-		echo "      macOS re-asks for Documents, Desktop, Downloads and Music on every rebuild." >&2; \
-		echo "      Add an Apple Development identity, or point PROWL_CODESIGN_IDENTITY at a" >&2; \
-		echo "      self-signed one, for prompt-free rebuilds." >&2; \
 		exit 0; \
-	fi; \
-	if ! security find-identity -v -p codesigning | grep -qF "\"$$identity\""; then \
-		echo "error: code-signing identity '$$identity' not found." >&2; \
-		echo "Name an available identity in PROWL_CODESIGN_IDENTITY, or set it to '-' to opt out." >&2; \
-		exit 1; \
 	fi; \
 	$(resolve_debug_product) \
 	if [ -z "$$build_dir" ] || [ -z "$$product" ] || [ "$$build_dir" = "null" ] || [ "$$product" = "null" ]; then \
@@ -397,13 +377,26 @@ test: ensure-ghostty embed-cli-debug embed-docs test-app
 test-scripts: # Run tests for the repository's Python scripts
 	@python3 -m unittest discover -s "$(CURRENT_MAKEFILE_DIR)/scripts" -p 'test_*.py'
 
+# The test host is a second Prowl Debug bundle, and macOS makes it the responsible
+# process for anything running in the terminal that launched it. Left ad-hoc it
+# carries a cdhash-pinned requirement that no grant matches, so a test run makes
+# the agents in the surrounding panes re-prompt for Documents, Desktop, Downloads
+# and Music — observed twice before this. Signing it with the same identity as the
+# app gives both the same requirement, so one grant covers both. With no identity
+# available the previous unsigned flags stand, which is what CI gets.
 test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 	@set -euo pipefail; \
 	result_bundle="$(CURRENT_MAKEFILE_DIR)/build/test-results/supacode-tests.xcresult"; \
 	mkdir -p "$$(dirname "$$result_bundle")"; \
 	rm -rf "$$result_bundle"; \
+	identity="$$(bash "$(CODESIGN_IDENTITY_SCRIPT)")"; \
+	if [ -n "$$identity" ]; then \
+		signing_args=(CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="$$identity" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES DEVELOPMENT_TEAM=); \
+	else \
+		signing_args=(CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=); \
+	fi; \
 	set +e; \
-	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental 2>&1 | mise exec -- xcsift -w --format toon; \
+	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" "$${signing_args[@]}" -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental 2>&1 | mise exec -- xcsift -w --format toon; \
 	xcodebuild_status=$${PIPESTATUS[0]}; \
 	set -e; \
 	if [ "$$xcodebuild_status" -ne 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ FORMAT_BASE_REF ?= origin/main
 BUILD_SETTINGS_CACHE := $(CURRENT_MAKEFILE_DIR)/.build_settings_cache.json
 PBXPROJ_PATH := $(CURRENT_MAKEFILE_DIR)/supacode.xcodeproj/project.pbxproj
 
+# Code-signing identity for the Debug bundle. Empty auto-selects one that carries
+# a Team ID; "-" opts out and keeps xcodebuild's ad-hoc signature. See sign-debug-app.
+PROWL_CODESIGN_IDENTITY ?=
+
 # Release-only analytics/crash credentials. Included from Config/Secrets.env if present,
 # or overridable from the environment (e.g. CI). Debug builds skip SDK init regardless.
 -include Config/Secrets.env
@@ -42,7 +46,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app sign-debug-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -113,6 +117,88 @@ embed-docs: # Stage docs/ into Resources for bundling into the app (.app/Content
 
 build-app: ensure-ghostty embed-cli-debug embed-docs # Build the macOS app (Debug)
 	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental 2>&1 | mise exec -- xcsift -w --format toon'
+	@$(MAKE) --no-print-directory sign-debug-app
+
+# Resolve BUILT_PRODUCTS_DIR and FULL_PRODUCT_NAME for the Debug configuration into
+# $$build_dir and $$product, reading the cached build settings when they are newer
+# than the project file. Leaves $$settings in scope for callers that need more fields.
+define resolve_debug_product
+	cache="$(BUILD_SETTINGS_CACHE)"; \
+	pbxproj="$(PBXPROJ_PATH)"; \
+	if [ -f "$$cache" ] && [ "$$cache" -nt "$$pbxproj" ]; then \
+		settings="$$(cat "$$cache")"; \
+	else \
+		settings="$$(xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug -showBuildSettings -json 2>/dev/null)"; \
+		printf '%s' "$$settings" > "$$cache"; \
+	fi; \
+	build_dir="$$(echo "$$settings" | jq -er '.[0].buildSettings.BUILT_PRODUCTS_DIR')"; \
+	product="$$(echo "$$settings" | jq -er '.[0].buildSettings.FULL_PRODUCT_NAME')";
+endef
+
+# Sign the Debug bundle with a stable identity. TCC stores the code requirement it
+# granted against, and an ad-hoc signature's requirement is pinned to the cdhash,
+# which every build changes: the grant stops matching and macOS re-asks for
+# Documents, Desktop, Downloads and Music. Those prompts name Prowl because a
+# terminal child's file access is attributed to the app responsible for it, so the
+# agents running in panes trip them. A named identity yields a cdhash-free
+# requirement, and the answers survive rebuilds.
+#
+# Precedence: an explicit PROWL_CODESIGN_IDENTITY wins, with "-" opting out;
+# otherwise auto-select an identity carrying a Team ID. When none exists the
+# bundle keeps its ad-hoc signature and the reason is announced rather than
+# silently accepted, because the prompts would otherwise look like a Prowl bug.
+sign-debug-app: # Sign the built Debug app so TCC grants survive rebuilds
+	@set -euo pipefail; \
+	if [ "$$(uname -s)" != "Darwin" ]; then \
+		exit 0; \
+	fi; \
+	identity="$(PROWL_CODESIGN_IDENTITY)"; \
+	if [ "$$identity" = "-" ]; then \
+		echo "code-signing opted out (PROWL_CODESIGN_IDENTITY=-): keeping the ad-hoc signature." >&2; \
+		exit 0; \
+	fi; \
+	if [ -z "$$identity" ]; then \
+		identity="$$(security find-identity -v -p codesigning 2>/dev/null \
+			| grep -oE '"(Apple Development|Apple Distribution|Developer ID Application): [^"]*"' \
+			| sed 's/^"//; s/"$$//' | head -n1 || true)"; \
+	fi; \
+	if [ -z "$$identity" ]; then \
+		echo "note: no Team-ID signing identity found; leaving the ad-hoc signature." >&2; \
+		echo "      macOS re-asks for Documents, Desktop, Downloads and Music on every rebuild." >&2; \
+		echo "      Add an Apple Development identity, or point PROWL_CODESIGN_IDENTITY at a" >&2; \
+		echo "      self-signed one, for prompt-free rebuilds." >&2; \
+		exit 0; \
+	fi; \
+	if ! security find-identity -v -p codesigning | grep -qF "\"$$identity\""; then \
+		echo "error: code-signing identity '$$identity' not found." >&2; \
+		echo "Name an available identity in PROWL_CODESIGN_IDENTITY, or set it to '-' to opt out." >&2; \
+		exit 1; \
+	fi; \
+	$(resolve_debug_product) \
+	if [ -z "$$build_dir" ] || [ -z "$$product" ] || [ "$$build_dir" = "null" ] || [ "$$product" = "null" ]; then \
+		echo "error: failed to resolve app path from build settings"; \
+		exit 1; \
+	fi; \
+	app="$$build_dir/$$product"; \
+	if [ ! -d "$$app/Contents" ]; then \
+		echo "error: not an app bundle: $$app"; \
+		exit 1; \
+	fi; \
+	codesign --force --sign "$$identity" --preserve-metadata=entitlements "$$app"; \
+	codesign --verify --verbose=4 "$$app" >/dev/null 2>&1 || { \
+		echo "error: '$$app' failed code-signature verification." >&2; \
+		codesign --verify --verbose=4 "$$app" >&2 || true; \
+		exit 1; \
+	}; \
+	dr="$$(codesign --display --requirements - "$$app" 2>&1)"; \
+	case "$$dr" in \
+		*cdhash*) \
+			echo "error: designated requirement is cdhash-pinned; TCC grants will not survive a rebuild." >&2; \
+			printf '%s\n' "$$dr" >&2; \
+			exit 1; \
+			;; \
+	esac; \
+	echo "signed $$app with '$$identity'"
 
 sync-cli-version: # Sync app MARKETING_VERSION into ProwlCLIShared/ProwlVersion.swift
 	@version="$$(/usr/bin/awk -F' = ' '/MARKETING_VERSION = [0-9.]*;/{gsub(/;/,"",$$2);print $$2; exit}' \
@@ -159,16 +245,7 @@ embed-cli: build-cli-release # Build release CLI and copy into Resources for dis
 
 run-app: build-app # Build then launch (Debug) with log streaming
 	@set -euo pipefail; \
-	cache="$(BUILD_SETTINGS_CACHE)"; \
-	pbxproj="$(PBXPROJ_PATH)"; \
-	if [ -f "$$cache" ] && [ "$$cache" -nt "$$pbxproj" ]; then \
-		settings="$$(cat "$$cache")"; \
-	else \
-		settings="$$(xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug -showBuildSettings -json 2>/dev/null)"; \
-		printf '%s' "$$settings" > "$$cache"; \
-	fi; \
-	build_dir="$$(echo "$$settings" | jq -er '.[0].buildSettings.BUILT_PRODUCTS_DIR')"; \
-	product="$$(echo "$$settings" | jq -er '.[0].buildSettings.FULL_PRODUCT_NAME')"; \
+	$(resolve_debug_product) \
 	exec_name="$$(echo "$$settings" | jq -r '.[0].buildSettings.EXECUTABLE_NAME')"; \
 	if [ -z "$$build_dir" ] || [ -z "$$product" ] || [ "$$build_dir" = "null" ] || [ "$$product" = "null" ] || [ -z "$$exec_name" ] || [ "$$exec_name" = "null" ]; then \
 		echo "error: failed to resolve app path from build settings"; \
@@ -179,16 +256,7 @@ run-app: build-app # Build then launch (Debug) with log streaming
 
 install-dev-build: build-app # Build Debug and install to /Applications
 	@set -euo pipefail; \
-	cache="$(BUILD_SETTINGS_CACHE)"; \
-	pbxproj="$(PBXPROJ_PATH)"; \
-	if [ -f "$$cache" ] && [ "$$cache" -nt "$$pbxproj" ]; then \
-		settings="$$(cat "$$cache")"; \
-	else \
-		settings="$$(xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug -showBuildSettings -json 2>/dev/null)"; \
-		printf '%s' "$$settings" > "$$cache"; \
-	fi; \
-	build_dir="$$(echo "$$settings" | jq -er '.[0].buildSettings.BUILT_PRODUCTS_DIR')"; \
-	product="$$(echo "$$settings" | jq -er '.[0].buildSettings.FULL_PRODUCT_NAME')"; \
+	$(resolve_debug_product) \
 	if [ -z "$$build_dir" ] || [ -z "$$product" ] || [ "$$build_dir" = "null" ] || [ "$$product" = "null" ]; then \
 		echo "error: failed to resolve app path from build settings"; \
 		exit 1; \

--- a/scripts/resolve-codesign-identity.sh
+++ b/scripts/resolve-codesign-identity.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Print the code-signing identity for local Debug products, or nothing when there
+# is none to use. Callers treat empty output as "leave it ad-hoc".
+#
+# Precedence: an explicit PROWL_CODESIGN_IDENTITY wins, with "-" opting out;
+# otherwise auto-select an identity that carries a Team ID. Only stdout carries
+# the identity, so callers can capture it with $(...) while the notes go to
+# stderr.
+set -euo pipefail
+
+explicit="${PROWL_CODESIGN_IDENTITY:-}"
+if [ "$explicit" = "-" ]; then
+  exit 0
+fi
+if [ -n "$explicit" ]; then
+  if ! security find-identity -v -p codesigning | grep -qF "\"$explicit\""; then
+    echo "error: code-signing identity '$explicit' not found." >&2
+    echo "Name an available identity in PROWL_CODESIGN_IDENTITY, or set it to '-' to opt out." >&2
+    exit 1
+  fi
+  printf '%s\n' "$explicit"
+  exit 0
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+# `|| true`: grep exits 1 when no identity matches, which under `set -e` would
+# abort before the empty-output path below.
+identity="$(security find-identity -v -p codesigning 2>/dev/null \
+  | grep -oE '"(Apple Development|Apple Distribution|Developer ID Application): [^"]*"' \
+  | sed 's/^"//; s/"$//' | head -n1 || true)"
+
+if [ -z "$identity" ]; then
+  echo "note: no Team-ID signing identity found; Debug products stay ad-hoc." >&2
+  echo "      macOS re-asks for Documents, Desktop, Downloads and Music on every rebuild." >&2
+  echo "      Add an Apple Development identity, or point PROWL_CODESIGN_IDENTITY at a" >&2
+  echo "      self-signed one, for prompt-free rebuilds." >&2
+  exit 0
+fi
+
+printf '%s\n' "$identity"


### PR DESCRIPTION
An ad-hoc signature pins the app's code requirement to its cdhash, so every rebuild invalidates the folder-access grants macOS recorded against the previous build. Prowl Debug re-prompts for Documents, Desktop, Downloads, and Music. The prompts land in whatever terminal pane started the build, because macOS attributes a terminal child's file access to the responsible app.

`make build-app` now signs the built Debug bundle with a real identity, and `make test-app` signs the test host with the same one. The test host is a second Prowl Debug bundle, and macOS makes it the responsible process for the terminal that launched it. An unsigned host re-prompts the agents in the surrounding panes on every test run.

`scripts/resolve-codesign-identity.sh` resolves the identity. `PROWL_CODESIGN_IDENTITY` names one explicitly, and `-` opts out. With no identity available the existing unsigned flags stand, which is what CI gets.

A stable identity gives every build the same designated requirement, so one answer to the prompt covers later builds. A rebuild changes the cdhash and leaves that requirement byte-identical.

`make check` passes on this branch, and `make test` reports zero failures across 2351 tests through the signed test host. `make build-app` signs the bundle, and `codesign --verify --deep --strict` accepts it.
