### PR TITLE
Fix managed completion signal edge cases

### DIFF
--- a/ProwlCLI/Transport/SocketTransportClient.swift
+++ b/ProwlCLI/Transport/SocketTransportClient.swift
@@ -34,6 +34,7 @@ enum SocketTransportClient {
       )
     }
     defer { close(clientFD) }
+    try configureNoSigPipe(clientFD)
     let deadline = timeoutMilliseconds.map {
       DispatchTime.now().uptimeNanoseconds + UInt64(max(1, $0)) * 1_000_000
     }
@@ -72,6 +73,24 @@ enum SocketTransportClient {
   }
 
   // MARK: - Low-level I/O using Darwin/Glibc read/write
+
+  private static func configureNoSigPipe(_ descriptor: Int32) throws {
+    #if canImport(Darwin)
+      var enabled: Int32 = 1
+      let result = withUnsafePointer(to: &enabled) {
+        setsockopt(
+          descriptor,
+          SOL_SOCKET,
+          SO_NOSIGPIPE,
+          $0,
+          socklen_t(MemoryLayout<Int32>.size)
+        )
+      }
+      guard result == 0 else {
+        throw ExitError(code: CLIErrorCode.transportFailed, message: "Failed to configure socket safety.")
+      }
+    #endif
+  }
 
   private static func configureTimeout(_ descriptor: Int32, milliseconds: Int) throws {
     let bounded = max(1, milliseconds)
@@ -172,6 +191,7 @@ enum SocketTransportClient {
     case EINVAL: "EINVAL"
     case ENOENT: "ENOENT"
     case ENOTSOCK: "ENOTSOCK"
+    case EPIPE: "EPIPE"
     case EPERM: "EPERM"
     default: "errno \(errorNumber)"
     }

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -95,6 +95,38 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertLessThan(start.duration(to: clock.now), .milliseconds(700))
   }
 
