### PR TITLE
Fix stale terminal selection anchors after long scrollback

### DIFF
--- a/docs-ai/007-ghostty-embedding-integration/000-plan.md
+++ b/docs-ai/007-ghostty-embedding-integration/000-plan.md
@@ -103,3 +103,6 @@ Action routing is layered, mirroring Ghostty's own target model:
 - Updated 2026-05-30: text & key-event safety — text-free ABI fork backport (#286),
   explicit-length text decoding (#348), no text reads from modifier key events (#374) —
   see [003-text-and-key-event-safety.md](003-text-and-key-event-safety.md)
+- Updated 2026-08-25: runtime-shared mouse press ownership prevents focus-transfer clicks
+  and cross-pane releases from corrupting terminal selection — see
+  [004-mouse-selection-ownership.md](004-mouse-selection-ownership.md)

--- a/docs-ai/007-ghostty-embedding-integration/004-mouse-selection-ownership.md
+++ b/docs-ai/007-ghostty-embedding-integration/004-mouse-selection-ownership.md
@@ -1,0 +1,42 @@
+# 007.004 — Mouse Selection Ownership
+
+## Context
+
+PR #722 fixed stale terminal selection anchors after long scrollback by hit-testing from
+the window content view, using the actual first responder for focus, consuming focus-transfer
+clicks in an active window, and forwarding a left-button release only after a corresponding
+press.
+
+The initial ownership state was stored per `GhosttySurfaceView`. Each surface also installs
+its own local event monitor. When an earlier-created pane consumed a focus-transfer click,
+AppKit stopped dispatching that event to later monitors. A later-created pane could therefore
+retain stale ownership and forward the subsequent release even though the new press belonged
+to no Ghostty surface.
+
+## Change
+
+- Added the runtime-scoped, `@MainActor` `GhosttySurfaceMouseCoordinator` in
+  `supacode/Infrastructure/Ghostty/GhosttySurfaceMouseCoordinator.swift`.
+- The coordinator records one left-button press owner by pane UUID for the entire
+  `GhosttyRuntime`. Every local left-button mouse-down clears that owner before window,
+  hit-test, or focus guards can return.
+- `GhosttySurfaceView+Mouse.swift` keeps the existing per-surface monitors for key-up and
+  modifier forwarding, while delegating left-button focus and ownership decisions to the
+  shared coordinator.
+- Only a pane that successfully forwarded a press can own it. A release is forwarded only
+  when its pane UUID matches the owner; every release clears ownership and resets Force Touch
+  pressure, including non-matching and duplicate releases.
+- `supacodeTests/GhosttySurfaceViewTests.swift` covers the monitor-order regression: pane A
+  is created first, pane B holds stale ownership, pane A consumes a focus-transfer click,
+  and pane B's later release is not forwarded.
+
+## Refs
+
+- PR #722.
+
+## Current state
+
+The ownership boundary is one Ghostty runtime, matching Prowl's single runtime that hosts all
+terminal panes. Window activation clicks still pass through after assigning first responder;
+focus-transfer clicks inside an already active key window are consumed so they cannot become
+terminal presses.

--- a/docs/.sync-meta.json
+++ b/docs/.sync-meta.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Metadata for the docs/ manual. The last_synced_commit is the commit at which docs/ was last verified against the implementation; the sync-docs skill (.claude/skills/sync-docs/SKILL.md) diffs HEAD against it and updates this file. Committed to git on purpose so the baseline persists across sessions and machines. A dotfile + .json so a future docs website does not render it as a page.",
-  "last_synced_commit": "475e5656e45ed2a7419f622004f12b569c7f6cd2",
-  "last_synced_date": "2026-08-22",
-  "note": "Verified the terminal input bridge and scrollback selection behavior; documented focus-transfer clicks and drag-selection ownership. Unrelated CLI version and Claude screen-profile changes did not require documentation updates."
+  "last_synced_commit": "0234418d830fbcabf3791f1b4a6e22dc59d83ec1",
+  "last_synced_date": "2026-08-25",
+  "note": "Verified runtime-shared terminal mouse press ownership against the existing scrollback, focus-transfer, and cross-pane release documentation; no manual text changes were required."
 }

--- a/docs/.sync-meta.json
+++ b/docs/.sync-meta.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Metadata for the docs/ manual. The last_synced_commit is the commit at which docs/ was last verified against the implementation; the sync-docs skill (.claude/skills/sync-docs/SKILL.md) diffs HEAD against it and updates this file. Committed to git on purpose so the baseline persists across sessions and machines. A dotfile + .json so a future docs website does not render it as a page.",
-  "last_synced_commit": "1abc11ffe293b6b124625fe8a9823beed6ae2a91",
-  "last_synced_date": "2026-08-20",
-  "note": "Verified the CLI target-grammar + workspace child diff + toolbar grouping range (PRs #700, #702-#704): docs for prowl create/close, child-repo diff entry points, and the update indicator placement were maintained in-branch; only added CREATE_FAILED/CLOSE_FAILED to the cli.md error-code list."
+  "last_synced_commit": "475e5656e45ed2a7419f622004f12b569c7f6cd2",
+  "last_synced_date": "2026-08-22",
+  "note": "Verified the terminal input bridge and scrollback selection behavior; documented focus-transfer clicks and drag-selection ownership. Unrelated CLI version and Claude screen-profile changes did not require documentation updates."
 }

