### PR TITLE
Fix Pi async subagent activity detection

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -23,7 +23,8 @@ Detection covers
 common wrappers (node, python, bun, bash, etc.) so agents launched indirectly are
 still found. Pi and Oh My Pi are independent detected agents. Pi recognizes its
 own minimal working/idle cues, including its built-in braille-prefixed `Working...`
-loader; Oh My Pi owns its richer spinner and interactive
+loader and a running `pi-subagents` background card after the parent turn settles;
+Oh My Pi owns its richer spinner and interactive
 Ask-prompt heuristics, plus its own session layout and icon. Grok Build also
 ships an `agent` symlink; Prowl only treats that name as Grok when the path points
 at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
@@ -34,8 +35,9 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    process names / argv against known agent executables, scoring argv[0] highest,
    then process name, then command-line tokens.
 2. **Screen heuristics.** Claude detection consumes the full active screen (bounded
-   by the terminal height); every other agent starts from the last ~24 non-blank
-   lines as a guard against transcript history. The classifier then selects
+   by the terminal height); Pi starts from the last ~32 non-blank lines so an
+   expanded background-agent widget stays intact, and every other agent starts
+   from the last ~24 as a guard against transcript history. The classifier then selects
    agent-specific live UI regions rather than treating every transcript line as current
    state. Structured confirmation/permission chrome is **Blocked**; status rows and
    spinners are **Working**. Claude working rows come from a live status block walked
@@ -51,8 +53,12 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    the current directory-trust, hook-review, and initial sign-in menus as **Blocked** from
    their complete selected-choice and footer structures. Ordinary prompt text and completed
    responses are not confirmation boundaries.