+  func testNativeHookBridgeSurvivesClosedPeerWithDefaultSIGPIPEDisposition() throws {
+    let socketPath = temporarySocketPath(suffix: "hook-sigpipe")
+    let server = try MockSocketServer(
+      socketPath: socketPath,
+      responseData: Data(),
+      closesAfterRequestLength: true
+    )
+    try server.start()
+    defer { server.stop() }
+    let payload = try JSONSerialization.data(
+      withJSONObject: [
+        "hook_event_name": "Stop",
+        "session_id": "session-1",
+        "cwd": "/tmp/project",
+        "reason": String(repeating: "x", count: AgentSignalInput.maximumDetailBytes),
+      ]
+    )
+
+    let result = try runProwlWithDefaultSIGPIPE(
+      args: ["agents", "_hook", "claude", "Stop"],
+      environment: [
+        AgentNativeHookInput.tokenEnvironmentKey: "token-1",
+        ProwlSocket.environmentKey: socketPath,
+      ],
+      stdinData: payload
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    XCTAssertEqual(result.stdout, "")
+    XCTAssertEqual(result.stderr, "")
+  }
+
   func testCodexHookForwardsExactPayloadOnTransportLossAndScrubsInternalEnvironment() throws {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(
       "prowl-hook-forward-\(UUID().uuidString)",
@@ -2975,6 +3007,25 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     )
   }
 
+  private func runProwlWithDefaultSIGPIPE(
+    args: [String],
+    environment: [String: String],
+    stdinData: Data
+  ) throws -> CommandResult {
+    let binaryPath = try ensureProwlBinary()
+    var mergedEnvironment = ProcessInfo.processInfo.environment
+    for (key, value) in environment {
+      mergedEnvironment[key] = value
+    }
+    return try runProcess(
+      executable: "/bin/sh",
+      arguments: ["-c", "trap - PIPE; exec \"$@\"", "sh", binaryPath] + args,
+      currentDirectory: repoRoot.path,
+      environment: mergedEnvironment,
+      stdinData: stdinData
+    )
+  }
+
   private func ensureProwlBinary() throws -> String {
     let candidates = [
       repoRoot.appendingPathComponent(".build/debug/prowl").path,
@@ -3475,6 +3526,7 @@ private final class MockSocketServer: @unchecked Sendable {
   private let socketPath: String
   private let responseData: Data
   private let responseByteDelayMicroseconds: useconds_t
+  private let closesAfterRequestLength: Bool
 
   private var serverFD: Int32 = -1
   private var receivedRequestData: Data?
@@ -3484,11 +3536,13 @@ private final class MockSocketServer: @unchecked Sendable {
   init(
     socketPath: String,
     responseData: Data,
-    responseByteDelayMicroseconds: useconds_t = 0
+    responseByteDelayMicroseconds: useconds_t = 0,
+    closesAfterRequestLength: Bool = false
   ) throws {
     self.socketPath = socketPath
     self.responseData = responseData
     self.responseByteDelayMicroseconds = responseByteDelayMicroseconds
+    self.closesAfterRequestLength = closesAfterRequestLength
   }
 
   deinit { stop() }
@@ -3553,6 +3607,10 @@ private final class MockSocketServer: @unchecked Sendable {
 
       do {
         let lengthData = try self.readExact(fd: clientFD, count: 4)
+        if self.closesAfterRequestLength {
+          self.requestSemaphore.signal()
+          return
+        }
         let bodyLength = lengthData.withUnsafeBytes {
           UInt32(bigEndian: $0.load(as: UInt32.self))
         }

--- a/docs-ai/064-agent-completion-signals/007-s3a-action.md
+++ b/docs-ai/064-agent-completion-signals/007-s3a-action.md
@@ -222,6 +222,30 @@ source wait. The regression tests coordinate accept, peer close, and MainActor r
 they prove the peer closed after identity capture but before routing. The owned-descriptor test failed against the
 previous monitor and passes after duplication; the three disconnect-seam tests also passed ten repeated runs.
 
+A second post-merge review exposed four additional asymmetric boundaries. The login-shell runner now stops waiting
+for inherited pipe writers after the tracked shell exits, while still draining all immediately buffered output. The
+launch option scanner stops at `--`, matching managed-option insertion. Codex thread rotation retains a per-process
+set of retired session IDs, so detector-confirmed and hook-driven rotation accept a new thread without allowing a
+late event to rebind an old one. Login-shell facts now end with an explicit marker and must form one ordered,
+contiguous record, preserving unrelated profile output while rejecting multiline value truncation.
+
+The same review hardened descriptor exhaustion and lifecycle handling: peer descriptor duplication happens before
+routing and fails the connection closed with a warning, and the monitor activates its owned DispatchSource during
+construction so no suspended source can reach deinitialization. Seven focused regressions failed against the prior
+implementation and passed ten repeated runs after correction. The review's proposed narrowing of menu split fallback
+was rejected because menu/palette compatibility intentionally retries any failed saved split as a tab; the user guide
+now documents that behavior. A finite managed first-generation lifetime remains a separate design decision: restoring
+the old ten-second cutoff would reintroduce the verified slow-start failure, while indefinite registration remains
+constrained by token, runtime, CWD, event, and ancestry validation.
+
+The descriptor-duplication regression initially used an unbounded client response read, which could stall the full
+parallel test host under load. It now coordinates accept, peer close, and explicit rejection with semantic evidence.
+The final serialized app suite passed 2549 tests in 40.8 seconds, and the default parallel suite completed without a
+stall. Its only failures were the two pre-existing `ShellClientStreamingTests` cancellation timing flakes; both passed
+immediately in an isolated two-test run. Static format/lint checks, the CLI build and 97-test integration suite, and
+the Debug app build also passed. A final read-only adversarial review found no P0/P1 defects; its sole P2 corrected
+user documentation that still described the first managed generation as subject to the old acquisition deadline.
+
 ## Deferred scope
 
 S3b owns Copilot/Droid/Qoder adapters. S3c owns Pi/OMP/OpenCode adapters and the Active Agents exact

--- a/docs-ai/064-agent-completion-signals/007-s3a-action.md
+++ b/docs-ai/064-agent-completion-signals/007-s3a-action.md
@@ -178,6 +178,50 @@ round 3 verified 2521 app tests, 96 CLI integration tests, 34 script tests, stri
 the Debug build; round-3 focused regressions also pass. No P0/P1/P2 code finding remains. The only
 residual is the separately documented visible-GUI acceptance limitation.
 
+## Post-merge review hardening
+
+A 15-finding review arrived after PR #721 merged. Each finding was traced against the merged code and the
+verified correctness paths were reproduced before correction. Ten logic/runtime regressions failed together in
+the first focused RED run; two native failure paths were also reproduced independently with default signal and
+kernel peer-credential probes.
+
+The 12 verified correctness findings are fixed:
+
+- the shell probe now drains stdout/stderr through EOF instead of spinning on `POLLHUP`, so successful Codex
+  preflight completes normally;
+- managed registrations survive transient generation lookup failure and a genuinely slow first process, Codex
+  thread rotation rebinds the exact channel, and confirmed process replacement clears the prior session;
+- outbound CLI sockets, accepted app-server sockets, and Codex app-server stdin suppress `SIGPIPE` at the
+  descriptor level, preserving fail-open behavior without relying on Ghostty's process-wide signal policy;
+- menu/palette split launches again fall back to a tab, while explicit CLI/workflow split requests remain strict;
+- generated Claude/Codex options stay before an existing `--`, and Claude option scanning stops at that boundary;
+- login-shell marker parsing tolerates unrelated profile output while still rejecting duplicate/incomplete facts;
+- every live forwarding-store instance holds an owner lock for its session directory, so a second Debug/Release
+  instance cannot sweep records that are merely old; crashed stores remain reclaimable;
+- the socket accept loop freezes same-user PID ancestry before MainActor routing, and native hooks continue routing
+  after their bounded client exits; ordinary long-running CLI requests retain disconnect cancellation;
+- deferred Ghostty surfaces apply the `font_size_adjusted` no-op only after native creation, preserving inherited
+  and preferred font sizes across config reloads.
+
+The three cleanup findings were deliberately not expanded into this correctness patch: the two subprocess runners
+still share only behavioral tests rather than a new abstraction, repeated evidence lookup remains bounded by entry
+deduplication/title coalescing, and startup orphan maintenance remains synchronous and normally tiny. No measured
+user impact justified broad lifecycle or concurrency refactors. The one-second shell deadline also remains: the
+verified defect was strict whole-stdout parsing, while the local real login shell completed in under 10 ms and the
+review supplied no slow-shell measurement. The deadline continues to fail soft with an explicit warning.
+
+Focused RED → GREEN coverage now includes successful child EOF, shell banners, `--`, generation flaps and delayed
+startup, Codex `/new`, process/session replacement, active cross-instance orphan ownership, split fallback, native
+font initialization, default-`SIGPIPE` CLI execution, early app-server exit, and short-lived socket peers.
+
+A follow-up disconnect-seam review found two additional lifetime gaps and one nondeterministic test. Accepted sockets
+now receive `SO_NOSIGPIPE` and `FD_CLOEXEC` immediately after `accept`. The disconnect monitor atomically duplicates
+its descriptor with `F_DUPFD_CLOEXEC`, monitors only that owned descriptor, and closes it from the DispatchSource
+cancellation handler; `handleClient` remains the sole owner of the accepted descriptor and performs no synchronous
+source wait. The regression tests coordinate accept, peer close, and MainActor routing with explicit semaphores, so
+they prove the peer closed after identity capture but before routing. The owned-descriptor test failed against the
+previous monitor and passes after duplication; the three disconnect-seam tests also passed ten repeated runs.
+
 ## Deferred scope
 
 S3b owns Copilot/Droid/Qoder adapters. S3c owns Pi/OMP/OpenCode adapters and the Active Agents exact

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -163,8 +163,9 @@ native event bridges without writing user, dedicated-home, or project configurat
 Only an app-issued token plus exact caller-process ancestry and matching pane/runtime/cwd can
 produce `hook_claude` / `hook_codex` evidence. The channel is not advertised as
 `verified_live` until a valid native event completes that end-to-end check. Early Claude
-`SessionStart` payloads wait for the first timely process generation instead of being lost;
-a late or replacement process, pane close, or launched-agent exit revokes coverage.
+`SessionStart` payloads wait for the first matching process generation instead of being lost.
+That first generation may attach after the detector's acquisition window; once attached, a
+replacement process, pane close, or launched-agent exit revokes coverage.
 
 Codex exposes only one effective notifier. Before launch, Prowl asks Codex's own bounded
 `app-server config/read` protocol for the effective notifier, applies selected-profile and

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -46,8 +46,10 @@ respawn.
 
 Every launch creates a **new** tab or split; Prowl never types the invocation into an
 existing shell. Toolbar and Command Palette launches use the Profile's saved placement in
-the current worktree and start interactively with no initial prompt. CLI launches override
-placement from the `create tab|pane` command and may supply the kickoff prompt. A prompted
+the current worktree and start interactively with no initial prompt; if a saved split cannot
+be created, these interactive launchers fall back to a foreground tab. CLI launches override
+placement from the `create tab|pane` command, remain strict about pane placement, and may
+supply the kickoff prompt. A prompted
 CLI launch is also an atomic dispatch: its create response includes a pending opaque receipt,
 the launched child alone receives `PROWL_DISPATCH_ID`, and the effective prompt tells the
 agent to finish with `prowl agents dispatch-complete --outcome … --summary …`; the required

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -739,7 +739,16 @@ struct SupacodeApp: App {
       }
     )
     let agentHookHandler = AgentNativeHookCommandHandler(
-      resolveCaller: resolveAgentSignalCaller,
+      resolveCaller: { context in
+        if !context.callerProcessAncestry.isEmpty {
+          return CallerPaneResolver.pane(
+            forCallerProcessAncestry: context.callerProcessAncestry,
+            paneByShellPID: terminalManager.paneByShellPID()
+          )
+        }
+        guard let processID = context.callerProcessID else { return nil }
+        return resolveAgentSignalCaller(processID)
+      },
       recordHook: { caller, input in
         terminalManager.recordAgentNativeHook(input, caller: caller)
       }

--- a/supacode/CLIService/AgentNativeHookCommandHandler.swift
+++ b/supacode/CLIService/AgentNativeHookCommandHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 final class AgentNativeHookCommandHandler: CommandHandler {
-  typealias ResolveCaller = @MainActor (pid_t) -> CallerPane?
+  typealias ResolveCaller = @MainActor (CLICommandContext) -> CallerPane?
   typealias RecordHook = @MainActor (CallerPane, AgentNativeHookInput) -> Bool
 
   private let resolveCaller: ResolveCaller
@@ -37,8 +37,8 @@ final class AgentNativeHookCommandHandler: CommandHandler {
     else {
       return failure(code: CLIErrorCode.invalidArgument)
     }
-    guard let processID = context.callerProcessID,
-      let caller = resolveCaller(processID),
+    guard context.callerProcessID != nil,
+      let caller = resolveCaller(context),
       recordHook(caller, input)
     else {
       return failure(code: CLIErrorCode.sourceRequired)

--- a/supacode/CLIService/CLICommandContext.swift
+++ b/supacode/CLIService/CLICommandContext.swift
@@ -3,16 +3,29 @@
 
 import Foundation
 
-/// Connection-scoped facts about the calling `prowl` process. Handlers that
-/// need caller identity (handoff's caller-pane resolution) read it; every
-/// other handler ignores it via the protocol's default forwarding.
+nonisolated struct CallerProcessIdentity: Sendable, Equatable {
+  let processID: pid_t
+  let startedAt: Date?
+}
+
+/// Connection-scoped facts about the calling `prowl` process. The ancestry is
+/// frozen at accept time because a short-lived hook may exit before MainActor
+/// routing begins.
 nonisolated struct CLICommandContext: Sendable, Equatable {
-  /// PID of the peer process on the socket (`LOCAL_PEERPID`), when the kernel
-  /// reported one.
   let callerProcessID: pid_t?
+  let callerProcessAncestry: [CallerProcessIdentity]
 
   init(callerProcessID: pid_t? = nil) {
     self.callerProcessID = callerProcessID
+    callerProcessAncestry = []
+  }
+
+  init(
+    callerProcessID: pid_t?,
+    callerProcessAncestry: [CallerProcessIdentity]
+  ) {
+    self.callerProcessID = callerProcessID
+    self.callerProcessAncestry = callerProcessAncestry
   }
 }
 
@@ -38,6 +51,27 @@ nonisolated struct CallerPane: Sendable, Equatable {
 /// caller outside any Prowl pane (another terminal app, a script, tmux's
 /// server-owned processes) resolves to nil — never to a guess.
 nonisolated enum CallerPaneResolver {
+  static func processAncestry(
+    forCallerProcess callerPID: pid_t,
+    parentProcessID: (pid_t) -> pid_t? = { pid in
+      ProcessDetection.processBSDInfo(pid: pid).map { pid_t($0.pbi_ppid) }
+    },
+    processStartDate: (pid_t) -> Date? = ProcessDetection.processStartDate
+  ) -> [CallerProcessIdentity] {
+    var pid = callerPID
+    var hops = 0
+    var ancestry: [CallerProcessIdentity] = []
+    while pid > 1, hops < 32 {
+      ancestry.append(
+        CallerProcessIdentity(processID: pid, startedAt: processStartDate(pid))
+      )
+      guard let parent = parentProcessID(pid), parent != pid else { break }
+      pid = parent
+      hops += 1
+    }
+    return ancestry
+  }
+
   static func pane(
     forCallerProcess callerPID: pid_t,
     paneByShellPID: [pid_t: CallerPane],
@@ -46,23 +80,34 @@ nonisolated enum CallerPaneResolver {
     },
     processStartDate: (pid_t) -> Date? = ProcessDetection.processStartDate
   ) -> CallerPane? {
-    var pid = callerPID
-    var hops = 0
-    var ancestry: [AgentProcessGeneration] = []
-    while pid > 1, hops < 32 {
-      if let startedAt = processStartDate(pid) {
-        ancestry.append(AgentProcessGeneration(pid: pid, startedAt: startedAt))
+    pane(
+      forCallerProcessAncestry: processAncestry(
+        forCallerProcess: callerPID,
+        parentProcessID: parentProcessID,
+        processStartDate: processStartDate
+      ),
+      paneByShellPID: paneByShellPID
+    )
+  }
+
+  static func pane(
+    forCallerProcessAncestry identities: [CallerProcessIdentity],
+    paneByShellPID: [pid_t: CallerPane]
+  ) -> CallerPane? {
+    var generations: [AgentProcessGeneration] = []
+    for identity in identities {
+      if let startedAt = identity.startedAt {
+        generations.append(
+          AgentProcessGeneration(pid: identity.processID, startedAt: startedAt)
+        )
       }
-      if let pane = paneByShellPID[pid] {
+      if let pane = paneByShellPID[identity.processID] {
         return CallerPane(
           worktreeID: pane.worktreeID,
           surfaceID: pane.surfaceID,
-          processAncestry: ancestry
+          processAncestry: generations
         )
       }
-      guard let parent = parentProcessID(pid), parent != pid else { return nil }
-      pid = parent
-      hops += 1
     }
     return nil
   }

--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -16,6 +16,7 @@ final class CLISocketServer {
   private let router: CLICommandRouter
   private let socketPath: String
   private let lockPath: String
+  private let onClientAccepted: (@Sendable () -> Void)?
   private var serverFD: Int32 = -1
   private var lockFD: Int32 = -1
   private var ownsSocket = false
@@ -24,11 +25,15 @@ final class CLISocketServer {
     label: "com.onevcat.prowl.cli-accept", qos: .userInitiated)
 
   init(
-    router: CLICommandRouter, socketPath: String = ProwlSocket.defaultPath, lockPath: String? = nil
+    router: CLICommandRouter,
+    socketPath: String = ProwlSocket.defaultPath,
+    lockPath: String? = nil,
+    onClientAccepted: (@Sendable () -> Void)? = nil
   ) {
     self.router = router
     self.socketPath = socketPath
     self.lockPath = lockPath ?? "\(socketPath).lock"
+    self.onClientAccepted = onClientAccepted
   }
 
   /// Start listening for CLI connections.
@@ -106,8 +111,13 @@ final class CLISocketServer {
     // not occupy a Swift cooperative-thread-pool thread (which would starve
     // the concurrency runtime and hang the app – especially during testing).
     let listeningFD = serverFD
+    let onClientAccepted = onClientAccepted
     acceptQueue.async { [weak self] in
-      Self.acceptLoop(serverFD: listeningFD, server: self)
+      Self.acceptLoop(
+        serverFD: listeningFD,
+        server: self,
+        onClientAccepted: onClientAccepted
+      )
     }
   }
 
@@ -173,7 +183,11 @@ final class CLISocketServer {
 
   // MARK: - Accept loop (runs on acceptQueue, NOT in Swift concurrency)
 
-  private nonisolated static func acceptLoop(serverFD: Int32, server: CLISocketServer?) {
+  private nonisolated static func acceptLoop(
+    serverFD: Int32,
+    server: CLISocketServer?,
+    onClientAccepted: (@Sendable () -> Void)?
+  ) {
     while true {
       let clientFD = Darwin.accept(serverFD, nil, nil)
       guard clientFD >= 0 else {
@@ -181,8 +195,20 @@ final class CLISocketServer {
         return
       }
       if let server {
+        guard configureAcceptedClient(clientFD), clientHasCurrentUser(clientFD) else {
+          Darwin.close(clientFD)
+          continue
+        }
+        let callerProcessID = peerProcessID(clientFD)
+        let context = CLICommandContext(
+          callerProcessID: callerProcessID,
+          callerProcessAncestry: callerProcessID.map {
+            CallerPaneResolver.processAncestry(forCallerProcess: $0)
+          } ?? []
+        )
+        onClientAccepted?()
         Task { @MainActor in
-          await server.handleClient(clientFD: clientFD)
+          await server.handleClient(clientFD: clientFD, context: context)
         }
       } else {
         Darwin.close(clientFD)
@@ -190,12 +216,10 @@ final class CLISocketServer {
     }
   }
 
-  private func handleClient(clientFD: Int32) async {
+  private func handleClient(clientFD: Int32, context: CLICommandContext) async {
     defer { Darwin.close(clientFD) }
 
     do {
-      guard Self.clientHasCurrentUser(clientFD) else { return }
-
       // Read length-prefixed request
       let lengthData = try Self.fdRead(fildes: clientFD, count: 4)
       let length = lengthData.withUnsafeBytes {
@@ -209,18 +233,24 @@ final class CLISocketServer {
       let decoder = JSONDecoder()
       let envelope = try decoder.decode(CommandEnvelope.self, from: requestData)
 
-      // Route to handler with connection-scoped caller identity
-      let context = CLICommandContext(callerProcessID: Self.peerProcessID(clientFD))
+      // Hidden native hooks are fire-and-forget: their caller identity was
+      // frozen at accept time, so routing must survive the bounded client exit.
+      let preservesRouteAfterDisconnect: Bool
+      if case .agentsHook = envelope.command {
+        preservesRouteAfterDisconnect = true
+      } else {
+        preservesRouteAfterDisconnect = false
+      }
       let routeTask = Task { @MainActor [router] in
         await router.route(envelope, context: context)
       }
       let monitor = CLIPeerDisconnectMonitor(fileDescriptor: clientFD) {
-        routeTask.cancel()
+        if !preservesRouteAfterDisconnect { routeTask.cancel() }
       }
-      monitor.start()
+      monitor?.start()
       let response = await routeTask.value
-      monitor.cancel()
-      guard !monitor.didDisconnect else { return }
+      monitor?.cancel()
+      guard monitor?.didDisconnect != true else { return }
 
       // Encode and send response
       let encoder = JSONEncoder()
@@ -236,13 +266,30 @@ final class CLISocketServer {
     }
   }
 
-  static func isAllowedPeerUID(_ peerUID: uid_t, currentUID: uid_t = geteuid()) -> Bool {
+  nonisolated static func configureAcceptedClient(_ fileDescriptor: Int32) -> Bool {
+    #if canImport(Darwin)
+      var enabled: Int32 = 1
+      let noSigPipe = withUnsafePointer(to: &enabled) {
+        setsockopt(
+          fileDescriptor,
+          SOL_SOCKET,
+          SO_NOSIGPIPE,
+          $0,
+          socklen_t(MemoryLayout<Int32>.size)
+        )
+      }
+      guard noSigPipe == 0 else { return false }
+    #endif
+    return (try? setCloseOnExec(fileDescriptor)) != nil
+  }
+
+  nonisolated static func isAllowedPeerUID(_ peerUID: uid_t, currentUID: uid_t = geteuid()) -> Bool {
     peerUID == currentUID
   }
 
   /// PID of the peer process on a connected AF_UNIX socket, or nil when the
   /// kernel cannot report one.
-  static func peerProcessID(_ clientFD: Int32) -> pid_t? {
+  nonisolated static func peerProcessID(_ clientFD: Int32) -> pid_t? {
     #if canImport(Darwin)
       var pid: pid_t = 0
       var length = socklen_t(MemoryLayout<pid_t>.size)
@@ -256,7 +303,7 @@ final class CLISocketServer {
     #endif
   }
 
-  private static func clientHasCurrentUser(_ clientFD: Int32) -> Bool {
+  private nonisolated static func clientHasCurrentUser(_ clientFD: Int32) -> Bool {
     #if canImport(Darwin)
       var peerUID = uid_t()
       var peerGID = gid_t()
@@ -301,7 +348,7 @@ final class CLISocketServer {
     }
   }
 
-  private static func setCloseOnExec(_ fileDescriptor: Int32) throws {
+  private nonisolated static func setCloseOnExec(_ fileDescriptor: Int32) throws {
     let flags = fcntl(fileDescriptor, F_GETFD)
     guard flags >= 0 else {
       throw CLIServiceError.closeOnExecFailed
@@ -362,16 +409,29 @@ final class CLISocketServer {
 /// Watches a fully-consumed request socket without consuming bytes. EOF or
 /// unexpected post-frame input cancels the request task so long waits cannot
 /// outlive their CLI process.
-private nonisolated final class CLIPeerDisconnectMonitor: @unchecked Sendable {
+nonisolated final class CLIPeerDisconnectMonitor: @unchecked Sendable {
   private let fileDescriptor: Int32
   private let onDisconnect: @Sendable () -> Void
+  private let source: DispatchSourceRead
   private let lock = NSLock()
-  private var source: DispatchSourceRead?
   private var disconnected = false
 
-  init(fileDescriptor: Int32, onDisconnect: @escaping @Sendable () -> Void) {
-    self.fileDescriptor = fileDescriptor
+  init?(fileDescriptor: Int32, onDisconnect: @escaping @Sendable () -> Void) {
+    let ownedDescriptor = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, 0)
+    guard ownedDescriptor >= 0 else { return nil }
+    let source = DispatchSource.makeReadSource(
+      fileDescriptor: ownedDescriptor,
+      queue: DispatchQueue.global(qos: .userInitiated)
+    )
+    self.fileDescriptor = ownedDescriptor
     self.onDisconnect = onDisconnect
+    self.source = source
+    source.setEventHandler { [weak self] in self?.inspect() }
+    source.setCancelHandler { Darwin.close(ownedDescriptor) }
+  }
+
+  deinit {
+    cancel()
   }
 
   var didDisconnect: Bool {
@@ -379,21 +439,11 @@ private nonisolated final class CLIPeerDisconnectMonitor: @unchecked Sendable {
   }
 
   func start() {
-    let source = DispatchSource.makeReadSource(
-      fileDescriptor: fileDescriptor,
-      queue: DispatchQueue.global(qos: .userInitiated)
-    )
-    source.setEventHandler { [weak self] in self?.inspect() }
-    lock.withLock { self.source = source }
     source.resume()
   }
 
   func cancel() {
-    let source = lock.withLock { () -> DispatchSourceRead? in
-      defer { self.source = nil }
-      return self.source
-    }
-    source?.cancel()
+    source.cancel()
   }
 
   private func inspect() {

--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -9,6 +9,8 @@ import Foundation
   import Glibc
 #endif
 
+private let cliSocketLogger = SupaLogger("CLISocketServer")
+
 @MainActor
 final class CLISocketServer {
   private static let maximumFrameLength = 32 * 1_024 * 1_024
@@ -17,6 +19,8 @@ final class CLISocketServer {
   private let socketPath: String
   private let lockPath: String
   private let onClientAccepted: (@Sendable () -> Void)?
+  private let onPeerMonitorUnavailable: (@Sendable () -> Void)?
+  private let duplicatePeerDescriptor: @Sendable (Int32) -> Int32
   private var serverFD: Int32 = -1
   private var lockFD: Int32 = -1
   private var ownsSocket = false
@@ -28,12 +32,18 @@ final class CLISocketServer {
     router: CLICommandRouter,
     socketPath: String = ProwlSocket.defaultPath,
     lockPath: String? = nil,
-    onClientAccepted: (@Sendable () -> Void)? = nil
+    onClientAccepted: (@Sendable () -> Void)? = nil,
+    onPeerMonitorUnavailable: (@Sendable () -> Void)? = nil,
+    duplicatePeerDescriptor: @escaping @Sendable (Int32) -> Int32 = {
+      fcntl($0, F_DUPFD_CLOEXEC, 0)
+    }
   ) {
     self.router = router
     self.socketPath = socketPath
     self.lockPath = lockPath ?? "\(socketPath).lock"
     self.onClientAccepted = onClientAccepted
+    self.onPeerMonitorUnavailable = onPeerMonitorUnavailable
+    self.duplicatePeerDescriptor = duplicatePeerDescriptor
   }
 
   /// Start listening for CLI connections.
@@ -241,16 +251,21 @@ final class CLISocketServer {
       } else {
         preservesRouteAfterDisconnect = false
       }
+      let monitorDescriptor = duplicatePeerDescriptor(clientFD)
+      guard monitorDescriptor >= 0 else {
+        cliSocketLogger.warning("Failed to duplicate a CLI peer descriptor")
+        onPeerMonitorUnavailable?()
+        return
+      }
       let routeTask = Task { @MainActor [router] in
         await router.route(envelope, context: context)
       }
-      let monitor = CLIPeerDisconnectMonitor(fileDescriptor: clientFD) {
+      let monitor = CLIPeerDisconnectMonitor(ownedFileDescriptor: monitorDescriptor) {
         if !preservesRouteAfterDisconnect { routeTask.cancel() }
       }
-      monitor?.start()
       let response = await routeTask.value
-      monitor?.cancel()
-      guard monitor?.didDisconnect != true else { return }
+      monitor.cancel()
+      guard !monitor.didDisconnect else { return }
 
       // Encode and send response
       let encoder = JSONEncoder()
@@ -416,18 +431,27 @@ nonisolated final class CLIPeerDisconnectMonitor: @unchecked Sendable {
   private let lock = NSLock()
   private var disconnected = false
 
-  init?(fileDescriptor: Int32, onDisconnect: @escaping @Sendable () -> Void) {
-    let ownedDescriptor = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, 0)
-    guard ownedDescriptor >= 0 else { return nil }
+  convenience init?(
+    fileDescriptor: Int32,
+    duplicateDescriptor: @Sendable (Int32) -> Int32 = { fcntl($0, F_DUPFD_CLOEXEC, 0) },
+    onDisconnect: @escaping @Sendable () -> Void
+  ) {
+    let ownedFileDescriptor = duplicateDescriptor(fileDescriptor)
+    guard ownedFileDescriptor >= 0 else { return nil }
+    self.init(ownedFileDescriptor: ownedFileDescriptor, onDisconnect: onDisconnect)
+  }
+
+  init(ownedFileDescriptor: Int32, onDisconnect: @escaping @Sendable () -> Void) {
     let source = DispatchSource.makeReadSource(
-      fileDescriptor: ownedDescriptor,
+      fileDescriptor: ownedFileDescriptor,
       queue: DispatchQueue.global(qos: .userInitiated)
     )
-    self.fileDescriptor = ownedDescriptor
+    fileDescriptor = ownedFileDescriptor
     self.onDisconnect = onDisconnect
     self.source = source
     source.setEventHandler { [weak self] in self?.inspect() }
-    source.setCancelHandler { Darwin.close(ownedDescriptor) }
+    source.setCancelHandler { Darwin.close(ownedFileDescriptor) }
+    source.activate()
   }
 
   deinit {
@@ -436,10 +460,6 @@ nonisolated final class CLIPeerDisconnectMonitor: @unchecked Sendable {
 
   var didDisconnect: Bool {
     lock.withLock { disconnected }
-  }
-
-  func start() {
-    source.resume()
   }
 
   func cancel() {

--- a/supacode/Domain/AgentRuntime/CodexConfigReadProcess.swift
+++ b/supacode/Domain/AgentRuntime/CodexConfigReadProcess.swift
@@ -166,21 +166,29 @@ nonisolated struct CodexConfigReadProcess: Sendable {
     process.standardInput = input
     process.standardOutput = output
     process.standardError = FileHandle.nullDevice
+    guard configureNoSigPipe(input.fileHandleForWriting.fileDescriptor) else {
+      throw CodexConfigReadProcessError.processFailed
+    }
     processBox.install(process)
     try process.run()
+    defer {
+      stop(process)
+      try? input.fileHandleForWriting.close()
+      try? output.fileHandleForReading.close()
+    }
     let request = CodexConfigReadProtocol.requestData(
       cwd: query.cwd.path(percentEncoded: false)
     )
-    try input.fileHandleForWriting.write(contentsOf: request)
-    try input.fileHandleForWriting.close()
+    do {
+      try input.fileHandleForWriting.write(contentsOf: request)
+      try input.fileHandleForWriting.close()
+    } catch {
+      throw CodexConfigReadProcessError.processFailed
+    }
 
     let descriptor = output.fileHandleForReading.fileDescriptor
     let deadline = DispatchTime.now().uptimeNanoseconds + UInt64(timeout * 1_000_000_000)
     var transcript = Data()
-    defer {
-      stop(process)
-      try? output.fileHandleForReading.close()
-    }
 
     while DispatchTime.now().uptimeNanoseconds < deadline {
       if Task.isCancelled { throw CodexConfigReadProcessError.cancelled }
@@ -210,6 +218,14 @@ nonisolated struct CodexConfigReadProcess: Sendable {
       }
     }
     throw CodexConfigReadProcessError.timeout
+  }
+
+  static func configureNoSigPipe(_ descriptor: Int32) -> Bool {
+    #if canImport(Darwin)
+      fcntl(descriptor, F_SETNOSIGPIPE, 1) == 0
+    #else
+      true
+    #endif
   }
 
   private static func stop(_ process: Process) {

--- a/supacode/Domain/AgentRuntime/CodexEffectiveNotifyResolver.swift
+++ b/supacode/Domain/AgentRuntime/CodexEffectiveNotifyResolver.swift
@@ -23,11 +23,12 @@ nonisolated private struct CodexLaunchOptionScanner {
 
   mutating func scan() throws {
     while index < arguments.count {
+      let argument = arguments[index]
+      if argument == "--" { break }
       if index == promptArgumentIndex {
         index += 1
         continue
       }
-      let argument = arguments[index]
       if argument == "--ignore-user-config" {
         throw CodexLaunchContextError.ignoredUserConfig
       }

--- a/supacode/Domain/AgentRuntime/CodexForwardingRecordStore.swift
+++ b/supacode/Domain/AgentRuntime/CodexForwardingRecordStore.swift
@@ -18,6 +18,7 @@ final class CodexForwardingRecordStore {
   private let orphanMaximumAge: TimeInterval
   private let now: @MainActor () -> Date
   private let retirementClock: any Clock<Duration>
+  private var sessionLockDescriptor: Int32 = -1
   private var retired: [URL: Date] = [:]
   private var cleanupTask: Task<Void, Never>?
 
@@ -39,10 +40,18 @@ final class CodexForwardingRecordStore {
       directoryHint: .isDirectory
     )
     try Self.ensureOwnerOnlyDirectory(sessionDirectory)
+    sessionLockDescriptor = try Self.acquireSessionOwnerLock(in: sessionDirectory)
     try FileManager.default.setAttributes(
       [.modificationDate: now()],
       ofItemAtPath: sessionDirectory.path(percentEncoded: false)
     )
+  }
+
+  isolated deinit {
+    if sessionLockDescriptor >= 0 {
+      flock(sessionLockDescriptor, LOCK_UN)
+      Darwin.close(sessionLockDescriptor)
+    }
   }
 
   func create(argv: [String]) throws -> CodexForwardingRecord {
@@ -149,11 +158,20 @@ final class CodexForwardingRecordStore {
         let values = try? directory.resourceValues(forKeys: [.contentModificationDateKey, .isDirectoryKey]),
         values.isDirectory == true,
         let modified = values.contentModificationDate,
-        modified <= cutoff,
-        canExclusivelyLeaseEveryRecord(in: directory)
+        modified <= cutoff
       else { continue }
-      try? FileManager.default.removeItem(at: directory)
+      removeOrphanDirectoryIfUnlocked(directory)
     }
+  }
+
+  private func removeOrphanDirectoryIfUnlocked(_ directory: URL) {
+    guard let descriptor = try? Self.acquireSessionOwnerLock(in: directory) else { return }
+    defer {
+      flock(descriptor, LOCK_UN)
+      Darwin.close(descriptor)
+    }
+    guard canExclusivelyLeaseEveryRecord(in: directory) else { return }
+    try? FileManager.default.removeItem(at: directory)
   }
 
   private func canExclusivelyLeaseEveryRecord(in directory: URL) -> Bool {
@@ -190,6 +208,27 @@ final class CodexForwardingRecordStore {
     guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else { return false }
     defer { flock(descriptor, LOCK_UN) }
     return unlink(path) == 0 || errno == ENOENT
+  }
+
+  private static func acquireSessionOwnerLock(in directory: URL) throws -> Int32 {
+    let lockURL = directory.appending(path: ".owner.lock", directoryHint: .notDirectory)
+    let descriptor = Darwin.open(
+      lockURL.path(percentEncoded: false),
+      O_RDWR | O_CREAT | O_NOFOLLOW | O_CLOEXEC,
+      0o600
+    )
+    guard descriptor >= 0 else { throw CodexForwardingRecordError.invalidRecord }
+    var metadata = stat()
+    guard fstat(descriptor, &metadata) == 0,
+      (metadata.st_mode & S_IFMT) == S_IFREG,
+      metadata.st_uid == geteuid(),
+      metadata.st_mode & 0o777 == 0o600,
+      flock(descriptor, LOCK_EX | LOCK_NB) == 0
+    else {
+      Darwin.close(descriptor)
+      throw CodexForwardingRecordError.invalidRecord
+    }
+    return descriptor
   }
 
   private static func ensureOwnerOnlyDirectory(_ directory: URL) throws {

--- a/supacode/Domain/AgentRuntime/CodexShellLaunchEnvironment.swift
+++ b/supacode/Domain/AgentRuntime/CodexShellLaunchEnvironment.swift
@@ -9,11 +9,13 @@ nonisolated enum CodexShellLaunchEnvironmentProbe {
   private static let executableMarker = "__PROWL_CODEX_EXECUTABLE__"
   private static let homeMarker = "__PROWL_CODEX_HOME_BASE__"
   private static let codexHomeMarker = "__PROWL_CODEX_HOME__"
+  private static let endMarker = "__PROWL_CODEX_END__"
   private static let script = """
     executable="$(command -v -- codex)" || exit 1
     printf '%s%s\n' '\(executableMarker)' "$executable"
     printf '%s%s\n' '\(homeMarker)' "${HOME-}"
     printf '%s%s\n' '\(codexHomeMarker)' "${CODEX_HOME-}"
+    printf '%s\n' '\(endMarker)'
     """
 
   static func resolve(
@@ -54,14 +56,21 @@ nonisolated enum CodexShellLaunchEnvironmentProbe {
   }
 
   private static func parse(_ output: String) -> [String: String]? {
+    let lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
     let markers = [executableMarker, homeMarker, codexHomeMarker]
-    var values: [String: String] = [:]
-    for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
-      let value = String(line)
-      guard let marker = markers.first(where: value.hasPrefix) else { continue }
-      guard values[marker] == nil else { return nil }
-      values[marker] = String(value.dropFirst(marker.count))
-    }
-    return values.count == markers.count ? values : nil
+    guard
+      markers.allSatisfy({ marker in lines.count(where: { $0.hasPrefix(marker) }) == 1 }),
+      lines.count(where: { $0 == endMarker }) == 1,
+      let startIndex = lines.firstIndex(where: { $0.hasPrefix(executableMarker) }),
+      lines.indices.contains(startIndex + 3),
+      lines[startIndex + 1].hasPrefix(homeMarker),
+      lines[startIndex + 2].hasPrefix(codexHomeMarker),
+      lines[startIndex + 3] == endMarker
+    else { return nil }
+    return [
+      executableMarker: String(lines[startIndex].dropFirst(executableMarker.count)),
+      homeMarker: String(lines[startIndex + 1].dropFirst(homeMarker.count)),
+      codexHomeMarker: String(lines[startIndex + 2].dropFirst(codexHomeMarker.count)),
+    ]
   }
 }

--- a/supacode/Domain/AgentRuntime/CodexShellLaunchEnvironment.swift
+++ b/supacode/Domain/AgentRuntime/CodexShellLaunchEnvironment.swift
@@ -54,17 +54,14 @@ nonisolated enum CodexShellLaunchEnvironmentProbe {
   }
 
   private static func parse(_ output: String) -> [String: String]? {
-    let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
-    guard lines.count == 4, lines.last?.isEmpty == true else { return nil }
+    let markers = [executableMarker, homeMarker, codexHomeMarker]
     var values: [String: String] = [:]
-    for line in lines.dropLast() {
+    for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
       let value = String(line)
-      guard
-        let marker = [executableMarker, homeMarker, codexHomeMarker].first(where: value.hasPrefix),
-        values[marker] == nil
-      else { return nil }
+      guard let marker = markers.first(where: value.hasPrefix) else { continue }
+      guard values[marker] == nil else { return nil }
       values[marker] = String(value.dropFirst(marker.count))
     }
-    return values.count == 3 ? values : nil
+    return values.count == markers.count ? values : nil
   }
 }

--- a/supacode/Domain/AgentRuntime/CodexShellProbeProcess.swift
+++ b/supacode/Domain/AgentRuntime/CodexShellProbeProcess.swift
@@ -21,6 +21,11 @@ nonisolated struct CodexShellProbeProcess: Sendable {
     let shellOverrideArguments: [String]
   }
 
+  private struct OutputDescriptor {
+    let fileDescriptor: Int32
+    let isStandardOutput: Bool
+  }
+
   private final class ProcessBox: @unchecked Sendable {
     private let lock = NSLock()
     private var process: Process?
@@ -102,9 +107,15 @@ nonisolated struct CodexShellProbeProcess: Sendable {
     process.standardError = errors
     processBox.install(process)
     try process.run()
-    let descriptors = [
-      output.fileHandleForReading.fileDescriptor,
-      errors.fileHandleForReading.fileDescriptor,
+    var descriptors = [
+      OutputDescriptor(
+        fileDescriptor: output.fileHandleForReading.fileDescriptor,
+        isStandardOutput: true
+      ),
+      OutputDescriptor(
+        fileDescriptor: errors.fileHandleForReading.fileDescriptor,
+        isStandardOutput: false
+      ),
     ]
     let deadline = DispatchTime.now().uptimeNanoseconds + UInt64(options.timeout * 1_000_000_000)
     var stdout = Data()
@@ -115,33 +126,30 @@ nonisolated struct CodexShellProbeProcess: Sendable {
       try? errors.fileHandleForReading.close()
     }
 
-    while process.isRunning || hasReadableData(descriptors) {
+    while process.isRunning || !descriptors.isEmpty {
       if Task.isCancelled { throw CodexShellProbeProcessError.cancelled }
       guard DispatchTime.now().uptimeNanoseconds < deadline else {
         throw CodexShellProbeProcessError.timeout
       }
-      var pollDescriptors = descriptors.map { pollfd(fd: $0, events: Int16(POLLIN), revents: 0) }
+      guard !descriptors.isEmpty else {
+        usleep(1_000)
+        continue
+      }
+      var pollDescriptors = descriptors.map {
+        pollfd(fd: $0.fileDescriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
+      }
       let status = poll(&pollDescriptors, nfds_t(pollDescriptors.count), 25)
       if status < 0 {
         if errno == EINTR { continue }
         throw CodexShellProbeProcessError.processFailed
       }
-      for index in pollDescriptors.indices where pollDescriptors[index].revents & Int16(POLLIN) != 0 {
-        var chunk = [UInt8](repeating: 0, count: 4 * 1_024)
-        let count = chunk.withUnsafeMutableBytes {
-          Darwin.read(descriptors[index], $0.baseAddress, $0.count)
-        }
-        if count > 0 {
-          if index == 0 {
-            stdout.append(contentsOf: chunk.prefix(count))
-          } else {
-            stderr.append(contentsOf: chunk.prefix(count))
-          }
-          guard stdout.count + stderr.count <= options.maximumOutputBytes else {
-            throw CodexShellProbeProcessError.outputTooLarge
-          }
-        }
-      }
+      try drainReadyDescriptors(
+        &descriptors,
+        pollDescriptors: pollDescriptors,
+        standardOutput: &stdout,
+        standardError: &stderr,
+        maximumOutputBytes: options.maximumOutputBytes
+      )
     }
     guard process.terminationStatus == 0 else { throw CodexShellProbeProcessError.processFailed }
     guard let stdoutText = String(data: stdout, encoding: .utf8),
@@ -150,9 +158,38 @@ nonisolated struct CodexShellProbeProcess: Sendable {
     return ShellOutput(stdout: stdoutText, stderr: stderrText, exitCode: process.terminationStatus)
   }
 
-  private static func hasReadableData(_ descriptors: [Int32]) -> Bool {
-    var values = descriptors.map { pollfd(fd: $0, events: Int16(POLLIN), revents: 0) }
-    return poll(&values, nfds_t(values.count), 0) > 0
+  private static func drainReadyDescriptors(
+    _ descriptors: inout [OutputDescriptor],
+    pollDescriptors: [pollfd],
+    standardOutput: inout Data,
+    standardError: inout Data,
+    maximumOutputBytes: Int
+  ) throws {
+    for index in pollDescriptors.indices.reversed() {
+      let events = pollDescriptors[index].revents
+      if events & Int16(POLLNVAL | POLLERR) != 0 {
+        throw CodexShellProbeProcessError.processFailed
+      }
+      guard events & Int16(POLLIN | POLLHUP) != 0 else { continue }
+      var chunk = [UInt8](repeating: 0, count: 4 * 1_024)
+      let count = chunk.withUnsafeMutableBytes {
+        Darwin.read(descriptors[index].fileDescriptor, $0.baseAddress, $0.count)
+      }
+      if count > 0 {
+        if descriptors[index].isStandardOutput {
+          standardOutput.append(contentsOf: chunk.prefix(count))
+        } else {
+          standardError.append(contentsOf: chunk.prefix(count))
+        }
+        guard standardOutput.count + standardError.count <= maximumOutputBytes else {
+          throw CodexShellProbeProcessError.outputTooLarge
+        }
+      } else if count == 0 {
+        descriptors.remove(at: index)
+      } else if errno != EINTR && errno != EAGAIN {
+        throw CodexShellProbeProcessError.processFailed
+      }
+    }
   }
 
   private static func stop(_ process: Process) {

--- a/supacode/Domain/AgentRuntime/CodexShellProbeProcess.swift
+++ b/supacode/Domain/AgentRuntime/CodexShellProbeProcess.swift
@@ -138,11 +138,17 @@ nonisolated struct CodexShellProbeProcess: Sendable {
       var pollDescriptors = descriptors.map {
         pollfd(fd: $0.fileDescriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
       }
-      let status = poll(&pollDescriptors, nfds_t(pollDescriptors.count), 25)
+      let processIsRunning = process.isRunning
+      let status = poll(
+        &pollDescriptors,
+        nfds_t(pollDescriptors.count),
+        processIsRunning ? 25 : 0
+      )
       if status < 0 {
         if errno == EINTR { continue }
         throw CodexShellProbeProcessError.processFailed
       }
+      if status == 0, !processIsRunning { break }
       try drainReadyDescriptors(
         &descriptors,
         pollDescriptors: pollDescriptors,

--- a/supacode/Domain/AgentRuntime/ManagedHookRendering.swift
+++ b/supacode/Domain/AgentRuntime/ManagedHookRendering.swift
@@ -97,11 +97,10 @@ nonisolated enum ClaudeHookSettingsPreparer {
         carrierIndex = source.argumentIndex + 1
       }
     } else {
-      let insertionIndex =
-        resolvedPromptIndex(
-          promptArgumentIndex,
-          arguments: arguments
-        ) ?? arguments.endIndex
+      let insertionIndex = managedOptionInsertionIndex(
+        promptArgumentIndex: promptArgumentIndex,
+        arguments: arguments
+      )
       arguments.insert(contentsOf: ["--settings", "{}"], at: insertionIndex)
       carrierIndex = insertionIndex + 1
     }
@@ -150,6 +149,7 @@ nonisolated enum ClaudeHookSettingsPreparer {
         continue
       }
       let argument = arguments[index]
+      if argument == "--" { break }
       if argument == "--settings" {
         guard arguments.indices.contains(index + 1), index + 1 != promptArgumentIndex else {
           return .malformed
@@ -242,12 +242,16 @@ nonisolated enum ClaudeHookSettingsPreparer {
     }
   }
 
-  private static func resolvedPromptIndex(
-    _ explicit: Int?,
+  private static func managedOptionInsertionIndex(
+    promptArgumentIndex: Int?,
     arguments: [String]
-  ) -> Int? {
-    guard let explicit, arguments.indices.contains(explicit) else { return nil }
-    return explicit
+  ) -> Int {
+    let promptIndex =
+      promptArgumentIndex.flatMap {
+        arguments.indices.contains($0) ? $0 : nil
+      } ?? arguments.endIndex
+    let sentinelIndex = arguments.firstIndex(of: "--") ?? arguments.endIndex
+    return min(promptIndex, sentinelIndex)
   }
 
   private static func degraded(_ invocation: AgentInvocation) -> AgentHookPreparationOutcome {
@@ -282,10 +286,12 @@ nonisolated enum CodexManagedNotifyRenderer {
     )
     let notifyJSON = notifyData.flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
     var arguments = invocation.arguments
-    let explicitPromptIndex = promptArgumentIndex.flatMap {
-      arguments.indices.contains($0) ? $0 : nil
-    }
-    let insertionIndex = explicitPromptIndex ?? arguments.endIndex
+    let promptIndex =
+      promptArgumentIndex.flatMap {
+        arguments.indices.contains($0) ? $0 : nil
+      } ?? arguments.endIndex
+    let sentinelIndex = arguments.firstIndex(of: "--") ?? arguments.endIndex
+    let insertionIndex = min(promptIndex, sentinelIndex)
     arguments.insert(contentsOf: ["-c", "notify=[]"], at: insertionIndex)
     return AgentHookPreparedInvocation(
       invocation: AgentInvocation(executable: invocation.executable, arguments: arguments),

--- a/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
+++ b/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
@@ -291,10 +291,13 @@ final class AgentObservationStore {
       return .rejected
     }
 
-    if input.runtime == .claude, input.signal.event == .sessionStart,
-      let currentSession = managed.sessionID,
+    if let currentSession = managed.sessionID,
       currentSession != input.signal.sessionID
     {
+      let mayRotateSession =
+        input.runtime == .codex
+        || (input.runtime == .claude && input.signal.event == .sessionStart)
+      guard mayRotateSession else { return .rejected }
       record.evidenceEpoch = UUID()
       record.channels.removeAll()
       record.latestCurrentSignal = nil
@@ -302,10 +305,6 @@ final class AgentObservationStore {
       if record.latestSignal != nil { record.latestSignalBinding = .stale }
       managed.evidenceEpoch = record.evidenceEpoch
       managed.verified = false
-    } else if let currentSession = managed.sessionID,
-      currentSession != input.signal.sessionID
-    {
-      return .rejected
     }
     record.sessionID = input.signal.sessionID
     managed.sessionID = input.signal.sessionID
@@ -363,6 +362,12 @@ final class AgentObservationStore {
     sessionID: String?
   ) -> AgentEvidenceEpochUpdate {
     var record = records[surfaceID] ?? SurfaceRecord()
+    if record.managedHook != nil,
+      record.processGeneration != nil,
+      processGeneration == nil
+    {
+      return AgentEvidenceEpochUpdate()
+    }
     let firstGenerationIsTimely =
       processGeneration.map {
         $0.startedAt <= (record.firstProcessGenerationStartedBefore ?? .distantPast)
@@ -370,12 +375,14 @@ final class AgentObservationStore {
     let attachesFirstLaunchGeneration =
       record.awaitingFirstProcessGeneration
       && record.processGeneration == nil
-      && firstGenerationIsTimely
+      && processGeneration != nil
+      && (firstGenerationIsTimely || record.managedHook != nil)
     let rejectsLateFirstGeneration =
       record.awaitingFirstProcessGeneration
       && record.processGeneration == nil
       && processGeneration != nil
       && !firstGenerationIsTimely
+      && record.managedHook == nil
     let processChanged =
       rejectsLateFirstGeneration
       || (!attachesFirstLaunchGeneration && record.processGeneration != processGeneration)
@@ -392,6 +399,7 @@ final class AgentObservationStore {
       record.activeTerminalSignal = nil
       if record.latestSignal != nil { record.latestSignalBinding = .stale }
       record.sessionlessSignalsAllowed = processChanged
+      if processChanged { record.sessionID = nil }
       if processChanged, let managed = record.managedHook {
         if let forwardingRecord = managed.launch.forwardingRecord {
           update.revokedForwardingRecords.append(forwardingRecord)
@@ -401,6 +409,7 @@ final class AgentObservationStore {
         managed.evidenceEpoch = record.evidenceEpoch
         managed.verified = false
         managed.pendingSignals.removeAll()
+        if managed.launch.runtime == .codex { managed.sessionID = nil }
         record.managedHook = managed
       }
     }

--- a/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
+++ b/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
@@ -18,6 +18,7 @@ private struct ManagedHookRegistrationRecord {
   var evidenceEpoch: UUID
   var processGeneration: AgentProcessGeneration?
   var sessionID: String?
+  var retiredSessionIDs: Set<String> = []
   var verified = false
   var pendingSignals: [PendingManagedHookSignal] = []
 }
@@ -290,6 +291,7 @@ final class AgentObservationStore {
     guard callerAncestry.contains(generation), managed.processGeneration == generation else {
       return .rejected
     }
+    if managed.retiredSessionIDs.contains(input.signal.sessionID) { return .rejected }
 
     if let currentSession = managed.sessionID,
       currentSession != input.signal.sessionID
@@ -298,6 +300,9 @@ final class AgentObservationStore {
         input.runtime == .codex
         || (input.runtime == .claude && input.signal.event == .sessionStart)
       guard mayRotateSession else { return .rejected }
+      if input.runtime == .codex {
+        managed.retiredSessionIDs.insert(currentSession)
+      }
       record.evidenceEpoch = UUID()
       record.channels.removeAll()
       record.latestCurrentSignal = nil
@@ -368,6 +373,7 @@ final class AgentObservationStore {
     {
       return AgentEvidenceEpochUpdate()
     }
+    let acceptedSessionID = acceptedManagedSessionID(sessionID, record: record)
     let firstGenerationIsTimely =
       processGeneration.map {
         $0.startedAt <= (record.firstProcessGenerationStartedBefore ?? .distantPast)
@@ -389,8 +395,8 @@ final class AgentObservationStore {
     let sessionChanged =
       !processChanged
       && record.sessionID != nil
-      && sessionID != nil
-      && record.sessionID != sessionID
+      && acceptedSessionID != nil
+      && record.sessionID != acceptedSessionID
     var update = AgentEvidenceEpochUpdate()
     if processChanged || sessionChanged {
       record.evidenceEpoch = UUID()
@@ -409,7 +415,14 @@ final class AgentObservationStore {
         managed.evidenceEpoch = record.evidenceEpoch
         managed.verified = false
         managed.pendingSignals.removeAll()
-        if managed.launch.runtime == .codex { managed.sessionID = nil }
+        if managed.launch.runtime == .codex {
+          if let managedSessionID = managed.sessionID,
+            managedSessionID != acceptedSessionID
+          {
+            managed.retiredSessionIDs.insert(managedSessionID)
+          }
+          managed.sessionID = nil
+        }
         record.managedHook = managed
       }
     }
@@ -423,7 +436,7 @@ final class AgentObservationStore {
       managed.pendingSignals.removeAll()
       record.managedHook = managed
       record.processGeneration = processGeneration
-      if let sessionID { record.sessionID = sessionID }
+      if let acceptedSessionID { record.sessionID = acceptedSessionID }
       records[surfaceID] = record
       for pendingSignal in pending {
         if case .accepted(let signal, _) = recordManagedHook(
@@ -437,9 +450,21 @@ final class AgentObservationStore {
       return update
     }
     record.processGeneration = processGeneration
-    if let sessionID { record.sessionID = sessionID }
+    if let acceptedSessionID { record.sessionID = acceptedSessionID }
     records[surfaceID] = record
     return update
+  }
+
+  private func acceptedManagedSessionID(
+    _ sessionID: String?,
+    record: SurfaceRecord
+  ) -> String? {
+    guard let sessionID,
+      let managed = record.managedHook,
+      managed.launch.runtime == .codex,
+      managed.retiredSessionIDs.contains(sessionID)
+    else { return sessionID }
+    return nil
   }
 
   func bindingForSignal(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -245,32 +245,44 @@ final class WorktreeTerminalManager {
   private func launchAgentProfile(_ plan: AgentProfileLaunchPlan, in worktree: Worktree) {
     Task { @MainActor [weak self] in
       guard let self else { return }
-      let request = AgentProfileLaunchRequest(
-        plan: plan,
-        placement: plan.placement == .split
-          ? .split(anchor: nil, direction: plan.splitDirection, background: false)
-          : .tab(background: false)
-      )
-      switch await prepareAgentProfileLaunch(request, in: worktree) {
-      case .failure where Task.isCancelled:
-        return
-      case .failure:
-        emit(.agentProfileLaunchFailed(worktreeID: worktree.id, profileName: plan.profileName))
-      case .success(let preparation):
-        switch launchPreparedAgentProfile(preparation, in: worktree) {
-        case .success:
-          for warning in preparation.warnings {
-            emit(
-              .agentProfileLaunchWarning(
-                worktreeID: worktree.id,
-                profileName: plan.profileName,
-                message: warning.message
-              )
-            )
+      var placement: AgentProfileLaunchRequest.Placement =
+        plan.placement == .split
+        ? .split(anchor: nil, direction: plan.splitDirection, background: false)
+        : .tab(background: false)
+      for attempt in 0..<2 {
+        let request = AgentProfileLaunchRequest(plan: plan, placement: placement)
+        switch await prepareAgentProfileLaunch(request, in: worktree) {
+        case .failure where Task.isCancelled:
+          return
+        case .failure(let error):
+          if attempt == 0, case .split = placement, error == .splitAnchorUnavailable {
+            placement = .tab(background: false)
+            continue
           }
-          emit(.agentProfileLaunched(worktreeID: worktree.id, profileID: plan.profileID))
-        case .failure:
           emit(.agentProfileLaunchFailed(worktreeID: worktree.id, profileName: plan.profileName))
+          return
+        case .success(let preparation):
+          switch launchPreparedAgentProfile(preparation, in: worktree) {
+          case .success:
+            for warning in preparation.warnings {
+              emit(
+                .agentProfileLaunchWarning(
+                  worktreeID: worktree.id,
+                  profileName: plan.profileName,
+                  message: warning.message
+                )
+              )
+            }
+            emit(.agentProfileLaunched(worktreeID: worktree.id, profileID: plan.profileID))
+            return
+          case .failure:
+            if attempt == 0, case .split = placement {
+              placement = .tab(background: false)
+              continue
+            }
+            emit(.agentProfileLaunchFailed(worktreeID: worktree.id, profileName: plan.profileName))
+            return
+          }
         }
       }
     }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -377,13 +377,6 @@ extension WorktreeTerminalState {
       failsSurfaceCreationForTesting: failsSurfaceCreationForTesting,
       defersSurfaceCreation: defersSurfaceCreation
     )
-    // Sending a no-op font size action marks the Ghostty surface as
-    // "font_size_adjusted", which prevents config reloads (triggered by
-    // keybind changes on worktree switch) from resetting the font to the
-    // config default.
-    if resolvedFontSize != nil {
-      view.performBindingAction("increase_font_size:0")
-    }
     configureBridgeCallbacks(for: view, tabId: tabId)
     configureSurfaceCallbacks(for: view, tabId: tabId)
     surfaces[view.id] = view

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -140,6 +140,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private let envVarEntries: UnsafeMutablePointer<ghostty_env_var_s>?
   private let envVarCount: Int
   private let fontSize: Float32
+  private let appliesFontSizeAdjustmentMarker: Bool
+  private(set) var didApplyFontSizeAdjustmentMarker = false
   private let context: ghostty_surface_context_e
   var surfaceContextForTesting: ghostty_surface_context_e {
     context
@@ -278,6 +280,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     self.runtime = runtime
     self.bridge = GhosttySurfaceBridge()
     self.fontSize = fontSize ?? 0
+    self.appliesFontSizeAdjustmentMarker = fontSize != nil
     self.context = context
     self.skipsSurfaceCreationForTesting = skipsSurfaceCreationForTesting
     self.failsSurfaceCreationForTesting = failsSurfaceCreationForTesting
@@ -382,6 +385,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return false
     }
     surfaceRef = runtime.registerSurface(surface)
+    // This no-op marks the native surface as font-size adjusted so a config
+    // reload cannot reset an inherited/preferred size. It must run post-create.
+    if appliesFontSizeAdjustmentMarker {
+      performBindingAction("increase_font_size:0")
+      didApplyFontSizeAdjustmentMarker = true
+    }
     return true
   }
 

--- a/supacodeTests/AgentHookRenderingTests.swift
+++ b/supacodeTests/AgentHookRenderingTests.swift
@@ -189,6 +189,49 @@ struct AgentHookRenderingTests {
     #expect(codex.argumentValues.values.first?.contains("dangerously-bypass-hook-trust") == false)
   }
 
+  @Test func managedArgumentsStayBeforeAnEndOfOptionsSentinel() throws {
+    let claude = ClaudeHookSettingsPreparer.prepare(
+      invocation: AgentInvocation(executable: "claude", arguments: ["--", "literal prompt"]),
+      launchDirectory: URL(filePath: "/tmp", directoryHint: .isDirectory),
+      promptArgumentIndex: 1,
+      hookCommands: hookCommands,
+      readFile: { _, _ in .unreadable }
+    )
+    let preparedClaude = try #require(claude.prepared)
+    let claudeSentinel = try #require(preparedClaude.invocation.arguments.firstIndex(of: "--"))
+    let settings = try #require(preparedClaude.invocation.arguments.firstIndex(of: "--settings"))
+    #expect(settings < claudeSentinel)
+
+    let codex = CodexManagedNotifyRenderer.prepare(
+      invocation: AgentInvocation(executable: "codex", arguments: ["exec", "--", "literal prompt"]),
+      bundledCLIPath: "/bundle/prowl",
+      promptArgumentIndex: 2
+    )
+    let codexSentinel = try #require(codex.invocation.arguments.firstIndex(of: "--"))
+    let override = try #require(codex.invocation.arguments.firstIndex(of: "-c"))
+    #expect(override < codexSentinel)
+  }
+
+  @Test func userSettingsAfterEndOfOptionsAreNotParsedAsOptions() throws {
+    var reads = 0
+    let outcome = ClaudeHookSettingsPreparer.prepare(
+      invocation: AgentInvocation(
+        executable: "claude",
+        arguments: ["--", "--settings", "/tmp/not-an-option"]
+      ),
+      launchDirectory: URL(filePath: "/tmp", directoryHint: .isDirectory),
+      hookCommands: hookCommands,
+      readFile: { _, _ in
+        reads += 1
+        return .unreadable
+      }
+    )
+
+    let prepared = try #require(outcome.prepared)
+    #expect(reads == 0)
+    #expect(prepared.invocation.arguments.prefix(3) == ["--settings", "{}", "--"])
+  }
+
   @Test func unpromptedOptionValuePairsAreNeverInferredAsPrompts() throws {
     let claude = ClaudeHookSettingsPreparer.prepare(
       invocation: AgentInvocation(executable: "claude", arguments: ["-p", "--model", "opus"]),

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -88,6 +88,62 @@ struct CLISocketServerTests {
     #expect(!CLISocketServer.isAllowedPeerUID(502, currentUID: 501))
   }
 
+  @Test func descriptorDuplicationFailureRejectsConnectionBeforeRouting() async throws {
+    let socketPath = temporarySocketPath(suffix: "monitor-dup-failure")
+    let pane = CallerPane(worktreeID: "wt", surfaceID: UUID())
+    var recordedSignal: AgentSignal?
+    let handler = AgentSignalCommandHandler(
+      resolveCaller: { _ in pane },
+      recordSignal: { _, signal in
+        recordedSignal = signal
+        return true
+      }
+    )
+    let accepted = DispatchSemaphore(value: 0)
+    let closed = DispatchSemaphore(value: 0)
+    let peerClosed = DisconnectObservation()
+    let rejected = DisconnectObservation()
+    let server = CLISocketServer(
+      router: CLICommandRouter(agentsSignalHandler: handler),
+      socketPath: socketPath,
+      onClientAccepted: {
+        accepted.signal()
+        if closed.wait(timeout: .now() + 10) == .success {
+          peerClosed.signal()
+        }
+      },
+      onPeerMonitorUnavailable: { rejected.signal() },
+      duplicatePeerDescriptor: { _ in -1 }
+    )
+    try server.start()
+    defer { server.stop() }
+    let requestData = try JSONEncoder().encode(
+      CommandEnvelope(
+        output: .json,
+        command: .agentsSignal(AgentSignalInput(event: .turnEnded, detail: "must not route"))
+      )
+    )
+
+    try await Task.detached {
+      try Self.sendAndCloseAfterAcceptance(
+        requestData: requestData,
+        socketPath: socketPath,
+        accepted: accepted,
+        closed: closed
+      )
+    }.value
+    let closedBeforeRouting = await Task.detached {
+      peerClosed.wait(timeout: .now() + 10)
+    }.value
+    #expect(closedBeforeRouting)
+    let connectionRejected = await Task.detached {
+      rejected.wait(timeout: .now() + 10)
+    }.value
+
+    #expect(connectionRejected)
+    #expect(recordedSignal == nil)
+  }
+
   @Test func socketRoundTripThreadsKernelPeerPIDIntoAgentSignalHandler() async throws {
     let socketPath = temporarySocketPath(suffix: "signal-context")
     let pane = CallerPane(worktreeID: "wt", surfaceID: UUID())
@@ -297,6 +353,26 @@ struct CLISocketServerTests {
   }
 
   #if canImport(Darwin)
+    @Test func disconnectMonitorActivatesDuringCreation() async throws {
+      var descriptors: [Int32] = [-1, -1]
+      #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+      defer { close(descriptors[0]) }
+      let observation = DisconnectObservation()
+      let monitor = try #require(
+        CLIPeerDisconnectMonitor(fileDescriptor: descriptors[0]) {
+          observation.signal()
+        }
+      )
+
+      close(descriptors[1])
+      let activatedDuringCreation = await Task.detached {
+        observation.wait(timeout: .now() + 1)
+      }.value
+
+      #expect(activatedDuringCreation)
+      monitor.cancel()
+    }
+
     @Test func disconnectMonitorOutlivesOriginalDescriptor() async throws {
       var descriptors: [Int32] = [-1, -1]
       #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
@@ -306,7 +382,6 @@ struct CLISocketServerTests {
           observation.signal()
         }
       )
-      monitor.start()
 
       close(descriptors[0])
       close(descriptors[1])
@@ -376,28 +451,6 @@ struct CLISocketServerTests {
     let lengthData = try readExact(socketFD, count: 4)
     let responseLength = lengthData.withUnsafeBytes { UInt32(bigEndian: $0.load(as: UInt32.self)) }
     return try readExact(socketFD, count: Int(responseLength))
-  }
-
-  nonisolated private static func sendAndClose(
-    requestData: Data,
-    socketPath: String
-  ) throws {
-    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
-    guard socketFD >= 0 else { throw CLIServiceError.socketCreationFailed }
-    defer { close(socketFD) }
-
-    let connected = withSocketAddress(socketPath) { address in
-      withUnsafePointer(to: address) { pointer in
-        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
-          connect(socketFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
-        }
-      }
-    }
-    guard connected == 0 else { throw TestSocketClientError.connectFailed }
-
-    var requestLength = UInt32(requestData.count).bigEndian
-    try withUnsafeBytes(of: &requestLength) { try writeAll(socketFD, buffer: $0) }
-    try requestData.withUnsafeBytes { try writeAll(socketFD, buffer: $0) }
   }
 
   nonisolated private static func sendAndCloseAfterAcceptance(

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -148,8 +148,9 @@ struct CLISocketServerTests {
     )
     var recordedInput: AgentNativeHookInput?
     let handler = AgentNativeHookCommandHandler(
-      resolveCaller: { processID in
-        #expect(processID == getpid())
+      resolveCaller: { context in
+        #expect(context.callerProcessID == getpid())
+        #expect(context.callerProcessAncestry.first?.processID == getpid())
         return pane
       },
       recordHook: { caller, received in
@@ -183,12 +184,87 @@ struct CLISocketServerTests {
     #expect(!responseText.contains(input.token))
   }
 
+  @Test func nativeHookRoutesAfterPeerClosesBeforeMainActorHandling() async throws {
+    let socketPath = temporarySocketPath(suffix: "hook-short-lived-peer")
+    let routeRecorded = DisconnectObservation()
+    let pane = CallerPane(worktreeID: "wt", surfaceID: UUID())
+    let input = AgentNativeHookInput(
+      runtime: .codex,
+      token: "private-token",
+      signal: AgentNativeHookSignal(
+        event: .turnEnded,
+        nativeEvent: "agent-turn-complete",
+        cwd: "/tmp/project",
+        sessionID: "thread-1"
+      )
+    )
+    var recordedInput: AgentNativeHookInput?
+    let handler = AgentNativeHookCommandHandler(
+      resolveCaller: { context in
+        #expect(context.callerProcessID == getpid())
+        #expect(context.callerProcessAncestry.first?.processID == getpid())
+        return pane
+      },
+      recordHook: { _, received in
+        recordedInput = received
+        routeRecorded.signal()
+        return true
+      }
+    )
+    let accepted = DispatchSemaphore(value: 0)
+    let closed = DispatchSemaphore(value: 0)
+    let peerClosed = DisconnectObservation()
+    let server = CLISocketServer(
+      router: CLICommandRouter(agentsHookHandler: handler),
+      socketPath: socketPath,
+      onClientAccepted: {
+        accepted.signal()
+        if closed.wait(timeout: .now() + 10) == .success {
+          peerClosed.signal()
+        }
+      }
+    )
+    try server.start()
+    defer { server.stop() }
+    let requestData = try JSONEncoder().encode(
+      CommandEnvelope(output: .json, command: .agentsHook(input))
+    )
+    let sendTask = Task.detached {
+      try Self.sendAndCloseAfterAcceptance(
+        requestData: requestData,
+        socketPath: socketPath,
+        accepted: accepted,
+        closed: closed
+      )
+    }
+
+    try await sendTask.value
+    let closedBeforeRouting = await Task.detached {
+      peerClosed.wait(timeout: .now() + 10)
+    }.value
+    #expect(closedBeforeRouting)
+    let didRoute = await Task.detached {
+      routeRecorded.wait(timeout: .now() + 10)
+    }.value
+    #expect(didRoute)
+    #expect(recordedInput == input)
+  }
+
   @Test func closingPeerCancelsInFlightWaitRequest() async throws {
     let socketPath = temporarySocketPath(suffix: "wait-peer-eof")
     let probe = CancellationProbe()
+    let accepted = DispatchSemaphore(value: 0)
+    let closed = DispatchSemaphore(value: 0)
+    let peerClosed = DisconnectObservation()
     let server = CLISocketServer(
       router: CLICommandRouter(agentsWaitHandler: CancellationProbeHandler(probe: probe)),
-      socketPath: socketPath
+      socketPath: socketPath,
+      onClientAccepted: {
+        accepted.signal()
+        if closed.wait(timeout: .now() + 10) == .success {
+          peerClosed.signal()
+        }
+      }
     )
     try server.start()
     defer { server.stop() }
@@ -200,21 +276,64 @@ struct CLISocketServerTests {
     )
     let requestData = try JSONEncoder().encode(envelope)
 
-    try await withCheckedThrowingContinuation { continuation in
-      DispatchQueue.global(qos: .userInitiated).async {
-        continuation.resume(
-          with: Result {
-            try Self.sendAndClose(requestData: requestData, socketPath: socketPath)
-          }
-        )
-      }
-    }
+    try await Task.detached {
+      try Self.sendAndCloseAfterAcceptance(
+        requestData: requestData,
+        socketPath: socketPath,
+        accepted: accepted,
+        closed: closed
+      )
+    }.value
 
-    await probe.waitUntilCancellationWasObserved()
+    let closedBeforeRouting = await Task.detached {
+      peerClosed.wait(timeout: .now() + 10)
+    }.value
+    #expect(closedBeforeRouting)
+    let cancellationObserved = await Task.detached {
+      probe.waitForCancellation(timeout: .now() + 10)
+    }.value
+    #expect(cancellationObserved)
     #expect(probe.wasCancelled)
   }
 
   #if canImport(Darwin)
+    @Test func disconnectMonitorOutlivesOriginalDescriptor() async throws {
+      var descriptors: [Int32] = [-1, -1]
+      #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+      let observation = DisconnectObservation()
+      let monitor = try #require(
+        CLIPeerDisconnectMonitor(fileDescriptor: descriptors[0]) {
+          observation.signal()
+        }
+      )
+      monitor.start()
+
+      close(descriptors[0])
+      close(descriptors[1])
+      let disconnected = await Task.detached {
+        observation.wait(timeout: .now() + 10)
+      }.value
+
+      #expect(disconnected)
+      monitor.cancel()
+    }
+
+    @Test func acceptedSocketSuppressesSIGPIPEAndClosesOnExec() throws {
+      var descriptors: [Int32] = [-1, -1]
+      #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+      defer {
+        close(descriptors[0])
+        close(descriptors[1])
+      }
+
+      #expect(CLISocketServer.configureAcceptedClient(descriptors[0]))
+      var enabled: Int32 = 0
+      var length = socklen_t(MemoryLayout<Int32>.size)
+      #expect(getsockopt(descriptors[0], SOL_SOCKET, SO_NOSIGPIPE, &enabled, &length) == 0)
+      #expect(enabled == 1)
+      #expect(fcntl(descriptors[0], F_GETFD) & FD_CLOEXEC != 0)
+    }
+
     @Test func kernelReportsPeerPIDForLocalSocket() throws {
       var descriptors: [Int32] = [-1, -1]
       #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
@@ -259,7 +378,10 @@ struct CLISocketServerTests {
     return try readExact(socketFD, count: Int(responseLength))
   }
 
-  nonisolated private static func sendAndClose(requestData: Data, socketPath: String) throws {
+  nonisolated private static func sendAndClose(
+    requestData: Data,
+    socketPath: String
+  ) throws {
     let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
     guard socketFD >= 0 else { throw CLIServiceError.socketCreationFailed }
     defer { close(socketFD) }
@@ -276,6 +398,35 @@ struct CLISocketServerTests {
     var requestLength = UInt32(requestData.count).bigEndian
     try withUnsafeBytes(of: &requestLength) { try writeAll(socketFD, buffer: $0) }
     try requestData.withUnsafeBytes { try writeAll(socketFD, buffer: $0) }
+  }
+
+  nonisolated private static func sendAndCloseAfterAcceptance(
+    requestData: Data,
+    socketPath: String,
+    accepted: DispatchSemaphore,
+    closed: DispatchSemaphore
+  ) throws {
+    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socketFD >= 0 else { throw CLIServiceError.socketCreationFailed }
+    defer {
+      close(socketFD)
+      closed.signal()
+    }
+    let connected = withSocketAddress(socketPath) { address in
+      withUnsafePointer(to: address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+          connect(socketFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+      }
+    }
+    guard connected == 0 else { throw TestSocketClientError.connectFailed }
+
+    var requestLength = UInt32(requestData.count).bigEndian
+    try withUnsafeBytes(of: &requestLength) { try writeAll(socketFD, buffer: $0) }
+    try requestData.withUnsafeBytes { try writeAll(socketFD, buffer: $0) }
+    guard accepted.wait(timeout: .now() + 10) == .success else {
+      throw CLIServiceError.readFailed
+    }
   }
 
   nonisolated private static func writeAll(_ fileDescriptor: Int32, buffer: UnsafeRawBufferPointer) throws {
@@ -394,6 +545,18 @@ struct CLISocketServerTests {
   }
 }
 
+private nonisolated final class DisconnectObservation: @unchecked Sendable {
+  private let semaphore = DispatchSemaphore(value: 0)
+
+  func signal() {
+    semaphore.signal()
+  }
+
+  func wait(timeout: DispatchTime) -> Bool {
+    semaphore.wait(timeout: timeout) == .success
+  }
+}
+
 private enum TestSocketClientError: Error {
   case connectFailed
 }
@@ -414,8 +577,8 @@ private struct CancellationProbeHandler: CommandHandler {
 
 private nonisolated final class CancellationProbe: @unchecked Sendable {
   private let lock = NSLock()
+  private let cancellationObserved = DispatchSemaphore(value: 0)
   private var cancellationContinuation: CheckedContinuation<Void, Never>?
-  private var observerContinuation: CheckedContinuation<Void, Never>?
   private var cancelled = false
 
   var wasCancelled: Bool {
@@ -437,27 +600,17 @@ private nonisolated final class CancellationProbe: @unchecked Sendable {
     }
   }
 
-  func waitUntilCancellationWasObserved() async {
-    await withCheckedContinuation { continuation in
-      let resumeImmediately = lock.withLock { () -> Bool in
-        guard !cancelled else { return true }
-        observerContinuation = continuation
-        return false
-      }
-      if resumeImmediately { continuation.resume() }
-    }
+  nonisolated func waitForCancellation(timeout: DispatchTime) -> Bool {
+    cancellationObserved.wait(timeout: timeout) == .success
   }
 
   private func markCancelled() {
-    let continuations = lock.withLock {
+    let continuation = lock.withLock {
       cancelled = true
-      defer {
-        cancellationContinuation = nil
-        observerContinuation = nil
-      }
-      return (cancellationContinuation, observerContinuation)
+      defer { cancellationContinuation = nil }
+      return cancellationContinuation
     }
-    continuations.0?.resume()
-    continuations.1?.resume()
+    cancellationObserved.signal()
+    continuation?.resume()
   }
 }

--- a/supacodeTests/CallerPaneResolverTests.swift
+++ b/supacodeTests/CallerPaneResolverTests.swift
@@ -26,6 +26,32 @@ struct CallerPaneResolverTests {
     )
   }
 
+  @Test func resolvesFromAnAncestrySnapshotAfterTheCallerIsGone() throws {
+    let pane = CallerPane(worktreeID: "wt", surfaceID: UUID())
+    let callerStart = Date(timeIntervalSince1970: 100)
+    let agentStart = Date(timeIntervalSince1970: 90)
+    let identities = [
+      CallerProcessIdentity(processID: 400, startedAt: callerStart),
+      CallerProcessIdentity(processID: 300, startedAt: agentStart),
+      CallerProcessIdentity(processID: 100, startedAt: nil),
+    ]
+
+    let resolved = try #require(
+      CallerPaneResolver.pane(
+        forCallerProcessAncestry: identities,
+        paneByShellPID: [100: pane]
+      )
+    )
+
+    #expect(resolved.surfaceID == pane.surfaceID)
+    #expect(
+      resolved.processAncestry == [
+        AgentProcessGeneration(pid: 400, startedAt: callerStart),
+        AgentProcessGeneration(pid: 300, startedAt: agentStart),
+      ]
+    )
+  }
+
   @Test func unresolvedAndCyclicAncestryNeverGuess() {
     let focusedButUnrelated = CallerPane(worktreeID: "focused", surfaceID: UUID())
 

--- a/supacodeTests/CodexConfigReadProcessTests.swift
+++ b/supacodeTests/CodexConfigReadProcessTests.swift
@@ -1,9 +1,43 @@
+import Darwin
 import Foundation
 import Testing
 
 @testable import supacode
 
 struct CodexConfigReadProcessTests {
+  @Test func appServerInputPipeSuppressesSIGPIPE() {
+    let pipe = Pipe()
+    defer {
+      try? pipe.fileHandleForReading.close()
+      try? pipe.fileHandleForWriting.close()
+    }
+    let descriptor = pipe.fileHandleForWriting.fileDescriptor
+    #expect(fcntl(descriptor, F_GETNOSIGPIPE) == 0)
+
+    #expect(CodexConfigReadProcess.configureNoSigPipe(descriptor))
+    #expect(fcntl(descriptor, F_GETNOSIGPIPE) == 1)
+  }
+
+  @Test func appServerExitBeforeInputFailsWithoutWaitingForTimeout() async throws {
+    let root = temporaryDirectory("codex-early-exit")
+    let home = root.appending(path: "home", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let executable = root.appending(path: "early-exit.sh", directoryHint: .notDirectory)
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+    let process = CodexConfigReadProcess(
+      executableURL: executable,
+      temporaryBaseDirectory: root,
+      timeout: 2
+    )
+    await #expect(throws: CodexConfigReadProcessError.processFailed) {
+      try await process.query(
+        CodexConfigQuery(kind: .base, codexHome: home, cwd: root, overrides: [])
+      )
+    }
+  }
+
   @Test func profileParserHomeIsOwnerOnlyAndRemovedAfterResponse() async throws {
     let root = temporaryDirectory("codex-process")
     let parser = root.appending(path: "parser", directoryHint: .isDirectory)

--- a/supacodeTests/CodexEffectiveNotifyResolverTests.swift
+++ b/supacodeTests/CodexEffectiveNotifyResolverTests.swift
@@ -133,6 +133,22 @@ struct CodexEffectiveNotifyResolverTests {
     }
   }
 
+  @Test func launchContextStopsScanningOptionsAtSentinel() throws {
+    let base = temporaryDirectory("codex-sentinel")
+    let context = try CodexLaunchContext.capture(
+      invocation: AgentInvocation(
+        executable: "codex",
+        arguments: ["exec", "--", "-C", "/must-remain-literal", "Prompt"]
+      ),
+      inheritedCWD: base,
+      environment: [:],
+      promptArgumentIndex: 4
+    )
+
+    #expect(context.effectiveCWD == base.standardizedFileURL)
+    #expect(context.configOverrides.isEmpty)
+  }
+
   @Test func positionalPromptNeverBecomesAConfigOverride() throws {
     let base = temporaryDirectory("codex-prompt")
     let invocation = AgentInvocation(

--- a/supacodeTests/CodexForwardingRecordStoreTests.swift
+++ b/supacodeTests/CodexForwardingRecordStoreTests.swift
@@ -95,17 +95,17 @@ struct CodexForwardingRecordStoreTests {
     }
   }
 
-  @Test func orphanSweepOnlyRemovesAgedOwnedSessionDirectories() throws {
+  @Test func orphanSweepKeepsAgedLiveStoreAndRemovesItAfterOwnerExit() throws {
     let base = temporaryDirectory("forward-orphans")
     defer { try? FileManager.default.removeItem(at: base) }
     var now = Date(timeIntervalSince1970: 1_000)
-    let oldStore = try CodexForwardingRecordStore(
+    var oldStore: CodexForwardingRecordStore? = try CodexForwardingRecordStore(
       baseDirectory: base,
       retirementGrace: 0,
       orphanMaximumAge: 60,
       now: { now }
     )
-    let oldRecord = try oldStore.create(argv: ["/tmp/old"])
+    let oldRecord = try #require(oldStore).create(argv: ["/tmp/old"])
     now.addTimeInterval(120)
 
     let liveStore = try CodexForwardingRecordStore(
@@ -117,8 +117,12 @@ struct CodexForwardingRecordStoreTests {
     let liveRecord = try liveStore.create(argv: ["/tmp/live"])
     liveStore.sweepOrphans()
 
-    #expect(!FileManager.default.fileExists(atPath: oldRecord.locator.path(percentEncoded: false)))
+    #expect(FileManager.default.fileExists(atPath: oldRecord.locator.path(percentEncoded: false)))
     #expect(FileManager.default.fileExists(atPath: liveRecord.locator.path(percentEncoded: false)))
+
+    oldStore = nil
+    liveStore.sweepOrphans()
+    #expect(!FileManager.default.fileExists(atPath: oldRecord.locator.path(percentEncoded: false)))
   }
 
   private func temporaryDirectory(_ name: String) -> URL {

--- a/supacodeTests/CodexShellLaunchEnvironmentTests.swift
+++ b/supacodeTests/CodexShellLaunchEnvironmentTests.swift
@@ -14,6 +14,7 @@ struct CodexShellLaunchEnvironmentTests {
           __PROWL_CODEX_EXECUTABLE__/opt/custom/bin/codex
           __PROWL_CODEX_HOME_BASE__/Users/tester
           __PROWL_CODEX_HOME__/tmp/codex-home
+          __PROWL_CODEX_END__
 
           """,
         stderr: "ignored",
@@ -44,6 +45,7 @@ struct CodexShellLaunchEnvironmentTests {
         __PROWL_CODEX_EXECUTABLE__/opt/codex
         __PROWL_CODEX_HOME_BASE__/Users/tester
         __PROWL_CODEX_HOME__
+        __PROWL_CODEX_END__
         Login complete
         """,
       stderr: "",
@@ -60,6 +62,30 @@ struct CodexShellLaunchEnvironmentTests {
 
     #expect(environment.executableURL.path(percentEncoded: false) == "/opt/codex")
     #expect(environment.processEnvironment == ["HOME": "/Users/tester"])
+  }
+
+  @Test func multilineMarkerValueDegradesInsteadOfUsingItsFirstLine() async {
+    let output = ShellOutput(
+      stdout: """
+        Login banner
+        __PROWL_CODEX_EXECUTABLE__/opt/codex
+        __PROWL_CODEX_HOME_BASE__/Users/tester
+        __PROWL_CODEX_HOME__/tmp/first
+        second
+        __PROWL_CODEX_END__
+        Login complete
+        """,
+      stderr: "",
+      exitCode: 0
+    )
+
+    #expect(
+      await CodexShellLaunchEnvironmentProbe.resolve(
+        cwd: URL(filePath: "/tmp", directoryHint: .isDirectory),
+        run: { _, _ in output },
+        isExecutable: { $0 == "/opt/codex" }
+      ) == nil
+    )
   }
 
   @Test func malformedNonAbsoluteAndFailedProbeDegrade() async {
@@ -101,6 +127,7 @@ struct CodexShellLaunchEnvironmentTests {
       __PROWL_CODEX_EXECUTABLE__/custom/bin/codex
       __PROWL_CODEX_HOME_BASE__/Users/tester
       __PROWL_CODEX_HOME__
+      __PROWL_CODEX_END__
 
       """
     let result = await CodexShellLaunchEnvironmentProbe.resolve(

--- a/supacodeTests/CodexShellLaunchEnvironmentTests.swift
+++ b/supacodeTests/CodexShellLaunchEnvironmentTests.swift
@@ -37,6 +37,31 @@ struct CodexShellLaunchEnvironmentTests {
       ])
   }
 
+  @Test func loginShellBannerDoesNotHideTheFramedLaunchFacts() async throws {
+    let output = ShellOutput(
+      stdout: """
+        Welcome from zprofile
+        __PROWL_CODEX_EXECUTABLE__/opt/codex
+        __PROWL_CODEX_HOME_BASE__/Users/tester
+        __PROWL_CODEX_HOME__
+        Login complete
+        """,
+      stderr: "",
+      exitCode: 0
+    )
+
+    let environment = try #require(
+      await CodexShellLaunchEnvironmentProbe.resolve(
+        cwd: URL(filePath: "/tmp", directoryHint: .isDirectory),
+        run: { _, _ in output },
+        isExecutable: { $0 == "/opt/codex" }
+      )
+    )
+
+    #expect(environment.executableURL.path(percentEncoded: false) == "/opt/codex")
+    #expect(environment.processEnvironment == ["HOME": "/Users/tester"])
+  }
+
   @Test func malformedNonAbsoluteAndFailedProbeDegrade() async {
     for output in [
       ShellOutput(stdout: "not-json", stderr: "", exitCode: 0),

--- a/supacodeTests/CodexShellProbeProcessTests.swift
+++ b/supacodeTests/CodexShellProbeProcessTests.swift
@@ -5,6 +5,23 @@ import Testing
 @testable import supacode
 
 struct CodexShellProbeProcessTests {
+  @Test func successfulChildReturnsOutputBeforeTheDeadline() async throws {
+    let root = temporaryDirectory("shell-success")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let process = CodexShellProbeProcess(
+      timeout: 0.5,
+      maximumOutputBytes: 1_024,
+      shellOverride: URL(filePath: "/bin/sh"),
+      shellOverrideArguments: ["-c", "printf stdout; printf stderr >&2"]
+    )
+    let output = try await process.run(cwd: root, script: "ignored")
+
+    #expect(output.stdout == "stdout")
+    #expect(output.stderr == "stderr")
+    #expect(output.exitCode == 0)
+  }
+
   @Test func hardTimeoutKillsLoginShellThatIgnoresTermination() async throws {
     let root = temporaryDirectory("shell-timeout")
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/supacodeTests/CodexShellProbeProcessTests.swift
+++ b/supacodeTests/CodexShellProbeProcessTests.swift
@@ -22,6 +22,32 @@ struct CodexShellProbeProcessTests {
     #expect(output.exitCode == 0)
   }
 
+  @Test func successfulChildDoesNotWaitForBackgroundDescendantEOF() async throws {
+    let root = temporaryDirectory("shell-background-child")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let shell = try executableScript(
+      in: root,
+      name: "background-child.sh",
+      contents: """
+        #!/bin/sh
+        printf stdout
+        sleep 2 &
+        """
+    )
+    let process = CodexShellProbeProcess(
+      timeout: 0.5,
+      maximumOutputBytes: 1_024,
+      shellOverride: URL(filePath: "/bin/sh"),
+      shellOverrideArguments: [shell.path(percentEncoded: false)]
+    )
+
+    let output = try await process.run(cwd: root, script: "ignored")
+
+    #expect(output.stdout == "stdout")
+    #expect(output.exitCode == 0)
+  }
+
   @Test func hardTimeoutKillsLoginShellThatIgnoresTermination() async throws {
     let root = temporaryDirectory("shell-timeout")
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/supacodeTests/ManagedAgentHookObservationTests.swift
+++ b/supacodeTests/ManagedAgentHookObservationTests.swift
@@ -217,6 +217,129 @@ struct ManagedAgentHookObservationTests {
     )
   }
 
+  @Test func transientGenerationLookupFailureKeepsManagedTrustAndForwarding() {
+    let now = Date(timeIntervalSince1970: 100)
+    let generation = AgentProcessGeneration(pid: 900, startedAt: now)
+    let store = AgentObservationStore(bufferCapacity: 8, now: { now })
+    let surfaceID = UUID()
+    let forward = CodexForwardingRecord(locator: URL(filePath: "/tmp/private/record.json"))
+    let registration = makeRegistration(runtime: .codex, cwd: "/tmp/project", forwardingRecord: forward)
+    _ = store.registerManagedHook(registration, surfaceID: surfaceID)
+    _ = store.updateEvidenceEpoch(surfaceID: surfaceID, processGeneration: generation, sessionID: nil)
+
+    let missing = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: nil,
+      sessionID: nil
+    )
+
+    #expect(missing.revokedForwardingRecords.isEmpty)
+    #expect(store.hasManagedHook(surfaceID: surfaceID))
+    _ = store.updateEvidenceEpoch(surfaceID: surfaceID, processGeneration: generation, sessionID: nil)
+    let input = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project"
+    )
+    #expect(store.recordManagedHook(input, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+  }
+
+  @Test func lateFirstManagedGenerationStillAttachesToThePreparedLaunch() {
+    var now = Date(timeIntervalSince1970: 100)
+    let store = AgentObservationStore(
+      bufferCapacity: 8,
+      now: { now },
+      dispatchGenerationWindow: 10
+    )
+    let surfaceID = UUID()
+    let registration = makeRegistration(runtime: .codex, cwd: "/tmp/project")
+    _ = store.registerManagedHook(registration, surfaceID: surfaceID)
+    now.addTimeInterval(11)
+    let generation = AgentProcessGeneration(pid: 900, startedAt: now)
+
+    let update = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: generation,
+      sessionID: nil
+    )
+    let input = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project"
+    )
+
+    #expect(update.revokedForwardingRecords.isEmpty)
+    #expect(store.hasManagedHook(surfaceID: surfaceID))
+    #expect(store.recordManagedHook(input, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+  }
+
+  @Test func codexThreadRotationRebindsTheManagedHook() throws {
+    let now = Date(timeIntervalSince1970: 100)
+    let generation = AgentProcessGeneration(pid: 900, startedAt: now)
+    let store = AgentObservationStore(bufferCapacity: 8, now: { now })
+    let surfaceID = UUID()
+    let registration = makeRegistration(runtime: .codex, cwd: "/tmp/project")
+    _ = store.registerManagedHook(registration, surfaceID: surfaceID)
+    _ = store.updateEvidenceEpoch(surfaceID: surfaceID, processGeneration: generation, sessionID: nil)
+    let first = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-1"
+    )
+    #expect(store.recordManagedHook(first, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+
+    _ = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: generation,
+      sessionID: "thread-2"
+    )
+    let second = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-2"
+    )
+
+    #expect(store.recordManagedHook(second, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+    let channel = try #require(
+      store.signalsPayload(surfaceID: surfaceID, formatter: formatter, includeDiagnosticLast: true)
+        .channels.first
+    )
+    #expect(channel.sessionID == "thread-2")
+  }
+
+  @Test func processReplacementClearsThePreviousSessionIdentity() {
+    let now = Date(timeIntervalSince1970: 100)
+    let first = AgentProcessGeneration(pid: 900, startedAt: now)
+    let second = AgentProcessGeneration(pid: 901, startedAt: now.addingTimeInterval(1))
+    let store = AgentObservationStore(bufferCapacity: 8, now: { now })
+    let surfaceID = UUID()
+    _ = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: first,
+      sessionID: "session-1"
+    )
+
+    _ = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: second,
+      sessionID: nil
+    )
+
+    #expect(
+      store.bindingForSignal(
+        surfaceID: surfaceID,
+        generationMatches: true,
+        signalSessionID: "session-2"
+      ) == .current
+    )
+  }
+
   @Test func validClaudeSessionStartRotatesFreshnessButRetainsLaunchChannel() throws {
     let now = Date(timeIntervalSince1970: 100)
     let store = AgentObservationStore(bufferCapacity: 8, now: { now })

--- a/supacodeTests/ManagedAgentHookObservationTests.swift
+++ b/supacodeTests/ManagedAgentHookObservationTests.swift
@@ -313,6 +313,68 @@ struct ManagedAgentHookObservationTests {
     #expect(channel.sessionID == "thread-2")
   }
 
+  @Test func detectorConfirmedThreadRotationRejectsLatePreviousThreadHook() {
+    let now = Date(timeIntervalSince1970: 100)
+    let generation = AgentProcessGeneration(pid: 900, startedAt: now)
+    let store = AgentObservationStore(bufferCapacity: 8, now: { now })
+    let surfaceID = UUID()
+    let registration = makeRegistration(runtime: .codex, cwd: "/tmp/project")
+    _ = store.registerManagedHook(registration, surfaceID: surfaceID)
+    _ = store.updateEvidenceEpoch(surfaceID: surfaceID, processGeneration: generation, sessionID: nil)
+    let first = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-1"
+    )
+    #expect(store.recordManagedHook(first, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+
+    _ = store.updateEvidenceEpoch(
+      surfaceID: surfaceID,
+      processGeneration: generation,
+      sessionID: "thread-2"
+    )
+
+    #expect(!store.recordManagedHook(first, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+    let second = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-2"
+    )
+    #expect(store.recordManagedHook(second, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+  }
+
+  @Test func hookDrivenThreadRotationRejectsLatePreviousThreadHook() {
+    let now = Date(timeIntervalSince1970: 100)
+    let generation = AgentProcessGeneration(pid: 900, startedAt: now)
+    let store = AgentObservationStore(bufferCapacity: 8, now: { now })
+    let surfaceID = UUID()
+    let registration = makeRegistration(runtime: .codex, cwd: "/tmp/project")
+    _ = store.registerManagedHook(registration, surfaceID: surfaceID)
+    _ = store.updateEvidenceEpoch(surfaceID: surfaceID, processGeneration: generation, sessionID: nil)
+    let first = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-1"
+    )
+    let second = makeInput(
+      runtime: .codex,
+      token: registration.token,
+      nativeEvent: "agent-turn-complete",
+      cwd: "/tmp/project",
+      sessionID: "thread-2"
+    )
+    #expect(store.recordManagedHook(first, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+    #expect(store.recordManagedHook(second, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+
+    #expect(!store.recordManagedHook(first, callerAncestry: [generation], surfaceID: surfaceID).isAccepted)
+  }
+
   @Test func processReplacementClearsThePreviousSessionIdentity() {
     let now = Date(timeIntervalSince1970: 100)
     let first = AgentProcessGeneration(pid: 900, startedAt: now)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -187,12 +187,13 @@ struct WorktreeTerminalManagerTests {
       directoryHint: .isDirectory
     )
     defer { try? FileManager.default.removeItem(at: base) }
-    let oldStore = try CodexForwardingRecordStore(
+    var oldStore: CodexForwardingRecordStore? = try CodexForwardingRecordStore(
       baseDirectory: base,
       orphanMaximumAge: 60,
       now: { Date(timeIntervalSince1970: 100) }
     )
-    let oldRecord = try oldStore.create(argv: ["/tmp/notifier"])
+    let oldRecord = try #require(oldStore).create(argv: ["/tmp/notifier"])
+    oldStore = nil
     let manager = WorktreeTerminalManager(
       runtime: GhosttyRuntime(),
       forwardingRecordBaseDirectory: base
@@ -201,6 +202,39 @@ struct WorktreeTerminalManagerTests {
     manager.startAgentHookRuntimeMaintenance()
 
     #expect(!FileManager.default.fileExists(atPath: oldRecord.locator.path(percentEncoded: false)))
+  }
+
+  @Test func menuSplitProfileFallsBackToATabWhenNoAnchorExists() async throws {
+    let manager = WorktreeTerminalManager(
+      runtime: GhosttyRuntime(),
+      hookResourcesProvider: { nil },
+      skipsSurfaceCreationForTesting: true
+    )
+    let worktree = makeWorktree()
+    let profileID = UUID()
+    let plan = AgentProfileLaunchPlan(
+      profileID: profileID,
+      profileName: "Codex",
+      runtime: .codex,
+      invocation: AgentInvocation(executable: "codex", arguments: []),
+      commandEnvironmentTokens: [],
+      placement: .split,
+      splitDirection: .right,
+      surfaceEnvironment: [:],
+      dedicatedHome: nil
+    )
+    let stream = manager.eventStream()
+
+    manager.handleCommand(.launchAgentProfile(worktree, plan: plan))
+    let event = await nextEvent(stream) {
+      switch $0 {
+      case .agentProfileLaunched, .agentProfileLaunchFailed: true
+      default: false
+      }
+    }
+
+    #expect(event == .agentProfileLaunched(worktreeID: worktree.id, profileID: profileID))
+    #expect(manager.state(for: worktree).tabManager.tabs.count == 1)
   }
 
   @Test func unavailableHookResourcesWarnOnceAndLaunchTheOriginalInvocation() async throws {

--- a/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
+++ b/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
@@ -215,6 +215,24 @@ struct WorktreeTerminalStateAgentProfileTests {
     #expect(state.surfaceView(for: launched.surfaceID)?.surfaceCreationArmed == true)
   }
 
+  @Test func deferredProfileAppliesFontSizeAdjustmentAfterSurfaceCreation() throws {
+    let state = makeState(
+      skipsSurfaceCreationForTesting: false,
+      defaultFontSize: 18
+    )
+    defer { state.cleanupAllAgentDetectionState() }
+
+    let launched = try state.launchAgentProfile(
+      AgentProfileLaunchRequest(
+        plan: makePlan(dedicatedHome: nil),
+        placement: .tab(background: false)
+      )
+    ).get()
+
+    let view = try #require(state.surfaceView(for: launched.surfaceID))
+    #expect(view.didApplyFontSizeAdjustmentMarker)
+  }
+
   @Test func deferredGhosttyCreationFailureRollsBackRegistrationAndSurface() {
     let state = makeState(
       skipsSurfaceCreationForTesting: false,
@@ -378,7 +396,8 @@ struct WorktreeTerminalStateAgentProfileTests {
 
   private func makeState(
     skipsSurfaceCreationForTesting: Bool = true,
-    failsSurfaceCreationForTesting: Bool = false
+    failsSurfaceCreationForTesting: Bool = false,
+    defaultFontSize: Float32? = nil
   ) -> WorktreeTerminalState {
     WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -389,6 +408,7 @@ struct WorktreeTerminalStateAgentProfileTests {
         workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
         repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
       ),
+      defaultFontSize: defaultFontSize,
       skipsSurfaceCreationForTesting: skipsSurfaceCreationForTesting,
       failsSurfaceCreationForTesting: failsSurfaceCreationForTesting
     )


### PR DESCRIPTION
## Summary

Follow-up hardening for #721 based on post-merge runtime reproduction and focused RED → GREEN tests.

- Fix process EOF, socket/pipe signal safety, login-shell parsing, and managed option placement.
- Preserve managed registration and session identity across transient evidence gaps while revoking confirmed replacements.
- Restore menu split fallback, protect cross-instance forwarding records, freeze caller identity at accept time, and initialize deferred surfaces after native creation.
- Harden the disconnect seam with accepted-socket signal suppression, monitor-owned descriptors, and deterministic peer-close tests.

## Review disposition

| # | Finding | Disposition |
|---|---|---|
| 1 | Shell probe spins on `POLLHUP`/EOF | Fixed with EOF-aware descriptor draining |
| 2 | Duplicated subprocess runners | Deferred; behavioral contracts are covered, no broad refactor without measured benefit |
| 3 | Outbound CLI socket can receive fatal `SIGPIPE` | Fixed with descriptor-level suppression and process-isolated coverage |
| 4 | App-server stdin can receive fatal `SIGPIPE` | Fixed with descriptor-level suppression, early cleanup, and early-exit coverage |
| 5 | Strict login-shell marker parsing / one-second deadline | Parser fixed for unrelated profile output; deadline retained based on local measurement and fail-soft behavior |
| 6 | Transient generation loss or slow first startup revokes registration | Fixed |
| 7 | Same-process thread/session rotation remains pinned | Fixed with verified rebinding |
| 8 | Process replacement retains stale session identity | Fixed by clearing prior session state |
| 9 | Repeated evidence lookup cost | Deferred; bounded by existing deduplication/coalescing and unmeasured |
| 10 | Menu/palette split launch loses tab fallback | Fixed; explicit CLI/workflow split requests remain strict |
| 11 | Managed options can be inserted after `--` | Fixed with sentinel-aware insertion/scanning |
| 12 | Orphan sweep can remove active cross-instance records | Fixed with per-session owner locks and exclusive record leases |
| 13 | Caller PID/ancestry captured after short-lived peer exits | Fixed by freezing same-user identity at accept time |
| 14 | Deferred surfaces miss native font initialization | Fixed after native surface creation |
| 15 | Startup maintenance performs synchronous filesystem work | Deferred; normally tiny and requires ownership-aware concurrency design before moving off actor isolation |

A final disconnect-seam review also found and fixed accepted-server-socket signal exposure, asynchronous monitor descriptor reuse, and a peer-close test race. The monitor now owns an atomic close-on-exec duplicate; test semaphores prove peer closure before routing.

## Validation

- `make test` — verified 2542 tests, zero failures
- `make check` — strict format/lint plus 34 script tests
- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration` — 97 tests
- `make build-app`
- Disconnect seam: 13/13 focused socket tests; three critical tests passed 10 repeated runs each
