### PR TITLE
Plan Agent Workflows (docs-ai 063)

### DIFF
--- a/docs-ai/047-cross-agent-handoff/000-plan.md
+++ b/docs-ai/047-cross-agent-handoff/000-plan.md
@@ -109,3 +109,4 @@ cwd, which is weaker than the pid-anchored, ambiguity-safe native session identi
   its runtime resume layer. Briefing is now explicit (`--brief` / `--no-brief`),
   and the HUD has only the deterministic Context Only fallback — see
   [006-remove-fork-briefing](006-remove-fork-briefing.md).
+- Updated 2026-08-22: successor direction — the fixed handoff flow is planned to become the built-in `prowl.handoff` workflow of [063-agent-workflows](../063-agent-workflows/000-plan.md); `prowl handoff to|save` becomes a deprecated alias and the `.prowl/handoff/` artifact contract survives as the `handoff.transition` action.

--- a/docs-ai/049-agents-toolbar-entry/000-plan.md
+++ b/docs-ai/049-agents-toolbar-entry/000-plan.md
@@ -173,3 +173,4 @@ plumbing from 047.003; no new pipeline work is expected.
   wave starts with zero rework if real usage surfaces the pain.
 - Updated 2026-07-20: cancel/Skip now make reducer acceptance the boundary for transcribing a preparation reply, and Skip gains a keyboard path — see [002-briefing-cancellation.md](002-briefing-cancellation.md).
 - Updated 2026-08-07: the redundant branch title was removed; Agents + Quick Launch now leads, followed by a separately surfaced Bell, across Normal, Shelf, and Canvas — see [058-unified-toolbar-layout](../058-unified-toolbar-layout/000-plan.md).
+- Updated 2026-08-22: the indefinitely deferred PR2 (dismiss-while-running, background progress) is subsumed by the toolbar status center planned in [063-agent-workflows](../063-agent-workflows/000-plan.md); the HUD choose stage is replaced there by a generic workflow start sheet and the staged HUD is scheduled for removal once `prowl.handoff` ships.

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -423,3 +423,4 @@ agent 列表不变。
 - 2026-08-01 — Handoff 的 briefing resume/fork 已删除;Profile 环境和 home
   只需沿 destination launch 传播,不再规划 `AgentResumeRequest` 双路径。见
   [047.006](../047-cross-agent-handoff/006-remove-fork-briefing.md)。
+- Updated 2026-08-22: profile-aware handoff 与跨 agent 编排规划为 [063-agent-workflows](../063-agent-workflows/000-plan.md)：workflow 的 role 以 `agents`/`suggest` 描述要求、在本机绑定 profile（共享文件不含 profile 名），启动经由带 `.prompt` intent、返回 pane 身份的 profile launch boundary；本文「后续方向」中的 handoff 迁移与 `prowl` CLI profile 感知由该条目承接。

--- a/docs-ai/055-agent-profile-runtimes/000-plan.md
+++ b/docs-ai/055-agent-profile-runtimes/000-plan.md
@@ -170,3 +170,4 @@ and final PR, then commit in reviewable layers and submit a non-draft PR to
 - Amp supports bare interactive Profiles and headless execution, but not a
   seeded interactive prompt through argv. The adapter rejects that intent
   explicitly instead of silently changing the requested interaction mode.
+- Updated 2026-08-22: the "profile-based handoff, cross-review, and other cross-agent orchestration" follow-up waves are planned as [063-agent-workflows](../063-agent-workflows/000-plan.md), consuming the launch intent and capability model established here.

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -5,7 +5,7 @@
 | **Status** | Planned (design in discussion; see Open questions) |
 | **Anchor date** | 2026-08-21 |
 | **Primary PRs** | TBD (see Delivery slicing) |
-| **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
+| **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), [release plan (living)](release-plan.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
 
 ## Background
 
@@ -377,54 +377,27 @@ Shapes are intentionally close to what exists so the runner and the CLI share on
 
 ### Delivery slicing
 
-Four tracks — terminal/CLI primitives (A), definitions/runner (B), UI (C), built-ins and
-docs (D) — plus 064's signal slices (S), shipped as **three releases** (decision
-2026-08-22, keeping Prowl's small-step cadence; PRs still merge to `main` one at a time
-and engine PRs without a user-facing surface simply stay dormant until their release):
+This section defines **what** each slice contains. **When** it ships and in what order —
+including the interleaving with 064's signal slices — is owned by the living
+[release-plan.md](release-plan.md) (three releases: R1 CLI primitives + signals, R2 Agent
+Workflows, R3 handoff migration; decision 2026-08-22). Only two couplings cross the two
+entries: 064-S1 delivers the `ObservedAgentState` observer that B3 consumes, and 064-S3
+attaches hooks through A2's launch boundary.
 