-   Other agent families keep their own patterns (including Oh My Pi's
-   `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
+   Pi also treats the adjacent `async subagent … · background` header and matching
+   braille job row as **Working**. The compact `subagents (N/M running)`, progressive
+   `Async agents · N agent(s) running`, and multi-job `Async agents · background`
+   layouts carry the same signal; completed, paused, and failed cards use static
+   glyphs and remain idle. Other agent families keep their own patterns (including
+   Oh My Pi's `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
    hexagons, Kimi's moon phases, etc.).
    Claude's live status row (`● <label>… (<elapsed> · …)`) accepts a multi-word
    label and a compound elapsed segment such as `28m 34s` or `1h 4m 2s`, so a turn

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 nonisolated let agentDetectionRecentLineLimit = 24
+nonisolated let piAgentDetectionRecentLineLimit = 32
 
 extension DetectedAgent {
   nonisolated func detectState(in screen: String) -> AgentRawState {
@@ -16,14 +17,22 @@ extension DetectedAgent {
   /// the live signal off when a long todo list plus a multi-line status line
   /// pushed the spinner row past the limit and a working agent read as idle.
   ///
-  /// Every other detector keeps the bounded tail as its guard against
-  /// transcript history. For the legacy scanners the tail is load-bearing —
-  /// they match with whole-text scans. Codex's structured profile anchors
-  /// its windows inside the tail instead; it shares Claude's bounded-bottom
-  /// exposure in principle and keeps the tail until its regions are bounded
-  /// by shape the same way.
+  /// Every other detector keeps a bounded tail as its guard against transcript
+  /// history. Pi retains 32 non-blank lines so pi-subagents' adaptive widget can
+  /// keep its header and live job row together; the remaining detectors keep 24.
+  /// For the legacy scanners the tail is load-bearing — they match with whole-text
+  /// scans. Codex's structured profile anchors its windows inside the tail instead;
+  /// it shares Claude's bounded-bottom exposure in principle and keeps the tail
+  /// until its regions are bounded by shape the same way.
   nonisolated func detectionScreenText(from screen: String) -> String {
-    self == .claude ? screen : agentDetectionRecentText(screen)
+    switch self {
+    case .claude:
+      screen
+    case .pi:
+      agentDetectionRecentLines(screen, limit: piAgentDetectionRecentLineLimit)
+    default:
+      agentDetectionRecentText(screen)
+    }
   }
 
   /// The one production entry point for building a profile snapshot. State
@@ -96,9 +105,154 @@ nonisolated func agentDetectionRecentLines(_ content: String, limit: Int) -> Str
 }
 
 nonisolated private func detectPi(_ content: String) -> AgentRawState {
-  content.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
-    isPiWorkingText(line.trimmingCharacters(in: .whitespaces))
-  } ? .working : .idle
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map {
+    $0.trimmingCharacters(in: .whitespaces)
+  }
+  return lines.contains(where: isPiWorkingText) || hasPiRunningAsyncSubagentCard(lines)
+    ? .working
+    : .idle
+}
+
+nonisolated private func hasPiRunningAsyncSubagentCard(_ lines: [String]) -> Bool {
+  if lines.contains(where: isPiAdaptiveAsyncSubagentRunningLine) {
+    return true
+  }
+  guard lines.count >= 2 else { return false }
+
+  return lines.indices.dropLast().contains { index in
+    guard let headerName = piAsyncSubagentName(from: lines[index]) else { return false }
+    return isPiAsyncSubagentJobLine(lines[index + 1], matching: headerName)
+  }
+}
+
+nonisolated private func piAsyncSubagentName(from header: String) -> (name: String, isPrefix: Bool)? {
+  let prefix = "async subagent "
+  let suffix = " · background"
+  guard header.hasPrefix(prefix) else { return nil }
+
+  let title: Substring
+  let isPrefix: Bool
+  if header.hasSuffix(suffix) {
+    title = header.dropFirst(prefix.count).dropLast(suffix.count)
+    isPrefix = false
+  } else {
+    guard header.hasSuffix("…") else { return nil }
+    let truncatedTitle = header.dropFirst(prefix.count).dropLast()
+    if let separator = truncatedTitle.range(of: " ·") {
+      title = truncatedTitle[..<separator.lowerBound]
+      isPrefix = false
+    } else {
+      title = truncatedTitle
+      isPrefix = true
+    }
+  }
+
+  let components = title.split(separator: " ")
+  let countToken = components.last
+  let completeCount = countToken?.dropFirst().dropLast()
+  let hasCompleteCount =
+    countToken?.first == "("
+    && countToken?.last == ")"
+    && completeCount?.isEmpty == false
+    && completeCount?.allSatisfy(\.isNumber) == true
+  let partialCount = countToken?.dropFirst()
+  let hasTruncatedCount =
+    isPrefix
+    && countToken?.first == "("
+    && countToken?.last != ")"
+    && partialCount?.allSatisfy(\.isNumber) == true
+  let hasTrailingCount = hasCompleteCount || hasTruncatedCount
+  let name = hasTrailingCount ? components.dropLast().joined(separator: " ") : String(title)
+  let nameIsPrefix = isPrefix && !hasTrailingCount
+  return name.contains(where: \.isLetter) ? (name, nameIsPrefix) : nil
+}
+
+nonisolated private func isPiAsyncSubagentJobLine(
+  _ line: String,
+  matching headerName: (name: String, isPrefix: Bool)
+) -> Bool {
+  guard let content = labeledBrailleSpinnerContent(line), content.hasPrefix(headerName.name) else { return false }
+  if headerName.isPrefix {
+    return true
+  }
+
+  let remainder = content.dropFirst(headerName.name.count)
+  if remainder.isEmpty || remainder.hasPrefix(" ·") {
+    return true
+  }
+  return [" [fresh]", " [fork]", " [mixed]"].contains { badge in
+    remainder == badge || remainder.hasPrefix("\(badge) ·")
+  }
+}
+
+nonisolated private func isPiAdaptiveAsyncSubagentRunningLine(_ line: String) -> Bool {
+  guard let content = labeledBrailleSpinnerContent(line) else { return false }
+  if content.hasSuffix("…") {
+    let visiblePrefix = content.dropLast()
+    if visiblePrefix.hasPrefix("subagents (") || visiblePrefix.hasPrefix("Async agents · ") {
+      return true
+    }
+  }
+  if content == "Async agents · background" {
+    return true
+  }
+  if content.hasPrefix("Async agents · ") {
+    return isPiProgressiveAsyncSummary(String(content.dropFirst("Async agents · ".count)))
+  }
+  return isPiSingleLineAsyncSummary(content)
+}
+
+nonisolated private func isPiProgressiveAsyncSummary(_ summary: String) -> Bool {
+  let components = summary.split(separator: " ", maxSplits: 2)
+  guard components.count == 3,
+    let count = Int(components[0]),
+    count > 0,
+    components[1] == (count == 1 ? "agent" : "agents")
+  else {
+    return false
+  }
+
+  let state = components[2]
+  if state == "running" {
+    return true
+  }
+  guard state.hasPrefix("running, ") else { return false }
+  return isPiAsyncCountStatus(state.dropFirst("running, ".count), expected: "queued")
+}
+
+nonisolated private func isPiSingleLineAsyncSummary(_ content: String) -> Bool {
+  let prefix = "subagents ("
+  guard content.hasPrefix(prefix), content.hasSuffix(")") else { return false }
+
+  let summary = content.dropFirst(prefix.count).dropLast()
+  let components = summary.split(separator: ",", omittingEmptySubsequences: false)
+  guard let runningSummary = components.first else { return false }
+  let running = runningSummary.split(separator: " ")
+  guard running.count == 2, running[1] == "running" else { return false }
+
+  let counts = running[0].split(separator: "/", omittingEmptySubsequences: false)
+  guard counts.count == 2,
+    let activeCount = Int(counts[0]),
+    let totalCount = Int(counts[1]),
+    activeCount > 0,
+    totalCount >= activeCount
+  else {
+    return false
+  }
+
+  let terminalStates = ["queued", "failed", "stopped", "paused"]
+  return components.dropFirst().allSatisfy { component in
+    terminalStates.contains { state in
+      isPiAsyncCountStatus(component.drop(while: \.isWhitespace), expected: state)
+    }
+  }
+}
+
+nonisolated private func isPiAsyncCountStatus(_ summary: Substring, expected: String) -> Bool {
+  let components = summary.split(separator: " ")
+  return components.count == 2
+    && Int(components[0]).map { $0 > 0 } == true
+    && components[1] == Substring(expected)
 }
 
 nonisolated private func detectOMP(_ content: String) -> AgentRawState {
@@ -121,7 +275,7 @@ nonisolated private func hasOMPWorkingLine(_ content: String) -> Bool {
     let trimmed = line.trimmingCharacters(in: .whitespaces)
     return isPiWorkingText(trimmed)
       || hasOMPInterruptHint(trimmed)
-      || hasOMPBrailleSpinner(trimmed)
+      || hasLabeledBrailleSpinner(trimmed)
   }
 }
 
@@ -149,12 +303,21 @@ nonisolated private func hasOMPInterruptHint(_ line: String) -> Bool {
   }
 }
 
-nonisolated private func hasOMPBrailleSpinner(_ line: String) -> Bool {
-  guard let first = line.unicodeScalars.first else { return false }
+nonisolated private func hasLabeledBrailleSpinner(_ line: String) -> Bool {
+  labeledBrailleSpinnerContent(line) != nil
+}
+
+nonisolated private func labeledBrailleSpinnerContent(_ line: String) -> String? {
+  guard let first = line.unicodeScalars.first,
+    (0x2800...0x28FF).contains(Int(first.value))
+  else {
+    return nil
+  }
+
   let rest = String(line.unicodeScalars.dropFirst())
-  return (0x2800...0x28FF).contains(Int(first.value))
-    && rest.hasPrefix(" ")
-    && rest.contains(where: \.isLetter)
+  guard rest.hasPrefix(" ") else { return nil }
+  let content = rest.dropFirst().trimmingCharacters(in: .whitespaces)
+  return content.contains(where: \.isLetter) ? content : nil
 }
 
 nonisolated private func detectGemini(_ content: String) -> AgentRawState {

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -15,6 +15,11 @@ struct ScreenHeuristicsTests {
     let screen = (1...(agentDetectionRecentLineLimit * 2)).map { "line \($0)" }.joined(separator: "\n")
 
     #expect(DetectedAgent.claude.detectionScreenText(from: screen) == screen)
+    #expect(
+      DetectedAgent.pi.detectionScreenText(from: screen)
+        == agentDetectionRecentLines(screen, limit: piAgentDetectionRecentLineLimit)
+    )
+    #expect(DetectedAgent.pi.detectionScreenText(from: screen) != agentDetectionRecentText(screen))
     #expect(DetectedAgent.codex.detectionScreenText(from: screen) == agentDetectionRecentText(screen))
     #expect(DetectedAgent.codex.detectionScreenText(from: screen) != screen)
     #expect(DetectedAgent.gemini.detectionScreenText(from: screen) == agentDetectionRecentText(screen))
@@ -26,6 +31,138 @@ struct ScreenHeuristicsTests {
     #expect(DetectedAgent.pi.detectState(in: "⣾ Working...") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Interrupting…") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Done") == .idle)
+  }
+
+  @Test func piDetectsRunningAsyncSubagentCardAfterParentTurnSettles() {
+    let screen = """
+      第二轮 reviewer 已启动并订阅完成通知喵：
+
+      - Run: 9bb327ff-e525-42b6-89d3-27db71a2a54b
+      - Fresh context、repo-only、只读
+      - 明确复核上一轮 5 项发现及修订后的新风险
+
+      完成后我会自行验证，并按证据决定是否修改计划。
+
+      Tool output: collapsed
+
+      async subagent reviewer · background
+      ⠋ reviewer · step 1/1 · 140 tool uses · 9m12s
+        ⠴ Step 1/1: reviewer · running (gpt-5.6-sol · thinking xhigh) · 20 turns · 140 tool uses
+          ⎿  active but long-running · last activity now
+          Press ctrl+o for live detail
+          output: /tmp/pi-subagents/async-subagent-runs/9bb327ff/output-0.log
+      ──────────────────────────────────────────────────────────────────────────────
+
+      ──────────────────────────────────────────────────────────────────────────────
+        1 active agent · Async runs 0/∞ · ↓ 278.7k tokens · ↓/← to inspect
+      ~/workspace (feature/review-plan)
+      """
+
+    #expect(DetectedAgent.pi.detectState(in: screen) == .working)
+  }
+
+  @Test func piDetectsAdaptiveAsyncSubagentLayouts() {
+    let workingScreens = [
+      "⠋ subagents (1/1 running)",
+      "⠋ subagents (2/3 running, 1 queued)",
+      "⠋ Async agents · 1 agent running",
+      "⠋ Async agents · 2 agents running, 1 queued",
+      "⠋ Async agents · background",
+      """
+      async subagent chain (2) · background
+      ⠋ chain [fresh] · step 1/2 · 20 tool uses · 2m14s
+      """,
+    ]
+
+    for screen in workingScreens {
+      #expect(DetectedAgent.pi.detectState(in: screen) == .working)
+    }
+  }
+
+  @Test func piDetectsRendererTruncatedAsyncSubagentLayouts() {
+    let workingScreens = [
+      """
+      async subagent reviewer · b…
+      ⠋ reviewer · step 1/1 · 1…
+      """,
+      """
+      async subagent revi…
+      ⠋ reviewer · step 1…
+      """,
+      """
+      async subagent chain (…
+      ⠋ chain [fresh] · step 1/2…
+      """,
+      """
+      async subagent chain (2…
+      ⠋ chain [fresh] · step 1/2…
+      """,
+      """
+      async subagent chain (2)…
+      ⠋ chain [fresh] · step 1/2…
+      """,
+      "⠋ subagents (1/1 ru…",
+      "⠋ Async agents · 1 agent ru…",
+      "⠋ Async agents · back…",
+    ]
+
+    for screen in workingScreens {
+      #expect(DetectedAgent.pi.detectState(in: screen) == .working)
+    }
+  }
+
+  @Test func piRetainsACompleteAsyncSubagentCardBeyondTheDefaultTail() {
+    let lowerChrome = (1...23).map { "lower widget row \($0)" }.joined(separator: "\n")
+    let screen = """
+      async subagent reviewer · background
+      ⠋ reviewer · step 1/1 · 140 tool uses · 9m12s
+      \(lowerChrome)
+      """
+
+    #expect(DetectedAgent.pi.detectState(in: screen) == .working)
+  }
+
+  @Test func piAsyncSubagentDetectionRejectsInactiveOrUnrelatedChrome() {
+    let idleScreens = [
+      """
+      async subagent reviewer · background
+      ✓ reviewer · step 1/1 · 140 tool uses · 9m12s
+        ✓ Step 1/1: reviewer · completed
+      """,
+      """
+      async subagent reviewer · background
+      The following spinner belongs to quoted transcript output.
+      ⠋ reviewer · running
+      """,
+      """
+      async subagent reviewer · background
+      ⠋ quoted output
+      """,
+      """
+      async subagent reviewer · background
+      ⠋ another-agent · step 1/1 · 12 tool uses · 1m2s
+      """,
+      """
+      async subagent · background
+      ⠋ reviewer · running
+      """,
+      """
+      async subagent reviewer · foreground
+      ⠋ reviewer · running
+      """,
+      """
+      ⠋ reviewer · step 1/1 · 140 tool uses · 9m12s
+      """,
+      "⠋ subagents (0/1 running)",
+      "⠋ subagents (2/1 running)",
+      "⠋ Async agents · 0 agents running",
+      "⠋ Async agents · backgrounded",
+      "● Async agents · 1 agent running",
+    ]
+
+    for screen in idleScreens {
+      #expect(DetectedAgent.pi.detectState(in: screen) == .idle)
+    }
   }
 
   @Test func ompDetectionUsesItsOwnRuntimeChrome() {


### PR DESCRIPTION
## Summary

- recognize live `pi-subagents` background work after the parent Pi turn settles
- cover full, single-line, progressive, multi-job, and narrow-pane truncated renderer layouts
- keep full-card matching tied to the adjacent job name/context and retain a Pi-specific 32-line bounded tail
- add regression and false-positive coverage, and update agent-detection documentation

## Validation

- `make check`
- `make test` — xcresult verified 2,470 tests, zero failures
- `make build-app`
- `ScreenHeuristicsTests` — 48/48 passed after the final fix

## Review

Three review rounds were completed. The final follow-up gate reported P0: 0, P1: 0, and approved the change.

## Residual heuristic limitation

An idle transcript that exactly reproduces a live renderer row can still look active in a single screen frame. The renderer exposes no reliable additional region boundary for this case, so this remains a non-blocking best-effort limitation of screen heuristics.