--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -147,8 +147,10 @@ Selection for Find** (`search_selection`). These are Ghostty-managed.
 ## Scrollback, CJK, copy/paste
 
 Scrollback, wide/CJK character rendering, and copy/paste are handled by Ghostty
-with its defaults — Prowl doesn't override them. Customize terminal behavior in
-your Ghostty config at `~/.config/ghostty/config`.
+with its defaults. Prowl's native mouse bridge preserves drag-selection anchors
+across long scrollback, split-focus changes, and releases outside the original
+pane. Customize terminal behavior in your Ghostty config at
+`~/.config/ghostty/config`.
 
 ## Color scheme
 
@@ -166,6 +168,9 @@ launch. Notification bodies are not persisted.
 - **Tab selection ≠ pane focus.** A tab can have several panes; selecting a tab
   doesn't pin which split has keyboard focus. The CLI's `pane.focused` is the
   truth.
+- Clicking an unfocused split in an already active window first transfers focus;
+  start a drag selection with the next press so the focus click is not treated as
+  a terminal press.
 - Closing the **last** tab leaves the worktree with no visible terminal (Shelf
   removes the book; Canvas drops the card).
 - `--capture` and stable reads depend on the pane's shell integration; agents

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -53,8 +53,13 @@ final class GhosttyRuntime {
   var runtimeOverrideSignature = ""
   var onConfigChange: (() -> Void)?
   var onQuit: (() -> Void)?
+  let mouseCoordinator: GhosttySurfaceMouseCoordinator
 
-  init(initialColorScheme: ColorScheme? = nil) {
+  init(
+    initialColorScheme: ColorScheme? = nil,
+    mouseCoordinator: GhosttySurfaceMouseCoordinator? = nil
+  ) {
+    self.mouseCoordinator = mouseCoordinator ?? GhosttySurfaceMouseCoordinator()
     guard let config = Self.loadConfig() else {
       preconditionFailure("ghostty_config_new failed")
     }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceMouseCoordinator.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceMouseCoordinator.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+@MainActor
+final class GhosttySurfaceMouseCoordinator {
+  private var leftMousePressOwnerID: UUID?
+  private let isActiveKeyWindow: (NSWindow) -> Bool
+
+  init(
+    isActiveKeyWindow: @escaping (NSWindow) -> Bool = { window in
+      NSApp.isActive && window.isKeyWindow
+    }
+  ) {
+    self.isActiveKeyWindow = isActiveKeyWindow
+  }
+
+  func forwardLeftMouseDown(for surfaceID: UUID, send: () -> Bool) {
+    leftMousePressOwnerID = nil
+    guard send() else { return }
+    leftMousePressOwnerID = surfaceID
+  }
+
+  func forwardLeftMouseUp(for surfaceID: UUID, send: () -> Void) {
+    let ownsPress = leftMousePressOwnerID == surfaceID
+    leftMousePressOwnerID = nil
+    guard ownsPress else { return }
+    send()
+  }
+
+  func localEventLeftMouseDown(_ event: NSEvent, for surfaceView: GhosttySurfaceView) -> NSEvent? {
+    leftMousePressOwnerID = nil
+    guard let window = surfaceView.window, let eventWindow = event.window, window === eventWindow else {
+      return event
+    }
+    guard window.contentView?.hitTest(event.locationInWindow) === surfaceView else { return event }
+    guard window.firstResponder !== surfaceView else { return event }
+    if isActiveKeyWindow(window) {
+      guard window.makeFirstResponder(surfaceView) else { return event }
+      return nil
+    }
+    window.makeFirstResponder(surfaceView)
+    return event
+  }
+}

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
@@ -25,12 +25,18 @@ extension GhosttySurfaceView {
   }
 
   override func mouseDown(with event: NSEvent) {
-    sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT)
+    resetLeftMousePressForNewMouseDown()
+    if sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT) {
+      markLeftMousePressForwarded()
+    }
   }
 
   override func mouseUp(with event: NSEvent) {
+    let didSendPress = consumeLeftMouseReleaseOwnership()
     prevPressureStage = 0
-    sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
+    if didSendPress {
+      sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
+    }
     if let surface {
       ghostty_surface_mouse_pressure(surface, 0, 0)
     }
@@ -172,11 +178,14 @@ extension GhosttySurfaceView {
   }
 
   func localEventLeftMouseDown(_ event: NSEvent) -> NSEvent? {
+    resetLeftMousePressForNewMouseDown()
     guard let window, event.window != nil, window == event.window else { return event }
-    let location = convert(event.locationInWindow, from: nil)
-    guard hitTest(location) == self else { return event }
-    guard !NSApp.isActive || !window.isKeyWindow else { return event }
-    guard !focused else { return event }
+    guard window.contentView?.hitTest(event.locationInWindow) == self else { return event }
+    guard window.firstResponder !== self else { return event }
+    if NSApp.isActive, window.isKeyWindow {
+      guard window.makeFirstResponder(self) else { return event }
+      return nil
+    }
     window.makeFirstResponder(self)
     return event
   }
@@ -215,14 +224,16 @@ extension GhosttySurfaceView {
     ghostty_surface_mouse_pos(surface, point.x, yPosition, mods)
   }
 
+  @discardableResult
   func sendMouseButton(
     _ event: NSEvent,
     state: ghostty_input_mouse_state_e,
     button: ghostty_input_mouse_button_e
-  ) {
-    guard let surface else { return }
+  ) -> Bool {
+    guard let surface else { return false }
     let mods = ghosttyMods(event.modifierFlags)
     ghostty_surface_mouse_button(surface, state, button, mods)
+    return true
   }
 
 }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
@@ -25,18 +25,17 @@ extension GhosttySurfaceView {
   }
 
   override func mouseDown(with event: NSEvent) {
-    resetLeftMousePressForNewMouseDown()
-    if sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT) {
-      markLeftMousePressForwarded()
+    runtime.mouseCoordinator.forwardLeftMouseDown(for: id) {
+      sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT)
     }
   }
 
   override func mouseUp(with event: NSEvent) {
-    let didSendPress = consumeLeftMouseReleaseOwnership()
-    prevPressureStage = 0
-    if didSendPress {
-      sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
+    runtime.mouseCoordinator.forwardLeftMouseUp(for: id) {
+      _ = sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
     }
+    prevPressureStage = 0
+    onMousePressureResetForTesting?()
     if let surface {
       ghostty_surface_mouse_pressure(surface, 0, 0)
     }
@@ -178,16 +177,7 @@ extension GhosttySurfaceView {
   }
 
   func localEventLeftMouseDown(_ event: NSEvent) -> NSEvent? {
-    resetLeftMousePressForNewMouseDown()
-    guard let window, event.window != nil, window == event.window else { return event }
-    guard window.contentView?.hitTest(event.locationInWindow) == self else { return event }
-    guard window.firstResponder !== self else { return event }
-    if NSApp.isActive, window.isKeyWindow {
-      guard window.makeFirstResponder(self) else { return event }
-      return nil
-    }
-    window.makeFirstResponder(self)
-    return event
+    runtime.mouseCoordinator.localEventLeftMouseDown(event, for: self)
   }
 
   func scrollMods(for event: NSEvent) -> ghostty_input_scroll_mods_t {
@@ -230,6 +220,9 @@ extension GhosttySurfaceView {
     state: ghostty_input_mouse_state_e,
     button: ghostty_input_mouse_button_e
   ) -> Bool {
+    if let mouseButtonHandlerForTesting {
+      return mouseButtonHandlerForTesting(state, button)
+    }
     guard let surface else { return false }
     let mods = ghosttyMods(event.modifierFlags)
     ghostty_surface_mouse_button(surface, state, button, mods)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -80,28 +80,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
   }
 
-  /// Tracks whether this surface forwarded the current left-button press to Ghostty.
-  ///
-  /// AppKit may deliver a release to a different surface than the one that received the
-  /// press (for example, when a drag crosses a split). Keeping the ownership transition
-  /// explicit prevents those unmatched releases from changing Ghostty's selection state.
-  struct LeftMousePressState {
-    private(set) var ownsPress = false
-
-    mutating func resetForNewMouseDown() {
-      ownsPress = false
-    }
-
-    mutating func markPressForwarded() {
-      ownsPress = true
-    }
-
-    mutating func consumeRelease() -> Bool {
-      defer { ownsPress = false }
-      return ownsPress
-    }
-  }
-
   final class CachedValue<T> {
     private var value: T?
     private let fetch: () -> T
@@ -176,7 +154,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
   var lastPerformKeyEvent: TimeInterval?
   private var currentCursor: NSCursor = .iBeam
   var focused = false
-  private var leftMousePressState = LeftMousePressState()
   private var detachedFocusClearTask: Task<Void, Never>?
   var markedText = NSMutableAttributedString()
   var keyboardLayoutChangeKeyUpSuppression: KeyboardLayoutChangeKeyUpSuppression?
@@ -222,20 +199,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
   var onFontSizeShortcut: (() -> Void)?
   var onOcclusionAppliedForTesting: ((Bool) -> Void)?
   var attachmentStateForTesting: (() -> (hasSuperview: Bool, hasWindow: Bool))?
+  var mouseButtonHandlerForTesting: ((ghostty_input_mouse_state_e, ghostty_input_mouse_button_e) -> Bool)?
+  var onMousePressureResetForTesting: (() -> Void)?
 
   var accessibilityPaneIndexHelp: String?
-
-  func resetLeftMousePressForNewMouseDown() {
-    leftMousePressState.resetForNewMouseDown()
-  }
-
-  func markLeftMousePressForwarded() {
-    leftMousePressState.markPressForwarded()
-  }
-
-  func consumeLeftMouseReleaseOwnership() -> Bool {
-    leftMousePressState.consumeRelease()
-  }
 
   private static let mouseCursorMap: [ghostty_action_mouse_shape_e: NSCursor] = [
     GHOSTTY_MOUSE_SHAPE_DEFAULT: .arrow,

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -80,6 +80,28 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
   }
 
+  /// Tracks whether this surface forwarded the current left-button press to Ghostty.
+  ///
+  /// AppKit may deliver a release to a different surface than the one that received the
+  /// press (for example, when a drag crosses a split). Keeping the ownership transition
+  /// explicit prevents those unmatched releases from changing Ghostty's selection state.
+  struct LeftMousePressState {
+    private(set) var ownsPress = false
+
+    mutating func resetForNewMouseDown() {
+      ownsPress = false
+    }
+
+    mutating func markPressForwarded() {
+      ownsPress = true
+    }
+
+    mutating func consumeRelease() -> Bool {
+      defer { ownsPress = false }
+      return ownsPress
+    }
+  }
+
   final class CachedValue<T> {
     private var value: T?
     private let fetch: () -> T
@@ -154,6 +176,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   var lastPerformKeyEvent: TimeInterval?
   private var currentCursor: NSCursor = .iBeam
   var focused = false
+  private var leftMousePressState = LeftMousePressState()
   private var detachedFocusClearTask: Task<Void, Never>?
   var markedText = NSMutableAttributedString()
   var keyboardLayoutChangeKeyUpSuppression: KeyboardLayoutChangeKeyUpSuppression?
@@ -201,6 +224,18 @@ final class GhosttySurfaceView: NSView, Identifiable {
   var attachmentStateForTesting: (() -> (hasSuperview: Bool, hasWindow: Bool))?
 
   var accessibilityPaneIndexHelp: String?
+
+  func resetLeftMousePressForNewMouseDown() {
+    leftMousePressState.resetForNewMouseDown()
+  }
+
+  func markLeftMousePressForwarded() {
+    leftMousePressState.markPressForwarded()
+  }
+
+  func consumeLeftMouseReleaseOwnership() -> Bool {
+    leftMousePressState.consumeRelease()
+  }
 
   private static let mouseCursorMap: [ghostty_action_mouse_shape_e: NSCursor] = [
     GHOSTTY_MOUSE_SHAPE_DEFAULT: .arrow,

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -97,6 +97,83 @@ struct GhosttySurfaceViewTests {
     #expect(!GhosttySurfaceView.hasKeyEquivalentFocusOwnership(cachedFocused: false, isActualFirstResponder: true))
   }
 
+  @Test func leftMouseReleaseRequiresOwnedPress() {
+    var state = GhosttySurfaceView.LeftMousePressState()
+
+    let releaseWithoutPress = state.consumeRelease()
+    #expect(!releaseWithoutPress)
+
+    state.markPressForwarded()
+    let ownedRelease = state.consumeRelease()
+    let duplicateRelease = state.consumeRelease()
+    #expect(ownedRelease)
+    #expect(!duplicateRelease)
+  }
+
+  @Test func newLeftMouseDownClearsStaleOwnership() {
+    var state = GhosttySurfaceView.LeftMousePressState()
+
+    state.markPressForwarded()
+    state.resetForNewMouseDown()
+
+    let releaseAfterReset = state.consumeRelease()
+    #expect(!releaseAfterReset)
+  }
+
+  @Test func contentViewHitTestFindsScrolledSurface() throws {
+    let runtime = GhosttyRuntime()
+    let surfaceView = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let windowSize = CGSize(width: 400, height: 300)
+    let window = NSWindow(
+      contentRect: NSRect(origin: .zero, size: windowSize),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    defer { window.orderOut(nil) }
+
+    let contentView = NSView(frame: NSRect(origin: .zero, size: windowSize))
+    let scrollView = NSScrollView(frame: contentView.bounds)
+    scrollView.hasVerticalScroller = false
+    scrollView.contentView.clipsToBounds = false
+    let documentView = NSView(frame: NSRect(x: 0, y: 0, width: windowSize.width, height: 3_000))
+    surfaceView.frame = NSRect(x: 0, y: 2_000, width: windowSize.width, height: windowSize.height)
+    documentView.addSubview(surfaceView)
+    scrollView.documentView = documentView
+    contentView.addSubview(scrollView)
+    window.contentView = contentView
+    window.orderFront(nil)
+
+    scrollView.contentView.scroll(to: NSPoint(x: 0, y: 2_000))
+    scrollView.reflectScrolledClipView(scrollView.contentView)
+
+    let locationInWindow = NSPoint(x: 100, y: 100)
+    let event = try #require(
+      NSEvent.mouseEvent(
+        with: .leftMouseDown,
+        location: locationInWindow,
+        modifierFlags: [],
+        timestamp: 1,
+        windowNumber: window.windowNumber,
+        context: nil,
+        eventNumber: 1,
+        clickCount: 1,
+        pressure: 1
+      )
+    )
+
+    let surfaceLocalPoint = surfaceView.convert(locationInWindow, from: nil)
+    #expect(surfaceView.hitTest(surfaceLocalPoint) !== surfaceView)
+    #expect(contentView.hitTest(locationInWindow) === surfaceView)
+    _ = surfaceView.localEventLeftMouseDown(event)
+    #expect(window.firstResponder === surfaceView)
+  }
+
   @Test func occlusionStateResendsDesiredValueAfterAttachmentChange() {
     var state = GhosttySurfaceView.OcclusionState()
 

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -97,27 +97,168 @@ struct GhosttySurfaceViewTests {
     #expect(!GhosttySurfaceView.hasKeyEquivalentFocusOwnership(cachedFocused: false, isActualFirstResponder: true))
   }
 
-  @Test func leftMouseReleaseRequiresOwnedPress() {
-    var state = GhosttySurfaceView.LeftMousePressState()
+  @Test func leftMouseReleaseRequiresSharedOwnedPress() throws {
+    let runtime = GhosttyRuntime()
+    let surfaceView = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let mouseDown = try makeMouseEvent(type: .leftMouseDown)
+    let mouseUp = try makeMouseEvent(type: .leftMouseUp)
+    var pressCount = 0
+    var releaseCount = 0
+    var pressureResetCount = 0
+    surfaceView.mouseButtonHandlerForTesting = { state, button in
+      #expect(button == GHOSTTY_MOUSE_LEFT)
+      if state == GHOSTTY_MOUSE_PRESS {
+        pressCount += 1
+      } else if state == GHOSTTY_MOUSE_RELEASE {
+        releaseCount += 1
+      }
+      return true
+    }
+    surfaceView.onMousePressureResetForTesting = { pressureResetCount += 1 }
 
-    let releaseWithoutPress = state.consumeRelease()
-    #expect(!releaseWithoutPress)
+    surfaceView.prevPressureStage = 2
+    surfaceView.mouseUp(with: mouseUp)
+    #expect(releaseCount == 0)
+    #expect(surfaceView.prevPressureStage == 0)
 
-    state.markPressForwarded()
-    let ownedRelease = state.consumeRelease()
-    let duplicateRelease = state.consumeRelease()
-    #expect(ownedRelease)
-    #expect(!duplicateRelease)
+    surfaceView.mouseDown(with: mouseDown)
+    surfaceView.prevPressureStage = 2
+    surfaceView.mouseUp(with: mouseUp)
+    surfaceView.mouseUp(with: mouseUp)
+
+    #expect(pressCount == 1)
+    #expect(releaseCount == 1)
+    #expect(pressureResetCount == 3)
+    #expect(surfaceView.prevPressureStage == 0)
   }
 
-  @Test func newLeftMouseDownClearsStaleOwnership() {
-    var state = GhosttySurfaceView.LeftMousePressState()
+  @Test func crossPaneMouseReleaseClearsSharedOwnershipAndResetsPressure() throws {
+    let runtime = GhosttyRuntime()
+    let paneA = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      skipsSurfaceCreationForTesting: true
+    )
+    let paneB = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      skipsSurfaceCreationForTesting: true
+    )
+    let mouseDown = try makeMouseEvent(type: .leftMouseDown)
+    let mouseUp = try makeMouseEvent(type: .leftMouseUp)
+    var paneAReleaseCount = 0
+    var paneBReleaseCount = 0
+    var paneAPressureResetCount = 0
+    var paneBPressureResetCount = 0
+    paneA.mouseButtonHandlerForTesting = { state, _ in
+      if state == GHOSTTY_MOUSE_RELEASE {
+        paneAReleaseCount += 1
+      }
+      return true
+    }
+    paneB.mouseButtonHandlerForTesting = { state, _ in
+      if state == GHOSTTY_MOUSE_RELEASE {
+        paneBReleaseCount += 1
+      }
+      return true
+    }
+    paneA.onMousePressureResetForTesting = { paneAPressureResetCount += 1 }
+    paneB.onMousePressureResetForTesting = { paneBPressureResetCount += 1 }
 
-    state.markPressForwarded()
-    state.resetForNewMouseDown()
+    paneB.mouseDown(with: mouseDown)
+    paneA.prevPressureStage = 2
+    paneA.mouseUp(with: mouseUp)
+    paneB.prevPressureStage = 2
+    paneB.mouseUp(with: mouseUp)
 
-    let releaseAfterReset = state.consumeRelease()
-    #expect(!releaseAfterReset)
+    #expect(paneAReleaseCount == 0)
+    #expect(paneBReleaseCount == 0)
+    #expect(paneAPressureResetCount == 1)
+    #expect(paneBPressureResetCount == 1)
+    #expect(paneA.prevPressureStage == 0)
+    #expect(paneB.prevPressureStage == 0)
+  }
+
+  @Test func focusTransferClickClearsLaterPaneMouseOwnershipBeforeRelease() throws {
+    let mouseCoordinator = GhosttySurfaceMouseCoordinator(isActiveKeyWindow: { _ in true })
+    let runtime = GhosttyRuntime(mouseCoordinator: mouseCoordinator)
+    let paneA = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      skipsSurfaceCreationForTesting: true
+    )
+    let paneB = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      skipsSurfaceCreationForTesting: true
+    )
+    let windowSize = CGSize(width: 400, height: 200)
+    let window = NSWindow(
+      contentRect: NSRect(origin: .zero, size: windowSize),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    defer { window.orderOut(nil) }
+
+    let contentView = NSView(frame: NSRect(origin: .zero, size: windowSize))
+    paneA.frame = NSRect(x: 0, y: 0, width: 200, height: 200)
+    paneB.frame = NSRect(x: 200, y: 0, width: 200, height: 200)
+    contentView.addSubview(paneA)
+    contentView.addSubview(paneB)
+    window.contentView = contentView
+    window.orderFront(nil)
+    #expect(window.makeFirstResponder(paneB))
+
+    var paneBReleaseCount = 0
+    var paneBPressureResetCount = 0
+    paneB.mouseButtonHandlerForTesting = { state, _ in
+      if state == GHOSTTY_MOUSE_RELEASE {
+        paneBReleaseCount += 1
+      }
+      return true
+    }
+    paneB.onMousePressureResetForTesting = { paneBPressureResetCount += 1 }
+
+    let stalePress = try makeMouseEvent(
+      type: .leftMouseDown,
+      window: window,
+      location: NSPoint(x: 300, y: 100)
+    )
+    paneB.mouseDown(with: stalePress)
+
+    let focusClick = try makeMouseEvent(
+      type: .leftMouseDown,
+      window: window,
+      location: NSPoint(x: 100, y: 100)
+    )
+    // Pane A installed its monitor before pane B. Consuming here models AppKit stopping
+    // monitor dispatch before pane B's monitor can observe the new mouse-down.
+    let result = paneA.localEventLeftMouseDown(focusClick)
+    #expect(result == nil)
+    #expect(window.firstResponder === paneA)
+
+    paneB.prevPressureStage = 2
+    paneB.mouseUp(
+      with: try makeMouseEvent(
+        type: .leftMouseUp,
+        window: window,
+        location: NSPoint(x: 100, y: 100)
+      )
+    )
+
+    #expect(paneBReleaseCount == 0)
+    #expect(paneBPressureResetCount == 1)
+    #expect(paneB.prevPressureStage == 0)
   }
 
   @Test func contentViewHitTestFindsScrolledSurface() throws {
@@ -590,6 +731,26 @@ struct GhosttySurfaceViewTests {
         charactersIgnoringModifiers: charactersIgnoringModifiers,
         isARepeat: false,
         keyCode: keyCode
+      )
+    )
+  }
+
+  private func makeMouseEvent(
+    type: NSEvent.EventType,
+    window: NSWindow? = nil,
+    location: NSPoint = .zero
+  ) throws -> NSEvent {
+    try #require(
+      NSEvent.mouseEvent(
+        with: type,
+        location: location,
+        modifierFlags: [],
+        timestamp: 1,
+        windowNumber: window?.windowNumber ?? 0,
+        context: nil,
+        eventNumber: 1,
+        clickCount: 1,
+        pressure: 1
       )
     )
   }


### PR DESCRIPTION
## Problem

After producing long terminal output, dragging in scrollback or switching split focus could reuse an old selection anchor.

## Root cause

- `GhosttySurfaceScrollView` moves the surface frame origin while scrolling.
- The AppKit bridge performed `hitTest` in the surface's local coordinate space.
- Focus-transfer clicks could leak an unmatched press.
- Per-surface press ownership could survive when an earlier-created pane consumed a focus click before later event monitors ran.
- `mouseUp` did not verify that the receiving pane owned the corresponding press.

## Fix

- Hit-test from `window.contentView`.
- Use `window.firstResponder` for actual focus.
- Consume focus-transfer clicks in an active key window while leaving window-activation clicks in the normal event path.
- Coordinate left-button press ownership once per `GhosttyRuntime`, keyed by pane UUID.
- Clear shared ownership before any local left-mouse-down guard or consumed focus click.
- Only assign ownership after Ghostty receives a press, and only forward a matching release.
- Clear ownership and reset Force Touch pressure for matching, non-matching, and duplicate releases.
- Record the ownership decision in `docs-ai/007-ghostty-embedding-integration` and keep the documentation sync baseline reachable.

## Tests

- `GhosttySurfaceViewTests`: 32/32 passed.
- Added the monitor-order regression: pane A is created first, pane B retains stale ownership, A consumes the focus-transfer click, and B's later mouse-up sends no Ghostty release.
- Full app test suite: 2,551 tests in the main batch (2,548 passed, 3 skipped; 2,575 parameterized executions passed) plus 2/2 isolated shell-cancellation tests.
- `make test-scripts`: 35/35 passed.
- `make build-app`: passed with 0 errors and 0 warnings.
- Manual Debug verification with 12,000 lines of output, historical drag selection, A/B creation-order focus transfer, cross-pane release, window reactivation, double/triple click, and Control-click.

## Local check note

`make check` is not fully green locally: its strict `swift-format` stage passed, then the full-tree SwiftLint stage stopped on six pre-existing `legacy_swiftui_aspect_ratio` violations in `RepositoryIconImage.swift` and `AddToProwlView.swift`. Both files are unchanged from the rebased `onevcat/main`, and SwiftLint passed for every changed Swift file.

## CI note

> The workflow is currently waiting for maintainer approval (`action_required`).
> No CI result is being claimed until that workflow is approved and completes.