-- **R1 — CLI orchestration primitives + completion signals**: C0 (Agents settings group
-  with Profiles + Command Line Tool only), A1, A2, 064-S1 (signal bus, `ObservedAgentState`
-  observer, `prowl agents signal`), 064-S2 (`prowl agents wait`, `signals` field,
-  `--include-screen`, skill rubric), 064-S3 wave 1 (launch-scoped hooks for the tier-A
-  runtimes). Outcome: onevcat's daily CLI-driven orchestration is first-class
-  (`create pane --profile --prompt -` → `agents wait` → `send`), deterministic for
-  Prowl-launched agents. Docs: `cli.md`, `agent-detection.md`, `prowl-cli` skill.
-- **R2 — Agent Workflows**: B1, B2, B3, C1, C2, D1 (incl. the Settings › Workflows page),
-  D2, and the 064-S5 part where the watchdog consumes exact signals. Outcome: the engine,
-  the GUI entry points, the first built-in (`prowl.adversarial-review`), custom workflows.
-  The shipped handoff (HUD + `prowl handoff`) stays untouched in R2. Docs:
-  `workflows.md`, `command-palette.md`, `active-agents.md`, `settings.md`.
-- **R3 — Handoff migration + signal completion**: D3 (`prowl.handoff` /
-  `prowl.handoff-checkpoint`, `HANDOFF_RETIRED` stubs, HUD removal), 064-S3 wave 2
-  (dedicated-home runtimes) and S4 (transcript file-watch / OSC producers), first V2 items
-  as capacity allows (observe mode, `on_attention: ask`, retention). The stubs are deleted
-  one release after R3. Docs: `handoff.md` rewrite.
-
-If R2 proves too large, it splits into R2a (B1+B2+B3+C1: workflows runnable from the CLI,
-visible in the status center) and R2b (C2+D1+D2: GUI entry, Settings, skills, E2E); the
-default is a single R2 because "runnable but no GUI entry" is hard to explain to users.
-
-Within a release the order below applies; C0 ∥ A1, A2 ∥ S1, and B1 ∥ B2 can proceed in
-parallel.
-
-| Release | Order | PR | Track | Depends | Expectation |
-| --- | --- | --- | --- | --- | --- |
-| R1 | 1 | **C0** Settings IA: `Section("Agents")` with **Profiles** (today's Agents page, renamed) and **Command Line Tool** (moved from Advanced); no Workflows page yet | C | — | Independent, small; decides where everything lands |
-| R1 | 2 | **A1** `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers | A | 060 | Foundation for every `launch` into a split |
-| R1 | 3 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list`; the boundary exposes the seam 064-S3 uses to attach launch-scoped hooks | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary |
-| R1 | 4 | **064-S1** signal bus + `ObservedAgentState` multicast observer (moved here from B3) + `prowl agents signal` | S | — | Layer 0 for every runtime; B3 later consumes the same observer |
-| R1 | 5 | **064-S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S | S1 | Route B usable; heuristic fallback honest |
-| R1 | 6 | **064-S3 wave 1** launch-scoped hooks for Claude Code, Codex (`notify`), Copilot, Droid, Qoder, Pi, OMP, OpenCode + self-check | S | A2, S1 | `agents wait` deterministic for Prowl-launched agents |
-| R2 | 7 | **B1** Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema` | B | — | Makes the DSL concrete and authorable (may merge during R1 without user-facing surface) |
-| R2 | 8 | **B2** Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries | B | B1 | Parallel with B1's tail |
-| R2 | 9 | **B3** Runner wiring: `WorkflowRunsFeature` effects, observer consumption via `AppFeature`, CLI preflight, `prowl workflow run/status/done/cancel` + contracts | B | A2, S1, B2 | Engine first powered on |
-| R2 | 10 | **C1** Status center fifth state + run panel + attention triggers + notifications (061 visual verification) | C | B3 | Runs become visible |
-| R2 | 11 | **C2** Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu) | C | B3 | GUI-initiated runs |
-| R2 | 12 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group | D | B1, C2 | Distribution and docs |
-| R2 | 13 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification; watchdog consumes exact signals (064-S5 part) | D | A2, C2, D1, S3 | Proves the engine on a fresh flow before touching shipped behavior |
-| R3 | 14 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill | D | D2 | Migrate the shipped feature last |
-| R3 | 15 | **064-S3 wave 2** (dedicated-home runtimes) + **064-S4** (transcript file-watch / OSC producers) | S | S3, 053 homes | More runtimes get exact signals |
-| R3+ | 16 | V2: observe mode (`expect.status` + `agents read`/hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor | — | — | — |
+| Slice | Track | Depends | Contents / expectation |
+| --- | --- | --- | --- |
+| **C0** | C | — | Settings IA: `Section("Agents")` with **Profiles** (today's Agents page, renamed) and **Command Line Tool** (moved from Advanced); the Workflows page comes with D1. Independent, small; decides where everything lands. |
+| **A1** | A | 060 | `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers. Foundation for every `launch` into a split. |
+| **A2** | A | A1 | Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list`; exposes the seam 064-S3 uses for launch-scoped hooks. Unlocks the CLI-driven route; the runner's `launch` boundary. |
+| **B1** | B | — | Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`. Makes the DSL concrete and authorable (no user-facing surface until R2). |
+| **B2** | B | B1 | Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries. |
+| **B3** | B | A2, 064-S1, B2 | Runner wiring: `WorkflowRunsFeature` effects, observer consumption via `AppFeature`, CLI preflight, `prowl workflow run/status/done/cancel` + contracts. Engine first powered on. |
+| **C1** | C | B3 | Status center fifth state + run panel + attention triggers + notifications (061 visual verification). Runs become visible. |
+| **C2** | C | B3 | Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu). GUI-initiated runs. |
+| **D1** | D | B1, C2 | `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group. Distribution and docs. |
+| **D2** | D | A2, C2, D1, 064-S3 wave 1 | `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification; the watchdog consumes exact signals (064-S5 part). Proves the engine on a fresh flow before touching shipped behavior. |
+| **D3** | D | D2 | `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to\|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill. Migrate the shipped feature last. |
+| **V2** | — | — | observe mode (`expect.status` + `agents read` / hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor. |
 
 ## Alternatives & decisions
 
@@ -507,10 +480,11 @@ parallel.
   when it is truly complete, and attention states that never discard a late delivery.
 - **PR order / releases** (revised 2026-08-22): three releases — R1 = C0, A1, A2,
   064-S1/S2/S3-wave-1 (CLI orchestration + signals); R2 = B1, B2, B3, C1, C2, D1, D2
-  (Agent Workflows); R3 = D3, 064-S3-wave-2/S4, first V2 items (handoff migration) — see
-  Delivery slicing. The new Adversarial Review flow validates the engine before the shipped
-  handoff is migrated; the `ObservedAgentState` observer moved from B3 to 064-S1 so R1 can
-  ship `agents wait`.
+  (Agent Workflows); R3 = D3, 064-S3-wave-2/S4, first V2 items (handoff migration). The
+  single source for order and release assignment is [release-plan.md](release-plan.md);
+  the slice tables in 063/064 define contents only. The new Adversarial Review flow
+  validates the engine before the shipped handoff is migrated; the `ObservedAgentState`
+  observer moved from B3 to 064-S1 so R1 can ship `agents wait`.
 - **Review round (2026-08-22)** — accepted corrections: runner as an `AppFeature` child
   fed by the single event subscription + a per-surface multicast observer for CLI waits;
   opaque per-step delivery tokens for `done`; `LegacyHandoffAdapter` with a full parameter

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -84,10 +84,10 @@ contract governance of 060.
 | Term | Meaning |
 | --- | --- |
 | Workflow | A `prowl.workflow/v1` YAML document: id, inputs, roles, steps. Sources: bundle (`prowl.*` ids), user (`~/.prowl/workflows/*.yaml`), repo (`<root>/.prowl/workflows/*.yaml`). |
-| Role | A participant: `source: current` (the pane the run was started from), `pick` (an existing detected agent pane chosen at start), or `launch` (a new agent Prowl starts). `launch` roles are `interactive` (TUI in a tab/split) or `headless` (one-shot adapter process with captured output). |
+| Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if a non-skipped step `message`s it, so a bare shell can still be the source of a context-only handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
 | Binding | Role → concrete Agent Profile, resolved at start and frozen into the run. |
 | Step | One verb: `message` (say something to a live role), `launch` (start a launch role), `action` (built-in Swift action), `notify`, `close`; plus `repeat` blocks. Each step has a `title` for the status slot and an optional `expect`. |
-| Expect | What must happen before the run advances: a named `output` delivered by the role via `prowl workflow done`, optional `sections`/`format` validation, optional `verdict` enum, `timeout`, `on_timeout`. |
+| Expect | Only on `message` / `launch` steps: what must happen before the run advances — a named `output` delivered by the step's target role via the generated `prowl workflow done` command, optional `sections`/`format` validation, optional `verdict` enum (safe slugs), optional `timeout` / `on_timeout`. |
 | Run | One execution: state snapshot + artifacts under `<root>/.prowl/workflow-runs/<run-id>/`. |
 
 ### Execution model: Prowl runs, agents participate
@@ -98,33 +98,106 @@ that advances one step at a time through existing terminal boundaries:
 - `launch` → the shared profile launch boundary (`launchAgentProfile` extended with
   `AgentStartIntent.prompt`, placement override, anchor surface, background, returning the
   created tab/surface identity — the #651 "shared terminal boundary" done properly).
-- `message` → `TerminalClient.sendTextToSurface` into the role's pane, gated by detection
-  (`blocked` → not injected, run enters `needsAttention`; `working` → queued, shown).
-- `expect` → a `WorkflowRequestRegistry` entry (generalizing `HandoffRequestRegistry`):
-  (run, step, role) claimable exactly once by `prowl workflow done` from the role's pane.
+- `message` → `TerminalClient.sendTextToSurface` into the role's pane, gated by detection.
+  Injection is synchronous (insert + submit, no Prowl-side queue); a `working` agent
+  receives the line in its own input queue (Claude Code and Codex queue typed input), and
+  the panel says so. A `message` step advances only after a *successful* injection: if
+  the role is `blocked`, its surface is gone, or injection fails, the step stays active in
+  `needsAttention` (Retry / Skip / Cancel) — it never advances on a line that was not
+  delivered. At most one pending injection exists per role; Cancel / Skip / Relaunch drop
+  it.
+- `expect` → a `WorkflowRequestRegistry` entry (generalizing `HandoffRequestRegistry`)
+  keyed by an **opaque per-activation delivery token** (a UUID, hence shell-safe) that
+  Prowl mints each time a step starts waiting — every `repeat` iteration is a new
+  activation `(run, step, ordinal, role)` with its own token, one delivery per activation —
+  and places in the generated completion command
+  (`PROWL_WORKFLOW_TOKEN=<token> prowl workflow done -`, the same env-prefix technique as
+  today's `PROWL_HANDOFF_REQUEST_ID`; `--token <token>` is the explicit form). The entry
+  is claimable exactly once; a `done` that arrives without the token, with a revoked token
+  (Skip / Cancel / Relaunch revoke), or from a pane other than the role's is rejected — so
+  a delayed or duplicated `done` from a pane that has since moved on to another step can
+  never be misattributed. Tokens are never written into YAML, and the **generated
+  command is the only spelling agents ever see**: one completion-command renderer produces
+  the initial hint, every nudge, and every re-delivery (token always present; for verdict
+  steps a `--verdict VALUE -` form plus one executable command per allowed value in the
+  materialized instruction and in `prowl workflow status`); built-ins and examples say
+  "finish with the generated completion command"; the validator warns when
+  `text`/`instruction` spells out `prowl workflow done`. `expect` is valid only on
+  `message` and `launch` (their target role delivers); native actions return typed
+  outputs synchronously. Skipping a step whose expected output is referenced by a later
+  template ends the run as `skipped` (the panel says which step depends on it) — V1 has
+  no optional template values, so the alternative would be an unrenderable step.
 - `action` → a registry of native Swift actions (`handoff.transition`, `git.context`).
 - `notify`/`close` → the existing bell pipeline and protected close path.
 
 **Data channels.** Inbound to an agent is always *file + short pointer*: long
 `instruction` text is materialized to `run.dir/instructions/<step>.md` and one line is
 typed (or passed as the kickoff prompt); short `text` is typed verbatim (single line).
-Outbound is `prowl workflow done [--verdict v] -` (stdin), resolved to (run, role, step) by
-caller-pane identity — no ids in the typed command, so shared YAML carries nothing
-machine-specific. `headless` roles are the adapter-stable alternative: output is captured
-by Prowl (`.headless` intent, stdout or `--output-last-message`-style files). Transcript
-observation (`agents read`) is reserved as a V2 assist, not a V1 channel.
+Outbound is `prowl workflow done [--verdict v] -` (stdin): the caller pane identifies the
+run/role, the delivery token identifies the awaited step — the YAML itself carries nothing
+machine-specific. Transcript observation (`agents read`) and headless adapter capture are
+V2 channels (see Alternatives).
+
+**Event topology.** `WorktreeTerminalManager.eventStream()` is single-consumer (a new
+subscription finishes the previous stream) and `AppFeature` is its only subscriber. The
+runner therefore lives as a child reducer of `AppFeature`, which forwards
+`agentEntryChanged` / `agentEntryRemoved` / `taskStatusChanged` to it; nothing else
+subscribes to `TerminalClient.events()`. `prowl agents wait` (and any other CLI observer)
+uses a new per-surface multicast observer on `WorktreeTerminalManager`, independent of the
+reducer stream and typed so that disappearance is observable:
+
+```swift
+enum ObservedAgentState: Sendable {
+  case snapshot(ActiveAgentEntry?)   // always the first element, even when no agent is detected
+  case changed(ActiveAgentEntry)
+  case removed                       // agent process gone; entry removed (today: agentEntryRemoved)
+  case surfaceClosed                 // pane closed; stream finishes after this
+}
+func observeAgentState(surfaceID: UUID) -> AsyncStream<ObservedAgentState>
+```
+
+Each subscriber gets its own bounded buffer (newest-wins coalescing, like
+`TerminalEventCoalescer`); registration and snapshot capture happen in one main-actor
+step so no change can fall between them, the snapshot precedes live events, cancellation
+removes the subscriber, and `surfaceClosed` terminates the stream. `agents wait` maps `removed` /
+`surfaceClosed` to a terminal `AGENT_GONE` error (not to `done`) unless `--until changed`
+was requested. The runner's watchdog likewise reads the role's *current* state first and
+schedules cancellable grace deadlines on the injected clock; it never relies on a later
+event alone.
 
 **Data bus.** `<root>/.prowl/workflow-runs/<run-id>/` holds `run.json`, `log.md`,
-`instructions/`, `skills/`, `outputs/<name>.md` (versioned per repeat iteration, latest
-wins in templates), `captures/`. Distribution is "the next instruction names the path";
-Prowl never inlines one agent's output into another agent's input box.
+`instructions/`, `skills/` (materialized from the embedded skill registry only — `skill:`
+ids are safe slugs that must resolve to a bundled skill), `outputs/<name>.md` (every
+delivery also kept as `<name>.<activation ordinal>.md`; latest wins in templates).
+Distribution is "the next instruction names the path"; Prowl never inlines one agent's
+output into another agent's input box, and every rendered line is re-validated as a
+single terminal line before injection (template values such as inputs or paths cannot
+smuggle a newline past the boundary). Outputs are agent-authored
+content persisted at the agent's request (default cap 1 MiB, hard max 4 MiB,
+`OUTPUT_TOO_LARGE` otherwise; same bounds as `agents read`), kept until the user deletes
+the run folder (retention policy is a V2 item, as for `.prowl/handoff/archive`). Step ids
+and output names are restricted to safe slugs because they become path components; run
+directories are created with canonical containment checks under
+`<root>/.prowl/workflow-runs/` (no symlink leaf), mirroring
+`AgentProfileHomeProvisioner`. Repo-scoped workflow files are untrusted input and go
+through the same validator.
 
-**Binding resolution** (per `launch` role, at start): remembered binding
-`(workflow id, role) → profile UUID` in `UserGlobalSettings` → enabled profile matching
-`suggest` exactly → 053's Recommended filtered by `agents` → ask. The Start sheet shows a
-picker per role with "Create profile from suggestion…" when nothing matches; `bind: auto`
-skips the sheet when resolution is unambiguous. `--role r=<name|uuid|auto>` overrides from
-the CLI.
+**Binding resolution** (per `launch` role, at start): remembered binding → enabled
+profile matching `suggest` exactly → 053's Recommended filtered by `agents` → ask. The
+memory key is `(definition scope, workflow id, role, role-requirements digest)` where
+scope is `bundle`, `user`, or `repo:<repository id>` and the digest covers the role's
+requirement block (`source`, `kind`, `agents`, `suggest`) — so a repo workflow that
+shadows a same-id user workflow, the same id in two repositories, two worktrees of one
+repository carrying divergent definitions, or an edited role in a same-id file never
+reuses a binding made for different requirements, while prompt-only edits keep it. Every
+candidate (remembered
+or `--role` override included) is re-validated before use: still exists, enabled,
+satisfies `agents`, and its adapter supports the intent the role needs (seeded prompt);
+otherwise resolution falls through to the next tier. The Start sheet shows a picker per
+role with "Create profile from suggestion…" when nothing matches; `bind: auto` skips the
+sheet when resolution is unambiguous. CLI overrides are source-specific (`--role
+<launch-role>=<profile name|uuid|auto>`, `--role <pick-role>=<pN|pane UUID>`; see the DSL
+spec §9).
 
 **Waiting is state-driven, not wall-clock.** `expect` has no default timeout: a working
 agent is never interrupted however long it takes. Instead the runner's watchdog consumes
@@ -133,8 +206,10 @@ periodic detection schedule) with grace periods, because detection is heuristic 
 wrong guess must be harmless: a role `blocked` for ≥ `blocked_grace` (default 30 s) →
 `needsAttention` (Focus pane / Cancel); a role `idle`/`done` for ≥ `idle_grace` (default
 3 min) without `done` → Prowl **auto-nudges once** (types `[Prowl] When your work for this
-step is fully complete, finish with: prowl workflow done -`, harmless if the agent was in
-fact still working — it just queues) and escalates to `needsAttention` (Nudge again / Keep
+step is fully complete, finish with: <the activation's rendered completion command — token
+and, for verdict steps, one executable command per value>`, harmless if the agent was in
+fact still working — the runtime just queues the line) and escalates to
+`needsAttention` (Nudge again / Keep
 waiting / Skip / Cancel) only after another `idle_grace`; the role's agent process
 disappearing → `needsAttention` (Relaunch role / Skip / Cancel). `needsAttention` is a UI
 state, never a deadline: a late `done` is still accepted. Grace values are global settings
@@ -143,11 +218,13 @@ state, never a deadline: a late `done` is still accepted. Grace values are globa
 
 **Invariants** (carried from 047/053/#651): a pane belongs to at most one run at a time
 (`PANE_BUSY`); injection only into panes bound to the run; roles and their plans are frozen
-at start; `done` is accepted only from the bound pane unless an explicit `--run/--step`
-(manual, logged) or `--force` is given; attention states wait for a person, they never
-discard delivered outputs; cancel never closes a pane; extra arguments, environment
-values, home paths, and credentials never enter requests, payloads, artifacts, or logs;
-the runner performs no git writes.
+at start; `done` is accepted only from the bound pane with a live delivery token, unless an
+explicit `--run/--step` (manual, logged) or `--force` is given; attention states wait for a
+person, they never discard delivered outputs; cancel never closes a pane; Prowl-originated
+metadata (requests, payloads, `run.json`, logs) never carries extra arguments, environment
+values, home paths, or credentials — agent-authored outputs are the agents'
+responsibility and stay under the self-ignored run directory; the runner performs no git
+writes.
 
 ### UI
 
@@ -197,8 +274,13 @@ the runner performs no git writes.
 ### CLI (per 060's four-layer rule)
 
 `prowl workflow list | run <id> [source] [--role r=…] [--input k=v] | status [run] | done
-[-|--file] [--verdict v] [--run --step] [--force] | cancel <run> | validate <file> |
-schema`; `prowl profiles list` (read-only, for CLI-driven orchestration); prerequisites
+[-|--file] [--verdict v] [--token t] [--run --step] [--force] | cancel <run> | validate
+<file> | schema` — `[source]` is 060's `GenericTarget` (`pN`, `tN`, UUID, worktree ref); omitted,
+the source is the caller pane when the workflow has a `current` role, and a worktree
+reference is required otherwise; `--role` is source-specific (`launch` role →
+`<profile name|uuid|auto>`, `pick` role → `<pN|pane UUID>` in the source worktree,
+`current` → none); `prowl profiles list` (read-only, for CLI-driven orchestration);
+prerequisites
 `prowl create pane <pane> --direction … [--profile <name|uuid> --prompt -]` (#699 extended)
 and `prowl agents wait <pane> --until idle|done|blocked [--timeout]`. `prowl handoff
 to|save` remain (see Open questions for alias vs. removal).
@@ -217,9 +299,28 @@ to|save` remain (see Open questions for alias vs. removal).
   notify. The receiver role carries **no `agents:` restriction**: any runtime whose adapter
   supports a seeded prompt is admissible (055 verified all but Amp, which the adapter
   rejects itself); the 047-era claude/codex-only admission is retired. The deprecated
-  `prowl handoff to --brief -` alias starts this run through the runner's internal API with
-  the `brief` output pre-delivered from stdin; `--no-brief` pre-marks the step skipped;
-  `prowl handoff save` maps to a small `prowl.handoff-checkpoint` built-in.
+  `prowl handoff` commands are served by a **`LegacyHandoffAdapter`** in the app (D3) that
+  maps every existing parameter onto the runner's internal start API and renders the
+  existing `prowl.cli.handoff.v2` response shape (schema-compatible; semantic differences
+  documented, not "byte-compatible"): `to <agent>` → the Recommended enabled profile of
+  that runtime, else `PROFILE_NOT_FOUND` with guidance; source selectors / positional
+  source → run source; `--brief -` / `--no-brief` → `brief` output pre-delivered / step
+  pre-skipped; `--note` → `handoff.transition` input; `--no-launch` → `launch` step
+  pre-skipped with the target token recorded (so `prowl handoff to gemini --no-launch`
+  keeps working without any profile); `save` → `prowl.handoff-checkpoint`. The adapter
+  preflights before any run or artifact exists, reproducing today's immediate errors
+  (`BRIEF_REQUIRED` when neither `--brief` nor `--no-brief` is given — the legacy path
+  never starts an agent-mediated brief step; `EMPTY_INPUT`; `INVALID_BRIEF`), and maps
+  action/transition failures to the legacy failure response. Because the
+  `brief` step is pre-supplied or pre-skipped, the `current` role needs no detected agent
+  — a bare shell pane remains a valid legacy source, as today. The adapter starts the run
+  with `failurePolicy: .fail` (the runner's generic `.attention` policy would hang a
+  synchronous CLI call): a launch/provision failure after the artifacts are written ends
+  the run as `failed`, keeps artifacts and log, and returns `HANDOFF_FAILED` exactly as the
+  current handler does. The adapter awaits run completion synchronously (no agent wait is
+  involved once the brief is supplied) and is covered by per-field socket parity tests:
+  no-agent source, `--no-brief`, `--no-launch`, profile lookup failure, provisioning
+  failure, launch failure.
 - `skills/prowl-workflows/SKILL.md`: how to author and run workflows; `prowl workflow
   schema` prints the machine-readable reference.
 
@@ -298,21 +399,27 @@ built-ins land, handoff migrated).
   bulk of a workflow; block scalars are essential. JSON remains valid input. Parsing
   Mermaid into stable orchestration semantics is fragile and was rejected.
 - **`done`-first outbound channel, not transcript observation.** `prowl workflow done` is
-  runtime-agnostic, validated, correlated by caller pane, and proven by the inline brief.
-  `agents read` covers only Claude/Codex and depends on intermittent session attribution;
-  it becomes a V2 assist. `headless` roles are the adapter-stable alternative where
-  interaction is not needed.
+  runtime-agnostic, validated, correlated by caller pane + delivery token, and proven by
+  the inline brief. `agents read` covers only Claude/Codex and depends on intermittent
+  session attribution; it becomes a V2 assist.
+- **Headless roles deferred to V2.** The adapters only *render* `.headless` invocations;
+  there is no process executor, output protocol, or per-runtime trusted-result extraction
+  yet (cwd/env, stdout/stderr bounds, exit/cancel/timeout semantics all undefined). Neither
+  V1 built-in needs it, and the interactive reviewer is the product default anyway, so
+  `kind: headless` stays a reserved key until a `HeadlessAgentExecutor` is specified.
 - **File + pointer inbound; `text` for short lines.** Typed text is one line by
   construction (TUIs submit on newline; `ghostty_surface_text` is not bracketed paste).
   Long content is materialized; short messages are typed verbatim so users can see them.
 - **Interactive reviewer by default.** Side-by-side visibility of the review happening is
-  part of the product's trust model (onevcat, 2026-08-21); headless is an opt-in role kind.
+  part of the product's trust model (onevcat, 2026-08-21); headless roles are a V2 item.
 - **Roles reference requirements, never local profile names.** `agents:` (allowed
   runtimes) + `suggest:` (match-or-create) + remembered local bindings keep shared files
   portable while profiles remain the only launch authority (053 boundary intact).
 - **`repeat … until <verdict>` in V1, no expression language.** The one loop onevcat's
   real flow needs is "re-review until clean"; termination reads a machine-declared
-  `--verdict`, never prose. `max` is mandatory.
+  `--verdict`, never prose. `max` is mandatory. `until` is evaluated **before entering and
+  after every iteration** (while-loop semantics), so a first-round `clean` verdict skips
+  the loop entirely.
 - **Step completion is `prowl workflow done`, not `submit <name>`.** Prowl knows which
   step awaits which pane, so the agent names nothing; output names live in YAML
   (`expect.output`).
@@ -324,8 +431,9 @@ built-ins land, handoff migrated).
 
 - **Handoff CLI**: `prowl workflow run prowl.handoff` is the primary invocation. The
   shipped `prowl handoff to|save` stays as a **deprecated alias** (stderr warning per 060's
-  deprecation policy, byte-compatible payload during the window) and is retired
-  afterwards. The `.prowl/handoff/` artifact contract survives inside the
+  deprecation policy; the `prowl.cli.handoff.v2` response shape is kept
+  schema-compatible by the `LegacyHandoffAdapter`, with semantic differences documented)
+  and is retired afterwards. The `.prowl/handoff/` artifact contract survives inside the
   `handoff.transition` action.
 - **Binding default**: built-ins use `bind: ask`. Users switch a workflow to `auto` without
   editing the file: a "Don't ask again for this workflow" toggle in the start sheet and a
@@ -344,6 +452,44 @@ built-ins land, handoff migrated).
 - **PR order**: C0 → A1 ∥ B1 → A2 ∥ B2 → B3 → C1 → C2 → D1 → D2 → D3 (see Delivery
   slicing); the new Adversarial Review flow validates the engine before the shipped handoff
   is migrated.
+- **Review round (2026-08-22)** — accepted corrections: runner as an `AppFeature` child
+  fed by the single event subscription + a per-surface multicast observer for CLI waits;
+  opaque per-step delivery tokens for `done`; `LegacyHandoffAdapter` with a full parameter
+  map instead of a "byte-compatible" claim; binding memory scoped by definition source +
+  repository and re-validated; `pick` restricted to the source worktree; `kind: headless`
+  moved to V2; output size caps, slug-safe ids, run-directory containment, and the
+  privacy wording split into Prowl metadata vs. agent-authored outputs; `until` checked
+  before entry and after each iteration.
+- **Review round 2 (2026-08-22)** — accepted: typed `ObservedAgentState` observer
+  (snapshot / changed / removed / surfaceClosed, per-subscriber buffering, `AGENT_GONE`
+  mapping for `agents wait`); the generated completion command is the only spelling in
+  built-ins/examples, `--token` in the grammar, shell-safe UUID tokens, tokenized nudges;
+  `LegacyHandoffAdapter` admits a bare-shell source when the brief is pre-supplied/skipped
+  and uses `failurePolicy: .fail` → `HANDOFF_FAILED`; skipping an output referenced later
+  ends the run as `skipped`; binding memory keyed additionally by a role-requirements
+  digest; `message` steps advance only after a successful synchronous injection (no
+  Prowl-side queue); P2 wording fixes (role `name`/`pane` semantics, `run` source
+  grammar, privacy phrasing, `repeat` terminal results).
+- **Review round 3 (2026-08-22)** — accepted: one completion-command renderer (token +
+  verdict choices, used for hints, nudges, re-deliveries); §3 binding key with a canonical
+  role-requirements digest as the single normative definition; per-activation identity
+  and tokens for `repeat`; `expect` restricted to `message`/`launch`; source-specific
+  `--role` grammar incl. `pick` panes; `LegacyHandoffAdapter` preflight (`BRIEF_REQUIRED`
+  / `EMPTY_INPUT` / `INVALID_BRIEF`, legacy failure mapping); rendered-text boundary
+  (post-substitution single-line validation, single-line string inputs, `UNSAFE_PATH`);
+  `skill:` restricted to the embedded registry; wording cleanups (runtime input queue,
+  bare-shell `current`, privacy phrasing, atomic observer registration, slug patterns).
+- **Review round 4 (2026-08-22; verified item by item before adopting)** — the renderer
+  now emits one complete executable command per verdict value on every transport (no
+  placeholders); run-global monotonic activation ordinals make `outputs/<name>.<ordinal>.md`
+  and `instructions/<step>.<ordinal>.md` collision-free, with atomic "latest" replacement;
+  native actions declare typed input/output schemas and `actions.<step>.<key>` is validated
+  like `outputs.*` (known action, declared key, producer dominates consumer); `repeat.max`
+  is a positive integer literal or exactly one integer-input template, resolved at start,
+  bounded `1…20`; verdict values are unique safe slugs and `until` literals must be
+  declared; optional fixes (`UNSAFE_PATH` listed, `tN` in the source grammar, concepts
+  table and binding text aligned with the DSL, `notify` fallback without a `current` role,
+  legacy parity list includes the preflight cases).
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -5,7 +5,7 @@
 | **Status** | Planned (design in discussion; see Open questions) |
 | **Anchor date** | 2026-08-21 |
 | **Primary PRs** | TBD (see Delivery slicing) |
-| **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
+| **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
 
 ## Background
 
@@ -292,10 +292,13 @@ reference is required otherwise; `--role` is source-specific (`launch` role →
 `<profile name|uuid|auto>`, `pick` role → `<pN|pane UUID>` in the source worktree,
 `current` → none); `prowl profiles list` (read-only, for CLI-driven orchestration);
 prerequisites
-`prowl create pane <pane> --direction … [--profile <name|uuid> --prompt -]` (#699 extended)
-and `prowl agents wait <pane> --until idle|done|blocked [--timeout]`. `prowl handoff
-to|save` are **retired**: one release of non-executing stubs that answer `HANDOFF_RETIRED`
-with the exact `prowl workflow run …` replacement, then removal (see Built-ins).
+`prowl create pane <pane> --direction … [--profile <name|uuid> --prompt -]` (#699 extended);
+`prowl agents signal` / `prowl agents wait` (deterministic completion signals for the
+CLI-driven route) are specified and delivered by
+[064 agent-completion-signals](../064-agent-completion-signals/000-plan.md), which consumes
+this entry's observer and launch boundary. `prowl handoff to|save` are **retired**: one
+release of non-executing stubs that answer `HANDOFF_RETIRED` with the exact `prowl workflow
+run …` replacement, then removal (see Built-ins).
 
 ### Built-ins and distribution
 
@@ -352,12 +355,11 @@ Shapes are intentionally close to what exists so the runner and the CLI share on
   (`PROFILE_NOT_FOUND` / `PROFILE_NOT_UNIQUE`); `prowl.cli.create.v1` is extended
   additively (`resource: pane`, `anchor`, `direction`, optional `launch {profile_id,
   profile_name, agent}`). `prowl profiles list` is a read-only snapshot of enabled/disabled
-  profiles with availability (`prowl.cli.profiles.v1`). `prowl agents wait <pane> --until
-  idle|done|blocked|changed --timeout 1…3600` consumes the typed `ObservedAgentState`
-  observer described above (snapshot first → immediate return when already satisfied;
-  `WAIT_TIMEOUT` on expiry; `removed` / `surfaceClosed` → error `AGENT_GONE` with the last
-  known status in the error payload) and returns `{status, raw_state, waited_ms}`
-  (`prowl.cli.agents.wait.v1`).
+  profiles with availability (`prowl.cli.profiles.v1`). `prowl agents wait` is owned by
+  [064](../064-agent-completion-signals/000-plan.md): it consumes the typed
+  `ObservedAgentState` observer described above (snapshot first; `removed` /
+  `surfaceClosed` → `AGENT_GONE`) and adds the signal bus, `source`/`confidence`, and
+  launch-scoped hooks on top of this entry's launch boundary.
 - **Tests**: terminal-layer coverage extends `supacodeTests/WorktreeTerminalStateAgentProfileTests.swift`
   (anchored split, placement override, background tab, returned identity, provisioning
   failure); planner intent rendering per adapter in `supacodeTests/AgentProfileTests.swift`
@@ -383,7 +385,7 @@ built-ins land, handoff migrated).
 | 1 | **C0** Settings IA: Agents group (Profiles / Workflows placeholder / Command Line Tool moved from Advanced) | C | — | Independent, small, decides where everything lands |
 | 2 | **A1** `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers | A | 060 | Foundation for every `launch` into a split |
 | 3 | **B1** Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`, read-only Settings list | B | — | Parallel with A1; makes the DSL concrete and authorable |
-| 4 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list` + `prowl agents wait` | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary |
+| 4 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list` (`prowl agents wait` moved to 064) | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary; 064-S3 attaches launch-scoped hooks here |
 | 5 | **B2** Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries | B | B1 | Parallel with A2 |
 | 6 | **B3** Runner wiring: `WorkflowRunsFeature` effects, detection-event subscription, CLI preflight, `prowl workflow run/status/done/cancel` + contracts | B | A2, B2 | Engine first powered on |
 | 7 | **C1** Status center fifth state + run panel + attention triggers + notifications (061 visual verification) | C | B3 | Runs become visible |
@@ -456,8 +458,15 @@ built-ins land, handoff migrated).
   memory. Direction: V1 edits YAML in an external editor; a GUI editor with file ↔ UI
   two-way sync is the long-term goal (see Open questions for the round-trip constraint).
 - **CLI-driven orchestration primitives ship with #699**: `prowl create tab|pane
-  --profile <name|uuid> [--prompt -]`, `prowl profiles list`, `prowl agents wait` are part
-  of the prerequisite PRs, not a later wave.
+  --profile <name|uuid> [--prompt -]` and `prowl profiles list` are part of the
+  prerequisite PRs, not a later wave. (`prowl agents wait` was initially listed here and
+  moved to 064 on 2026-08-22 — see below.)
+- **Completion signals split out as 064 (2026-08-22)**: the layered signal bus,
+  `prowl agents signal`, launch-scoped hooks, and `prowl agents wait` with
+  `source`/`confidence` are an independent entry. 063 V1 does not depend on it (steps
+  complete on `done`; the heuristic watchdog is harmless by design); 064 consumes 063's
+  observer (B3) and launch boundary (A2), and in return sharpens the watchdog and enables
+  063's V2 observe mode / `on_attention: ask <role>`.
 - **Settings IA**: Agents becomes a sidebar group with Profiles / Workflows / Command Line
   Tool pages (see Design / UI); the CLI install leaves Advanced.
 - **No default wall-clock timeout; state-driven watchdog with grace periods** (see Design

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -1,0 +1,357 @@
+# 063 — Agent Workflows: Plan
+
+| | |
+| --- | --- |
+| **Status** | Planned (design in discussion; see Open questions) |
+| **Anchor date** | 2026-08-21 |
+| **Primary PRs** | TBD (see Delivery slicing) |
+| **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
+
+## Background
+
+Prowl already runs several coding agents side by side, identifies them per pane, launches
+them through Agent Profiles (053/055), reads their trustworthy results (059), and hands a
+task from one agent to another (047/049). The handoff that exists today is valuable but
+structurally stuck:
+
+- Its flow is a fixed state machine (`HandoffStage` `requesting → finishing`,
+  `HandoffHudPhase` choose/run/finish in
+  `supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift`); target list, briefing
+  sections, kickoff prompt, and injection text are literals
+  (`supacode/CLIService/Shared/HandoffAgentSupport.swift`,
+  `supacode/CLIService/HandoffCommandHandler.swift`,
+  `supacode/Domain/Handoff/HandoffInjection.swift`).
+- Its two launch paths (CLI → `WorktreeTerminalState.createTab(initialInput:)`, HUD
+  fallback → `TerminalClient.Command.createTabWithInput`) bypass Agent Profiles entirely:
+  `AgentStartRequest.dedicatedHome` is always nil, and model/effort/extra arguments/env
+  never reach the receiver. PR #651 tried to thread a profile UUID through that fixed flow;
+  the direction (profile-bound receiver, freeze before commit, one shared launch boundary
+  returning exact pane identity, no secrets in artifacts) is right, the shape is not.
+- The orchestration onevcat actually runs day to day — agent 1 opens a split, launches
+  agent 2 with a prompt, monitors it, reads its result, fixes, asks for another round until
+  clean — lives only in ad-hoc `prowl` CLI usage and cannot be reproduced or shared.
+
+The foundations that make a general solution possible are all on `main` now: a pure
+profile launch planner with a typed `.prompt` start intent
+(`supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift`,
+`supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift`), text injection into a live pane
+(`TerminalClient.sendTextToSurface`), caller-pane identity for CLI calls
+(`supacode/CLIService/CLICommandContext.swift`), one-shot request ownership
+(`supacode/Domain/Handoff/HandoffRequestRegistry.swift`), briefing validation
+(`HandoffStore.validatedBriefing`), the agent status event stream, a toolbar status slot
+(`supacode/Features/Repositories/Views/ToolbarStatusView.swift`), and the four-layer CLI
+contract governance of 060.
+
+## Goals
+
+- Replace the hard-coded handoff flow with **Agent Workflows**: data-driven, multi-agent
+  orchestrations declared in a YAML DSL (`prowl.workflow/v1`, normative text in
+  [dsl-spec.md](dsl-spec.md)) and executed by a reducer-owned runner inside Prowl.
+- Make the orchestration onevcat runs by hand (launch reviewer in a split → review →
+  fix → re-review until clean) expressible, reproducible, and shareable as a file.
+- Bind workflow roles to Agent Profiles **without** coupling the file to a machine: a
+  workflow declares abstract role requirements; the role → profile binding is local,
+  remembered, and overridable.
+- Surface runs in the toolbar's central status slot (`Adversarial Review · 3/6 · Round 2:
+  reviewer re-checking`) with a popover for steps, role panes, and controls; keep every
+  existing entry point (Agents capsule popover, Command Palette, Active Agents context menu).
+- Let agents participate through the `prowl` CLI only (`prowl workflow done`), so every
+  recognized runtime can play any interactive role, and keep the pure-CLI route (an agent
+  orchestrating others by hand) first-class by shipping the missing primitives.
+- Ship two built-in workflows — `prowl.handoff` (replacing the current implementation) and
+  `prowl.adversarial-review` — plus bundled skills, and a documented path for users (and
+  their agents) to author custom workflows.
+
+### Non-goals
+
+- A visual workflow editor. Authoring is YAML + `prowl workflow validate` + agent
+  assistance (bundled docs/skill).
+- General control flow (conditions, parallel fan-out, nesting) in V1. V1 control flow is
+  sequential steps plus one bounded `repeat … until <verdict>` construct.
+- Executing shell commands, writing arbitrary files, git/network operations, sending
+  keystrokes, or answering permission prompts from a workflow.
+- Launching agents outside Agent Profiles. `suggest` may match or create a profile; it
+  never bypasses one.
+- Cross-worktree roles (all roles of a run live in the source worktree) and resuming runs
+  across app restarts — both V2 candidates.
+- Analytics for workflows; workflow ids, role bindings, and run content never enter
+  PostHog/Sentry.
+
+## Design / Approach
+
+### Concepts
+
+| Term | Meaning |
+| --- | --- |
+| Workflow | A `prowl.workflow/v1` YAML document: id, inputs, roles, steps. Sources: bundle (`prowl.*` ids), user (`~/.prowl/workflows/*.yaml`), repo (`<root>/.prowl/workflows/*.yaml`). |
+| Role | A participant: `source: current` (the pane the run was started from), `pick` (an existing detected agent pane chosen at start), or `launch` (a new agent Prowl starts). `launch` roles are `interactive` (TUI in a tab/split) or `headless` (one-shot adapter process with captured output). |
+| Binding | Role → concrete Agent Profile, resolved at start and frozen into the run. |
+| Step | One verb: `message` (say something to a live role), `launch` (start a launch role), `action` (built-in Swift action), `notify`, `close`; plus `repeat` blocks. Each step has a `title` for the status slot and an optional `expect`. |
+| Expect | What must happen before the run advances: a named `output` delivered by the role via `prowl workflow done`, optional `sections`/`format` validation, optional `verdict` enum, `timeout`, `on_timeout`. |
+| Run | One execution: state snapshot + artifacts under `<root>/.prowl/workflow-runs/<run-id>/`. |
+
+### Execution model: Prowl runs, agents participate
+
+The runner is a TCA feature (`WorkflowRunsFeature`, reducer-owned like the handoff HUD was)
+that advances one step at a time through existing terminal boundaries:
+
+- `launch` → the shared profile launch boundary (`launchAgentProfile` extended with
+  `AgentStartIntent.prompt`, placement override, anchor surface, background, returning the
+  created tab/surface identity — the #651 "shared terminal boundary" done properly).
+- `message` → `TerminalClient.sendTextToSurface` into the role's pane, gated by detection
+  (`blocked` → not injected, run enters `needsAttention`; `working` → queued, shown).
+- `expect` → a `WorkflowRequestRegistry` entry (generalizing `HandoffRequestRegistry`):
+  (run, step, role) claimable exactly once by `prowl workflow done` from the role's pane.
+- `action` → a registry of native Swift actions (`handoff.transition`, `git.context`).
+- `notify`/`close` → the existing bell pipeline and protected close path.
+
+**Data channels.** Inbound to an agent is always *file + short pointer*: long
+`instruction` text is materialized to `run.dir/instructions/<step>.md` and one line is
+typed (or passed as the kickoff prompt); short `text` is typed verbatim (single line).
+Outbound is `prowl workflow done [--verdict v] -` (stdin), resolved to (run, role, step) by
+caller-pane identity — no ids in the typed command, so shared YAML carries nothing
+machine-specific. `headless` roles are the adapter-stable alternative: output is captured
+by Prowl (`.headless` intent, stdout or `--output-last-message`-style files). Transcript
+observation (`agents read`) is reserved as a V2 assist, not a V1 channel.
+
+**Data bus.** `<root>/.prowl/workflow-runs/<run-id>/` holds `run.json`, `log.md`,
+`instructions/`, `skills/`, `outputs/<name>.md` (versioned per repeat iteration, latest
+wins in templates), `captures/`. Distribution is "the next instruction names the path";
+Prowl never inlines one agent's output into another agent's input box.
+
+**Binding resolution** (per `launch` role, at start): remembered binding
+`(workflow id, role) → profile UUID` in `UserGlobalSettings` → enabled profile matching
+`suggest` exactly → 053's Recommended filtered by `agents` → ask. The Start sheet shows a
+picker per role with "Create profile from suggestion…" when nothing matches; `bind: auto`
+skips the sheet when resolution is unambiguous. `--role r=<name|uuid|auto>` overrides from
+the CLI.
+
+**Waiting is state-driven, not wall-clock.** `expect` has no default timeout: a working
+agent is never interrupted however long it takes. Instead the runner's watchdog consumes
+the existing detection events (`agentEntryChanged` / `agentEntryRemoved`, produced by the
+periodic detection schedule) with grace periods, because detection is heuristic and a
+wrong guess must be harmless: a role `blocked` for ≥ `blocked_grace` (default 30 s) →
+`needsAttention` (Focus pane / Cancel); a role `idle`/`done` for ≥ `idle_grace` (default
+3 min) without `done` → Prowl **auto-nudges once** (types `[Prowl] When your work for this
+step is fully complete, finish with: prowl workflow done -`, harmless if the agent was in
+fact still working — it just queues) and escalates to `needsAttention` (Nudge again / Keep
+waiting / Skip / Cancel) only after another `idle_grace`; the role's agent process
+disappearing → `needsAttention` (Relaunch role / Skip / Cancel). `needsAttention` is a UI
+state, never a deadline: a late `done` is still accepted. Grace values are global settings
+(Settings › Workflows); an author may still add an explicit `expect.timeout` with
+`on_timeout: attention|skip|cancel` for hard caps.
+
+**Invariants** (carried from 047/053/#651): a pane belongs to at most one run at a time
+(`PANE_BUSY`); injection only into panes bound to the run; roles and their plans are frozen
+at start; `done` is accepted only from the bound pane unless an explicit `--run/--step`
+(manual, logged) or `--force` is given; attention states wait for a person, they never
+discard delivered outputs; cancel never closes a pane; extra arguments, environment
+values, home paths, and credentials never enter requests, payloads, artifacts, or logs;
+the runner performs no git writes.
+
+### UI
+
+- **Status center**: `ToolbarStatusView` gains a `workflowRun` state with priority
+  toast > active run of the selected worktree > PR > palette hint. The slot itself stays
+  minimal — an animated running indicator plus the current step's `title` (orange
+  attention glyph in `needsAttention`; a count badge when the worktree has several active
+  runs) — because the principal item cannot carry more. Everything else lives in the
+  hover-open/pin-on-click popover (same pattern as `PullRequestChecksPopoverButton` /
+  `ToolbarNotificationsPopoverButton`): header (workflow, worktree, elapsed, state), role
+  chips (profile icon + name + `pN`, click → focus), a height-capped **scrolling** step
+  list (authors may declare any number of steps; `repeat` iterations grouped as `Round
+  k/max`; the active step rendered as title + dimmed body with the full instruction
+  text), the attention block with its actions (Focus pane / Nudge / Keep waiting / Skip /
+  Relaunch / Cancel as applicable), and Cancel / Reveal run folder / Open log. Completion
+  reuses the `success` toast. Notifications for attention and completion go through the
+  bell with click-to-focus, silenced while the user watches that worktree. Detailed
+  visual design is deferred to C1 (build-time, 061 visual verification). Follows 061: the
+  principal slot stays a display item; no new glass exceptions.
+- **Start sheet**: the centered HUD card pattern of the handoff HUD (keyboard-capturing,
+  not window-modal) becomes `WorkflowStartOverlay`: title/description → "You: <agent> in
+  pN" for the `current` role → one picker per `launch` role (filtered by `agents`,
+  pre-selected, unavailable rows dimmed with reason, "Create from suggestion…" when
+  nothing matches) → one pane picker per `pick` role (detected agents excluding panes
+  already in a run and the current pane) → inputs → "Don't ask again for this workflow"
+  (when `bind: ask`) → Cancel / Run. A CLI-not-installed banner with an inline Install
+  action disables Run. `bind: auto` with unambiguous bindings and defaulted inputs skips
+  the sheet.
+- **Entry points**: Agents capsule popover gains a Workflows section (`Hand Off…` stays
+  its first row); Command Palette `Run Workflow: <name>`; Active Agents row context menu
+  `Run Workflow ▸` and an `in <workflow> · <role>` subtitle on rows that belong to a run.
+  The start sheet replaces the handoff HUD's choose stage; the HUD's run/finish stages are
+  subsumed by the status center (049's deferred PR2).
+- **Settings information architecture**: the Agents star feature becomes a sidebar
+  *group* (`Section("Agents")`, same native pattern as the Repositories group in
+  `supacode/Features/Settings/Views/SettingsView.swift`) with three pages — **Profiles**
+  (today's Agents page, renamed), **Workflows** (new), **Command Line Tool** (the `prowl`
+  install/status/socket/"Ask your agent" entry, moved out of Advanced because agents are
+  its primary consumer). Workflows ↔ Profiles stay linked by cross-reference, not by
+  merging: each workflow row shows its role → profile bindings (editable, jump to
+  Profiles); a CLI dependency banner with an inline Install action sits atop Workflows and
+  the runner preflights CLI installation before a run. Workflows page contents: Built-in
+  / User / Repo lists, enable toggle, per-workflow "ask for bindings" override, validation
+  status with YAML line errors, Reveal, New Workflow… (template file), Ask your agent to
+  write one (prompt pointing at bundled `docs/` + `skills/`).
+
+### CLI (per 060's four-layer rule)
+
+`prowl workflow list | run <id> [source] [--role r=…] [--input k=v] | status [run] | done
+[-|--file] [--verdict v] [--run --step] [--force] | cancel <run> | validate <file> |
+schema`; `prowl profiles list` (read-only, for CLI-driven orchestration); prerequisites
+`prowl create pane <pane> --direction … [--profile <name|uuid> --prompt -]` (#699 extended)
+and `prowl agents wait <pane> --until idle|done|blocked [--timeout]`. `prowl handoff
+to|save` remain (see Open questions for alias vs. removal).
+
+### Built-ins and distribution
+
+- `Resources/workflows/*.yaml` and `Resources/skills/` are embedded like `docs/`
+  (`Makefile` `embed-docs` pattern); `skill:` references are materialized into the run
+  directory so sandboxed agents can read them.
+- `prowl.adversarial-review`: interactive reviewer in a right split (transparency and user
+  trust outweigh headless precision), `repeat … until outputs.findings.verdict == clean`
+  with `max_rounds`.
+- `prowl.handoff`: `message source` (brief) → `action handoff.transition` (keeps the
+  `.prowl/handoff/` artifact contract; outputs `kickoff_prompt`, `artifact_path`,
+  `has_briefing`) → `launch receiver` (background tab, prompt from the action output) →
+  notify. The receiver role carries **no `agents:` restriction**: any runtime whose adapter
+  supports a seeded prompt is admissible (055 verified all but Amp, which the adapter
+  rejects itself); the 047-era claude/codex-only admission is retired. The deprecated
+  `prowl handoff to --brief -` alias starts this run through the runner's internal API with
+  the `brief` output pre-delivered from stdin; `--no-brief` pre-marks the step skipped;
+  `prowl handoff save` maps to a small `prowl.handoff-checkpoint` built-in.
+- `skills/prowl-workflows/SKILL.md`: how to author and run workflows; `prowl workflow
+  schema` prints the machine-readable reference.
+
+### Prerequisite interfaces (A1/A2) and test strategy
+
+Shapes are intentionally close to what exists so the runner and the CLI share one boundary.
+
+- **Anchored split primitive** (`supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift`):
+  `createSplit(of anchorSurfaceID: UUID, direction:, initialInput:, additionalEnvironment:,
+  focusing:) -> Result<UUID, SplitCreationError>` — the current
+  `createSplitOnFocusedSurface` becomes a wrapper that resolves the focused surface and
+  delegates. No focus-then-split (per #699).
+- **Launch boundary** (`WorktreeTerminalState.swift`, `TerminalClient.swift`,
+  `AgentProfileLaunchPlan.swift`): `AgentProfileLaunchPlanner.plan(for:intent:homeBaseDirectory:)`
+  gains the intent (default `.interactive`; stays pure); a new
+  `AgentProfileLaunchRequest { plan, placement: .tab(background:) | .split(anchor: UUID?,
+  direction:), workingDirectoryOverride: URL?, title: String? }`;
+  `WorktreeTerminalState.launchAgentProfile(_ request) -> Result<LaunchedSurface {tabID,
+  surfaceID}, AgentProfileLaunchError>`; a synchronous result-returning `TerminalClient`
+  closure (same style as `createTabInDirectory`), with the existing fire-and-forget
+  `Command.launchAgentProfile(worktree, plan:)` kept as a wrapper that still emits
+  `agentProfileLaunched` / `agentProfileLaunchFailed` for the menu/palette path.
+- **CLI additions**: `CreateInput` gains `direction` and an optional `launch { profile:
+  <name|uuid>, prompt: String? }`; `LifecycleCommandHandler` gains a `createPane` provider
+  and a profile-launch provider; profile lookup is UUID first, then exact unique name
+  (`PROFILE_NOT_FOUND` / `PROFILE_NOT_UNIQUE`); `prowl.cli.create.v1` is extended
+  additively (`resource: pane`, `anchor`, `direction`, optional `launch {profile_id,
+  profile_name, agent}`). `prowl profiles list` is a read-only snapshot of enabled/disabled
+  profiles with availability (`prowl.cli.profiles.v1`). `prowl agents wait <pane> --until
+  idle|done|blocked|changed --timeout 1…3600` subscribes to the per-surface
+  `ActiveAgentEntry` events (immediate return when already satisfied; `WAIT_TIMEOUT`
+  otherwise) and returns `{status, raw_state, waited_ms}` (`prowl.cli.agents.wait.v1`).
+- **Tests**: terminal-layer coverage extends `supacodeTests/WorktreeTerminalStateAgentProfileTests.swift`
+  (anchored split, placement override, background tab, returned identity, provisioning
+  failure); planner intent rendering per adapter in `supacodeTests/AgentProfileTests.swift`
+  / `AgentRuntimeAdapterTests.swift` (Amp rejects seeded prompts); handler coverage in
+  `supacodeTests/CLILifecycleCommandHandlerTests.swift` and new handlers for `profiles
+  list` / `agents wait` (TestClock for the timeout); parser tests beside
+  `ProwlCLITests/AgentsCommandParsingTests.swift`; socket round trips plus schema validation
+  in `ProwlCLITests/ProwlCLIIntegrationTests.swift`; contracts (`create.md`,
+  `targeting.md`, new `profiles.md`, `agents-wait.md`), `docs/components/cli.md`, and the
+  `prowl-cli` skill updated in the same PRs; the runner's own tests use fake
+  `TerminalClient` closures, a temp run directory, and `TestClock` for the watchdog.
+
+### Delivery slicing
+
+Four tracks — terminal/CLI primitives (A), definitions/runner (B), UI (C), built-ins and
+docs (D) — merged in the order below. C0 ∥ A1 ∥ B1 and A2 ∥ B2 can proceed in parallel.
+Milestones: **M1** (C0+A1+B1+A2: CLI-driven orchestration usable, DSL authorable and
+validatable), **M2** (B2+B3+C1+C2: engine and GUI run workflows), **M3** (D1+D2+D3:
+built-ins land, handoff migrated).
+
+| Order | PR | Track | Depends | Rationale |
+| --- | --- | --- | --- | --- |
+| 1 | **C0** Settings IA: Agents group (Profiles / Workflows placeholder / Command Line Tool moved from Advanced) | C | — | Independent, small, decides where everything lands |
+| 2 | **A1** `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers | A | 060 | Foundation for every `launch` into a split |
+| 3 | **B1** Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`, read-only Settings list | B | — | Parallel with A1; makes the DSL concrete and authorable |
+| 4 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list` + `prowl agents wait` | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary |
+| 5 | **B2** Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries | B | B1 | Parallel with A2 |
+| 6 | **B3** Runner wiring: `WorkflowRunsFeature` effects, detection-event subscription, CLI preflight, `prowl workflow run/status/done/cancel` + contracts | B | A2, B2 | Engine first powered on |
+| 7 | **C1** Status center fifth state + run panel + attention triggers + notifications (061 visual verification) | C | B3 | Runs become visible |
+| 8 | **C2** Start sheet (bindings, suggestion-based profile creation, don't-ask-again) + entry points (capsule popover, palette, Active Agents context menu) | C | B3 | GUI-initiated runs |
+| 9 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows complete (enable/validate/Reveal/New/Ask-agent/per-workflow auto) | D | B1, C2 | Distribution and docs |
+| 10 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification | D | A2, C2, D1 | Proves the engine on a fresh flow before touching shipped behavior |
+| 11 | **D3** `prowl.handoff` built-in + `handoff.transition`; `prowl handoff` → deprecated alias; remove `HandoffHudFeature`; rewrite `docs/components/handoff.md` | D | D2 | Migrate the shipped feature last |
+| 12 | V2: fan-out (`count`, `wait all`), observe mode (`agents read` capture), run persistence/resume, cross-worktree roles, GUI editor | — | — | — |
+
+## Alternatives & decisions
+
+- **Prowl-native runner, not an orchestrator agent.** A reducer-owned state machine is
+  deterministic, observable in the toolbar, costs no extra model turns, and is the natural
+  generalization of 047/049's "trigger + observer" HUD. The CLI-driven route stays possible
+  (and is why #699/profile launch/`agents wait` are prerequisites), but it is not the
+  product's main line.
+- **YAML (Yams) as the source of truth; Mermaid render-only.** Multi-line prompts are the
+  bulk of a workflow; block scalars are essential. JSON remains valid input. Parsing
+  Mermaid into stable orchestration semantics is fragile and was rejected.
+- **`done`-first outbound channel, not transcript observation.** `prowl workflow done` is
+  runtime-agnostic, validated, correlated by caller pane, and proven by the inline brief.
+  `agents read` covers only Claude/Codex and depends on intermittent session attribution;
+  it becomes a V2 assist. `headless` roles are the adapter-stable alternative where
+  interaction is not needed.
+- **File + pointer inbound; `text` for short lines.** Typed text is one line by
+  construction (TUIs submit on newline; `ghostty_surface_text` is not bracketed paste).
+  Long content is materialized; short messages are typed verbatim so users can see them.
+- **Interactive reviewer by default.** Side-by-side visibility of the review happening is
+  part of the product's trust model (onevcat, 2026-08-21); headless is an opt-in role kind.
+- **Roles reference requirements, never local profile names.** `agents:` (allowed
+  runtimes) + `suggest:` (match-or-create) + remembered local bindings keep shared files
+  portable while profiles remain the only launch authority (053 boundary intact).
+- **`repeat … until <verdict>` in V1, no expression language.** The one loop onevcat's
+  real flow needs is "re-review until clean"; termination reads a machine-declared
+  `--verdict`, never prose. `max` is mandatory.
+- **Step completion is `prowl workflow done`, not `submit <name>`.** Prowl knows which
+  step awaits which pane, so the agent names nothing; output names live in YAML
+  (`expect.output`).
+- **Run directory under the target root**, mirroring `.prowl/handoff/`: sandboxed agents
+  read cwd-relative files most reliably; definitions live beside it in
+  `<root>/.prowl/workflows/` so a repo can ship its workflows.
+
+## Decisions recorded during design review (2026-08-21)
+
+- **Handoff CLI**: `prowl workflow run prowl.handoff` is the primary invocation. The
+  shipped `prowl handoff to|save` stays as a **deprecated alias** (stderr warning per 060's
+  deprecation policy, byte-compatible payload during the window) and is retired
+  afterwards. The `.prowl/handoff/` artifact contract survives inside the
+  `handoff.transition` action.
+- **Binding default**: built-ins use `bind: ask`. Users switch a workflow to `auto` without
+  editing the file: a "Don't ask again for this workflow" toggle in the start sheet and a
+  per-workflow toggle in Settings › Workflows store a local override next to the binding
+  memory. Direction: V1 edits YAML in an external editor; a GUI editor with file ↔ UI
+  two-way sync is the long-term goal (see Open questions for the round-trip constraint).
+- **CLI-driven orchestration primitives ship with #699**: `prowl create tab|pane
+  --profile <name|uuid> [--prompt -]`, `prowl profiles list`, `prowl agents wait` are part
+  of the prerequisite PRs, not a later wave.
+- **Settings IA**: Agents becomes a sidebar group with Profiles / Workflows / Command Line
+  Tool pages (see Design / UI); the CLI install leaves Advanced.
+- **No default wall-clock timeout; state-driven watchdog with grace periods** (see Design
+  / Execution model). Detection is heuristic, so every trigger is designed to be harmless
+  when wrong: grace before acting, a nudge that only asks the agent to finish with `done`
+  when it is truly complete, and attention states that never discard a late delivery.
+- **PR order**: C0 → A1 ∥ B1 → A2 ∥ B2 → B3 → C1 → C2 → D1 → D2 → D3 (see Delivery
+  slicing); the new Adversarial Review flow validates the engine before the shipped handoff
+  is migrated.
+
+## Open questions
+
+- GUI workflow editor (V2): Yams does not preserve comments/formatting on re-serialization;
+  two-way sync needs either a comment-preserving writer or a "managed file" policy.
+- Exact Swift interface shapes for the split primitive, the launch boundary, and the
+  CLI additions of A1/A2, plus the test strategy — final design round.
+
+## Amendments
+
+(append `- Updated 2026-MM-DD: ... — see [00N-topic.md](00N-topic.md)` lines here)

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -84,7 +84,7 @@ contract governance of 060.
 | Term | Meaning |
 | --- | --- |
 | Workflow | A `prowl.workflow/v1` YAML document: id, inputs, roles, steps. Sources: bundle (`prowl.*` ids), user (`~/.prowl/workflows/*.yaml`), repo (`<root>/.prowl/workflows/*.yaml`). |
-| Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if a non-skipped step `message`s it, so a bare shell can still be the source of a context-only handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
+| Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if the runner will actually deliver a `message` to it — steps pre-skipped or completed by a seeded output at start do not count — so a bare shell can still be the source of a context-only or pre-briefed handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
 | Binding | Role → concrete Agent Profile, resolved at start and frozen into the run. |
 | Step | One verb: `message` (say something to a live role), `launch` (start a launch role), `action` (built-in Swift action), `notify`, `close`; plus `repeat` blocks. Each step has a `title` for the status slot and an optional `expect`. |
 | Expect | Only on `message` / `launch` steps: what must happen before the run advances — a named `output` delivered by the step's target role via the generated `prowl workflow done` command, optional `sections`/`format` validation, optional `verdict` enum (safe slugs), optional `timeout` / `on_timeout`. |
@@ -130,7 +130,10 @@ that advances one step at a time through existing terminal boundaries:
   `message` and `launch` (their target role delivers); native actions return typed
   outputs synchronously. Skipping a step whose expected output is referenced by a later
   template ends the run as `skipped` (the panel says which step depends on it) — V1 has
-  no optional template values, so the alternative would be an unrenderable step.
+  no optional template values, so the alternative would be an unrenderable step. The one
+  tolerated consumer is a `with` input declared optional by the action's schema: the key is
+  simply absent, which is how skipping the brief turns `prowl.handoff` into a context-only
+  transition (the old HUD's "Context Only" fallback, now a generic rule).
 - `action` → a registry of native Swift actions (`handoff.transition`, `git.context`).
 - `notify`/`close` → the existing bell pipeline and protected close path.
 
@@ -530,6 +533,13 @@ built-ins land, handoff migrated).
   ordinal, `outputs/brief.<ordinal>.md`, `seeded` record, no token/pane), preserving the
   invalid-brief-before-any-artifact property; the destination-only binding is
   cross-referenced from the binding model, the `run` response, and `run.json`.
+- **Review round 9 (2026-08-22; verified before adopting, mechanism chosen differently)** —
+  instead of an adapter-private input overlay, the Skip rule tolerates missing outputs for
+  optional action inputs (key absent → `handoff.transition` context-only), which serves
+  `--no-brief`, `save --no-brief`, and the GUI "Context Only" skip with one rule; `current`
+  role admission depends on whether a message will actually be delivered (pre-skipped and
+  seeded-completed steps do not count); seeded outputs are validated against the step's
+  `expect`; outputs may be agent- or caller-authored.
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -85,7 +85,7 @@ contract governance of 060.
 | --- | --- |
 | Workflow | A `prowl.workflow/v1` YAML document: id, inputs, roles, steps. Sources: bundle (`prowl.*` ids), user (`~/.prowl/workflows/*.yaml`), repo (`<root>/.prowl/workflows/*.yaml`). |
 | Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if the runner will actually deliver a `message` to it — steps pre-skipped or completed by a seeded output at start do not count — so a bare shell can still be the source of a context-only or pre-briefed handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
-| Binding | Role → concrete Agent Profile, resolved at start and frozen into the run. |
+| Binding | Role → concrete Agent Profile (or, for `pick`, an existing pane), resolved at start and frozen into the run; the only exception is the internal destination-only binding the legacy handoff adapter uses for `--no-launch` (agent token, no profile). |
 | Step | One verb: `message` (say something to a live role), `launch` (start a launch role), `action` (built-in Swift action), `notify`, `close`; plus `repeat` blocks. Each step has a `title` for the status slot and an optional `expect`. |
 | Expect | Only on `message` / `launch` steps: what must happen before the run advances — a named `output` delivered by the step's target role via the generated `prowl workflow done` command, optional `sections`/`format` validation, optional `verdict` enum (safe slugs), optional `timeout` / `on_timeout`. |
 | Run | One execution: state snapshot + artifacts under `<root>/.prowl/workflow-runs/<run-id>/`. |
@@ -183,7 +183,9 @@ Distribution is "the next instruction names the path"; Prowl never inlines one a
 output into another agent's input box, and every rendered line is re-validated as a
 single terminal line before injection (template values such as inputs or paths cannot
 smuggle a newline past the boundary). Outputs are agent-authored
-content persisted at the agent's request (default cap 1 MiB, hard max 4 MiB,
+content persisted at the agent's request — or, for the internal seeded outputs of the
+legacy adapter, caller-supplied content validated against the step's `expect` — (default
+cap 1 MiB, hard max 4 MiB,
 `OUTPUT_TOO_LARGE` otherwise; same bounds as `agents read`), kept until the user deletes
 the run folder (retention policy is a V2 item, as for `.prowl/handoff/archive`). Step ids
 and output names are restricted to safe slugs because they become path components; run

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -315,7 +315,9 @@ to|save` remain (see Open questions for alias vs. removal).
   destination-only binding carrying the validated token and the `launch` step is
   pre-skipped (so `prowl handoff to gemini --no-launch` keeps its archive/log/`to_agent`
   behavior for every detected-agent token); source selectors / positional source → run
-  source; `--brief -` / `--no-brief` → `brief` output pre-delivered / step pre-skipped
+  source; `--brief -` → the `brief` step completed by a *seeded output* (validated in
+  preflight, then materialized as a versioned `outputs/brief.<ordinal>.md` with a `seeded`
+  record — no fabricated delivery or token; DSL spec §5); `--no-brief` → step pre-skipped
   (absent briefing = context-only transition: archive, remove the stale `current.md`,
   regenerate `context.md`, context-only kickoff); `--note` → `handoff.transition` input;
   `save` → `prowl.handoff-checkpoint`. The adapter
@@ -523,6 +525,11 @@ built-ins land, handoff migrated).
   typed destination-only binding (token, no profile/pane/plan) that `handoff.transition`
   resolves `to` from, profile lookup happens only when a launch is requested; both cases
   join the parity matrix; Retry revokes/re-mints a token only when the step has `expect`.
+- **Review round 8 (2026-08-22; verified before adopting)** — internal-only *seeded
+  outputs* give a pre-delivered legacy brief a legal run-store identity (run-global
+  ordinal, `outputs/brief.<ordinal>.md`, `seeded` record, no token/pane), preserving the
+  invalid-brief-before-any-artifact property; the destination-only binding is
+  cross-referenced from the binding model, the `run` response, and `run.json`.
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -84,8 +84,8 @@ contract governance of 060.
 | Term | Meaning |
 | --- | --- |
 | Workflow | A `prowl.workflow/v1` YAML document: id, inputs, roles, steps. Sources: bundle (`prowl.*` ids), user (`~/.prowl/workflows/*.yaml`), repo (`<root>/.prowl/workflows/*.yaml`). |
-| Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if the runner will actually deliver a `message` to it — steps pre-skipped or completed by a seeded output at start do not count — so a bare shell can still be the source of a context-only or pre-briefed handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
-| Binding | Role → concrete Agent Profile (or, for `pick`, an existing pane), resolved at start and frozen into the run; the only exception is the internal destination-only binding the legacy handoff adapter uses for `--no-launch` (agent token, no profile). |
+| Role | A participant: `source: current` (the pane the run was started from; it must host a detected agent only if the runner will actually deliver a `message` to it — steps skipped at start via `--skip` / the start sheet do not count — so a bare shell can still be the source of a context-only handoff), `pick` (an existing detected agent pane in the same worktree, chosen at start), or `launch` (a new agent Prowl starts). V1 launch roles are interactive (TUI in a tab/split); `kind: headless` is reserved for V2 (see Alternatives). |
+| Binding | Role → concrete Agent Profile (or, for `pick`, an existing pane), resolved at start and frozen into the run. |
 | Step | One verb: `message` (say something to a live role), `launch` (start a launch role), `action` (built-in Swift action), `notify`, `close`; plus `repeat` blocks. Each step has a `title` for the status slot and an optional `expect`. |
 | Expect | Only on `message` / `launch` steps: what must happen before the run advances — a named `output` delivered by the step's target role via the generated `prowl workflow done` command, optional `sections`/`format` validation, optional `verdict` enum (safe slugs), optional `timeout` / `on_timeout`. |
 | Run | One execution: state snapshot + artifacts under `<root>/.prowl/workflow-runs/<run-id>/`. |
@@ -183,9 +183,7 @@ Distribution is "the next instruction names the path"; Prowl never inlines one a
 output into another agent's input box, and every rendered line is re-validated as a
 single terminal line before injection (template values such as inputs or paths cannot
 smuggle a newline past the boundary). Outputs are agent-authored
-content persisted at the agent's request — or, for the internal seeded outputs of the
-legacy adapter, caller-supplied content validated against the step's `expect` — (default
-cap 1 MiB, hard max 4 MiB,
+content persisted at the agent's request (default cap 1 MiB, hard max 4 MiB,
 `OUTPUT_TOO_LARGE` otherwise; same bounds as `agents read`), kept until the user deletes
 the run folder (retention policy is a V2 item, as for `.prowl/handoff/archive`). Step ids
 and output names are restricted to safe slugs because they become path components; run
@@ -285,9 +283,10 @@ writes.
 
 ### CLI (per 060's four-layer rule)
 
-`prowl workflow list | run <id> [source] [--role r=…] [--input k=v] | status [run] | done
-[-|--file] [--verdict v] [--token t] [--run --step] [--force] | cancel <run> | validate
-<file> | schema` — `[source]` is 060's `GenericTarget` (`pN`, `tN`, UUID, worktree ref); omitted,
+`prowl workflow list | run <id> [source] [--role r=…] [--input k=v] [--skip <step>] | status
+[run] | done [-|--file] [--verdict v] [--token t] [--run --step] [--force] | cancel <run> |
+validate <file> | schema` — `[source]` is 060's `GenericTarget` (`pN`, `tN`, UUID,
+worktree ref); omitted,
 the source is the caller pane when the workflow has a `current` role, and a worktree
 reference is required otherwise; `--role` is source-specific (`launch` role →
 `<profile name|uuid|auto>`, `pick` role → `<pN|pane UUID>` in the source worktree,
@@ -295,7 +294,8 @@ reference is required otherwise; `--role` is source-specific (`launch` role →
 prerequisites
 `prowl create pane <pane> --direction … [--profile <name|uuid> --prompt -]` (#699 extended)
 and `prowl agents wait <pane> --until idle|done|blocked [--timeout]`. `prowl handoff
-to|save` remain (see Open questions for alias vs. removal).
+to|save` are **retired**: one release of non-executing stubs that answer `HANDOFF_RETIRED`
+with the exact `prowl workflow run …` replacement, then removal (see Built-ins).
 
 ### Built-ins and distribution
 
@@ -310,36 +310,20 @@ to|save` remain (see Open questions for alias vs. removal).
   `has_briefing`) → `launch receiver` (background tab, prompt from the action output) →
   notify. The receiver role carries **no `agents:` restriction**: any runtime whose adapter
   supports a seeded prompt is admissible (055 verified all but Amp, which the adapter
-  rejects itself); the 047-era claude/codex-only admission is retired. The deprecated
-  `prowl handoff` commands are served by a **`LegacyHandoffAdapter`** in the app (D3) that
-  maps every existing parameter onto the runner's internal start API and renders the
-  existing `prowl.cli.handoff.v2` response shape (schema-compatible; semantic differences
-  documented, not "byte-compatible"): `to <agent>` with a requested launch → the
-  Recommended enabled profile of that runtime, else `PROFILE_NOT_FOUND` with guidance;
-  `to <agent> --no-launch` → no profile lookup, the receiver role is frozen as a typed
-  destination-only binding carrying the validated token and the `launch` step is
-  pre-skipped (so `prowl handoff to gemini --no-launch` keeps its archive/log/`to_agent`
-  behavior for every detected-agent token); source selectors / positional source → run
-  source; `--brief -` → the `brief` step completed by a *seeded output* (validated in
-  preflight, then materialized as a versioned `outputs/brief.<ordinal>.md` with a `seeded`
-  record — no fabricated delivery or token; DSL spec §5); `--no-brief` → step pre-skipped
-  (absent briefing = context-only transition: archive, remove the stale `current.md`,
-  regenerate `context.md`, context-only kickoff); `--note` → `handoff.transition` input;
-  `save` → `prowl.handoff-checkpoint`. The adapter
-  preflights before any run or artifact exists, reproducing today's immediate errors
-  (`BRIEF_REQUIRED` when neither `--brief` nor `--no-brief` is given — the legacy path
-  never starts an agent-mediated brief step; `EMPTY_INPUT`; `INVALID_BRIEF`), and maps
-  action/transition failures to the legacy failure response. Because the
-  `brief` step is pre-supplied or pre-skipped, the `current` role needs no detected agent
-  — a bare shell pane remains a valid legacy source, as today. The adapter starts the run
-  with `failurePolicy: .fail` (the runner's generic `.attention` policy would hang a
-  synchronous CLI call): a launch/provision failure after the artifacts are written ends
-  the run as `failed`, keeps artifacts and log, and returns `HANDOFF_FAILED` exactly as the
-  current handler does. The adapter awaits run completion synchronously (no agent wait is
-  involved once the brief is supplied) and is covered by per-field socket parity tests
-  (the DSL spec §11 list is normative: no-agent source, `--no-brief`, `--no-launch`,
-  omitted brief choice, empty stdin, invalid sections, action/transition failure, profile
-  lookup failure, provisioning failure, launch failure).
+  rejects itself); the 047-era claude/codex-only admission is retired. Skipping the brief
+  (start sheet, `--skip brief`, or the panel) gives the context-only transition through
+  the Skip rule — the replacement for the old HUD's "Context Only". A second small
+  built-in, `prowl.handoff-checkpoint` (brief → `handoff.checkpoint`), covers "save
+  progress for a later successor". **The legacy `prowl handoff to|save` commands are
+  retired, not adapted** (decision 2026-08-22): for one release they are non-executing
+  stubs returning `HANDOFF_RETIRED` with the copy-pasteable replacement
+  (`prowl workflow run prowl.handoff [--role receiver=…] [--skip brief]` /
+  `prowl workflow run prowl.handoff-checkpoint`, briefing delivered with the returned
+  `prowl workflow done -`); afterwards the commands, `HandoffCommandHandler`,
+  `HandoffHudFeature`, `HandoffRequestRegistry`, and the `prowl.cli.handoff.v2` contract
+  are deleted. A self-initiated run returns the first step's instruction and completion
+  command in its response instead of typing them into the caller's own pane, so an agent's
+  self-handoff stays two commands.
 - `skills/prowl-workflows/SKILL.md`: how to author and run workflows; `prowl workflow
   schema` prints the machine-readable reference.
 
@@ -406,7 +390,7 @@ built-ins land, handoff migrated).
 | 8 | **C2** Start sheet (bindings, suggestion-based profile creation, don't-ask-again) + entry points (capsule popover, palette, Active Agents context menu) | C | B3 | GUI-initiated runs |
 | 9 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows complete (enable/validate/Reveal/New/Ask-agent/per-workflow auto) | D | B1, C2 | Distribution and docs |
 | 10 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification | D | A2, C2, D1 | Proves the engine on a fresh flow before touching shipped behavior |
-| 11 | **D3** `prowl.handoff` built-in + `handoff.transition`; `prowl handoff` → deprecated alias; remove `HandoffHudFeature`; rewrite `docs/components/handoff.md` | D | D2 | Migrate the shipped feature last |
+| 11 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill | D | D2 | Migrate the shipped feature last |
 | 12 | V2: fan-out (`count`, `wait all`), observe mode (`agents read` capture), run persistence/resume, cross-worktree roles, GUI editor | — | — | — |
 
 ## Alternatives & decisions
@@ -447,15 +431,25 @@ built-ins land, handoff migrated).
 - **Run directory under the target root**, mirroring `.prowl/handoff/`: sandboxed agents
   read cwd-relative files most reliably; definitions live beside it in
   `<root>/.prowl/workflows/` so a repo can ship its workflows.
+- **Retire `prowl handoff` instead of emulating it.** Ten review rounds showed that
+  preserving every legacy semantic (`--no-brief`, `--no-launch`, bare-shell sources,
+  synchronous failure codes, the v2 payload) needed an adapter with its own preflight,
+  seeded outputs, a destination-only binding kind, and a parity matrix — all machinery
+  that exists only for compatibility. A `HANDOFF_RETIRED` stub with the exact replacement
+  command gives users the same migration in one line; `--skip brief` and the optional
+  action input cover the context-only case generically.
 
 ## Decisions recorded during design review (2026-08-21)
 
-- **Handoff CLI**: `prowl workflow run prowl.handoff` is the primary invocation. The
-  shipped `prowl handoff to|save` stays as a **deprecated alias** (stderr warning per 060's
-  deprecation policy; the `prowl.cli.handoff.v2` response shape is kept
-  schema-compatible by the `LegacyHandoffAdapter`, with semantic differences documented)
-  and is retired afterwards. The `.prowl/handoff/` artifact contract survives inside the
-  `handoff.transition` action.
+- **Handoff CLI** (revised 2026-08-22): `prowl workflow run prowl.handoff` is the only
+  invocation. The shipped `prowl handoff to|save` are **retired outright** — one release of
+  non-executing `HANDOFF_RETIRED` stubs carrying the exact replacement command, then
+  removal. The earlier plan to keep a schema-compatible alias through a
+  `LegacyHandoffAdapter` (with its preflight, seeded outputs, destination-only binding,
+  and `failurePolicy: .fail`) was dropped as not worth its complexity once migration
+  guidance proved to be a one-line message; review-round notes below that mention those
+  mechanisms are historical. The `.prowl/handoff/` artifact contract survives inside the
+  `handoff.transition` / `handoff.checkpoint` actions.
 - **Binding default**: built-ins use `bind: ask`. Users switch a workflow to `auto` without
   editing the file: a "Don't ask again for this workflow" toggle in the start sheet and a
   per-workflow toggle in Settings › Workflows store a local override next to the binding

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -309,12 +309,16 @@ to|save` remain (see Open questions for alias vs. removal).
   `prowl handoff` commands are served by a **`LegacyHandoffAdapter`** in the app (D3) that
   maps every existing parameter onto the runner's internal start API and renders the
   existing `prowl.cli.handoff.v2` response shape (schema-compatible; semantic differences
-  documented, not "byte-compatible"): `to <agent>` → the Recommended enabled profile of
-  that runtime, else `PROFILE_NOT_FOUND` with guidance; source selectors / positional
-  source → run source; `--brief -` / `--no-brief` → `brief` output pre-delivered / step
-  pre-skipped; `--note` → `handoff.transition` input; `--no-launch` → `launch` step
-  pre-skipped with the target token recorded (so `prowl handoff to gemini --no-launch`
-  keeps working without any profile); `save` → `prowl.handoff-checkpoint`. The adapter
+  documented, not "byte-compatible"): `to <agent>` with a requested launch → the
+  Recommended enabled profile of that runtime, else `PROFILE_NOT_FOUND` with guidance;
+  `to <agent> --no-launch` → no profile lookup, the receiver role is frozen as a typed
+  destination-only binding carrying the validated token and the `launch` step is
+  pre-skipped (so `prowl handoff to gemini --no-launch` keeps its archive/log/`to_agent`
+  behavior for every detected-agent token); source selectors / positional source → run
+  source; `--brief -` / `--no-brief` → `brief` output pre-delivered / step pre-skipped
+  (absent briefing = context-only transition: archive, remove the stale `current.md`,
+  regenerate `context.md`, context-only kickoff); `--note` → `handoff.transition` input;
+  `save` → `prowl.handoff-checkpoint`. The adapter
   preflights before any run or artifact exists, reproducing today's immediate errors
   (`BRIEF_REQUIRED` when neither `--brief` nor `--no-brief` is given — the legacy path
   never starts an agent-mediated brief step; `EMPTY_INPUT`; `INVALID_BRIEF`), and maps
@@ -512,6 +516,13 @@ built-ins land, handoff migrated).
   parity matrix; message Retry is a new invocation (token revoked and re-minted; guidance
   when an insert succeeded but the submit failed); the plan's token paragraph now
   cross-references the DSL invocation/activation lifecycle.
+- **Review round 7 (2026-08-22; verified before adopting)** — absent
+  `handoff.transition.briefing` is normatively the context-only *transition* (archive,
+  remove stale `current.md`, regenerate context, context-only kickoff, `has_briefing:
+  false`) — distinct from the checkpoint rule; `--no-launch` freezes the receiver as a
+  typed destination-only binding (token, no profile/pane/plan) that `handoff.transition`
+  resolves `to` from, profile lookup happens only when a launch is requested; both cases
+  join the parity matrix; Retry revokes/re-mints a token only when the step has `expect`.
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -119,8 +119,9 @@ that advances one step at a time through existing terminal boundaries:
   never be misattributed. Tokens are never written into YAML, and the **generated
   command is the only spelling agents ever see**: one completion-command renderer produces
   the initial hint, every nudge, and every re-delivery (token always present; for verdict
-  steps a `--verdict VALUE -` form plus one executable command per allowed value in the
-  materialized instruction and in `prowl workflow status`); built-ins and examples say
+  steps one complete executable command per allowed value on every transport — typed
+  line, materialized instruction, and `prowl workflow status` — never a placeholder);
+  built-ins and examples say
   "finish with the generated completion command"; the validator warns when
   `text`/`instruction` spells out `prowl workflow done`. `expect` is valid only on
   `message` and `launch` (their target role delivers); native actions return typed
@@ -131,8 +132,10 @@ that advances one step at a time through existing terminal boundaries:
 - `notify`/`close` → the existing bell pipeline and protected close path.
 
 **Data channels.** Inbound to an agent is always *file + short pointer*: long
-`instruction` text is materialized to `run.dir/instructions/<step>.md` and one line is
-typed (or passed as the kickoff prompt); short `text` is typed verbatim (single line).
+`instruction` text is materialized (one file per invocation, named by the run-global
+invocation ordinal — the DSL spec §§5/8 are normative for run-directory layout) and one
+line is typed (or passed as the kickoff prompt); short `text` is typed verbatim (single
+line).
 Outbound is `prowl workflow done [--verdict v] -` (stdin): the caller pane identifies the
 run/role, the delivery token identifies the awaited step — the YAML itself carries nothing
 machine-specific. Transcript observation (`agents read`) and headless adapter capture are
@@ -166,9 +169,10 @@ schedules cancellable grace deadlines on the injected clock; it never relies on 
 event alone.
 
 **Data bus.** `<root>/.prowl/workflow-runs/<run-id>/` holds `run.json`, `log.md`,
-`instructions/`, `skills/` (materialized from the embedded skill registry only — `skill:`
-ids are safe slugs that must resolve to a bundled skill), `outputs/<name>.md` (every
-delivery also kept as `<name>.<activation ordinal>.md`; latest wins in templates).
+`instructions/` and `outputs/` (both versioned by the run-global invocation ordinal, latest
+output view replaced atomically — layout normative in the DSL spec §8), `skills/`
+(materialized from the embedded skill registry only — `skill:` ids are safe slugs that must
+resolve to a bundled skill).
 Distribution is "the next instruction names the path"; Prowl never inlines one agent's
 output into another agent's input box, and every rendered line is re-validated as a
 single terminal line before injection (template values such as inputs or paths cannot
@@ -318,9 +322,10 @@ to|save` remain (see Open questions for alias vs. removal).
   synchronous CLI call): a launch/provision failure after the artifacts are written ends
   the run as `failed`, keeps artifacts and log, and returns `HANDOFF_FAILED` exactly as the
   current handler does. The adapter awaits run completion synchronously (no agent wait is
-  involved once the brief is supplied) and is covered by per-field socket parity tests:
-  no-agent source, `--no-brief`, `--no-launch`, profile lookup failure, provisioning
-  failure, launch failure.
+  involved once the brief is supplied) and is covered by per-field socket parity tests
+  (the DSL spec §11 list is normative: no-agent source, `--no-brief`, `--no-launch`,
+  omitted brief choice, empty stdin, invalid sections, action/transition failure, profile
+  lookup failure, provisioning failure, launch failure).
 - `skills/prowl-workflows/SKILL.md`: how to author and run workflows; `prowl workflow
   schema` prints the machine-readable reference.
 
@@ -350,9 +355,11 @@ Shapes are intentionally close to what exists so the runner and the CLI share on
   additively (`resource: pane`, `anchor`, `direction`, optional `launch {profile_id,
   profile_name, agent}`). `prowl profiles list` is a read-only snapshot of enabled/disabled
   profiles with availability (`prowl.cli.profiles.v1`). `prowl agents wait <pane> --until
-  idle|done|blocked|changed --timeout 1…3600` subscribes to the per-surface
-  `ActiveAgentEntry` events (immediate return when already satisfied; `WAIT_TIMEOUT`
-  otherwise) and returns `{status, raw_state, waited_ms}` (`prowl.cli.agents.wait.v1`).
+  idle|done|blocked|changed --timeout 1…3600` consumes the typed `ObservedAgentState`
+  observer described above (snapshot first → immediate return when already satisfied;
+  `WAIT_TIMEOUT` on expiry; `removed` / `surfaceClosed` → error `AGENT_GONE` with the last
+  known status in the error payload) and returns `{status, raw_state, waited_ms}`
+  (`prowl.cli.agents.wait.v1`).
 - **Tests**: terminal-layer coverage extends `supacodeTests/WorktreeTerminalStateAgentProfileTests.swift`
   (anchored split, placement override, background tab, returned identity, provisioning
   failure); planner intent rendering per adapter in `supacodeTests/AgentProfileTests.swift`
@@ -490,6 +497,12 @@ built-ins land, handoff migrated).
   declared; optional fixes (`UNSAFE_PATH` listed, `tN` in the source grammar, concepts
   table and binding text aligned with the DSL, `notify` fallback without a `current` role,
   legacy parity list includes the preflight cases).
+- **Review round 5 (2026-08-22; verified before adopting)** — run-directory specifics in
+  the plan now defer to the DSL spec (§§5/8 normative); a run-global *invocation* ordinal
+  is minted on entry to every `message`/`launch` execution (artifact naming for
+  non-waiting steps too), with *activation* = waiting invocation; `--role r=<binding>` in
+  the synopsis; `agents wait` wording aligned with the `ObservedAgentState` observer and
+  `AGENT_GONE` payload; a compact V1 action schema table added to the DSL.
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -107,10 +107,13 @@ that advances one step at a time through existing terminal boundaries:
   delivered. At most one pending injection exists per role; Cancel / Skip / Relaunch drop
   it.
 - `expect` → a `WorkflowRequestRegistry` entry (generalizing `HandoffRequestRegistry`)
-  keyed by an **opaque per-activation delivery token** (a UUID, hence shell-safe) that
-  Prowl mints each time a step starts waiting — every `repeat` iteration is a new
-  activation `(run, step, ordinal, role)` with its own token, one delivery per activation —
-  and places in the generated completion command
+  keyed by an **opaque per-activation delivery token** (a UUID, hence shell-safe). Lifecycle
+  (normative in the DSL spec §5): every `message`/`launch` execution mints a run-global
+  invocation ordinal on entry; when the step has an `expect`, that invocation is an
+  activation `(run, step, ordinal, role)` whose token is minted *before* the line is
+  rendered and injected (the injected text carries it); every `repeat` iteration and every
+  Retry/Relaunch is a new invocation. One delivery per activation. The token is placed in
+  the generated completion command
   (`PROWL_WORKFLOW_TOKEN=<token> prowl workflow done -`, the same env-prefix technique as
   today's `PROWL_HANDOFF_REQUEST_ID`; `--token <token>` is the explicit form). The entry
   is claimable exactly once; a `done` that arrives without the token, with a revoked token
@@ -503,6 +506,12 @@ built-ins land, handoff migrated).
   non-waiting steps too), with *activation* = waiting invocation; `--role r=<binding>` in
   the synopsis; `agents wait` wording aligned with the `ObservedAgentState` observer and
   `AGENT_GONE` payload; a compact V1 action schema table added to the DSL.
+- **Review round 6 (2026-08-22; verified before adopting)** — `handoff.checkpoint.briefing`
+  is optional (absent = context-only checkpoint, preserving today's `handoff save
+  --no-brief`) with a `has_briefing` output, and both `save` variants join the legacy
+  parity matrix; message Retry is a new invocation (token revoked and re-minted; guidance
+  when an insert succeeded but the submit failed); the plan's token paragraph now
+  cross-references the DSL invocation/activation lifecycle.
 
 ## Open questions
 

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -152,8 +152,9 @@ subscription finishes the previous stream) and `AppFeature` is its only subscrib
 runner therefore lives as a child reducer of `AppFeature`, which forwards
 `agentEntryChanged` / `agentEntryRemoved` / `taskStatusChanged` to it; nothing else
 subscribes to `TerminalClient.events()`. `prowl agents wait` (and any other CLI observer)
-uses a new per-surface multicast observer on `WorktreeTerminalManager`, independent of the
-reducer stream and typed so that disappearance is observable:
+uses a per-surface multicast observer on `WorktreeTerminalManager`, independent of the
+reducer stream and typed so that disappearance is observable. The observer is delivered
+by 064-S1 in release R1 (it was first specified here) and consumed by this entry's B3:
 
 ```swift
 enum ObservedAgentState: Sendable {
@@ -276,7 +277,9 @@ writes.
   its primary consumer). Workflows ↔ Profiles stay linked by cross-reference, not by
   merging: each workflow row shows its role → profile bindings (editable, jump to
   Profiles); a CLI dependency banner with an inline Install action sits atop Workflows and
-  the runner preflights CLI installation before a run. Workflows page contents: Built-in
+  the runner preflights CLI installation before a run. The group ships in R1 with
+  Profiles + Command Line Tool (C0); the Workflows page arrives with D1 in R2. Workflows
+  page contents: Built-in
   / User / Repo lists, enable toggle, per-workflow "ask for bindings" override, validation
   status with YAML line errors, Reveal, New Workflow… (template file), Ask your agent to
   write one (prompt pointing at bundled `docs/` + `skills/`).
@@ -375,25 +378,53 @@ Shapes are intentionally close to what exists so the runner and the CLI share on
 ### Delivery slicing
 
 Four tracks — terminal/CLI primitives (A), definitions/runner (B), UI (C), built-ins and
-docs (D) — merged in the order below. C0 ∥ A1 ∥ B1 and A2 ∥ B2 can proceed in parallel.
-Milestones: **M1** (C0+A1+B1+A2: CLI-driven orchestration usable, DSL authorable and
-validatable), **M2** (B2+B3+C1+C2: engine and GUI run workflows), **M3** (D1+D2+D3:
-built-ins land, handoff migrated).
+docs (D) — plus 064's signal slices (S), shipped as **three releases** (decision
+2026-08-22, keeping Prowl's small-step cadence; PRs still merge to `main` one at a time
+and engine PRs without a user-facing surface simply stay dormant until their release):
 
-| Order | PR | Track | Depends | Rationale |
-| --- | --- | --- | --- | --- |
-| 1 | **C0** Settings IA: Agents group (Profiles / Workflows placeholder / Command Line Tool moved from Advanced) | C | — | Independent, small, decides where everything lands |
-| 2 | **A1** `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers | A | 060 | Foundation for every `launch` into a split |
-| 3 | **B1** Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`, read-only Settings list | B | — | Parallel with A1; makes the DSL concrete and authorable |
-| 4 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list` (`prowl agents wait` moved to 064) | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary; 064-S3 attaches launch-scoped hooks here |
-| 5 | **B2** Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries | B | B1 | Parallel with A2 |
-| 6 | **B3** Runner wiring: `WorkflowRunsFeature` effects, detection-event subscription, CLI preflight, `prowl workflow run/status/done/cancel` + contracts | B | A2, B2 | Engine first powered on |
-| 7 | **C1** Status center fifth state + run panel + attention triggers + notifications (061 visual verification) | C | B3 | Runs become visible |
-| 8 | **C2** Start sheet (bindings, suggestion-based profile creation, don't-ask-again) + entry points (capsule popover, palette, Active Agents context menu) | C | B3 | GUI-initiated runs |
-| 9 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows complete (enable/validate/Reveal/New/Ask-agent/per-workflow auto) | D | B1, C2 | Distribution and docs |
-| 10 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification | D | A2, C2, D1 | Proves the engine on a fresh flow before touching shipped behavior |
-| 11 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill | D | D2 | Migrate the shipped feature last |
-| 12 | V2: fan-out (`count`, `wait all`), observe mode (`agents read` capture), run persistence/resume, cross-worktree roles, GUI editor | — | — | — |
+- **R1 — CLI orchestration primitives + completion signals**: C0 (Agents settings group
+  with Profiles + Command Line Tool only), A1, A2, 064-S1 (signal bus, `ObservedAgentState`
+  observer, `prowl agents signal`), 064-S2 (`prowl agents wait`, `signals` field,
+  `--include-screen`, skill rubric), 064-S3 wave 1 (launch-scoped hooks for the tier-A
+  runtimes). Outcome: onevcat's daily CLI-driven orchestration is first-class
+  (`create pane --profile --prompt -` → `agents wait` → `send`), deterministic for
+  Prowl-launched agents. Docs: `cli.md`, `agent-detection.md`, `prowl-cli` skill.
+- **R2 — Agent Workflows**: B1, B2, B3, C1, C2, D1 (incl. the Settings › Workflows page),
+  D2, and the 064-S5 part where the watchdog consumes exact signals. Outcome: the engine,
+  the GUI entry points, the first built-in (`prowl.adversarial-review`), custom workflows.
+  The shipped handoff (HUD + `prowl handoff`) stays untouched in R2. Docs:
+  `workflows.md`, `command-palette.md`, `active-agents.md`, `settings.md`.
+- **R3 — Handoff migration + signal completion**: D3 (`prowl.handoff` /
+  `prowl.handoff-checkpoint`, `HANDOFF_RETIRED` stubs, HUD removal), 064-S3 wave 2
+  (dedicated-home runtimes) and S4 (transcript file-watch / OSC producers), first V2 items
+  as capacity allows (observe mode, `on_attention: ask`, retention). The stubs are deleted
+  one release after R3. Docs: `handoff.md` rewrite.
+
+If R2 proves too large, it splits into R2a (B1+B2+B3+C1: workflows runnable from the CLI,
+visible in the status center) and R2b (C2+D1+D2: GUI entry, Settings, skills, E2E); the
+default is a single R2 because "runnable but no GUI entry" is hard to explain to users.
+
+Within a release the order below applies; C0 ∥ A1, A2 ∥ S1, and B1 ∥ B2 can proceed in
+parallel.
+
+| Release | Order | PR | Track | Depends | Expectation |
+| --- | --- | --- | --- | --- | --- |
+| R1 | 1 | **C0** Settings IA: `Section("Agents")` with **Profiles** (today's Agents page, renamed) and **Command Line Tool** (moved from Advanced); no Workflows page yet | C | — | Independent, small; decides where everything lands |
+| R1 | 2 | **A1** `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers | A | 060 | Foundation for every `launch` into a split |
+| R1 | 3 | **A2** Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list`; the boundary exposes the seam 064-S3 uses to attach launch-scoped hooks | A | A1 | Unlocks the CLI-driven route and is the runner's `launch` boundary |
+| R1 | 4 | **064-S1** signal bus + `ObservedAgentState` multicast observer (moved here from B3) + `prowl agents signal` | S | — | Layer 0 for every runtime; B3 later consumes the same observer |
+| R1 | 5 | **064-S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S | S1 | Route B usable; heuristic fallback honest |
+| R1 | 6 | **064-S3 wave 1** launch-scoped hooks for Claude Code, Codex (`notify`), Copilot, Droid, Qoder, Pi, OMP, OpenCode + self-check | S | A2, S1 | `agents wait` deterministic for Prowl-launched agents |
+| R2 | 7 | **B1** Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema` | B | — | Makes the DSL concrete and authorable (may merge during R1 without user-facing surface) |
+| R2 | 8 | **B2** Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries | B | B1 | Parallel with B1's tail |
+| R2 | 9 | **B3** Runner wiring: `WorkflowRunsFeature` effects, observer consumption via `AppFeature`, CLI preflight, `prowl workflow run/status/done/cancel` + contracts | B | A2, S1, B2 | Engine first powered on |
+| R2 | 10 | **C1** Status center fifth state + run panel + attention triggers + notifications (061 visual verification) | C | B3 | Runs become visible |
+| R2 | 11 | **C2** Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu) | C | B3 | GUI-initiated runs |
+| R2 | 12 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group | D | B1, C2 | Distribution and docs |
+| R2 | 13 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification; watchdog consumes exact signals (064-S5 part) | D | A2, C2, D1, S3 | Proves the engine on a fresh flow before touching shipped behavior |
+| R3 | 14 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill | D | D2 | Migrate the shipped feature last |
+| R3 | 15 | **064-S3 wave 2** (dedicated-home runtimes) + **064-S4** (transcript file-watch / OSC producers) | S | S3, 053 homes | More runtimes get exact signals |
+| R3+ | 16 | V2: observe mode (`expect.status` + `agents read`/hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor | — | — | — |
 
 ## Alternatives & decisions
 
@@ -464,18 +495,22 @@ built-ins land, handoff migrated).
 - **Completion signals split out as 064 (2026-08-22)**: the layered signal bus,
   `prowl agents signal`, launch-scoped hooks, and `prowl agents wait` with
   `source`/`confidence` are an independent entry. 063 V1 does not depend on it (steps
-  complete on `done`; the heuristic watchdog is harmless by design); 064 consumes 063's
-  observer (B3) and launch boundary (A2), and in return sharpens the watchdog and enables
-  063's V2 observe mode / `on_attention: ask <role>`.
+  complete on `done`; the heuristic watchdog is harmless by design); 064-S1 delivers the
+  `ObservedAgentState` observer that B3 consumes, 064-S3 builds on the launch boundary
+  (A2), and in return 064 sharpens the watchdog and enables 063's V2 observe mode /
+  `on_attention: ask <role>`.
 - **Settings IA**: Agents becomes a sidebar group with Profiles / Workflows / Command Line
   Tool pages (see Design / UI); the CLI install leaves Advanced.
 - **No default wall-clock timeout; state-driven watchdog with grace periods** (see Design
   / Execution model). Detection is heuristic, so every trigger is designed to be harmless
   when wrong: grace before acting, a nudge that only asks the agent to finish with `done`
   when it is truly complete, and attention states that never discard a late delivery.
-- **PR order**: C0 → A1 ∥ B1 → A2 ∥ B2 → B3 → C1 → C2 → D1 → D2 → D3 (see Delivery
-  slicing); the new Adversarial Review flow validates the engine before the shipped handoff
-  is migrated.
+- **PR order / releases** (revised 2026-08-22): three releases — R1 = C0, A1, A2,
+  064-S1/S2/S3-wave-1 (CLI orchestration + signals); R2 = B1, B2, B3, C1, C2, D1, D2
+  (Agent Workflows); R3 = D3, 064-S3-wave-2/S4, first V2 items (handoff migration) — see
+  Delivery slicing. The new Adversarial Review flow validates the engine before the shipped
+  handoff is migrated; the `ObservedAgentState` observer moved from B3 to 064-S1 so R1 can
+  ship `agents wait`.
 - **Review round (2026-08-22)** — accepted corrections: runner as an `AppFeature` child
   fed by the single event subscription + a per-surface multicast observer for CLI waits;
   opaque per-step delivery tokens for `done`; `LegacyHandoffAdapter` with a full parameter

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -29,7 +29,7 @@ icon: magnifyingglass.circle         # optional SF Symbol
 
 inputs:                              # optional; provided by the start sheet or `--input k=v`
   max_rounds: { type: integer, default: 5, min: 1, max: 10 }
-  focus:      { type: string,  default: "", prompt: "What should the reviewer focus on?" }
+  focus:      { type: string,  default: "", prompt: "What should the reviewer focus on?" }   # string inputs are single-line (no line terminators / control characters), validated at start
   mode:       { type: enum, values: [strict, lenient], default: strict }
 
 roles:   …                           # §3
@@ -46,41 +46,53 @@ repo file for that worktree.
 ```yaml
 roles:
   author:
-    source: current                  # the pane the run was started from; must have a detected agent
+    source: current                  # the pane the run was started from (needs a detected agent only if a step messages it — see table)
   reviewer:
     source: launch                   # Prowl starts a new agent for this role
-    kind: interactive                # interactive (default) | headless
+    kind: interactive                # V1: interactive only; `headless` is a reserved V2 value (§12)
     agents: [codex, claude]          # optional allow-list of agent tokens (as in `prowl agents` `type`); omitted = any launchable
     suggest:                         # optional; match an existing enabled profile exactly, or offer to create one
       agent: codex
       reasoning_effort: xhigh
       execution_mode: standard
     bind: ask                        # ask (default) | auto
-    placement: split                 # split | tab (default: split for interactive, tab for headless)
+    placement: split                 # split | tab (default: split)
     direction: right                 # right | left | up | down (split only)
     background: false                # true = do not focus/select the new surface
   partner:
-    source: pick                     # an existing detected agent pane chosen at start (CLI: --role partner=p12)
+    source: pick                     # an existing detected agent pane in the SAME worktree, chosen at start (CLI: --role partner=p12)
 ```
 
 | Field | Rules |
 | --- | --- |
-| `source` | Exactly one `current` role per workflow (optional: a workflow may have none, then it needs no detected agent at the entry). `pick` roles are chosen from `prowl agents` at start. |
-| `kind` | Only for `launch`. `headless` roles accept a single `launch` step, cannot receive `message`, and deliver their captured output automatically. |
+| `source` | At most one `current` role per workflow. A `current` role must host a detected agent only if some step that is not pre-skipped at start `message`s it; otherwise a bare shell pane is a valid source (context-only handoff, legacy `handoff save`). A workflow without a `current` role needs an explicit worktree at start. `pick` roles are chosen from the detected agents of the source worktree at start; a pane already in a run is not offered. |
+| `kind` | Only for `launch`. V1 accepts `interactive` only; `headless` is reserved (§12) because no executor/output protocol exists yet. |
 | `agents` | Tokens from the detected-agent catalog. Validator warns (not errors) when none is installed locally. |
 | `suggest` | Subset of profile preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`). Never a reference to a profile name or UUID. |
 | `bind` | `ask`: the start sheet always shows the role picker (pre-filled). `auto`: the sheet appears only when resolution is ambiguous. |
 
 **Binding resolution** (per `launch` role, at start, in order): remembered local binding
-`(workflow id, role) → profile UUID` → enabled profile matching `suggest` exactly →
-Recommended profile (053 rules) filtered by `agents` → ask. The chosen profile is frozen
-into the run together with its launch plan; later profile edits do not affect the run.
-`--role <role>=<profile name|uuid|auto>` overrides from the CLI.
+→ enabled profile matching `suggest` exactly → Recommended profile (053 rules) filtered by
+`agents` → ask. The memory key is the four-tuple
+`(definition scope, workflow id, role, role-requirements digest)` where scope is
+`bundle` | `user` | `repo:<repository id>` and the digest is SHA-256 over the canonical
+JSON encoding (sorted keys, `agents` sorted, absent keys omitted) of the role's requirement
+block `{source, kind, agents, suggest}` — so a change to any requirement invalidates the
+memory while prompt-only edits keep it. This paragraph is the single normative definition;
+§10 refers back to it. Every candidate, including a remembered binding or a `--role`
+override, is re-validated first (exists, enabled, satisfies `agents`, adapter supports a
+seeded prompt); a failing candidate falls through to the next tier. The chosen profile is
+frozen into the run together with its launch plan; later profile edits do not affect the
+run. CLI overrides are source-specific (§9): `--role <launch-role>=<profile name|uuid|auto>`,
+`--role <pick-role>=<agent pane: pN | pane UUID>`; `current` roles take no override.
 
 ## 4. Steps
 
 Each step has `id` (unique within the workflow), optional `title` (templated; shown in the
-status center and panel), exactly one verb, and an optional `expect` (§5).
+status center and panel), exactly one verb, and — on `message` and `launch` steps only —
+an optional `expect` (§5) whose delivery role is the step's target role. `action`,
+`notify`, and `close` cannot carry `expect` (validation error): they have no pane that
+could deliver; native actions return synchronous typed outputs instead.
 
 ```yaml
 steps:
@@ -89,7 +101,7 @@ steps:
     message: author                          # ① speak to a live interactive role
     instruction: |                           #    multi-line → materialized to run.dir/instructions/brief.md; one pointer line is typed
       Write a short brief for an adversarial reviewer: ## Scope, ## Claims, ## How to verify.
-      When done: prowl workflow done -
+      Deliver it with the generated completion command.   # never spell `prowl workflow done` yourself — the runner appends the tokenized command
     expect: { output: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
 
   - id: launch
@@ -107,12 +119,12 @@ steps:
       - id: fix
         title: "Round {{ loop.index }}: author addressing findings"
         message: author
-        text: "Findings: {{ outputs.findings.path }}. Fix or rebut each, commit, then `prowl workflow done -` with your disposition."
+        text: "Findings: {{ outputs.findings.path }}. Fix or rebut each item, commit, then deliver your disposition with the generated completion command."
         expect: { output: disposition, timeout: 30m }
       - id: rereview
         title: "Round {{ loop.index }}: reviewer re-checking"
         message: reviewer
-        text: "Disposition: {{ outputs.disposition.path }}. Re-review the new commits; `prowl workflow done --verdict clean|issues -`."
+        text: "Disposition: {{ outputs.disposition.path }}. Re-review the new commits and deliver findings with the generated completion command, choosing the verdict clean or issues."
         expect: { output: findings, verdict: [clean, issues], timeout: 30m }
 
   - id: context
@@ -128,19 +140,30 @@ steps:
 
 | Verb | Payload keys | Allowed target | Notes |
 | --- | --- | --- | --- |
-| `message: <role>` | `text` (single line, typed verbatim) **or** `instruction` (multi-line, materialized + pointer) | live interactive role (`current`, `pick`, or a `launch` role already launched) | Injection is gated: `blocked` → not typed, run → `needsAttention`; `working` → queued, shown in the panel. |
-| `launch: <role>` | `prompt` (kickoff, templated), optional `skill` | `launch` role, at most once per run (V1) | Interactive: profile plan with `AgentStartIntent.prompt`; headless: adapter one-shot with captured output. A single-line `prompt` is passed verbatim; a multi-line one is materialized and the kickoff becomes the pointer line. |
-| `action: <id>` | `with` (templated map) | — | V1 registry: `handoff.transition` (inputs `briefing?`, `from`, `to`; performs archive-first `.prowl/handoff/` transition; outputs `kickoff_prompt`, `artifact_path`, `has_briefing`), `handoff.checkpoint`, `git.context`. |
-| `notify: <text>` | — | — | Bell pipeline; click focuses the `current` role's pane. |
+| `message: <role>` | `text` (single line, typed verbatim) **or** `instruction` (multi-line, materialized + pointer) | live interactive role (`current`, `pick`, or a `launch` role already launched) | Injection is gated: `blocked` → not typed, run → `needsAttention`; `working` → the line is accepted by the agent runtime's own input queue (Prowl keeps none), shown in the panel. |
+| `launch: <role>` | `prompt` (kickoff, templated), optional `skill` (an id from the embedded skill registry — same pattern as a workflow id, e.g. `prowl.adversarial-reviewer`; it must resolve to a bundled skill, unknown ids are validation errors; custom skills are V2) | `launch` role, at most once per run (V1) | Profile plan with `AgentStartIntent.prompt`. The single-/multi-line decision is made on the *rendered* prompt: one line → passed verbatim (after the §10 rendered-text check); otherwise materialized, and the kickoff becomes the pointer line. |
+| `action: <id>` | `with` (templated map) | — | V1 registry: `handoff.transition` (inputs `briefing?`, `from`, `to`; performs archive-first `.prowl/handoff/` transition; outputs `kickoff_prompt`, `artifact_path`, `has_briefing`), `handoff.checkpoint`, `git.context`. Every registered action declares a typed schema for its `with` inputs (required/optional) and its output keys; `prowl workflow schema` prints them. |
+| `notify: <text>` | — | — | Bell pipeline; click focuses the `current` role's pane, or — when the workflow has no `current` role — the source worktree (status panel). |
 | `close: <role>` | — | `launch` roles | Never implicit; cancel never closes panes. |
-| `repeat` | `max` (required), `until` (optional), `steps` | — | `until` compares a declared verdict only: `outputs.<name>.verdict == <value>` or `in [..]`. Reaching `max` without `until` ends the run as `max_rounds_reached`. |
+| `repeat` | `max` (required), `until` (optional), `steps` | — | While-loop semantics: `until` is evaluated **before entering** and **after every iteration**, so a verdict already satisfied by an earlier step skips the loop. `until` compares a declared verdict only: `outputs.<name>.verdict == <value>` or `in [..]`, every literal must belong to that output's declared `verdict` set. `max` is either a positive integer literal or a template that references exactly one `integer` input (nothing else); it is resolved at start, must lie in `1…20` (the V1 ceiling), and an invalid value is `WORKFLOW_INVALID` (literal) or a start-time `INVALID_ARGUMENT` (input). Reaching `max` with `until` still unsatisfied (or absent) ends the run as `max_rounds_reached`. |
 
-**Typed line formats.** Every line Prowl types into a pane starts with `[Prowl] ` so its
-origin is visible. `text` → `[Prowl] <text>`; `instruction` → `[Prowl] Read <absolute
-path> and follow it`. When the step has an `expect`, the runner appends the completion
-hint itself — ` — finish with: prowl workflow done [--verdict a|b] -` — so authors never
-repeat it. The watchdog nudge is `[Prowl] When your work for this step is fully complete,
-finish with: prowl workflow done -`.
+**Typed line formats and the completion-command renderer.** Every line Prowl types into a
+pane starts with `[Prowl] ` so its origin is visible. `text` → `[Prowl] <text>`;
+`instruction` → `[Prowl] Read <absolute path> and follow it`. Every *rendered* line is
+checked before insertion: it must contain no line terminator or control character
+(§10, "Rendered-text boundary"). When the step has an `expect`, one **completion-command
+renderer** — the only place that spells the command — appends the activation's command
+(§5): without `verdict`, ` — finish with: PROWL_WORKFLOW_TOKEN=<token> prowl workflow done
+-`; with `verdict: [clean, issues]`, one complete, directly executable command per allowed
+value joined by ` or `: ` — finish with: PROWL_WORKFLOW_TOKEN=<token> prowl workflow done
+--verdict clean -  or  PROWL_WORKFLOW_TOKEN=<token> prowl workflow done --verdict issues -`
+(no placeholders, nothing to substitute; `verdict` is limited to 2–4 values so the line
+stays bounded). The materialized instruction file and `prowl workflow status` list the
+same commands. The same renderer produces the watchdog nudge
+(`[Prowl] When your work for this step is fully complete, finish with: <rendered command>`)
+and every re-delivery after Relaunch, so no path ever shows a token-less or
+verdict-less command. Authors never spell the command (the validator warns when
+`text`/`instruction` contains `prowl workflow done`).
 
 ## 5. `expect`
 
@@ -149,14 +172,32 @@ expect:
   output: findings          # output name; default = step id; the same name may be produced by several steps (latest wins)
   format: markdown          # markdown (default) | text | json (parseable)
   sections: ["## Findings"] # markdown: required headings (fence/preamble stripped before checking, as HandoffStore.validatedBriefing)
-  verdict: [clean, issues]  # declares allowed values; `prowl workflow done --verdict <v>` then becomes mandatory
+  verdict: [clean, issues]  # declares 2–4 allowed values (safe slugs); the rendered completion command then carries `--verdict <value>` and it becomes mandatory
   timeout: 2h               # optional hard cap; NO default — without it Prowl waits as long as the agent works
   on_timeout: attention     # only with `timeout`: attention (default) | skip | cancel
 ```
 
-- A `launch` step of a `headless` role may omit `expect`; the captured output is stored
-  under `outputs.<step id>` (or `expect.output` if given).
-- Exactly one successful `done` is accepted per (run, step); later ones get `STEP_NOT_EXPECTING`.
+- **Activation identity.** Each time a step starts waiting — once for a plain step, once
+  per iteration inside `repeat` — the runner creates a new *activation*
+  `(run id, step id, activation ordinal, delivery role)` and mints a fresh delivery token
+  for it; the previous activation of the same step (if any) is terminal. The **activation
+  ordinal is run-global and monotonic** (1, 2, 3, … across all steps and iterations), so it
+  alone identifies an activation within a run. Exactly one successful `done` is accepted
+  per activation, identified by its token; a later, stale, or token-less delivery gets
+  `STEP_NOT_EXPECTING` / `TOKEN_REQUIRED` / `TOKEN_INVALID`. Skip / Cancel / Relaunch
+  revoke the *current* activation's token (Relaunch then mints a new activation). Every
+  delivery is persisted as `outputs/<name>.<ordinal>.md` (collision-free by construction,
+  even when several steps produce the same output name); `outputs/<name>.md` is the
+  "latest" view, replaced atomically (temp file + rename); materialized instructions are
+  versioned the same way (`instructions/<step>.<ordinal>.md`), and `run.json` records the
+  activation → step / iteration / output-file mapping.
+- Output bodies are capped (default 1 MiB, hard max 4 MiB → `OUTPUT_TOO_LARGE`).
+- **Skip rule.** Skipping an `expect` (panel Skip or `on_timeout: skip`) marks its output
+  missing. If any later step's template references that output (or the `until` of an
+  enclosing `repeat` depends on its verdict), the run ends as `skipped` instead of
+  advancing — V1 has no optional template values. The panel states which step depends on
+  the output before the user confirms Skip; the validator warns when `on_timeout: skip`
+  would end the run this way.
 - Waiting is supervised by the state-driven watchdog (§10), not by wall-clock time; a
   `working` role is never interrupted.
 
@@ -166,24 +207,36 @@ expect:
 | --- | --- |
 | `run.id`, `run.dir` | run UUID, `<root>/.prowl/workflow-runs/<run-id>` |
 | `worktree.path`, `worktree.name`, `worktree.branch` | source worktree |
-| `roles.<r>.name`, `roles.<r>.agent`, `roles.<r>.pane` | frozen profile display name, agent token, pane short handle (`p12`) |
+| `roles.<r>.name`, `roles.<r>.agent`, `roles.<r>.pane` | `launch`: frozen profile display name, agent token, pane short handle (`p12`) once launched — referencing `pane` before the role's `launch` step is a validation error. `current` / `pick`: the pane's launch-profile name when Prowl launched it, otherwise the detected agent's display name (or `shell` when none); `agent` is the detected token or empty. |
 | `outputs.<name>.path`, `outputs.<name>.verdict` | latest delivered output; referencing an output before any step can have produced it is a validation error |
-| `actions.<step>.<key>` | native action outputs |
+| `actions.<step>.<key>` | native action outputs; `<step>` must be an `action` step, `<key>` a key declared by that action's registry schema, and the producer must dominate the reference in control flow (earlier in the same sequence; inside `repeat`, earlier in the same iteration body or outside the loop before it) — otherwise `WORKFLOW_INVALID` |
 | `inputs.<k>` | start inputs |
-| `loop.index`, `loop.count` | 1-based iteration inside `repeat`; `loop.count` = iterations completed (usable after the loop) |
+| `loop.index`, `loop.count` | 1-based iteration inside `repeat`; `loop.count` = iterations completed (usable after the loop; `0` when the pre-entry `until` check skipped the loop) |
 
 No expressions, defaults, or inlined output text (`outputs.<name>.text` does not exist).
 
 ## 7. Validation (`prowl workflow validate`, Settings status)
 
-Errors: unknown `schema`/keys; undefined role; `message` to a `headless` role or to a
-`launch` role before its `launch` step; a `launch` role launched twice; `close` of a
-non-`launch` role; duplicate step ids; `repeat` without `max`, nested `repeat`, or `launch`
-inside `repeat`; `until` referencing an undeclared verdict; unknown template variable or
-premature `outputs.*` reference; `text` containing a newline; user file using a `prowl.` id;
-more than one `current` role.
+Errors: unknown `schema`/keys; undefined role; `kind: headless` (reserved); `message` to
+a `launch` role before its `launch` step; a `launch` role launched twice; `close` of a
+non-`launch` role; `expect` on `action` / `notify` / `close`; duplicate step ids; `repeat`
+without `max`, nested `repeat`, or `launch` inside `repeat`; `until` referencing an
+undeclared verdict; unknown template variable or premature `outputs.*` / `roles.<r>.pane` /
+`actions.<step>.<key>` reference (unknown action step, undeclared key, or a producer that
+does not dominate the consumer); unknown `action` id or `with` keys violating the action's
+schema; `repeat.max` that is neither a positive integer literal in `1…20` nor a template
+of exactly one `integer` input; `text` containing a line terminator; a string input default
+containing a line terminator or control character; `skill` that does not match the
+workflow-id pattern or does not resolve to a bundled skill; `verdict` with fewer than 2 or
+more than 4 values, duplicate values, or a value that is not a safe slug; an `until`
+literal outside the declared set; user file using a `prowl.` id; more than one `current`
+role; ids that are not safe slugs — workflow `id` and `skill` ids must match
+`^[a-z0-9][a-z0-9_.-]{0,63}$` (a leading alphanumeric rules out `.`/`..`); step ids, role
+names, output names, input names, and verdict values must match
+`^[a-z0-9][a-z0-9_-]{0,63}$` — because they become path components and CLI arguments.
 Warnings: no installed agent satisfies `agents`; no enabled profile matches `suggest`;
-`timeout` above 2h.
+`timeout` above 2h; `text`/`instruction` spelling out `prowl workflow done` (the runner
+appends the rendered command itself); `on_timeout: skip` on an output referenced later.
 
 ## 8. Run directory
 
@@ -192,59 +245,105 @@ Warnings: no installed agent satisfies `agents`; no enabled profile matches `sug
   run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids),
                             # step states, timestamps; no env values, no extra arguments, no credentials
   log.md                    # human-readable, append-only
-  instructions/<step>.md    # materialized `instruction` / `prompt` text
+  instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per activation (run-global ordinal)
   skills/<id>/SKILL.md      # materialized bundled skills
-  outputs/<name>.md         # validated deliveries; inside `repeat` versioned as <name>.<iteration>.md, latest symlink/copy
-  captures/<step>.md        # headless captures
+  outputs/<name>.md         # latest validated delivery (atomically replaced); every delivery is also kept as <name>.<ordinal>.md
 ```
 
 `<root>/.prowl/workflow-runs/.gitignore` contains `*` (self-ignoring, as `.prowl/handoff/`).
 Definitions shipped with a repo live in `<root>/.prowl/workflows/` (not ignored).
+
+Safety: the run directory and every file below it are created only from validated slugs
+and the run UUID, under canonical containment checks against
+`<root>/.prowl/workflow-runs/` (no symlink leaf, resolved parent + leaf compared to the
+resolved base — the `AgentProfileHomeProvisioner` gate). Repo-scoped definitions are
+untrusted input; nothing from a workflow file is interpolated into a path except validated
+slugs. Outputs are agent-authored content persisted at the agent's request (size caps in
+§5); they are kept until the user removes the run folder (retention policy: V2). Privacy
+wording as in §10: Prowl-authored persisted and response metadata (`run.json`, `log.md`,
+the non-body fields of CLI payloads) carries profile UUID/name and agent tokens only —
+never extra arguments, environment values, home paths, or credentials; the agent-provided
+output body is excluded from that claim.
 
 ## 9. CLI participant protocol
 
 ```bash
 prowl workflow list [--json]                                  # sources, enabled, validation status
 prowl workflow run <id|name> [source] [--role r=<profile|uuid|auto>]... [--input k=v]... [--json]
+                                                              # [source]: 060 GenericTarget (pN | tN | UUID | worktree ref); omitted → caller pane
+                                                              # when the workflow has a `current` role (SOURCE_REQUIRED outside a pane), a
+                                                              # worktree reference otherwise
 prowl workflow status [run-id] [--json]                       # no args: "who am I" — caller pane's run, role, awaited step and its requirements
-prowl workflow done [-|--file <path>] [--verdict <v>] [--run <id> --step <id>] [--force] [--json]
+prowl workflow done [-|--file <path>] [--verdict <v>] [--token <token>] [--run <id> --step <id>] [--force] [--json]
 prowl workflow cancel <run-id> [--json]
 prowl workflow validate <file> [--json]
 prowl workflow schema                                         # JSON Schema / reference for authoring agents
 ```
 
-**Resolution of `done`.** The caller pane (socket peer PID → process ancestry → shell PID
-→ pane) identifies the run, role, and awaited step. A pane belongs to at most one run at a
-time, so no ids are needed in the typed command. Explicit `--run --step` is required when no
-caller pane exists (manual delivery, logged as `source=manual`); if both exist and disagree,
+**Resolution of `done`.** Two independent facts must agree: the **caller pane** (socket
+peer PID → process ancestry → shell PID → pane) identifies the run and role, and the
+**delivery token** (`PROWL_WORKFLOW_TOKEN`, read from the environment of the `prowl`
+process exactly like `PROWL_HANDOFF_REQUEST_ID` today, or `--token`) identifies the awaited
+step. Prowl mints the token when the step starts waiting, embeds it in the typed hint, and
+revokes it on Skip / Cancel / Relaunch; a stale or duplicated `done` from a pane that has
+moved on to another step is therefore rejected instead of misattributed. A pane belongs
+to at most one run at a time, so no run/step ids are needed in the typed command. Explicit
+`--run --step` is required when no caller pane exists (manual delivery, logged as
+`source=manual`, no token needed): it targets the step's *current* activation and is
+attributed to that activation's delivery role; if the step is not currently waiting the
+result is `STEP_NOT_EXPECTING`. If caller pane and explicit ids disagree,
 `ROLE_MISMATCH` unless `--force`. Launched surfaces may additionally carry
 `PROWL_WORKFLOW_RUN` / `PROWL_WORKFLOW_ROLE` as a cross-check hint; the registry is the
 authority.
 
+**`--role` grammar** (source-specific; duplicate overrides for one role and overrides for
+unknown roles are `INVALID_ARGUMENT`; a missing override falls back to binding resolution):
+
+```text
+--role <launch-role>=<profile name | profile UUID | auto>
+--role <pick-role>=<pN | pane UUID>        # must be a detected agent pane in the source worktree, not in another run (PANE_BUSY), not the current pane
+# current roles take no override
+```
+
+The `run` response records every frozen binding (launch: profile id/name/agent; pick:
+pane id/handle and detected agent).
+
 Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BUSY`,
-`ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `OUTPUT_INVALID` (sections/format/verdict),
-`VERDICT_REQUIRED`.
+`ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `TOKEN_REQUIRED`, `TOKEN_INVALID`,
+`OUTPUT_INVALID` (sections/format/verdict), `OUTPUT_TOO_LARGE`, `VERDICT_REQUIRED`,
+`PROFILE_NOT_FOUND`, `PROFILE_NOT_UNIQUE`, `SKILL_NOT_FOUND`, `RENDERED_TEXT_INVALID`
+(a rendered `text`/pointer/`--input` value would not survive as one terminal line),
+`UNSAFE_PATH`. (`AGENT_GONE` and `WAIT_TIMEOUT` belong to the `agents wait` contract, not
+to `prowl workflow`.)
 
 Companion primitives for CLI-driven orchestration (same boundaries as the runner):
 `prowl create pane <pane> --direction <dir> [--profile <name|uuid> --prompt -]`,
 `prowl create tab <worktree> [--profile … --prompt -]`, `prowl profiles list`,
-`prowl agents wait <pane> --until idle|done|blocked [--timeout]`, `prowl send`,
-`prowl agents read`.
+`prowl agents wait <pane> --until idle|done|blocked|changed [--timeout]`, `prowl send`,
+`prowl agents read`. `agents wait` consumes the typed per-surface observer
+(`ObservedAgentState`: `snapshot` first, then `changed` / `removed` / `surfaceClosed`);
+it returns immediately when the snapshot already satisfies `--until`, and maps `removed`
+/ `surfaceClosed` to the terminal error `AGENT_GONE` (never to `done`) unless `--until
+changed` was requested.
 
 ## 10. Run semantics
 
 | Topic | Rule |
 | --- | --- |
 | Start | Resolve bindings, freeze plans, create run dir, write `run.json`, then execute step 1. `current` role must not already be in a run (`PANE_BUSY`). |
-| Advance | A step completes when its `expect` is satisfied (or it has none). `repeat` re-evaluates `until` after each iteration. |
-| Watchdog | Driven by the periodic detection events (`agentEntryChanged` / `agentEntryRemoved`) plus an injected clock; every trigger has a grace period because detection is heuristic and a wrong guess must be harmless. Awaited role `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention` (Focus pane / Cancel). Awaited role `idle`/`done` ≥ `idle_grace` (default 3 min) without `done` → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: prowl workflow done -`, which merely queues if the agent is still working), then `needsAttention` after another `idle_grace` (Nudge again / Keep waiting / Skip / Cancel). Awaited role's agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). `working` never triggers anything. Grace values are global settings. |
+| Advance | A step completes when its `expect` is satisfied (or it has none and its effect succeeded). `repeat` evaluates `until` before entry and after each iteration; `max` reached with `until` still false ends the run as `max_rounds_reached`. |
+| Message delivery | Injection is synchronous (`insertCommittedText` + submit); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
+| Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
+| Activation | Defined in §5: every wait is a new activation with its own token; one delivery per activation; revocation is per activation; outputs are versioned by activation ordinal. |
+| Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
+| Watchdog | Driven by the periodic detection events (`agentEntryChanged` / `agentEntryRemoved`, forwarded to the runner by `AppFeature`'s single terminal-event subscription — `WorktreeTerminalManager.eventStream()` is single-consumer) plus an injected clock. When a step starts waiting the watchdog reads the role's current state first and schedules cancellable grace deadlines; it never depends on a later event alone. Every trigger has a grace period because detection is heuristic and a wrong guess must be harmless. Awaited role `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention` (Focus pane / Cancel). Awaited role `idle`/`done` ≥ `idle_grace` (default 3 min) without `done` → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`, harmless if the agent is still working because the runtime merely queues the line), then `needsAttention` after another `idle_grace` (Nudge again / Keep waiting / Skip / Cancel). Awaited role's agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). `working` never triggers anything. Grace values are global settings. |
 | `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |
 | Explicit `timeout` | Only when an author sets `expect.timeout`: `attention` (default) enters `needsAttention`; `skip` / `cancel` act automatically. |
 | Cancel | Stops advancing and injecting; keeps all panes and outputs; logs. |
 | Failure | Launch/plan/provision failure → `needsAttention` with Retry / Skip role / Cancel; outputs already delivered are kept. |
 | Concurrency | One run per pane; many runs per worktree; the status center shows the selected worktree's most recent active run, the panel lists all. |
 | Restart | V1: runs found on disk at launch are marked `interrupted`; no resume. |
-| Privacy | `run.json`, logs, and CLI payloads carry profile UUID/name and agent tokens only. |
+| Privacy | Prowl-authored response metadata and persisted metadata (`run.json`, logs, the non-body fields of CLI payloads) carry profile UUID/name and agent tokens only — never extra arguments, environment values, home paths, or credentials. The agent-provided output body of `workflow done` is explicitly excluded from that claim: it is persisted as delivered, under the self-ignored run directory, within the size caps of §5. |
 
 ## 11. Built-in workflows (V1)
 
@@ -253,14 +352,36 @@ Companion primitives for CLI-driven orchestration (same boundaries as the runner
   steps: `message source` (brief, sections `## Objective`, `## Current State`,
   `## Next Steps`) → `action handoff.transition` (archive-first `.prowl/handoff/`
   contract) → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) →
-  `notify`. `prowl handoff to <agent> --brief -` remains as a deprecated alias that starts
-  this run with the `brief` output pre-delivered (`--no-brief`: step pre-skipped);
-  `prowl handoff save` maps to `prowl.handoff-checkpoint` (brief → `action
-  handoff.checkpoint`).
+  `notify`. The deprecated `prowl handoff` commands are served by a `LegacyHandoffAdapter`
+  that maps `to <agent>` → Recommended enabled profile of that runtime (else
+  `PROFILE_NOT_FOUND`), source selectors → run source, `--brief -` / `--no-brief` → `brief`
+  output pre-delivered / step pre-skipped, `--note` → `handoff.transition` input,
+  `--no-launch` → `launch` step pre-skipped with the target token recorded (no profile
+  needed), `save` → `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`). The
+  adapter **preflights before creating any run or artifact**, reproducing the current
+  handler's immediate errors: neither `--brief` nor `--no-brief` → `BRIEF_REQUIRED` (the
+  legacy path never starts an agent-mediated brief step or a hidden model turn); empty
+  stdin → `EMPTY_INPUT`; a briefing missing the required sections → `INVALID_BRIEF`;
+  unknown agent token → the existing argument error. With the `brief` step pre-supplied or
+  pre-skipped the `current` role needs no detected agent, so a bare shell pane stays a
+  valid legacy source. Action/transition failures map to the documented legacy failure
+  response (never an attention state or partial success). The adapter starts the run with
+  `failurePolicy: .fail`: a provisioning/launch failure after the artifacts are written
+  ends the run as `failed` (artifacts and log kept) and returns `HANDOFF_FAILED`
+  immediately, as the current handler does. It awaits run completion synchronously and
+  renders the existing `prowl.cli.handoff.v2` response shape (schema-compatible;
+  differences documented and covered by per-field socket parity tests: no-agent source,
+  `--no-brief`, `--no-launch`, omitted brief choice → `BRIEF_REQUIRED`, empty stdin →
+  `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`, action/transition failure, profile
+  lookup failure, provisioning failure, launch failure).
 - `prowl.adversarial-review` — as in §4; interactive reviewer in a right split by default.
 
 ## 12. Reserved for V2
 
 `when:` (conditions on verdicts), `count:` / `wait: { all: […] }` (fan-out),
-`expect.status: idle` + `capture: result` (observe mode via `agents read`), `worktree:` on
-roles (cross-repo review), run resume, nested `repeat`, `outputs.<name>.json` field access.
+`expect.status: idle` + `capture: result` (observe mode via `agents read`), `kind:
+headless` roles backed by a specified `HeadlessAgentExecutor` (cwd/env, stdout/stderr
+bounds, exit/cancel/timeout semantics, per-runtime trusted result extraction), `worktree:`
+on roles (cross-repo review), run resume, output retention policy, nested `repeat`,
+`outputs.<name>.json` field access, custom (non-bundled) `skill:` sources with their own
+rooted discovery and containment rules, `expect … from: <role>` on native actions.

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -351,11 +351,13 @@ Companion primitives for CLI-driven orchestration (same boundaries as the runner
 `prowl create pane <pane> --direction <dir> [--profile <name|uuid> --prompt -]`,
 `prowl create tab <worktree> [--profile … --prompt -]`, `prowl profiles list`,
 `prowl agents wait <pane> --until idle|done|blocked|changed [--timeout]`, `prowl send`,
-`prowl agents read`. `agents wait` consumes the typed per-surface observer
-(`ObservedAgentState`: `snapshot` first, then `changed` / `removed` / `surfaceClosed`);
-it returns immediately when the snapshot already satisfies `--until`, and maps `removed`
-/ `surfaceClosed` to the terminal error `AGENT_GONE` (never to `done`) unless `--until
-changed` was requested.
+`prowl agents read`. `agents wait` (and `agents signal`) are specified in
+[064 agent-completion-signals](../064-agent-completion-signals/000-plan.md); they consume
+the typed per-surface observer (`ObservedAgentState`: `snapshot` first, then `changed` /
+`removed` / `surfaceClosed`, plus 064's `.signal`), return immediately when the snapshot
+already satisfies `--until`, report `source`/`confidence`, and map `removed` /
+`surfaceClosed` to the terminal error `AGENT_GONE` (never to `done`) unless `--until
+changed` / `exit` was requested.
 
 ## 10. Run semantics
 

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -99,7 +99,7 @@ steps:
   - id: brief
     title: "Author writing the brief"
     message: author                          # ① speak to a live interactive role
-    instruction: |                           #    multi-line → materialized to run.dir/instructions/brief.md; one pointer line is typed
+    instruction: |                           #    multi-line → materialized to a run instruction file (run.dir/instructions/brief.<ordinal>.md); one pointer line is typed
       Write a short brief for an adversarial reviewer: ## Scope, ## Claims, ## How to verify.
       Deliver it with the generated completion command.   # never spell `prowl workflow done` yourself — the runner appends the tokenized command
     expect: { output: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
@@ -171,7 +171,7 @@ JSON Schema):
 | Action | `with` inputs | Outputs |
 | --- | --- | --- |
 | `handoff.transition` | `briefing` (path, optional), `from` (role, required), `to` (role, required), `note` (string, optional) | `kickoff_prompt` (string), `artifact_path` (path), `has_briefing` (bool) |
-| `handoff.checkpoint` | `briefing` (path, required), `note` (string, optional) | `artifact_path` (path) |
+| `handoff.checkpoint` | `briefing` (path, optional — absent = context-only checkpoint: regenerate `context.md`, keep an earlier valid `current.md` if present, as today's `handoff save --no-brief`), `note` (string, optional) | `artifact_path` (path), `has_briefing` (bool, for this invocation) |
 | `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary), `branch` (string) |
 
 ## 5. `expect`
@@ -342,7 +342,7 @@ changed` was requested.
 | --- | --- |
 | Start | Resolve bindings, freeze plans, create run dir, write `run.json`, then execute step 1. `current` role must not already be in a run (`PANE_BUSY`). |
 | Advance | A step completes when its `expect` is satisfied (or it has none and its effect succeeded). `repeat` evaluates `until` before entry and after each iteration; `max` reached with `until` still false ends the run as `max_rounds_reached`. |
-| Message delivery | Injection is synchronous (`insertCommittedText` + submit); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
+| Message delivery | Injection is synchronous (`insertCommittedText` + submit, treated as one operation); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). If the insert succeeded but the submit failed, the attention text says that the line may still sit unsubmitted in the pane's input (Focus pane lets the user press Enter there). **Retry** re-executes the step as a new invocation: it revokes the previous activation's token, mints a new ordinal/token, and injects the freshly rendered line. At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
 | Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
 | Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
@@ -381,9 +381,11 @@ changed` was requested.
   immediately, as the current handler does. It awaits run completion synchronously and
   renders the existing `prowl.cli.handoff.v2` response shape (schema-compatible;
   differences documented and covered by per-field socket parity tests: no-agent source,
-  `--no-brief`, `--no-launch`, omitted brief choice → `BRIEF_REQUIRED`, empty stdin →
-  `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`, action/transition failure, profile
-  lookup failure, provisioning failure, launch failure).
+  `to … --no-brief`, `--no-launch`, `save --brief -`, `save --no-brief` with and without
+  an existing valid `current.md` (context-only checkpoint keeps it), omitted brief choice
+  → `BRIEF_REQUIRED`, empty stdin → `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`,
+  action/transition failure, profile lookup failure, provisioning failure, launch
+  failure).
 - `prowl.adversarial-review` — as in §4; interactive reviewer in a right split by default.
 
 ## 12. Reserved for V2

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -170,7 +170,7 @@ JSON Schema):
 
 | Action | `with` inputs | Outputs |
 | --- | --- | --- |
-| `handoff.transition` | `briefing` (path, optional), `from` (role, required), `to` (role, required), `note` (string, optional) | `kickoff_prompt` (string), `artifact_path` (path), `has_briefing` (bool) |
+| `handoff.transition` | `briefing` (path, optional — **absent = context-only transition**, exactly today's `handoff to --no-brief`: archive the outgoing `current.md`/`context.md`, then *remove* `current.md` so a stale briefing can never impersonate a fresh one, regenerate `context.md`, and select the context/archive-only kickoff prompt), `from` (role, required), `to` (role, required; its agent token comes from the role's frozen binding — a profile binding yields the profile's agent, a legacy *destination-only* binding (see §11) yields the recorded token), `note` (string, optional) | `kickoff_prompt` (string; briefing or context-only variant), `artifact_path` (path), `has_briefing` (bool) |
 | `handoff.checkpoint` | `briefing` (path, optional — absent = context-only checkpoint: regenerate `context.md`, keep an earlier valid `current.md` if present, as today's `handoff save --no-brief`), `note` (string, optional) | `artifact_path` (path), `has_briefing` (bool, for this invocation) |
 | `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary), `branch` (string) |
 
@@ -342,7 +342,7 @@ changed` was requested.
 | --- | --- |
 | Start | Resolve bindings, freeze plans, create run dir, write `run.json`, then execute step 1. `current` role must not already be in a run (`PANE_BUSY`). |
 | Advance | A step completes when its `expect` is satisfied (or it has none and its effect succeeded). `repeat` evaluates `until` before entry and after each iteration; `max` reached with `until` still false ends the run as `max_rounds_reached`. |
-| Message delivery | Injection is synchronous (`insertCommittedText` + submit, treated as one operation); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). If the insert succeeded but the submit failed, the attention text says that the line may still sit unsubmitted in the pane's input (Focus pane lets the user press Enter there). **Retry** re-executes the step as a new invocation: it revokes the previous activation's token, mints a new ordinal/token, and injects the freshly rendered line. At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
+| Message delivery | Injection is synchronous (`insertCommittedText` + submit, treated as one operation); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). If the insert succeeded but the submit failed, the attention text says that the line may still sit unsubmitted in the pane's input (Focus pane lets the user press Enter there). **Retry** re-executes the step as a new invocation: it mints a new ordinal (and, when the step has an `expect`, revokes the previous activation's token and mints a new one) and injects the freshly rendered line. At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
 | Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
 | Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
@@ -363,11 +363,18 @@ changed` was requested.
   `## Next Steps`) → `action handoff.transition` (archive-first `.prowl/handoff/`
   contract) → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) →
   `notify`. The deprecated `prowl handoff` commands are served by a `LegacyHandoffAdapter`
-  that maps `to <agent>` → Recommended enabled profile of that runtime (else
-  `PROFILE_NOT_FOUND`), source selectors → run source, `--brief -` / `--no-brief` → `brief`
-  output pre-delivered / step pre-skipped, `--note` → `handoff.transition` input,
-  `--no-launch` → `launch` step pre-skipped with the target token recorded (no profile
-  needed), `save` → `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`). The
+  that maps source selectors → run source, `--brief -` / `--no-brief` → `brief` output
+  pre-delivered / step pre-skipped, `--note` → `handoff.transition` input, `save` →
+  `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`), and `to <agent>` by
+  launch intent: **when a launch is requested**, the receiver role is bound to the
+  Recommended enabled profile of that runtime (else `PROFILE_NOT_FOUND`); **with
+  `--no-launch`**, no profile lookup happens at all — the receiver role is frozen with a
+  typed *destination-only* binding (`legacyDestination(agent: <validated detected-agent
+  token>)`, an internal run-state binding kind that carries no profile, pane, or plan) and
+  the `launch` step is pre-skipped. `handoff.transition` resolves `to` from that binding, so
+  archive names, the transition log line, and the `to_agent` response field keep the
+  recorded token exactly as today, and `prowl handoff to gemini --no-launch` keeps working
+  for every detected-agent token. The
   adapter **preflights before creating any run or artifact**, reproducing the current
   handler's immediate errors: neither `--brief` nor `--no-brief` → `BRIEF_REQUIRED` (the
   legacy path never starts an agent-mediated brief step or a hidden model turn); empty
@@ -381,8 +388,11 @@ changed` was requested.
   immediately, as the current handler does. It awaits run completion synchronously and
   renders the existing `prowl.cli.handoff.v2` response shape (schema-compatible;
   differences documented and covered by per-field socket parity tests: no-agent source,
-  `to … --no-brief`, `--no-launch`, `save --brief -`, `save --no-brief` with and without
-  an existing valid `current.md` (context-only checkpoint keeps it), omitted brief choice
+  `to … --no-brief` with a stale `current.md` present (archived and removed, context-only
+  kickoff, `has_briefing: false`), `to gemini --no-launch` in both brief and context-only
+  variants (asserting `to_agent`, archive/log target, no profile lookup, no launch),
+  `save --brief -`, `save --no-brief` with and without an existing valid `current.md`
+  (context-only checkpoint keeps it), omitted brief choice
   → `BRIEF_REQUIRED`, empty stdin → `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`,
   action/transition failure, profile lookup failure, provisioning failure, launch
   failure).

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -65,7 +65,7 @@ roles:
 
 | Field | Rules |
 | --- | --- |
-| `source` | At most one `current` role per workflow. A `current` role must host a detected agent only if the runner will actually **deliver** to it — i.e. at least one `message` step targeting it is neither pre-skipped nor completed by a seeded output (§5) at start; otherwise a bare shell pane is a valid source (context-only handoff, legacy `handoff save`, legacy `--brief -`). The check runs after the internal start API has applied its pre-skips/seeds. A workflow without a `current` role needs an explicit worktree at start. `pick` roles are chosen from the detected agents of the source worktree at start; a pane already in a run is not offered. |
+| `source` | At most one `current` role per workflow. A `current` role must host a detected agent only if the runner will actually **deliver** to it — i.e. at least one `message` step targeting it is not skipped at start (`--skip <step>` / the start sheet's skip option, §9); otherwise a bare shell pane is a valid source (e.g. a context-only handoff). A workflow without a `current` role needs an explicit worktree at start. `pick` roles are chosen from the detected agents of the source worktree at start; a pane already in a run is not offered. |
 | `kind` | Only for `launch`. V1 accepts `interactive` only; `headless` is reserved (§12) because no executor/output protocol exists yet. |
 | `agents` | Tokens from the detected-agent catalog. Validator warns (not errors) when none is installed locally. |
 | `suggest` | Subset of profile preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`). Never a reference to a profile name or UUID. |
@@ -84,10 +84,7 @@ override, is re-validated first (exists, enabled, satisfies `agents`, adapter su
 seeded prompt); a failing candidate falls through to the next tier. The chosen profile is
 frozen into the run together with its launch plan; later profile edits do not affect the
 run. CLI overrides are source-specific (§9): `--role <launch-role>=<profile name|uuid|auto>`,
-`--role <pick-role>=<agent pane: pN | pane UUID>`; `current` roles take no override. One
-internal exception exists: the `LegacyHandoffAdapter` (§11) may freeze a launch role as a
-*destination-only* binding (agent token, no profile) when its launch step is pre-skipped;
-a generic resolver never performs profile lookup for such a role.
+`--role <pick-role>=<agent pane: pN | pane UUID>`; `current` roles take no override.
 
 ## 4. Steps
 
@@ -173,8 +170,8 @@ JSON Schema):
 
 | Action | `with` inputs | Outputs |
 | --- | --- | --- |
-| `handoff.transition` | `briefing` (path, optional — **absent = context-only transition**, exactly today's `handoff to --no-brief`: archive the outgoing `current.md`/`context.md`, then *remove* `current.md` so a stale briefing can never impersonate a fresh one, regenerate `context.md`, and select the context/archive-only kickoff prompt), `from` (role, required), `to` (role, required; its agent token comes from the role's frozen binding — a profile binding yields the profile's agent, a legacy *destination-only* binding (see §11) yields the recorded token), `note` (string, optional) | `kickoff_prompt` (string; briefing or context-only variant), `artifact_path` (path), `has_briefing` (bool) |
-| `handoff.checkpoint` | `briefing` (path, optional — absent = context-only checkpoint: regenerate `context.md`, keep an earlier valid `current.md` if present, as today's `handoff save --no-brief`), `note` (string, optional) | `artifact_path` (path), `has_briefing` (bool, for this invocation) |
+| `handoff.transition` | `briefing` (path, optional — **absent = context-only transition**: archive the outgoing `current.md`/`context.md`, then *remove* `current.md` so a stale briefing can never impersonate a fresh one, regenerate `context.md`, and select the context/archive-only kickoff prompt), `from` (role, required), `to` (role, required; its agent token is the frozen profile binding's agent), `note` (string, optional) | `kickoff_prompt` (string; briefing or context-only variant), `artifact_path` (path), `has_briefing` (bool) |
+| `handoff.checkpoint` | `briefing` (path, optional — absent = context-only checkpoint: regenerate `context.md`, keep an earlier valid `current.md` if present), `note` (string, optional) | `artifact_path` (path), `has_briefing` (bool, for this invocation) |
 | `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary), `branch` (string) |
 
 ## 5. `expect`
@@ -204,20 +201,9 @@ expect:
   several steps produce the same output name); `outputs/<name>.md` is the "latest" view,
   replaced atomically (temp file + rename); `run.json` records the invocation → step /
   iteration / activation / file mapping.
-- **Seeded outputs (internal, adapter-only).** The runner's internal start API lets an
-  in-app caller (today only the `LegacyHandoffAdapter`, §11) supply a body for a step's
-  output *before* any agent participates. The runner validates it against the target
-  step's `expect` (format, sections, verdict, size cap) exactly as a delivery; after that
-  check and the caller's own preflight succeed and the run directory exists, the runner
-  allocates a run-global ordinal,
-  atomically writes `outputs/<name>.<ordinal>.md` plus the latest view, and records the
-  step in `run.json` as `seeded` (no source-pane delivery, no activation, no token). The
-  step counts as completed and its `expect` is satisfied; templates resolve
-  `outputs.<name>.path` normally; later invocations continue the same monotonic ordinal
-  sequence. Seeding is not reachable from YAML or the public CLI.
 - Output bodies are capped (default 1 MiB, hard max 4 MiB → `OUTPUT_TOO_LARGE`).
-- **Skip rule.** Skipping an `expect` (panel Skip, `on_timeout: skip`, or an internal
-  pre-skip) marks its output missing. A missing output is tolerated by exactly one kind of
+- **Skip rule.** Skipping an `expect` (panel Skip, `on_timeout: skip`, or a skip chosen at
+  start via `--skip <step>` / the start sheet) marks its output missing. A missing output is tolerated by exactly one kind of
   consumer: a `with` input that the action's registry schema declares **optional** — the
   key is then absent from the action's effective input (this is how `handoff.transition`
   degrades to a context-only transition, i.e. the old HUD's "Context Only"). Every other
@@ -272,7 +258,7 @@ non-optional consumer references (the run would end as `skipped`).
 
 ```
 <root>/.prowl/workflow-runs/<run-id>/
-  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids, or a destination-only agent token), seeded/invocation records,
+  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids), invocation records,
                             # step states, timestamps; no env values, no extra arguments, no credentials
   log.md                    # human-readable, append-only
   instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per invocation (run-global ordinal, §5)
@@ -288,10 +274,9 @@ and the run UUID, under canonical containment checks against
 `<root>/.prowl/workflow-runs/` (no symlink leaf, resolved parent + leaf compared to the
 resolved base — the `AgentProfileHomeProvisioner` gate). Repo-scoped definitions are
 untrusted input; nothing from a workflow file is interpolated into a path except validated
-slugs. Outputs are agent-authored content persisted at the agent's request — or, for
-seeded outputs (§5), caller-supplied content validated against the step's `expect` — with
-the size caps of §5; they are kept until the user removes the run folder (retention
-policy: V2). Privacy
+slugs. Outputs are agent-authored content persisted at the agent's request, within the
+size caps of §5; they are kept until the user removes the run folder (retention policy:
+V2). Privacy
 wording as in §10: Prowl-authored persisted and response metadata (`run.json`, `log.md`,
 the non-body fields of CLI payloads) carries profile UUID/name and agent tokens only —
 never extra arguments, environment values, home paths, or credentials; the agent-provided
@@ -301,7 +286,7 @@ output body is excluded from that claim.
 
 ```bash
 prowl workflow list [--json]                                  # sources, enabled, validation status
-prowl workflow run <id|name> [source] [--role r=<binding>]... [--input k=v]... [--json]   # <binding> grammar is source-specific, see below
+prowl workflow run <id|name> [source] [--role r=<binding>]... [--input k=v]... [--skip <step-id>]... [--json]   # <binding> grammar is source-specific, see below
                                                               # [source]: 060 GenericTarget (pN | tN | UUID | worktree ref); omitted → caller pane
                                                               # when the workflow has a `current` role (SOURCE_REQUIRED outside a pane), a
                                                               # worktree reference otherwise
@@ -337,9 +322,22 @@ unknown roles are `INVALID_ARGUMENT`; a missing override falls back to binding r
 # current roles take no override
 ```
 
-The `run` response records every frozen binding (launch: profile id/name/agent, or — for
-the internal destination-only binding of §11 — agent token only; pick: pane id/handle and
-detected agent).
+The `run` response records every frozen binding (launch: profile id/name/agent; pick: pane
+id/handle and detected agent).
+
+**`--skip <step-id>`** (repeatable) marks a step skipped at start. It is accepted only for
+steps whose `expect` output has no non-optional consumer (§5 Skip rule) — e.g.
+`prowl workflow run prowl.handoff --skip brief` is a context-only handoff; anything else is
+`INVALID_ARGUMENT` naming the dependent step. The start sheet offers the same choice
+("Skip <step title>") for such steps, which is also how a bare-shell pane can start a
+handoff.
+
+**Self-initiated runs.** When `run` is invoked from the pane that becomes the `current`
+role and the first step is a `message` to that role, the response carries that step's
+rendered instruction (or pointer) and its completion command, and the runner does **not**
+also type them into the caller's pane — the caller already has them. For an agent this
+makes a self-handoff two commands: `prowl workflow run prowl.handoff`, then the returned
+`… prowl workflow done -` with its briefing on stdin.
 
 Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BUSY`,
 `ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `TOKEN_REQUIRED`, `TOKEN_INVALID`,
@@ -384,54 +382,25 @@ changed` was requested.
   `background: true`, no `agents` restriction — any adapter with seeded-prompt support);
   steps: `message source` (brief, sections `## Objective`, `## Current State`,
   `## Next Steps`) → `action handoff.transition` (archive-first `.prowl/handoff/`
-  contract) → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) →
-  `notify`. The deprecated `prowl handoff` commands are served by a `LegacyHandoffAdapter`
-  that maps source selectors → run source, `--brief -` → the `brief` step completed by a
-  **seeded output** (§5: validated during adapter preflight, then materialized as
-  `outputs/brief.<ordinal>.md` with a `seeded` record once the run exists, so
-  `{{ outputs.brief.path }}` resolves normally and no pane delivery or token is fabricated),
-  `--no-brief` → `brief` step pre-skipped / output missing — the built-in's
-  `with: { briefing: "{{ outputs.brief.path }}" }` then drops the key by the §5 Skip rule
-  (optional action input), so the run continues with context-only semantics, exactly as a
-  GUI user skipping the brief step gets "Context Only"; no adapter-specific overlay exists,
-  `--note` → `handoff.transition` input, `save` →
-  `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`), and `to <agent>` by
-  launch intent: **when a launch is requested**, the receiver role is bound to the
-  Recommended enabled profile of that runtime (else `PROFILE_NOT_FOUND`); **with
-  `--no-launch`**, no profile lookup happens at all — the receiver role is frozen with a
-  typed *destination-only* binding (`legacyDestination(agent: <validated detected-agent
-  token>)`, an internal run-state binding kind that carries no profile, pane, or plan) and
-  the `launch` step is pre-skipped. `handoff.transition` resolves `to` from that binding, so
-  archive names, the transition log line, and the `to_agent` response field keep the
-  recorded token exactly as today, and `prowl handoff to gemini --no-launch` keeps working
-  for every detected-agent token. The
-  adapter **preflights before creating any run or artifact**, reproducing the current
-  handler's immediate errors: neither `--brief` nor `--no-brief` → `BRIEF_REQUIRED` (the
-  legacy path never starts an agent-mediated brief step or a hidden model turn); empty
-  stdin → `EMPTY_INPUT`; a briefing missing the required sections → `INVALID_BRIEF`;
-  unknown agent token → the existing argument error. With the `brief` step pre-supplied or
-  pre-skipped the `current` role needs no detected agent, so a bare shell pane stays a
-  valid legacy source. Action/transition failures map to the documented legacy failure
-  response (never an attention state or partial success). The adapter starts the run with
-  `failurePolicy: .fail`: a provisioning/launch failure after the artifacts are written
-  ends the run as `failed` (artifacts and log kept) and returns `HANDOFF_FAILED`
-  immediately, as the current handler does. It awaits run completion synchronously and
-  renders the existing `prowl.cli.handoff.v2` response shape (schema-compatible;
-  differences documented and covered by per-field socket parity tests: no-agent source,
-  `to … --no-brief` with a stale `current.md` present (archived and removed, context-only
-  kickoff, `has_briefing: false`), `to gemini --no-launch` in both brief and context-only
-  variants (asserting `to_agent`, archive/log target, no profile lookup, no launch),
-  `to --brief -` and `save --brief -` (invalid brief rejected before any run directory or
-  `.prowl` artifact exists; valid brief yields a versioned seeded output, a `seeded`
-  `run.json` record, the rendered action input, and a later invocation continuing the
-  ordinal sequence), `to --no-brief` and `save --no-brief` completing (not `skipped`) with
-  the `briefing` input absent, `save --no-brief` with and without an existing valid
-  `current.md` (context-only checkpoint keeps it), every one of these four from a bare
-  shell source (no detected agent), omitted brief choice
-  → `BRIEF_REQUIRED`, empty stdin → `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`,
-  action/transition failure, profile lookup failure, provisioning failure, launch
-  failure).
+  contract, `with: { briefing: "{{ outputs.brief.path }}", from: source, to: receiver }`)
+  → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) → `notify`.
+  Skipping `brief` (start sheet, `--skip brief`, or the panel) yields the context-only
+  transition through the §5 Skip rule — the replacement for the old HUD's "Context Only".
+- `prowl.handoff-checkpoint` — `message source` (brief) → `action handoff.checkpoint`;
+  the "save progress for a later successor" use case (no receiver, no launch).
 - `prowl.adversarial-review` — as in §4; interactive reviewer in a right split by default.
+
+**Retirement of `prowl handoff`.** The shipped `prowl handoff to|save` commands are
+retired rather than adapted: for one release they remain as *stubs* that execute nothing
+and return the structured error `HANDOFF_RETIRED` (JSON envelope; plain text + stderr
+otherwise) whose message is the copy-pasteable replacement —
+`prowl workflow run prowl.handoff [--role receiver=<profile|auto>] [--skip brief]` for `to`,
+`prowl workflow run prowl.handoff-checkpoint` for `save`, plus the note that the briefing
+is now delivered with the returned `prowl workflow done -` command. After that release the
+commands, `HandoffCommandHandler`, `HandoffHudFeature`, `HandoffRequestRegistry`, and the
+`prowl.cli.handoff.v2` contract are removed; the `.prowl/handoff/` artifact contract itself
+lives on inside the two actions. `docs/components/handoff.md` and the `prowl-cli` skill are
+rewritten around the workflow commands in the same change.
 
 ## 12. Reserved for V2
 

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -84,7 +84,10 @@ override, is re-validated first (exists, enabled, satisfies `agents`, adapter su
 seeded prompt); a failing candidate falls through to the next tier. The chosen profile is
 frozen into the run together with its launch plan; later profile edits do not affect the
 run. CLI overrides are source-specific (§9): `--role <launch-role>=<profile name|uuid|auto>`,
-`--role <pick-role>=<agent pane: pN | pane UUID>`; `current` roles take no override.
+`--role <pick-role>=<agent pane: pN | pane UUID>`; `current` roles take no override. One
+internal exception exists: the `LegacyHandoffAdapter` (§11) may freeze a launch role as a
+*destination-only* binding (agent token, no profile) when its launch step is pre-skipped;
+a generic resolver never performs profile lookup for such a role.
 
 ## 4. Steps
 
@@ -201,6 +204,15 @@ expect:
   several steps produce the same output name); `outputs/<name>.md` is the "latest" view,
   replaced atomically (temp file + rename); `run.json` records the invocation → step /
   iteration / activation / file mapping.
+- **Seeded outputs (internal, adapter-only).** The runner's internal start API lets an
+  in-app caller (today only the `LegacyHandoffAdapter`, §11) supply an already-validated
+  body for a step's output *before* any agent participates. After the caller's preflight
+  succeeds and the run directory exists, the runner allocates a run-global ordinal,
+  atomically writes `outputs/<name>.<ordinal>.md` plus the latest view, and records the
+  step in `run.json` as `seeded` (no source-pane delivery, no activation, no token). The
+  step counts as completed and its `expect` is satisfied; templates resolve
+  `outputs.<name>.path` normally; later invocations continue the same monotonic ordinal
+  sequence. Seeding is not reachable from YAML or the public CLI.
 - Output bodies are capped (default 1 MiB, hard max 4 MiB → `OUTPUT_TOO_LARGE`).
 - **Skip rule.** Skipping an `expect` (panel Skip or `on_timeout: skip`) marks its output
   missing. If any later step's template references that output (or the `until` of an
@@ -252,7 +264,7 @@ appends the rendered command itself); `on_timeout: skip` on an output referenced
 
 ```
 <root>/.prowl/workflow-runs/<run-id>/
-  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids),
+  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids, or a destination-only agent token), seeded/invocation records,
                             # step states, timestamps; no env values, no extra arguments, no credentials
   log.md                    # human-readable, append-only
   instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per invocation (run-global ordinal, §5)
@@ -315,8 +327,9 @@ unknown roles are `INVALID_ARGUMENT`; a missing override falls back to binding r
 # current roles take no override
 ```
 
-The `run` response records every frozen binding (launch: profile id/name/agent; pick:
-pane id/handle and detected agent).
+The `run` response records every frozen binding (launch: profile id/name/agent, or — for
+the internal destination-only binding of §11 — agent token only; pick: pane id/handle and
+detected agent).
 
 Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BUSY`,
 `ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `TOKEN_REQUIRED`, `TOKEN_INVALID`,
@@ -363,8 +376,12 @@ changed` was requested.
   `## Next Steps`) → `action handoff.transition` (archive-first `.prowl/handoff/`
   contract) → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) →
   `notify`. The deprecated `prowl handoff` commands are served by a `LegacyHandoffAdapter`
-  that maps source selectors → run source, `--brief -` / `--no-brief` → `brief` output
-  pre-delivered / step pre-skipped, `--note` → `handoff.transition` input, `save` →
+  that maps source selectors → run source, `--brief -` → the `brief` step completed by a
+  **seeded output** (§5: validated during adapter preflight, then materialized as
+  `outputs/brief.<ordinal>.md` with a `seeded` record once the run exists, so
+  `{{ outputs.brief.path }}` resolves normally and no pane delivery or token is fabricated),
+  `--no-brief` → `brief` step pre-skipped / output missing (the action's optional input is
+  absent → context-only semantics), `--note` → `handoff.transition` input, `save` →
   `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`), and `to <agent>` by
   launch intent: **when a launch is requested**, the receiver role is bound to the
   Recommended enabled profile of that runtime (else `PROFILE_NOT_FOUND`); **with
@@ -391,7 +408,10 @@ changed` was requested.
   `to … --no-brief` with a stale `current.md` present (archived and removed, context-only
   kickoff, `has_briefing: false`), `to gemini --no-launch` in both brief and context-only
   variants (asserting `to_agent`, archive/log target, no profile lookup, no launch),
-  `save --brief -`, `save --no-brief` with and without an existing valid `current.md`
+  `to --brief -` and `save --brief -` (invalid brief rejected before any run directory or
+  `.prowl` artifact exists; valid brief yields a versioned seeded output, a `seeded`
+  `run.json` record, the rendered action input, and a later invocation continuing the
+  ordinal sequence), `save --no-brief` with and without an existing valid `current.md`
   (context-only checkpoint keeps it), omitted brief choice
   → `BRIEF_REQUIRED`, empty stdin → `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`,
   action/transition failure, profile lookup failure, provisioning failure, launch

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -65,7 +65,7 @@ roles:
 
 | Field | Rules |
 | --- | --- |
-| `source` | At most one `current` role per workflow. A `current` role must host a detected agent only if some step that is not pre-skipped at start `message`s it; otherwise a bare shell pane is a valid source (context-only handoff, legacy `handoff save`). A workflow without a `current` role needs an explicit worktree at start. `pick` roles are chosen from the detected agents of the source worktree at start; a pane already in a run is not offered. |
+| `source` | At most one `current` role per workflow. A `current` role must host a detected agent only if the runner will actually **deliver** to it — i.e. at least one `message` step targeting it is neither pre-skipped nor completed by a seeded output (§5) at start; otherwise a bare shell pane is a valid source (context-only handoff, legacy `handoff save`, legacy `--brief -`). The check runs after the internal start API has applied its pre-skips/seeds. A workflow without a `current` role needs an explicit worktree at start. `pick` roles are chosen from the detected agents of the source worktree at start; a pane already in a run is not offered. |
 | `kind` | Only for `launch`. V1 accepts `interactive` only; `headless` is reserved (§12) because no executor/output protocol exists yet. |
 | `agents` | Tokens from the detected-agent catalog. Validator warns (not errors) when none is installed locally. |
 | `suggest` | Subset of profile preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`). Never a reference to a profile name or UUID. |
@@ -205,21 +205,28 @@ expect:
   replaced atomically (temp file + rename); `run.json` records the invocation → step /
   iteration / activation / file mapping.
 - **Seeded outputs (internal, adapter-only).** The runner's internal start API lets an
-  in-app caller (today only the `LegacyHandoffAdapter`, §11) supply an already-validated
-  body for a step's output *before* any agent participates. After the caller's preflight
-  succeeds and the run directory exists, the runner allocates a run-global ordinal,
+  in-app caller (today only the `LegacyHandoffAdapter`, §11) supply a body for a step's
+  output *before* any agent participates. The runner validates it against the target
+  step's `expect` (format, sections, verdict, size cap) exactly as a delivery; after that
+  check and the caller's own preflight succeed and the run directory exists, the runner
+  allocates a run-global ordinal,
   atomically writes `outputs/<name>.<ordinal>.md` plus the latest view, and records the
   step in `run.json` as `seeded` (no source-pane delivery, no activation, no token). The
   step counts as completed and its `expect` is satisfied; templates resolve
   `outputs.<name>.path` normally; later invocations continue the same monotonic ordinal
   sequence. Seeding is not reachable from YAML or the public CLI.
 - Output bodies are capped (default 1 MiB, hard max 4 MiB → `OUTPUT_TOO_LARGE`).
-- **Skip rule.** Skipping an `expect` (panel Skip or `on_timeout: skip`) marks its output
-  missing. If any later step's template references that output (or the `until` of an
-  enclosing `repeat` depends on its verdict), the run ends as `skipped` instead of
-  advancing — V1 has no optional template values. The panel states which step depends on
-  the output before the user confirms Skip; the validator warns when `on_timeout: skip`
-  would end the run this way.
+- **Skip rule.** Skipping an `expect` (panel Skip, `on_timeout: skip`, or an internal
+  pre-skip) marks its output missing. A missing output is tolerated by exactly one kind of
+  consumer: a `with` input that the action's registry schema declares **optional** — the
+  key is then absent from the action's effective input (this is how `handoff.transition`
+  degrades to a context-only transition, i.e. the old HUD's "Context Only"). Every other
+  reference — `text` / `instruction` / `prompt` / `notify` templates, required action
+  inputs, or the `until` of an enclosing `repeat` — makes the run end as `skipped` instead
+  of advancing, because V1 has no optional template values. The panel states the
+  consequence ("continues without a briefing" vs. "ends the run; step X depends on it")
+  before the user confirms Skip; the validator warns when `on_timeout: skip` would end the
+  run this way.
 - Waiting is supervised by the state-driven watchdog (§10), not by wall-clock time; a
   `working` role is never interrupted.
 
@@ -258,7 +265,8 @@ names, output names, input names, and verdict values must match
 `^[a-z0-9][a-z0-9_-]{0,63}$` — because they become path components and CLI arguments.
 Warnings: no installed agent satisfies `agents`; no enabled profile matches `suggest`;
 `timeout` above 2h; `text`/`instruction` spelling out `prowl workflow done` (the runner
-appends the rendered command itself); `on_timeout: skip` on an output referenced later.
+appends the rendered command itself); `on_timeout: skip` on an output that a later
+non-optional consumer references (the run would end as `skipped`).
 
 ## 8. Run directory
 
@@ -280,8 +288,10 @@ and the run UUID, under canonical containment checks against
 `<root>/.prowl/workflow-runs/` (no symlink leaf, resolved parent + leaf compared to the
 resolved base — the `AgentProfileHomeProvisioner` gate). Repo-scoped definitions are
 untrusted input; nothing from a workflow file is interpolated into a path except validated
-slugs. Outputs are agent-authored content persisted at the agent's request (size caps in
-§5); they are kept until the user removes the run folder (retention policy: V2). Privacy
+slugs. Outputs are agent-authored content persisted at the agent's request — or, for
+seeded outputs (§5), caller-supplied content validated against the step's `expect` — with
+the size caps of §5; they are kept until the user removes the run folder (retention
+policy: V2). Privacy
 wording as in §10: Prowl-authored persisted and response metadata (`run.json`, `log.md`,
 the non-body fields of CLI payloads) carries profile UUID/name and agent tokens only —
 never extra arguments, environment values, home paths, or credentials; the agent-provided
@@ -380,8 +390,11 @@ changed` was requested.
   **seeded output** (§5: validated during adapter preflight, then materialized as
   `outputs/brief.<ordinal>.md` with a `seeded` record once the run exists, so
   `{{ outputs.brief.path }}` resolves normally and no pane delivery or token is fabricated),
-  `--no-brief` → `brief` step pre-skipped / output missing (the action's optional input is
-  absent → context-only semantics), `--note` → `handoff.transition` input, `save` →
+  `--no-brief` → `brief` step pre-skipped / output missing — the built-in's
+  `with: { briefing: "{{ outputs.brief.path }}" }` then drops the key by the §5 Skip rule
+  (optional action input), so the run continues with context-only semantics, exactly as a
+  GUI user skipping the brief step gets "Context Only"; no adapter-specific overlay exists,
+  `--note` → `handoff.transition` input, `save` →
   `prowl.handoff-checkpoint` (brief → `action handoff.checkpoint`), and `to <agent>` by
   launch intent: **when a launch is requested**, the receiver role is bound to the
   Recommended enabled profile of that runtime (else `PROFILE_NOT_FOUND`); **with
@@ -411,8 +424,10 @@ changed` was requested.
   `to --brief -` and `save --brief -` (invalid brief rejected before any run directory or
   `.prowl` artifact exists; valid brief yields a versioned seeded output, a `seeded`
   `run.json` record, the rendered action input, and a later invocation continuing the
-  ordinal sequence), `save --no-brief` with and without an existing valid `current.md`
-  (context-only checkpoint keeps it), omitted brief choice
+  ordinal sequence), `to --no-brief` and `save --no-brief` completing (not `skipped`) with
+  the `briefing` input absent, `save --no-brief` with and without an existing valid
+  `current.md` (context-only checkpoint keeps it), every one of these four from a bare
+  shell source (no detected agent), omitted brief choice
   → `BRIEF_REQUIRED`, empty stdin → `EMPTY_INPUT`, invalid sections → `INVALID_BRIEF`,
   action/transition failure, profile lookup failure, provisioning failure, launch
   failure).

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -277,7 +277,7 @@ non-optional consumer references (the run would end as `skipped`).
   log.md                    # human-readable, append-only
   instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per invocation (run-global ordinal, §5)
   skills/<id>/SKILL.md      # materialized bundled skills
-  outputs/<name>.md         # latest validated delivery (atomically replaced); every delivery is also kept as <name>.<ordinal>.md
+  outputs/<name>.md         # latest validated output (atomically replaced); every output version is also kept as <name>.<ordinal>.md
 ```
 
 `<root>/.prowl/workflow-runs/.gitignore` contains `*` (self-ignoring, as `.prowl/handoff/`).

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -1,0 +1,266 @@
+# Agent Workflow DSL — `prowl.workflow/v1` (living spec)
+
+> Living document: the normative definition of the workflow file format, run semantics,
+> and the CLI participant protocol. Updated in place as the design settles and the
+> implementation lands; history and rationale live in [000-plan.md](000-plan.md).
+>
+> Status: **draft** (2026-08-21) — not yet implemented. Sections marked *TBD* are open.
+
+## 1. Principles
+
+1. **The DSL describes intent; the runner owns transport.** A file says "ask the reviewer
+   for findings", never "inject via ghostty" or "use adapter X". Transports can change
+   without touching workflow files.
+2. **Declarative and sequential.** No shell, no scripts, no expressions. V1 control flow is
+   ordered steps plus one bounded `repeat … until <verdict>`.
+3. **Long content goes through files; only one line ever enters a TUI.**
+4. **Portable by construction.** A file never names a local Agent Profile, pane, or run id.
+   Bindings are resolved locally at start and remembered.
+5. **Only run-bound panes are touched.** A workflow can speak only to its own roles.
+
+## 2. Document structure
+
+```yaml
+schema: prowl.workflow/v1            # required
+id: prowl.adversarial-review         # required slug; `prowl.` prefix reserved for bundled workflows
+name: Adversarial Review             # required; UI title
+description: …                       # optional; popover/Settings subtitle
+icon: magnifyingglass.circle         # optional SF Symbol
+
+inputs:                              # optional; provided by the start sheet or `--input k=v`
+  max_rounds: { type: integer, default: 5, min: 1, max: 10 }
+  focus:      { type: string,  default: "", prompt: "What should the reviewer focus on?" }
+  mode:       { type: enum, values: [strict, lenient], default: strict }
+
+roles:   …                           # §3
+steps:   …                           # §4
+```
+
+Sources and precedence: bundle (`Resources/workflows/`, ids `prowl.*`) < user
+(`~/.prowl/workflows/*.yaml`) < repo (`<root>/.prowl/workflows/*.yaml`). A user/repo file may
+not reuse a `prowl.*` id; the same non-reserved id in user and repo scope resolves to the
+repo file for that worktree.
+
+## 3. Roles
+
+```yaml
+roles:
+  author:
+    source: current                  # the pane the run was started from; must have a detected agent
+  reviewer:
+    source: launch                   # Prowl starts a new agent for this role
+    kind: interactive                # interactive (default) | headless
+    agents: [codex, claude]          # optional allow-list of agent tokens (as in `prowl agents` `type`); omitted = any launchable
+    suggest:                         # optional; match an existing enabled profile exactly, or offer to create one
+      agent: codex
+      reasoning_effort: xhigh
+      execution_mode: standard
+    bind: ask                        # ask (default) | auto
+    placement: split                 # split | tab (default: split for interactive, tab for headless)
+    direction: right                 # right | left | up | down (split only)
+    background: false                # true = do not focus/select the new surface
+  partner:
+    source: pick                     # an existing detected agent pane chosen at start (CLI: --role partner=p12)
+```
+
+| Field | Rules |
+| --- | --- |
+| `source` | Exactly one `current` role per workflow (optional: a workflow may have none, then it needs no detected agent at the entry). `pick` roles are chosen from `prowl agents` at start. |
+| `kind` | Only for `launch`. `headless` roles accept a single `launch` step, cannot receive `message`, and deliver their captured output automatically. |
+| `agents` | Tokens from the detected-agent catalog. Validator warns (not errors) when none is installed locally. |
+| `suggest` | Subset of profile preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`). Never a reference to a profile name or UUID. |
+| `bind` | `ask`: the start sheet always shows the role picker (pre-filled). `auto`: the sheet appears only when resolution is ambiguous. |
+
+**Binding resolution** (per `launch` role, at start, in order): remembered local binding
+`(workflow id, role) → profile UUID` → enabled profile matching `suggest` exactly →
+Recommended profile (053 rules) filtered by `agents` → ask. The chosen profile is frozen
+into the run together with its launch plan; later profile edits do not affect the run.
+`--role <role>=<profile name|uuid|auto>` overrides from the CLI.
+
+## 4. Steps
+
+Each step has `id` (unique within the workflow), optional `title` (templated; shown in the
+status center and panel), exactly one verb, and an optional `expect` (§5).
+
+```yaml
+steps:
+  - id: brief
+    title: "Author writing the brief"
+    message: author                          # ① speak to a live interactive role
+    instruction: |                           #    multi-line → materialized to run.dir/instructions/brief.md; one pointer line is typed
+      Write a short brief for an adversarial reviewer: ## Scope, ## Claims, ## How to verify.
+      When done: prowl workflow done -
+    expect: { output: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
+
+  - id: launch
+    title: "Reviewer starting round 1"
+    launch: reviewer                         # ② start a launch role with a kickoff prompt
+    prompt: "Read {{ outputs.brief.path }} and the bundled reviewer skill, then review."
+    skill: prowl.adversarial-reviewer        #    optional; bundled skill materialized to run.dir/skills/<id>/SKILL.md and referenced
+    expect: { output: findings, sections: ["## Findings", "## Verdict"], verdict: [clean, issues], timeout: 30m }
+
+  - id: rounds
+    repeat:                                  # ③ bounded loop (V1: not nested; no `launch` inside)
+      max: "{{ inputs.max_rounds }}"
+      until: outputs.findings.verdict == clean
+    steps:
+      - id: fix
+        title: "Round {{ loop.index }}: author addressing findings"
+        message: author
+        text: "Findings: {{ outputs.findings.path }}. Fix or rebut each, commit, then `prowl workflow done -` with your disposition."
+        expect: { output: disposition, timeout: 30m }
+      - id: rereview
+        title: "Round {{ loop.index }}: reviewer re-checking"
+        message: reviewer
+        text: "Disposition: {{ outputs.disposition.path }}. Re-review the new commits; `prowl workflow done --verdict clean|issues -`."
+        expect: { output: findings, verdict: [clean, issues], timeout: 30m }
+
+  - id: context
+    action: git.context                      # ④ built-in native action (Swift); outputs under {{ actions.<id>.* }}
+    with: { root: "{{ worktree.path }}" }
+
+  - id: done
+    notify: "Adversarial review: {{ outputs.findings.verdict }} after {{ loop.count }} round(s)"   # ⑤
+
+  - id: cleanup
+    close: reviewer                          # ⑥ only launch roles; protected close (confirms if the agent is still running)
+```
+
+| Verb | Payload keys | Allowed target | Notes |
+| --- | --- | --- | --- |
+| `message: <role>` | `text` (single line, typed verbatim) **or** `instruction` (multi-line, materialized + pointer) | live interactive role (`current`, `pick`, or a `launch` role already launched) | Injection is gated: `blocked` → not typed, run → `needsAttention`; `working` → queued, shown in the panel. |
+| `launch: <role>` | `prompt` (kickoff, templated), optional `skill` | `launch` role, at most once per run (V1) | Interactive: profile plan with `AgentStartIntent.prompt`; headless: adapter one-shot with captured output. A single-line `prompt` is passed verbatim; a multi-line one is materialized and the kickoff becomes the pointer line. |
+| `action: <id>` | `with` (templated map) | — | V1 registry: `handoff.transition` (inputs `briefing?`, `from`, `to`; performs archive-first `.prowl/handoff/` transition; outputs `kickoff_prompt`, `artifact_path`, `has_briefing`), `handoff.checkpoint`, `git.context`. |
+| `notify: <text>` | — | — | Bell pipeline; click focuses the `current` role's pane. |
+| `close: <role>` | — | `launch` roles | Never implicit; cancel never closes panes. |
+| `repeat` | `max` (required), `until` (optional), `steps` | — | `until` compares a declared verdict only: `outputs.<name>.verdict == <value>` or `in [..]`. Reaching `max` without `until` ends the run as `max_rounds_reached`. |
+
+**Typed line formats.** Every line Prowl types into a pane starts with `[Prowl] ` so its
+origin is visible. `text` → `[Prowl] <text>`; `instruction` → `[Prowl] Read <absolute
+path> and follow it`. When the step has an `expect`, the runner appends the completion
+hint itself — ` — finish with: prowl workflow done [--verdict a|b] -` — so authors never
+repeat it. The watchdog nudge is `[Prowl] When your work for this step is fully complete,
+finish with: prowl workflow done -`.
+
+## 5. `expect`
+
+```yaml
+expect:
+  output: findings          # output name; default = step id; the same name may be produced by several steps (latest wins)
+  format: markdown          # markdown (default) | text | json (parseable)
+  sections: ["## Findings"] # markdown: required headings (fence/preamble stripped before checking, as HandoffStore.validatedBriefing)
+  verdict: [clean, issues]  # declares allowed values; `prowl workflow done --verdict <v>` then becomes mandatory
+  timeout: 2h               # optional hard cap; NO default — without it Prowl waits as long as the agent works
+  on_timeout: attention     # only with `timeout`: attention (default) | skip | cancel
+```
+
+- A `launch` step of a `headless` role may omit `expect`; the captured output is stored
+  under `outputs.<step id>` (or `expect.output` if given).
+- Exactly one successful `done` is accepted per (run, step); later ones get `STEP_NOT_EXPECTING`.
+- Waiting is supervised by the state-driven watchdog (§10), not by wall-clock time; a
+  `working` role is never interrupted.
+
+## 6. Template variables (whitelist; substitution only)
+
+| Variable | Value |
+| --- | --- |
+| `run.id`, `run.dir` | run UUID, `<root>/.prowl/workflow-runs/<run-id>` |
+| `worktree.path`, `worktree.name`, `worktree.branch` | source worktree |
+| `roles.<r>.name`, `roles.<r>.agent`, `roles.<r>.pane` | frozen profile display name, agent token, pane short handle (`p12`) |
+| `outputs.<name>.path`, `outputs.<name>.verdict` | latest delivered output; referencing an output before any step can have produced it is a validation error |
+| `actions.<step>.<key>` | native action outputs |
+| `inputs.<k>` | start inputs |
+| `loop.index`, `loop.count` | 1-based iteration inside `repeat`; `loop.count` = iterations completed (usable after the loop) |
+
+No expressions, defaults, or inlined output text (`outputs.<name>.text` does not exist).
+
+## 7. Validation (`prowl workflow validate`, Settings status)
+
+Errors: unknown `schema`/keys; undefined role; `message` to a `headless` role or to a
+`launch` role before its `launch` step; a `launch` role launched twice; `close` of a
+non-`launch` role; duplicate step ids; `repeat` without `max`, nested `repeat`, or `launch`
+inside `repeat`; `until` referencing an undeclared verdict; unknown template variable or
+premature `outputs.*` reference; `text` containing a newline; user file using a `prowl.` id;
+more than one `current` role.
+Warnings: no installed agent satisfies `agents`; no enabled profile matches `suggest`;
+`timeout` above 2h.
+
+## 8. Run directory
+
+```
+<root>/.prowl/workflow-runs/<run-id>/
+  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids),
+                            # step states, timestamps; no env values, no extra arguments, no credentials
+  log.md                    # human-readable, append-only
+  instructions/<step>.md    # materialized `instruction` / `prompt` text
+  skills/<id>/SKILL.md      # materialized bundled skills
+  outputs/<name>.md         # validated deliveries; inside `repeat` versioned as <name>.<iteration>.md, latest symlink/copy
+  captures/<step>.md        # headless captures
+```
+
+`<root>/.prowl/workflow-runs/.gitignore` contains `*` (self-ignoring, as `.prowl/handoff/`).
+Definitions shipped with a repo live in `<root>/.prowl/workflows/` (not ignored).
+
+## 9. CLI participant protocol
+
+```bash
+prowl workflow list [--json]                                  # sources, enabled, validation status
+prowl workflow run <id|name> [source] [--role r=<profile|uuid|auto>]... [--input k=v]... [--json]
+prowl workflow status [run-id] [--json]                       # no args: "who am I" — caller pane's run, role, awaited step and its requirements
+prowl workflow done [-|--file <path>] [--verdict <v>] [--run <id> --step <id>] [--force] [--json]
+prowl workflow cancel <run-id> [--json]
+prowl workflow validate <file> [--json]
+prowl workflow schema                                         # JSON Schema / reference for authoring agents
+```
+
+**Resolution of `done`.** The caller pane (socket peer PID → process ancestry → shell PID
+→ pane) identifies the run, role, and awaited step. A pane belongs to at most one run at a
+time, so no ids are needed in the typed command. Explicit `--run --step` is required when no
+caller pane exists (manual delivery, logged as `source=manual`); if both exist and disagree,
+`ROLE_MISMATCH` unless `--force`. Launched surfaces may additionally carry
+`PROWL_WORKFLOW_RUN` / `PROWL_WORKFLOW_ROLE` as a cross-check hint; the registry is the
+authority.
+
+Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BUSY`,
+`ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `OUTPUT_INVALID` (sections/format/verdict),
+`VERDICT_REQUIRED`.
+
+Companion primitives for CLI-driven orchestration (same boundaries as the runner):
+`prowl create pane <pane> --direction <dir> [--profile <name|uuid> --prompt -]`,
+`prowl create tab <worktree> [--profile … --prompt -]`, `prowl profiles list`,
+`prowl agents wait <pane> --until idle|done|blocked [--timeout]`, `prowl send`,
+`prowl agents read`.
+
+## 10. Run semantics
+
+| Topic | Rule |
+| --- | --- |
+| Start | Resolve bindings, freeze plans, create run dir, write `run.json`, then execute step 1. `current` role must not already be in a run (`PANE_BUSY`). |
+| Advance | A step completes when its `expect` is satisfied (or it has none). `repeat` re-evaluates `until` after each iteration. |
+| Watchdog | Driven by the periodic detection events (`agentEntryChanged` / `agentEntryRemoved`) plus an injected clock; every trigger has a grace period because detection is heuristic and a wrong guess must be harmless. Awaited role `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention` (Focus pane / Cancel). Awaited role `idle`/`done` ≥ `idle_grace` (default 3 min) without `done` → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: prowl workflow done -`, which merely queues if the agent is still working), then `needsAttention` after another `idle_grace` (Nudge again / Keep waiting / Skip / Cancel). Awaited role's agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). `working` never triggers anything. Grace values are global settings. |
+| `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |
+| Explicit `timeout` | Only when an author sets `expect.timeout`: `attention` (default) enters `needsAttention`; `skip` / `cancel` act automatically. |
+| Cancel | Stops advancing and injecting; keeps all panes and outputs; logs. |
+| Failure | Launch/plan/provision failure → `needsAttention` with Retry / Skip role / Cancel; outputs already delivered are kept. |
+| Concurrency | One run per pane; many runs per worktree; the status center shows the selected worktree's most recent active run, the panel lists all. |
+| Restart | V1: runs found on disk at launch are marked `interrupted`; no resume. |
+| Privacy | `run.json`, logs, and CLI payloads carry profile UUID/name and agent tokens only. |
+
+## 11. Built-in workflows (V1)
+
+- `prowl.handoff` — roles `source: current`, `receiver: launch` (`placement: tab`,
+  `background: true`, no `agents` restriction — any adapter with seeded-prompt support);
+  steps: `message source` (brief, sections `## Objective`, `## Current State`,
+  `## Next Steps`) → `action handoff.transition` (archive-first `.prowl/handoff/`
+  contract) → `launch receiver` (`prompt: "{{ actions.transition.kickoff_prompt }}"`) →
+  `notify`. `prowl handoff to <agent> --brief -` remains as a deprecated alias that starts
+  this run with the `brief` output pre-delivered (`--no-brief`: step pre-skipped);
+  `prowl handoff save` maps to `prowl.handoff-checkpoint` (brief → `action
+  handoff.checkpoint`).
+- `prowl.adversarial-review` — as in §4; interactive reviewer in a right split by default.
+
+## 12. Reserved for V2
+
+`when:` (conditions on verdicts), `count:` / `wait: { all: […] }` (fan-out),
+`expect.status: idle` + `capture: result` (observe mode via `agents read`), `worktree:` on
+roles (cross-repo review), run resume, nested `repeat`, `outputs.<name>.json` field access.

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -165,6 +165,15 @@ and every re-delivery after Relaunch, so no path ever shows a token-less or
 verdict-less command. Authors never spell the command (the validator warns when
 `text`/`instruction` contains `prowl workflow done`).
 
+**V1 native action schemas** (normative summary; `prowl workflow schema` prints the full
+JSON Schema):
+
+| Action | `with` inputs | Outputs |
+| --- | --- | --- |
+| `handoff.transition` | `briefing` (path, optional), `from` (role, required), `to` (role, required), `note` (string, optional) | `kickoff_prompt` (string), `artifact_path` (path), `has_briefing` (bool) |
+| `handoff.checkpoint` | `briefing` (path, required), `note` (string, optional) | `artifact_path` (path) |
+| `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary), `branch` (string) |
+
 ## 5. `expect`
 
 ```yaml
@@ -177,20 +186,21 @@ expect:
   on_timeout: attention     # only with `timeout`: attention (default) | skip | cancel
 ```
 
-- **Activation identity.** Each time a step starts waiting — once for a plain step, once
-  per iteration inside `repeat` — the runner creates a new *activation*
-  `(run id, step id, activation ordinal, delivery role)` and mints a fresh delivery token
-  for it; the previous activation of the same step (if any) is terminal. The **activation
-  ordinal is run-global and monotonic** (1, 2, 3, … across all steps and iterations), so it
-  alone identifies an activation within a run. Exactly one successful `done` is accepted
-  per activation, identified by its token; a later, stale, or token-less delivery gets
-  `STEP_NOT_EXPECTING` / `TOKEN_REQUIRED` / `TOKEN_INVALID`. Skip / Cancel / Relaunch
-  revoke the *current* activation's token (Relaunch then mints a new activation). Every
-  delivery is persisted as `outputs/<name>.<ordinal>.md` (collision-free by construction,
-  even when several steps produce the same output name); `outputs/<name>.md` is the
-  "latest" view, replaced atomically (temp file + rename); materialized instructions are
-  versioned the same way (`instructions/<step>.<ordinal>.md`), and `run.json` records the
-  activation → step / iteration / output-file mapping.
+- **Invocation and activation identity.** Every execution of a `message` or `launch` step
+  — once for a plain step, once per iteration inside `repeat`, again after Relaunch —
+  mints a run-global, monotonic **invocation ordinal** (1, 2, 3, … across all steps and
+  iterations) on entry, whether or not the step waits; it names the step's artifacts
+  (`instructions/<step>.<ordinal>.md`). When the step has an `expect`, the same invocation
+  is also its *activation* `(run id, step id, ordinal, delivery role)`: the runner mints a
+  fresh delivery token for it, and the previous activation of the same step (if any) is
+  terminal. Exactly one successful `done` is accepted per activation, identified by its
+  token; a later, stale, or token-less delivery gets `STEP_NOT_EXPECTING` /
+  `TOKEN_REQUIRED` / `TOKEN_INVALID`. Skip / Cancel / Relaunch revoke the *current*
+  activation's token (Relaunch then mints a new invocation/activation). Every delivery is
+  persisted as `outputs/<name>.<ordinal>.md` (collision-free by construction, even when
+  several steps produce the same output name); `outputs/<name>.md` is the "latest" view,
+  replaced atomically (temp file + rename); `run.json` records the invocation → step /
+  iteration / activation / file mapping.
 - Output bodies are capped (default 1 MiB, hard max 4 MiB → `OUTPUT_TOO_LARGE`).
 - **Skip rule.** Skipping an `expect` (panel Skip or `on_timeout: skip`) marks its output
   missing. If any later step's template references that output (or the `until` of an
@@ -245,7 +255,7 @@ appends the rendered command itself); `on_timeout: skip` on an output referenced
   run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids),
                             # step states, timestamps; no env values, no extra arguments, no credentials
   log.md                    # human-readable, append-only
-  instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per activation (run-global ordinal)
+  instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per invocation (run-global ordinal, §5)
   skills/<id>/SKILL.md      # materialized bundled skills
   outputs/<name>.md         # latest validated delivery (atomically replaced); every delivery is also kept as <name>.<ordinal>.md
 ```
@@ -269,7 +279,7 @@ output body is excluded from that claim.
 
 ```bash
 prowl workflow list [--json]                                  # sources, enabled, validation status
-prowl workflow run <id|name> [source] [--role r=<profile|uuid|auto>]... [--input k=v]... [--json]
+prowl workflow run <id|name> [source] [--role r=<binding>]... [--input k=v]... [--json]   # <binding> grammar is source-specific, see below
                                                               # [source]: 060 GenericTarget (pN | tN | UUID | worktree ref); omitted → caller pane
                                                               # when the workflow has a `current` role (SOURCE_REQUIRED outside a pane), a
                                                               # worktree reference otherwise
@@ -334,7 +344,7 @@ changed` was requested.
 | Advance | A step completes when its `expect` is satisfied (or it has none and its effect succeeded). `repeat` evaluates `until` before entry and after each iteration; `max` reached with `until` still false ends the run as `max_rounds_reached`. |
 | Message delivery | Injection is synchronous (`insertCommittedText` + submit); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
 | Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
-| Activation | Defined in §5: every wait is a new activation with its own token; one delivery per activation; revocation is per activation; outputs are versioned by activation ordinal. |
+| Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
 | Watchdog | Driven by the periodic detection events (`agentEntryChanged` / `agentEntryRemoved`, forwarded to the runner by `AppFeature`'s single terminal-event subscription — `WorktreeTerminalManager.eventStream()` is single-consumer) plus an injected clock. When a step starts waiting the watchdog reads the role's current state first and schedules cancellable grace deadlines; it never depends on a later event alone. Every trigger has a grace period because detection is heuristic and a wrong guess must be harmless. Awaited role `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention` (Focus pane / Cancel). Awaited role `idle`/`done` ≥ `idle_grace` (default 3 min) without `done` → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`, harmless if the agent is still working because the runtime merely queues the line), then `needsAttention` after another `idle_grace` (Nudge again / Keep waiting / Skip / Cancel). Awaited role's agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). `working` never triggers anything. Grace values are global settings. |
 | `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -1,0 +1,89 @@
+# Agent Workflows (063) + Agent Completion Signals (064) — release plan (living)
+
+> Living document: the single place that says **when** and **in what order** the slices of
+> [063](000-plan.md) and [064](../064-agent-completion-signals/000-plan.md) ship. The
+> slices themselves — what each PR contains — are defined in the owning plan's
+> "Delivery slicing" section. Update this file when scope moves between releases.
+
+## Ownership
+
+| Prefix | Owner | Meaning |
+| --- | --- | --- |
+| A | 063 | terminal / CLI primitives (`create pane`, profile launch boundary) |
+| B | 063 | workflow definitions and runner |
+| C | 063 | UI (Settings IA, status center, start sheet, entry points) |
+| D | 063 | built-ins, skills, docs, handoff migration |
+| S | 064 | completion signals (bus, `agents signal` / `agents wait`, hooks, producers) |
+
+Cross-entry couplings (only these two): 064-S1 delivers the `ObservedAgentState` observer
+that 063-B3 consumes; 064-S3 attaches launch-scoped hooks through 063-A2's launch boundary.
+063 V1 does not otherwise depend on 064 (steps complete on `prowl workflow done`).
+
+## Releases
+
+PRs merge to `main` one at a time (each keeps `main` shippable); engine PRs without a
+user-facing surface may merge before "their" release and stay dormant. Three releases:
+
+### R1 — CLI orchestration primitives + completion signals
+
+| Order | Slice | Entry | Depends | Outcome |
+| --- | --- | --- | --- | --- |
+| 1 | **C0** Settings IA: `Section("Agents")` with Profiles (renamed) + Command Line Tool (from Advanced); no Workflows page yet | 063 | — | CLI install lives with Agents |
+| 1 | **A1** `prowl create pane` (#699) + anchored split primitive | 063 | 060 | CLI can split |
+| 2 | **A2** profile launch boundary + `create tab\|pane --profile <p> --prompt -` + `profiles list` | 063 | A1 | CLI launches a profile with a kickoff prompt and gets the pane back |
+| 2 | **S1** signal bus + `ObservedAgentState` multicast observer + `prowl agents signal` | 064 | — | layer-0 signals for every runtime |
+| 3 | **S2** `prowl agents wait` (`source`/`confidence`, `--include-screen`) + `agents` `signals` field + skill rubric | 064 | S1 | no hand-written polling; heuristic results are labelled |
+| 4 | **S3 wave 1** launch-scoped hooks for tier-A runtimes (Claude Code, Codex `notify`, Copilot, Droid, Qoder, Pi, OMP, OpenCode) + self-check | 064 | A2, S1 | `agents wait` is deterministic for Prowl-launched agents |
+
+User-visible result: onevcat's daily CLI-driven orchestration is first-class
+(`create pane --profile --prompt -` → `agents wait` → `send`). Docs: `docs/components/cli.md`,
+`agent-detection.md`, `settings.md`, `prowl-cli` skill. Parallelism: C0 ∥ A1, A2 ∥ S1.
+
+### R2 — Agent Workflows
+
+| Order | Slice | Entry | Depends | Outcome |
+| --- | --- | --- | --- | --- |
+| 1 | **B1** definitions (Yams, model, validator, JSON Schema, three-source discovery, `workflow list/validate/schema`) | 063 | — | DSL authorable and validatable (may merge during R1) |
+| 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) | 063 | B1 | — |
+| 3 | **B3** runner wiring + `workflow run/status/done/cancel` | 063 | A2, S1, B2 | engine powered on |
+| 4 | **C1** status center + run panel + notifications | 063 | B3 | runs visible |
+| 5 | **C2** start sheet + entry points (capsule popover, palette, Active Agents) | 063 | B3 | GUI-initiated runs |
+| 6 | **D1** `embed-skills`, `prowl-workflows` authoring skill, `docs/components/workflows.md`, Settings › Workflows page | 063 | B1, C2 | custom workflows, agent-assisted authoring |
+| 7 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E; watchdog consumes exact signals (064-S5 part) | 063 + 064 | A2, C2, D1, S3 wave 1 | first built-in workflow |
+
+The shipped handoff (HUD + `prowl handoff`) stays untouched in R2. Fallback split if R2 is
+too large: R2a = B1–C1 (workflows runnable from the CLI, visible in the status center),
+R2b = C2–D2 (GUI entry, Settings, skills, E2E). Default is one R2. Docs: `workflows.md`,
+`command-palette.md`, `active-agents.md`, `settings.md`.
+
+### R3 — Handoff migration + signal completion
+
+| Order | Slice | Entry | Depends | Outcome |
+| --- | --- | --- | --- | --- |
+| 1 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins, `HANDOFF_RETIRED` stubs, removal of `HandoffHudFeature` / `HandoffCommandHandler` / `HandoffRequestRegistry`, `docs/components/handoff.md` rewrite | 063 | D2 | handoff is a workflow |
+| 1 | **S3 wave 2** tier-B runtimes via dedicated-home profiles (Gemini, Qwen, Grok, Cline, Kimi) | 064 | S3 wave 1, 053 homes | more runtimes exact |
+| 1 | **S4** transcript file-watch + OSC producers | 064 | S1 | layer-2 signals without hooks |
+
+The `HANDOFF_RETIRED` stubs are deleted one release after R3.
+
+### R3+ — V2
+
+063 V2 items (observe mode, `on_attention: ask <role>`, fan-out, retention, run resume,
+cross-worktree roles, GUI editor) and the rest of 064-S5; scheduled by demand.
+
+## Dependency graph
+
+```
+R1:  C0            A1 ──► A2 ──┐
+                   S1 ──► S2   ├──► S3w1
+                      └────────┘
+R2:  B1 ──► B2 ──► B3 (◄ A2, S1) ──► C1 ──► C2 ──► D1 ──► D2 (◄ S3w1)
+R3:  D3 (◄ D2)        S3w2 (◄ S3w1)        S4 (◄ S1)
+R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
+```
+
+## Change log
+
+- 2026-08-22 — first version: three releases agreed; `ObservedAgentState` observer moved
+  from 063-B3 to 064-S1; C0 ships without the Workflows page; `prowl agents wait` owned by
+  064-S2.

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -146,20 +146,19 @@ permission or question dialog), tells the agent to use `--include-screen` and
 
 ### Delivery slicing
 
-Release mapping (decision 2026-08-22, shared with 063): **R1** ships S1, S2, and S3
-wave 1 together with 063's C0/A1/A2 — the "CLI orchestration primitives + completion
-signals" release; **R2** (Agent Workflows) consumes the signals in the runner's watchdog
-(S5 part); **R3** ships S3 wave 2 and S4 alongside the handoff migration.
+This section defines **what** each slice contains; **when** it ships, and how it
+interleaves with 063's slices, is owned by the shared living
+[release-plan.md](../063-agent-workflows/release-plan.md) (R1: S1, S2, S3 wave 1 with
+063's C0/A1/A2; R2: the S5 watchdog part; R3: S3 wave 2 and S4).
 
-| Release | Order | Slice | Depends | Notes |
-| --- | --- | --- | --- | --- |
-| R1 | 1 | **S1** Signal bus state + the `ObservedAgentState` multicast observer (snapshot / changed / removed / surfaceClosed / `.signal`; moved here from 063-B3 so it ships first) + `prowl agents signal` (CLI four layers) | — | Layer 0 works for every runtime immediately; 063-B3 later consumes the same observer |
-| R1 | 2 | **S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S1 | Route B usable; heuristic fallback honest |
-| R1 | 3 | **S3 wave 1** Launch-scoped hook injection (adapter `signalHooks`, self-check) for tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (turn-complete only; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT` | 063 A2, S1, research matrix | `agents wait` deterministic for Prowl-launched agents on these runtimes |
-| R2 | 4 | **S5 (part)** 063's watchdog consumes exact signals (nudge on `turn-complete` without `done`, immediate attention on `needs-input`) | 063 C1, S3 | Recorded in 063 amendments |
-| R3 | 5 | **S3 wave 2** tier B (`configDirOnly`: Gemini, Qwen, Grok, Cline, Kimi) for dedicated-home profiles only; tier C (Cursor, Amp: project files) is not attached | S3 wave 1, 053 dedicated homes | More runtimes get exact signals |
-| R3 | 6 | **S4** Transcript file-watch and OSC producers | S1 | Layer 2 without hooks |
-| R3+ | 7 | **S5 (rest)** 063 V2 observe mode (`expect.status` + `agents read` / hook `last_assistant_message`) and `on_attention: ask <role>` | S3, S4, 063 V2 | — |
+| Slice | Depends | Contents / expectation |
+| --- | --- | --- |
+| **S1** | — | Signal bus state + the `ObservedAgentState` multicast observer (snapshot / changed / removed / surfaceClosed / `.signal`; first specified in 063, delivered here so it ships first) + `prowl agents signal` (CLI four layers). Layer 0 works for every runtime immediately; 063-B3 later consumes the same observer. |
+| **S2** | S1 | `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric. Route B usable; heuristic fallback honest. |
+| **S3 wave 1** | 063-A2, S1, research matrix | Launch-scoped hook injection (adapter `signalHooks`, self-check) for tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (turn-complete only; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT`. `agents wait` becomes deterministic for Prowl-launched agents on these runtimes. |
+| **S3 wave 2** | S3 wave 1, 053 dedicated homes | Tier B (`configDirOnly`: Gemini, Qwen, Grok, Cline, Kimi) for dedicated-home profiles only; tier C (Cursor, Amp: project files) is not attached. |
+| **S4** | S1 | Transcript file-watch and OSC producers — layer 2 without hooks. |
+| **S5** | 063 C1 (part), S3/S4 + 063 V2 (rest) | 063's watchdog consumes exact signals (nudge on `turn-complete` without `done`, immediate attention on `needs-input`) — ships with 063-D2; later: 063 V2 observe mode (`expect.status` + `agents read` / hook `last_assistant_message`) and `on_attention: ask <role>`. Recorded in 063 amendments. |
 
 ### Verification
 

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned (per-runtime matrix pending research) |
+| **Status** | Planned (research matrix recorded 2026-08-22) |
 | **Anchor date** | 2026-08-22 |
 | **Primary PRs** | TBD |
 | **Related** | [063 agent-workflows](../063-agent-workflows/000-plan.md) (consumer; defines the `ObservedAgentState` observer this entry feeds), [030 agent-status-detection](../030-agent-status-detection/000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [#473](https://github.com/onevcat/Prowl/issues/473), [#676](https://github.com/onevcat/Prowl/issues/676), `docs/components/agent-detection.md`, `docs/components/cli.md` |
@@ -149,7 +149,7 @@ permission or question dialog), tells the agent to use `--include-screen` and
 | --- | --- | --- | --- |
 | 1 | **S1** Signal bus state + `.signal` observer case + `prowl agents signal` (CLI four layers) | 063 B3's observer | Layer 0 works for every runtime immediately |
 | 2 | **S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S1 | Route B usable; heuristic fallback honest |
-| 3 | **S3** Launch-scoped hook injection per runtime (adapter `signalHooks`, self-check) | 063 A2, research matrix | Start with Claude Code and Codex; add runtimes as verified |
+| 3 | **S3** Launch-scoped hook injection per runtime (adapter `signalHooks`, self-check) | 063 A2, research matrix | Wave 1 = tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (turn-complete only; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT`. Wave 2 = tier B (`configDirOnly`: Gemini, Qwen, Grok, Cline, Kimi) for dedicated-home profiles only. Tier C (Cursor, Amp: project files) is not attached. |
 | 4 | **S4** Transcript file-watch and OSC producers | S1 | Layer 2 without hooks |
 | 5 | **S5** 063 consumption: watchdog uses exact signals; V2 observe mode / `on_attention: ask` | 063 C1+, S3 | Recorded in 063 amendments |
 
@@ -177,13 +177,39 @@ arrive, `wait` resolves with `source=hook`, and a manually launched agent resolv
   detection/adapters/CLI rather than the runner, and need their own per-runtime
   maintenance; 063 consumes them through one observer type.
 
+## Research outcome (2026-08-22)
+
+The per-runtime matrix lives in
+[research-agent-completion-signals.md](research-agent-completion-signals.md) (all 15 CLIs
+installed locally; live hook runs for claude, codex, copilot, kimi, droid, pi, omp,
+opencode; partial for qodercli/qwen/amp; docs/bundle for the rest). Key conclusions:
+
+- Eight runtimes accept a Prowl hook **per launch without touching user config**
+  (tier A above); five more only through a Prowl-owned home (tier B, i.e. dedicated-home
+  profiles); Cursor Agent and Amp only via project files (not attached).
+- Codex's hook system is trust-gated per command hash; per-launch `-c hooks.*` needs
+  `--dangerously-bypass-hook-trust`, which Prowl will **not** pass. Codex gets
+  `turn-complete` through the ungated `notify` config; its permission prompts stay
+  heuristic/transcript-based.
+- Claude Code holds all hooks in interactive sessions until the workspace-trust dialog is
+  accepted — the self-check grace must tolerate that, and a trust prompt is itself a
+  `blocked` state worth surfacing.
+- Kimi's `--config-file` replaces the whole config; per-launch hooks there mean Prowl
+  re-supplying the user's provider config — deferred to tier B.
+- Several payloads carry `last_assistant_message` (Claude, Codex, Qoder, Qwen, Grok,
+  Gemini) — a cheap result channel for 063's V2 observe mode on those runtimes.
+- Terminal escapes (OSC 9/99/777/BEL, 9;4) are focus-/threshold-gated everywhere and
+  therefore only a layer-2 hint, never a completion proof.
+
 ## Open questions
 
-- Per-runtime hook/notify/event support, per-launch enablement syntax, and payload shapes
-  — being researched; results land in `research-agent-completion-signals.md`.
 - Whether hook subprocesses can always reach Prowl's socket from sandboxed runtimes
-  (Codex sandbox); `PROWL_CLI_SOCKET` and the bundled binary path must be passed through.
-- Exact `stable-for` and self-check grace defaults.
+  (Codex sandbox, OpenCode/Pi/OMP plugin runtimes); `PROWL_CLI_SOCKET` and the bundled
+  binary path must be passed through and verified per runtime in S3.
+- Exact `stable-for` and self-check grace defaults (Claude's trust-dialog hold suggests a
+  generous, state-aware grace rather than a fixed few seconds).
+- Re-verification cadence: the matrix is versioned per row; S3 adapters need fixture tests
+  that fail loudly when a CLI's hook syntax changes.
 
 ## Amendments
 

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -1,0 +1,190 @@
+# 064 — Agent Completion Signals: Plan
+
+| | |
+| --- | --- |
+| **Status** | Planned (per-runtime matrix pending research) |
+| **Anchor date** | 2026-08-22 |
+| **Primary PRs** | TBD |
+| **Related** | [063 agent-workflows](../063-agent-workflows/000-plan.md) (consumer; defines the `ObservedAgentState` observer this entry feeds), [030 agent-status-detection](../030-agent-status-detection/000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [#473](https://github.com/onevcat/Prowl/issues/473), [#676](https://github.com/onevcat/Prowl/issues/676), `docs/components/agent-detection.md`, `docs/components/cli.md` |
+
+## Background
+
+Prowl's per-pane agent status (`working` / `blocked` / `idle` / `done`) comes from
+heuristic screen and process detection (030/045, `supacode/Domain/AgentDetection/PaneAgentState.swift`)
+plus the 3 s working hold. It is good enough for the sidebar and Active Agents, and #676
+documents the states it still misreports. Two consumers need something stronger:
+
+- An agent orchestrating other agents through the `prowl` CLI (the "route B" flow that
+  onevcat runs daily and that 063 formalizes) has to *wait* for a sibling agent to finish.
+  Today that means a hand-written polling loop over `prowl agents --json`, a completion
+  signal based on a conventional file name, and no way to tell a trustworthy "finished"
+  from a heuristic guess. Ten rounds of CLI-driven adversarial review during the 063
+  design (2026-08-22) reproduced every one of these pains.
+- The 063 runner's watchdog nudges and escalates on heuristic state; a deterministic
+  "turn complete" / "needs input" event would make those nudges exact instead of guessed.
+
+Several agent CLIs already expose deterministic, agent-reported events — hooks, notify
+commands, plugin events — and most can be enabled per launch without touching the user's
+global configuration. Prowl launches agents itself (053/055), so it can attach such hooks
+at launch and have the agent report to Prowl through the bundled `prowl` binary.
+
+## Goals
+
+- Introduce one **agent signal bus** per pane that merges four layers of evidence, each
+  tagged with `source` and `confidence`:
+  0. cooperative signals — `prowl agents signal` (and 063's `prowl workflow done`);
+  1. native hooks installed by Prowl at launch (agent-reported, exact);
+  2. deterministic observations — native transcript turn-end markers (059), agent process
+     exit, OSC progress/notification sequences the CLI emits itself;
+  3. heuristic screen/process detection (existing).
+- Add `prowl agents signal <event>` so any agent (or a hook it runs) can report
+  `turn-complete` / `needs-input` / `session-start` / `session-end`, attributed by the
+  caller pane (a hook is a child of the agent process, so process ancestry still resolves
+  the pane).
+- Add `prowl agents wait <pane> --until … [--timeout] [--min-confidence] [--include-screen]`
+  that resolves on the bus and reports *what kind* of signal it got.
+- Make `prowl agents` honest about what each pane can offer (`signals` field) and make
+  hook installation self-checking with visible degradation.
+- Keep per-runtime knowledge in the runtime adapters (055 capability model) with a living
+  research matrix, so a changed hook API is a one-adapter change.
+
+### Non-goals
+
+- Making heuristic detection itself authoritative. Layer 3 remains a hint.
+- Prowl calling an LLM to judge screens. Judgment belongs to the orchestrating agent (the
+  skill gives it the screen tail and a rubric); an on-device Foundation Model classifier is
+  at most a V2 experiment.
+- Editing the user's global agent configuration (`~/.claude/settings.json`, `~/.codex/config.toml`, …).
+  Hooks are attached only through launch-scoped flags/config the adapter has verified; a
+  runtime without such a channel simply stays at layers 2–3.
+- Waiting semantics inside 063 workflows: the runner still completes steps only on
+  `prowl workflow done`; this entry improves its watchdog and enables 063's V2 observe mode.
+
+## Design / Approach
+
+### The bus and its producers
+
+`WorktreeTerminalManager` gains per-surface signal state feeding the typed observer 063
+defines (`ObservedAgentState`: `snapshot` / `changed` / `removed` / `surfaceClosed`),
+extended with `.signal(AgentSignal)` where
+
+```swift
+struct AgentSignal: Sendable, Equatable {
+  enum Kind { case turnComplete, needsInput, sessionStart, sessionEnd, progress(Int?) }
+  enum Source { case cli, hook(runtime: AgentProfileRuntime, event: String), transcript, process, osc, screen }
+  enum Confidence { case exact, high, heuristic }
+  let kind: Kind; let source: Source; let confidence: Confidence; let at: Date
+  let sessionID: String?; let detail: String?        // e.g. hook payload excerpt; never secrets
+}
+```
+
+| Producer | Mechanism | Confidence |
+| --- | --- | --- |
+| `prowl agents signal` | CLI handler, caller-pane attribution, optional `--origin hook:<runtime>.<event>` and `--session <id>` | exact |
+| Launch-scoped hooks | adapter capability `signalHooks` renders the launch flag/config that makes the CLI run `<bundled prowl> agents signal --event … --origin hook:…` on its native events (per-runtime syntax: research matrix) | exact |
+| Transcript turn-end | 059's reader on the exact/high-attributed transcript, file-watch instead of polling | high/exact |
+| Process exit | existing `agentEntryRemoved` | exact |
+| OSC | existing progress/notification OSC handling in the Ghostty bridge, surfaced as signals | high |
+| Screen/process heuristics | existing detection | heuristic |
+
+Every producer writes to the same per-surface state; the reducer-side consumer (063
+runner via `AppFeature`) and the CLI-side consumer (`agents wait` via the multicast
+observer) see identical events. Registration and snapshot capture stay one main-actor step.
+
+### `prowl agents wait`
+
+```
+prowl agents wait <pane> --until idle|blocked|changed|exit [--timeout 1…600]
+                 [--min-confidence exact|high|heuristic] [--include-screen <lines>] [--json]
+```
+
+- Snapshot first: return immediately when the current state already satisfies `--until`
+  at the required confidence.
+- Default `--min-confidence auto`: if the pane has a deterministic channel (a live Prowl
+  hook, or an exact/high transcript attribution), only layer 0–2 events resolve the wait;
+  heuristic events merely update "last known". Without such a channel the wait resolves
+  heuristically once the state has been stable for `stable-for` (3 s hold + 2 s) and says
+  so.
+- Response: `{status, raw_state, source, confidence, waited_ms, signals: […]}`; with
+  `--include-screen N`, a stable `detection`-source screen tail and, when available, the
+  059 result state — everything an orchestrating agent needs to judge a heuristic result in
+  one call.
+- `removed` / `surfaceClosed` → `AGENT_GONE` (unless `--until exit`); timeout →
+  `WAIT_TIMEOUT` with the last known status/source. The 600 s cap matches typical agent
+  tool timeouts; the skill documents "re-arm on timeout".
+
+### Self-check and visibility
+
+When a Prowl-launched runtime declares a `sessionStart` hook, the launch boundary expects
+the corresponding signal within a grace window; if it never arrives the pane is marked
+`signals: none` (hooks did not load) instead of silently pretending. `prowl agents`
+JSON gains `signals: {channels: [hook, transcript, osc], last: {...}}` per pane, and the
+Active Agents panel shows a small "exact" badge for panes with a live deterministic channel.
+
+### Judging heuristic results (skill, not code)
+
+When `source == screen`, the orchestrating agent — not Prowl — decides: the `prowl-cli`
+skill ships a rubric (finished answer + empty prompt box vs. spinner/tool output vs. a
+permission or question dialog), tells the agent to use `--include-screen` and
+`agents read`, and forbids destructive actions on heuristic evidence alone. 063's V2
+`on_attention: ask <role>` is the declarative form of the same idea.
+
+### Maintenance rules
+
+- Each runtime's hook support, event → `AgentSignal.Kind` mapping, payload parsing, and
+  launch-time rendering live in its adapter (`supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift`
+  family) behind a `signalHooks` capability, with fixture tests for the rendered
+  flag/config and for payload decoding. A CLI that changes its hook API is a one-adapter
+  change plus a matrix row update.
+- `research-agent-completion-signals.md` (living, this folder) records per runtime:
+  mechanism, events, per-launch enablement syntax, payload fields, OSC behavior,
+  transcript marker, verification method, version, date.
+- CLI contracts follow 060's four layers: `prowl.cli.agents.signal.v1`,
+  `prowl.cli.agents.wait.v1`, the `agents` `signals` field; schema-validated in socket
+  tests; `docs/components/cli.md` and the `prowl-cli` skill updated in the same PRs.
+
+### Delivery slicing
+
+| Order | Slice | Depends | Notes |
+| --- | --- | --- | --- |
+| 1 | **S1** Signal bus state + `.signal` observer case + `prowl agents signal` (CLI four layers) | 063 B3's observer | Layer 0 works for every runtime immediately |
+| 2 | **S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S1 | Route B usable; heuristic fallback honest |
+| 3 | **S3** Launch-scoped hook injection per runtime (adapter `signalHooks`, self-check) | 063 A2, research matrix | Start with Claude Code and Codex; add runtimes as verified |
+| 4 | **S4** Transcript file-watch and OSC producers | S1 | Layer 2 without hooks |
+| 5 | **S5** 063 consumption: watchdog uses exact signals; V2 observe mode / `on_attention: ask` | 063 C1+, S3 | Recorded in 063 amendments |
+
+### Verification
+
+Unit: bus merge/ordering, confidence gating, `wait` resolution matrix (already-satisfied,
+transition, removal, pane close, timeout, two concurrent waiters), hook rendering per
+adapter, payload decoding, self-check degradation. Socket: `signal`/`wait` round trips and
+schema. Live: one Prowl-launched Claude Code and Codex pane each — verify hook signals
+arrive, `wait` resolves with `source=hook`, and a manually launched agent resolves with
+`source=screen` plus screen tail.
+
+## Alternatives & decisions
+
+- **Layered bus rather than a smarter heuristic.** #676 shows the heuristic can be
+  improved but never made authoritative for TUIs; deterministic channels exist and should
+  be used where present, with honest downgrade elsewhere.
+- **Judgment by the orchestrating agent, not by Prowl.** Prowl has no model access worth
+  adding for this; the waiting agent already has the task context and can read the screen
+  tail that `wait` returns. On-device FM classification is deferred as an experiment.
+- **Hooks only through launch-scoped channels.** Mirrors 053/006's launch-scoped
+  environment decision: Prowl-launched panes get Prowl hooks; user-launched agents are
+  never reconfigured.
+- **Separate entry from 063.** The signals are valuable without workflows, touch
+  detection/adapters/CLI rather than the runner, and need their own per-runtime
+  maintenance; 063 consumes them through one observer type.
+
+## Open questions
+
+- Per-runtime hook/notify/event support, per-launch enablement syntax, and payload shapes
+  — being researched; results land in `research-agent-completion-signals.md`.
+- Whether hook subprocesses can always reach Prowl's socket from sandboxed runtimes
+  (Codex sandbox); `PROWL_CLI_SOCKET` and the bundled binary path must be passed through.
+- Exact `stable-for` and self-check grace defaults.
+
+## Amendments
+
+(append `- Updated 2026-MM-DD: ... — see [00N-topic.md](00N-topic.md)` lines here)

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -64,9 +64,10 @@ at launch and have the agent report to Prowl through the bundled `prowl` binary.
 
 ### The bus and its producers
 
-`WorktreeTerminalManager` gains per-surface signal state feeding the typed observer 063
-defines (`ObservedAgentState`: `snapshot` / `changed` / `removed` / `surfaceClosed`),
-extended with `.signal(AgentSignal)` where
+`WorktreeTerminalManager` gains per-surface signal state feeding the typed multicast
+observer first specified in 063 and delivered by this entry's S1 (`ObservedAgentState`:
+`snapshot` / `changed` / `removed` / `surfaceClosed`), extended with `.signal(AgentSignal)`
+where
 
 ```swift
 struct AgentSignal: Sendable, Equatable {
@@ -145,13 +146,20 @@ permission or question dialog), tells the agent to use `--include-screen` and
 
 ### Delivery slicing
 
-| Order | Slice | Depends | Notes |
-| --- | --- | --- | --- |
-| 1 | **S1** Signal bus state + `.signal` observer case + `prowl agents signal` (CLI four layers) | 063 B3's observer | Layer 0 works for every runtime immediately |
-| 2 | **S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S1 | Route B usable; heuristic fallback honest |
-| 3 | **S3** Launch-scoped hook injection per runtime (adapter `signalHooks`, self-check) | 063 A2, research matrix | Wave 1 = tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (turn-complete only; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT`. Wave 2 = tier B (`configDirOnly`: Gemini, Qwen, Grok, Cline, Kimi) for dedicated-home profiles only. Tier C (Cursor, Amp: project files) is not attached. |
-| 4 | **S4** Transcript file-watch and OSC producers | S1 | Layer 2 without hooks |
-| 5 | **S5** 063 consumption: watchdog uses exact signals; V2 observe mode / `on_attention: ask` | 063 C1+, S3 | Recorded in 063 amendments |
+Release mapping (decision 2026-08-22, shared with 063): **R1** ships S1, S2, and S3
+wave 1 together with 063's C0/A1/A2 — the "CLI orchestration primitives + completion
+signals" release; **R2** (Agent Workflows) consumes the signals in the runner's watchdog
+(S5 part); **R3** ships S3 wave 2 and S4 alongside the handoff migration.
+
+| Release | Order | Slice | Depends | Notes |
+| --- | --- | --- | --- | --- |
+| R1 | 1 | **S1** Signal bus state + the `ObservedAgentState` multicast observer (snapshot / changed / removed / surfaceClosed / `.signal`; moved here from 063-B3 so it ships first) + `prowl agents signal` (CLI four layers) | — | Layer 0 works for every runtime immediately; 063-B3 later consumes the same observer |
+| R1 | 2 | **S2** `prowl agents wait` + `agents` `signals` field + `--include-screen` + skill rubric | S1 | Route B usable; heuristic fallback honest |
+| R1 | 3 | **S3 wave 1** Launch-scoped hook injection (adapter `signalHooks`, self-check) for tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (turn-complete only; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT` | 063 A2, S1, research matrix | `agents wait` deterministic for Prowl-launched agents on these runtimes |
+| R2 | 4 | **S5 (part)** 063's watchdog consumes exact signals (nudge on `turn-complete` without `done`, immediate attention on `needs-input`) | 063 C1, S3 | Recorded in 063 amendments |
+| R3 | 5 | **S3 wave 2** tier B (`configDirOnly`: Gemini, Qwen, Grok, Cline, Kimi) for dedicated-home profiles only; tier C (Cursor, Amp: project files) is not attached | S3 wave 1, 053 dedicated homes | More runtimes get exact signals |
+| R3 | 6 | **S4** Transcript file-watch and OSC producers | S1 | Layer 2 without hooks |
+| R3+ | 7 | **S5 (rest)** 063 V2 observe mode (`expect.status` + `agents read` / hook `last_assistant_message`) and `on_attention: ask <role>` | S3, S4, 063 V2 | — |
 
 ### Verification
 

--- a/docs-ai/064-agent-completion-signals/research-agent-completion-signals.md
+++ b/docs-ai/064-agent-completion-signals/research-agent-completion-signals.md
@@ -1,0 +1,135 @@
+# Agent completion signals — per-runtime research (living)
+
+> Living document for [064](000-plan.md): which deterministic "turn complete / needs
+> input / session start-end" channels each recognized agent CLI offers, how they can be
+> enabled per launch, what the payload carries, and what is not achievable. Update rows in
+> place when a CLI changes; record the version and verification method per row.
+
+**Baseline (2026-08-22, this Mac):** claude 2.1.239 · codex 0.147.0 · gemini 0.46.0 ·
+cursor-agent 2026.05.09 · cline 3.0.48→3.0.56 · opencode 1.18.11 · copilot 1.0.77 ·
+kimi 1.41.0 · droid 0.186.0 · amp 0.0.1783746383 · qodercli 1.0.48 · qwen 0.21.3 ·
+grok 0.2.118 · pi 0.84.2 · omp 17.2.7.
+
+**Method:** `--help`; string search over binaries/bundles; read-only inspection of each
+tool's session directory; official docs; and, where auth allowed, a live non-interactive
+run with a capture hook (a script appending argv + stdin JSON to a scratch log) to prove
+per-launch enablement and real payloads. Live hook runs succeeded for claude, codex,
+copilot, kimi, droid, pi, omp, opencode; partially for qodercli (SessionStart/End), qwen
+(SessionStart), amp (session.start/agent.start); blocked by login for gemini,
+cursor-agent, cline; not attempted for grok (no per-launch channel). No user config files
+were modified; all runs used scratch directories and per-launch flags/env.
+
+Confidence: **V** verified locally (live run or binary/source) · **D** official docs ·
+**C** community · **?** unknown.
+
+## 1. Summary matrix
+
+| Runtime | Turn-complete signal | Blocked / permission signal | Per-launch enablement (exact) | Payload: session id / last message | OSC self-report | Transcript marker | Conf. |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Claude Code | hooks `Stop` (`StopFailure` on API error); `SessionStart` / `SessionEnd` | hooks `PermissionRequest` (immediate); `Notification` `notification_type` = `permission_prompt` (~6 s after prompt), `idle_prompt` (~60 s), `elicitation_dialog`; `Elicitation` | `claude --settings '<json>'` or `--settings file.json` (hooks MERGE with user hooks) — live-verified; `--session-id <uuid>`; `CLAUDE_CONFIG_DIR` = full relocation | stdin JSON: `session_id`, `cwd`, `transcript_path`, `permission_mode`, `last_assistant_message` (Stop) | `preferredNotifChannel` auto/iterm2(OSC 9)/kitty/ghostty/terminal_bell — same idle/permission gating; OSC 9;4 via `terminalProgressBarEnabled` | `~/.claude/projects/<enc-cwd>/<id>.jsonl`: assistant `stop_reason:"end_turn"` then `system/turn_duration` | V |
+| Codex | `notify=[…]` → `agent-turn-complete`; hooks `Stop`; `SessionStart` / `SessionEnd` | hooks `PermissionRequest`; nothing for idle | `-c 'notify=["/abs/cmd"]'` (no trust gate) — live-verified; `-c 'hooks.Stop=[{hooks=[{type="command",command="/abs/cmd"}]}]'` fires ONLY with `--dangerously-bypass-hook-trust` (else silently skipped) — both live-verified; `CODEX_HOME` = full relocation | notify: JSON as last argv: `thread-id`, `turn-id`, `cwd`, `last-assistant-message`; hooks stdin: `session_id`, `turn_id`, `transcript_path`, `cwd`, `last_assistant_message` | `tui.notifications` (+ `tui.notification_method` osc9/bel, `tui.notification_condition` unfocused default / always); no 9;4 | `~/.codex/sessions/Y/M/D/rollout-*.jsonl`: `event_msg` `task_complete` / `turn_aborted` | V |
+| Gemini CLI | hooks `AfterAgent` (once per turn); `SessionStart` / `SessionEnd` | hooks `Notification` `notification_type:"ToolPermission"` only; no idle/ask hook | no `--settings` flag; project `.gemini/settings.json`; `GEMINI_CLI_SYSTEM_SETTINGS_PATH=/file.json` (system layer, merges) — untested; `GEMINI_CLI_HOME` = full relocation | stdin JSON: `session_id`, `transcript_path`, `cwd`, `prompt_response` (AfterAgent) | off by default: `general.enableNotifications` + `notificationMethod` auto/osc9/osc777/bell; no 9;4 | `~/.gemini/tmp/<hash>/chats/session-*.jsonl` (no explicit marker) | D + bundle |
+| Cursor Agent | hooks `stop` (`status` completed/aborted/error), `afterAgentResponse` (`text`); `sessionStart` / `sessionEnd` | none (Claude-compat map sets `PermissionRequest→null`, `Notification→null`) | no flag/env (`CURSOR_CONFIG_DIR` does not move hooks.json); project `<workspace>/.cursor/hooks.json` or `.claude/settings(.local).json`; `--plugin-dir` hooks not executed in this build | stdin JSON: `conversation_id`/`session_id`, `transcript_path`, `workspace_roots`, `text` | `cli-config.json` `notifications:true`: focus-gated → OSC 9 (iTerm2), OSC 777 (Ghostty/Warp), OSC 99 (Kitty), BEL (Terminal.app); no 9;4 | `~/.cursor/projects/<slug>/agent-transcripts/<chatId>/<chatId>.jsonl` (no marker) | V (bundle) |
+| Cline | file hooks `TaskComplete` (=`agent_end`), `TaskError`, `TaskCancel`; `TaskStart` / `SessionShutdown` | none | dirs `~/.cline/hooks`, `<cwd>/.cline/hooks`, `<cwd>/.clinerules/hooks`; `--hooks-dir <path>` only sets `CLINE_HOOKS_DIR`, no reader found → unverified; `CLINE_DIR` = full relocation | stdin JSON: `taskId`, `hookName`, `workspaceRoots`, `turn.outputText`; no transcript path | none | `~/.cline/data/tasks/<taskId>/ui_messages.json`: `say:completion_result` → `ask:completion_result`; any `type:"ask"` = waiting | V (source) |
+| OpenCode | plugin `event`: `session.idle`, `session.status {type:"idle"}`; `session.created` / `session.deleted`; SSE `GET /event` | `permission.asked` (until `permission.replied`), `question.asked`; sync `permission.ask` hook | `OPENCODE_CONFIG_CONTENT='{"plugin":["file:///abs/probe.ts"]}'` — live-verified; project `.opencode/plugins/*.ts` — live-verified; `OPENCODE_CONFIG=/file.json`; `--pure` disables | in-process `{type, properties:{sessionID,…}}`; `message.updated` `finish:"stop"` | only `tui.attention` (default disabled): OSC 99/777 when blurred | `~/.local/share/opencode/opencode.db` message `time.completed` / `finish:"stop"` | V |
+| Copilot CLI | hooks `agentStop` (`stopReason:"end_turn"`); `sessionStart` / `sessionEnd` | hooks `notification` `notification_type` `permission_prompt`, `elicitation_dialog`; `permissionRequest` | `--plugin-dir <dir>` (`plugin.json` + `hooks.json`) — live-verified; `COPILOT_PLUGIN_DIR_ONLY=1`; repo `.github/hooks/*.json` (trust-gated); `COPILOT_HOME` = full relocation | stdin JSON: `sessionId`, `cwd`, `transcriptPath`, `stopReason`; no last message | `terminalProgress` OSC 9;4 (default on); `beep` BEL (off); `notifications` toast (off) | `~/.copilot/session-state/<id>/events.jsonl`: `assistant.turn_end`, `session.shutdown` | V |
+| Kimi CLI | `[[hooks]]` `Stop` (`StopFailure`); `SessionStart` / `SessionEnd` | none in hooks; `wire.jsonl` `ApprovalRequest` + BEL | `--config-file FILE` / `--config '<toml/json>'` REPLACE the whole config (must include providers) — live-verified with a full copy; `KIMI_SHARE_DIR` = full relocation | stdin JSON: `hook_event_name`, `session_id`, `cwd`, `stop_hook_active`; no transcript / last message | BEL on approval/question only | `~/.kimi/sessions/<md5 cwd>/<id>/wire.jsonl`: `TurnEnd`; `ApprovalRequest` = blocked | V |
+| Factory Droid | hooks `Stop`; `SessionStart` / `SessionEnd` | hooks `Notification` `permission_prompt`, `idle_prompt`, `elicitation_dialog` | `--settings /abs/file.json` (merged for this process only), also on `droid exec` — live-verified | stdin JSON: `session_id`, `transcript_path`, `cwd`, `permission_mode`; no last message | OSC 9;4 only when `TERM_PROGRAM` contains ghostty; `completionSound` / `awaitingInputSound` (`bell` = BEL) | `~/.factory/sessions/<enc-cwd>/<id>.jsonl` (no explicit marker) | V |
+| Amp | plugin `agent.end` (`status` done/error/cancelled, `messages[]`); `session.start` | no event; in-process `ctx.thread.state` idle/running/awaiting-approval/error | project `.amp/plugins/*.ts` or `~/.config/amp/plugins/` only (no flag/env) — project load live-verified; `--settings-file` REPLACES user settings | in-process: `thread.id`, `messages`; no cwd field | `amp.notifications.enabled` (default on): local sounds; BEL only over SSH/`AMP_FORCE_BEL`; OSC 777 when unfocused | server-side threads; local files are stubs → unreliable | V + D |
+| Qoder CLI | hooks `Stop` (`last_assistant_message`), `StopFailure`; `SessionStart` / `SessionEnd` | hooks `PermissionRequest`, `PermissionDenied`, `Notification` `permission_prompt` (not focus-gated), `idle_prompt` (focus-gated), `elicitation_dialog`, `Elicitation` | `--settings '<json>'` or `--settings file.json` (highest priority, not trust-gated) — live-verified (both forms); `--config-dir` / `QODER_CONFIG_DIR`; `--setting-sources` may drop flag hooks | stdin JSON: `session_id`, `transcript_path`, `cwd`, `permission_mode`, `agent_id` | `general.enableNotifications` (default false): OSC 9 else BEL, unfocused only; no 9;4 | `~/.qoder/projects/<enc-cwd>/<id>.jsonl`: assistant `stop_reason:"end_turn"` | V |
+| Qwen Code | hooks `Stop` (`last_assistant_message`), `StopFailure`; `SessionStart` / `SessionEnd` | hooks `PermissionRequest`, `PermissionDenied`, `Notification` `permission_prompt`, `idle_prompt` (not focus-gated) | no flag; project `.qwen/settings.json` — live-verified; `QWEN_CODE_SYSTEM_SETTINGS_PATH` exists but did NOT fire hooks in test; `QWEN_HOME` = full relocation | stdin JSON: `session_id`, `transcript_path`, `cwd`, `timestamp`, `permission_mode`, `model` | `general.terminalBell` (default true): OSC 9/99/777/BEL, unfocused only; completion only after ≥20 s turns | `~/.qwen/projects/<enc-cwd>/chats/<id>.jsonl` + `<id>.runtime.json` (pid); no turn marker in 0.21.3 | V |
+| Grok Build | hooks `Stop` (`reason:"end_turn"`, `lastAssistantMessage`); `[[ui.notifications.hooks]]` on `turn_complete`; `SessionStart` / `SessionEnd` | hooks `Notification` (`permission_prompt`, `idle_prompt`), `PermissionDenied`; `[[ui.notifications.hooks]]` `approval_required` | NO flag/env on the TUI (`GROK_HOME` relocates incl. auth); `~/.grok/hooks/*.json`, trusted `<project>/.grok/hooks/*.json`, Claude/Cursor-compat files | stdin JSON camelCase: `sessionId`, `cwd`, `lastAssistantMessage`; env `GROK_SESSION_ID`, `GROK_EVENT`, `GROK_MESSAGE` | default ON but focus-gated: OSC 777/9/99/BEL; OSC 9;4 `progress_bar=true` | `~/.grok/sessions/<urlenc-cwd>/<id>/updates.jsonl` `turn_completed`; `events.jsonl` `permission_requested`, `turn_ended` | D + binary |
+| Pi | extension `agent_end` → `agent_settled` (idle); `session_start` / `session_shutdown` | none (no permission system) | `pi -e /abs/ext.ts` — live-verified; `PI_CODING_AGENT_DIR` = full relocation | in-process: `ctx.sessionManager.getSessionFile()`, `ctx.cwd`, `agent_end.messages` | none by default; OSC 9;4 if `terminal.showTerminalProgress`; OSC 133 | `~/.pi/agent/sessions/--<enc>--/<ts>_<id>.jsonl`: assistant `stopReason:"stop"` | V |
+| Oh My Pi | extension `session_stop` → `agent_end`; `session_start` / `session_shutdown` | `tool_approval_requested` / `_resolved` (only with an approval handler; default `approvalMode: yolo`); `ask` tool → built-in notification only | `omp --hook /abs/ext.ts` (or `-e`) — live-verified; `--config overlay.yml` (repeatable); `--profile` isolates | in-process: session file, `ctx.cwd`, `agent_end.messages` | default ON: OSC 9/99/BEL; `PI_NOTIFICATIONS=off`; OSC 9;4 if `terminal.showProgress` | `~/.omp/agent/sessions/<enc>/<ts>_<id>.jsonl`: assistant `stopReason:"stop"`; `custom/session_exit` | V |
+
+## 2. Per-runtime notes (abridged; sources)
+
+- **Claude Code** — https://code.claude.com/docs/en/hooks , https://code.claude.com/docs/en/terminal-config.
+  `Stop` fires when the main agent finishes (not on interrupt). Live: `claude -p … --settings
+  '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/abs/capture.sh"}]}],…}}'`
+  fired SessionStart → Stop → SessionEnd; payload includes `transcript_path`,
+  `last_assistant_message`, `permission_mode`. Env: `CLAUDE_PROJECT_DIR`,
+  `CLAUDE_CODE_SESSION_ID`, `CLAUDE_PID`. Caveat (docs): interactive sessions hold all hooks
+  until the workspace-trust dialog is accepted.
+- **Codex** — https://learn.chatgpt.com/docs/hooks.md ,
+  https://learn.chatgpt.com/docs/config-file/config-advanced.md#notifications. Live:
+  `codex exec -c 'notify=["/abs/capture.sh","tag"]'` fired `agent-turn-complete` (payload as
+  last argv incl. `last-assistant-message`); `-c hooks.*` fired only with
+  `--dangerously-bypass-hook-trust`. An internal "memories" sub-session (cwd
+  `~/.codex/memories`, `transcript_path:null`) also fires SessionStart/End — filter on cwd.
+- **Gemini CLI** — https://geminicli.com/docs/hooks/reference/ ,
+  https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/notifications.md. Hooks
+  merge across user/project/system layers; project hooks are fingerprinted/trust-warned.
+- **Cursor Agent** — https://cursor.com/docs/agent/hooks. `stop` only fires when a
+  user/project `hooks.json` defines it; plugin hooks run only in builds ≥ 2026-08-11.
+- **Cline** — https://docs.cline.bot/customization/hooks.md. The Claude-style hook list in
+  the binary is a bundled Claude settings schema, not Cline hooks.
+- **OpenCode** — https://opencode.ai/docs/plugins , https://opencode.ai/docs/server. Live:
+  `session.status {busy}` → … → `session.status {idle}` + `session.idle` (fires even after a
+  model error). `opencode serve` exposes SSE `GET /event`.
+- **Copilot CLI** — https://docs.github.com/en/copilot/reference/hooks-reference. Live:
+  `copilot -p … --plugin-dir <dir>` (`plugin.json` + `hooks.json`) fired
+  sessionStart / agentStop / sessionEnd; `--session-id` makes the transcript path
+  deterministic.
+- **Kimi CLI** — https://moonshotai.github.io/kimi-cli/en/customization/hooks.html.
+  `--config-file` replaces the whole config (no merge): a Prowl-generated copy must
+  re-supply the user's providers.
+- **Factory Droid** — https://docs.factory.ai/reference/hooks-reference. Live:
+  `droid exec --settings /abs/settings.json` fired SessionStart/Stop/SessionEnd (Stop even
+  though the exec failed).
+- **Amp** — https://ampcode.com/manual/plugin-api. Plugins only from project
+  `.amp/plugins/` or `~/.config/amp/plugins/`; `ctx.thread.state` exposes
+  `awaiting-approval` in-process.
+- **Qoder CLI** — https://docs.qoder.com/cli/hooks. Live: `--settings` inline JSON and
+  file both fired SessionStart/End (quota error before Stop); flag hooks are not trust-gated.
+- **Qwen Code** — https://qwenlm.github.io/qwen-code-docs/en/users/features/hooks/. Live:
+  project `.qwen/settings.json` fired SessionStart; `QWEN_CODE_SYSTEM_SETTINGS_PATH` did not.
+- **Grok Build** — https://docs.x.ai/build/features/hooks ,
+  https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/10-hooks.md.
+  No per-launch flag on the TUI; `--plugin-dir` only on `grok agent` (ACP).
+- **Pi** — https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md.
+  Live: `pi -e /abs/probe.ts -p …` → session_start → agent_start → turn_start → turn_end →
+  agent_end → agent_settled → session_shutdown.
+- **Oh My Pi** — https://github.com/can1357/oh-my-pi/blob/master/docs/extensions.md. Live:
+  `omp --hook /abs/probe.ts -p …` → session_start → … → session_stop → agent_end →
+  session_shutdown. Session dirs use hashed names in 17.2.5–17.2.8.
+
+## 3. What is not achievable (as of the baseline)
+
+**No per-launch injection without touching global config or a file inside the user's
+project:** Grok Build (TUI), Cursor Agent, Amp, Cline (`--hooks-dir` unverified), Gemini
+and Qwen (project settings only; system-settings env untested / did not fire), Kimi (only
+by replacing the whole config), Codex hooks beyond `notify` (trust bypass flag required).
+
+**No native "blocked / waiting for input" channel:** Cursor Agent, Cline, Kimi (hooks),
+Amp (event), Pi (no permission system), Codex idle between turns, Gemini beyond
+`ToolPermission`, OMP `ask`.
+
+**Last assistant message in the payload** only for Claude Code, Codex, Grok, Gemini
+(`prompt_response`), Cursor (`afterAgentResponse.text`), Cline (`turn.outputText`),
+Amp/Pi/OMP/OpenCode (in-process messages), Qoder/Qwen (docs). Not in Copilot `agentStop`,
+Droid `Stop`, Kimi `Stop`.
+
+**Terminal escapes are never a deterministic channel:** every runtime gates its OSC
+9/99/777/BEL on focus, idle thresholds, or opt-in settings; OSC 9;4 progress (where
+emitted) separates working from not-working but not blocked from idle.
+
+**No usable local transcript with a turn marker:** Amp (server-side). Weak/no explicit
+marker: Gemini, Cursor, Droid, Qwen 0.21.3, Cline, Pi/OMP (infer from assistant
+`stopReason`).
+
+## 4. Implications for Prowl (feeds 064 §Design / S3)
+
+| Tier | Runtimes | Channel Prowl can attach at launch |
+| --- | --- | --- |
+| **A — flag/env per launch, no user config touched** | Claude Code (`--settings`), Codex (`-c notify=[…]`, turn-complete only), Copilot CLI (`--plugin-dir`), Factory Droid (`--settings`), Qoder CLI (`--settings`), Pi (`-e`), Oh My Pi (`--hook`), OpenCode (`OPENCODE_CONFIG_CONTENT`) | `signalHooks = .launchFlag` — first S3 wave |
+| **B — only via a Prowl-owned home** | Gemini (`GEMINI_CLI_HOME`), Qwen (`QWEN_HOME`), Grok (`GROK_HOME`), Cline (`CLINE_DIR`), Kimi (`KIMI_SHARE_DIR`; or full-config replacement), plus Claude/Codex/Copilot for completeness | `signalHooks = .configDirOnly` — available only for profiles that bind a dedicated home (053); Prowl writes the hook file into the provisioned home |
+| **C — project files only** | Cursor Agent (`<workspace>/.cursor/hooks.json`), Amp (`.amp/plugins/`) | not attached (Prowl does not write into the user's project); layers 2–3 only |
+
+Blocked/permission coverage via hooks: Claude, Codex (trust-gated), Gemini (tool
+permission), Copilot, Droid, Qoder, Qwen, Grok, OpenCode (plugin), OMP (only with an
+approval handler). Runtimes where blocked detection stays heuristic/transcript-only: Cursor,
+Cline, Kimi (transcript `ApprovalRequest`), Amp, Pi.
+
+Payloads with `last_assistant_message` (Claude, Codex, Qoder, Qwen, Grok, Gemini) let 063's
+V2 observe mode capture a result without transcript parsing for those runtimes.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -39,6 +39,9 @@ Living documents hosted here:
 - `013-prowl-cli/contracts/` — normative CLI contracts
 - `017-upstream-sync-process/upstream-ledger.md` — upstream review ledger (baseline + decisions)
 - `020-observability/runbook.md` — observability/diagnostics runbook
+- `063-agent-workflows/dsl-spec.md` — Agent Workflow DSL (`prowl.workflow/v1`) normative spec
+- `063-agent-workflows/release-plan.md` — release/order plan shared by 063 and 064
+- `064-agent-completion-signals/research-agent-completion-signals.md` — per-runtime completion-signal matrix
 
 Some entries also host verbatim historical attachments migrated from doc-onevcat (e.g.
 `023-shelf-mode/jank-investigation.md`, `017-.../batch-2026-07-06-post-v0.10.5.md`,

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -114,3 +114,4 @@ agent-facing manual for that).
 | 060 | [prowl-cli-targeting-and-contract-governance](060-prowl-cli-targeting-and-contract-governance/000-plan.md) | 2026-08-16 | Unified target grammar, CLI contract rebaseline, and durable documentation governance |
 | 061 | [native-toolbar-controls](061-native-toolbar-controls/000-plan.md) | 2026-08-17 | Native macOS toolbar grouping, Liquid Glass ownership, and review standards |
 | 062 | [workspace-child-diff](062-workspace-child-diff/000-plan.md) | 2026-08-19 | Per-repository diff for workspace children via unified DiffTarget routing |
+| 063 | [agent-workflows](063-agent-workflows/000-plan.md) | 2026-08-21 | Agent Workflows: YAML-declared, profile-bound multi-agent orchestration (runner, `prowl workflow` CLI, status center, built-in handoff/adversarial review); successor to 047's fixed handoff flow |

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -115,3 +115,4 @@ agent-facing manual for that).
 | 061 | [native-toolbar-controls](061-native-toolbar-controls/000-plan.md) | 2026-08-17 | Native macOS toolbar grouping, Liquid Glass ownership, and review standards |
 | 062 | [workspace-child-diff](062-workspace-child-diff/000-plan.md) | 2026-08-19 | Per-repository diff for workspace children via unified DiffTarget routing |
 | 063 | [agent-workflows](063-agent-workflows/000-plan.md) | 2026-08-21 | Agent Workflows: YAML-declared, profile-bound multi-agent orchestration (runner, `prowl workflow` CLI, status center, built-in handoff/adversarial review); successor to 047's fixed handoff flow |
+| 064 | [agent-completion-signals](064-agent-completion-signals/000-plan.md) | 2026-08-22 | Layered agent signal bus (cooperative / launch-scoped hooks / transcript+process+OSC / heuristic), `prowl agents signal` + `agents wait` with source/confidence, per-runtime hook research |


### PR DESCRIPTION
## Summary

- Add `docs-ai/063-agent-workflows/000-plan.md`: RFC for Agent Workflows — YAML-declared, profile-bound multi-agent orchestration run by Prowl (runner, `prowl workflow` CLI participant protocol, toolbar status center, start sheet, Settings IA with an Agents group, built-in `prowl.handoff` / `prowl.adversarial-review`), with decisions, prerequisite interfaces (`prowl create pane`, profile launch boundary), delivery slicing, and open questions.
- Add `docs-ai/063-agent-workflows/dsl-spec.md`: living spec for `prowl.workflow/v1` (roles, steps, `expect`, `repeat … until <verdict>`, templates, validation, run directory, CLI protocol, state-driven watchdog).
- Index the entry in `docs-ai/README.md` and append amendments to 047, 049, 053, and 055 pointing at the successor direction.

Docs-only; no source, build, or test changes.
