### PR TITLE
Make shell cancellation tests deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,18 +348,40 @@ test-scripts: # Run tests for the repository's Python scripts
 
 test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 	@set -euo pipefail; \
-	result_bundle="$(CURRENT_MAKEFILE_DIR)/build/test-results/supacode-tests.xcresult"; \
-	mkdir -p "$$(dirname "$$result_bundle")"; \
-	rm -rf "$$result_bundle"; \
-	set +e; \
-	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" $(TEST_SIGNING_ARGS) -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental 2>&1 | mise exec -- xcsift -w --format toon; \
-	xcodebuild_status=$${PIPESTATUS[0]}; \
-	set -e; \
-	if [ "$$xcodebuild_status" -ne 0 ]; then \
-		bash "$(CURRENT_MAKEFILE_DIR)/scripts/print-xcresult-failures.sh" "$$result_bundle" || true; \
-		exit "$$xcodebuild_status"; \
-	fi; \
-	bash "$(CURRENT_MAKEFILE_DIR)/scripts/assert-xcresult-tests.sh" "$$result_bundle"
+	result_root="$(CURRENT_MAKEFILE_DIR)/build/test-results"; \
+	mkdir -p "$$result_root"; \
+	run_xcode_tests() { \
+		local result_bundle="$$1"; \
+		local action="$$2"; \
+		local expected_test_count="$$3"; \
+		shift 3; \
+		rm -rf "$$result_bundle"; \
+		set +e; \
+		xcodebuild "$$action" -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" $(TEST_SIGNING_ARGS) -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental "$$@" 2>&1 | mise exec -- xcsift -w --format toon; \
+		local xcodebuild_status=$${PIPESTATUS[0]}; \
+		set -e; \
+		if [ "$$xcodebuild_status" -ne 0 ]; then \
+			bash "$(CURRENT_MAKEFILE_DIR)/scripts/print-xcresult-failures.sh" "$$result_bundle" || true; \
+			return "$$xcodebuild_status"; \
+		fi; \
+		if [ -n "$$expected_test_count" ]; then \
+			bash "$(CURRENT_MAKEFILE_DIR)/scripts/assert-xcresult-tests.sh" "$$result_bundle" "$$expected_test_count"; \
+		else \
+			bash "$(CURRENT_MAKEFILE_DIR)/scripts/assert-xcresult-tests.sh" "$$result_bundle"; \
+		fi; \
+	}; \
+	shell_cancellation_tests=( \
+		"supacodeTests/ShellClientStreamingTests/cancellingRunStreamConsumerTerminatesProcessAfterItIsReady()" \
+		"supacodeTests/ShellClientStreamingTests/runTerminatesReadyProcessWhenCallingTaskIsCancelled()" \
+	); \
+	skip_args=(); \
+	only_args=(); \
+	for test_id in "$${shell_cancellation_tests[@]}"; do \
+		skip_args+=("-skip-testing:$$test_id"); \
+		only_args+=("-only-testing:$$test_id"); \
+	done; \
+	run_xcode_tests "$$result_root/supacode-tests.xcresult" test "" "$${skip_args[@]}"; \
+	run_xcode_tests "$$result_root/supacode-shell-cancellation-tests.xcresult" test-without-building 2 "$${only_args[@]}"
 
 test-cli-smoke: build-cli # Smoke test CLI executable
 	@set -euo pipefail; \

--- a/ProwlCLITests/DispatchSchemaTests.swift
+++ b/ProwlCLITests/DispatchSchemaTests.swift
@@ -49,7 +49,7 @@ final class DispatchSchemaTests: XCTestCase {
   private func assertValid(_ instance: String) throws {
     let schemaText = try XCTUnwrap(String(data: ProwlCLIContractBundle.schemaData, encoding: .utf8))
     let result = try Schema(instance: schemaText).validate(instance: instance)
-    XCTAssertTrue(result.isValid, "Expected valid schema fixture: \(result.errors)")
+    XCTAssertTrue(result.isValid, "Expected valid schema fixture: \(result.errors ?? [])")
   }
 
   private func assertInvalid(_ instance: String) throws {

--- a/ProwlCLITests/LifecycleWarningSchemaTests.swift
+++ b/ProwlCLITests/LifecycleWarningSchemaTests.swift
@@ -44,6 +44,6 @@ final class LifecycleWarningSchemaTests: XCTestCase {
   private func assertValidity(_ instance: String, expected: Bool) throws {
     let schemaText = try XCTUnwrap(String(data: ProwlCLIContractBundle.schemaData, encoding: .utf8))
     let result = try Schema(instance: schemaText).validate(instance: instance)
-    XCTAssertEqual(result.isValid, expected, "Schema errors: \(result.errors)")
+    XCTAssertEqual(result.isValid, expected, "Schema errors: \(result.errors ?? [])")
   }
 }

--- a/scripts/assert-xcresult-tests.sh
+++ b/scripts/assert-xcresult-tests.sh
@@ -2,12 +2,17 @@
 
 set -euo pipefail
 
-if [[ "$#" -ne 1 ]]; then
-  echo "usage: $0 <xcresult-path>" >&2
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+  echo "usage: $0 <xcresult-path> [expected-test-count]" >&2
   exit 2
 fi
 
 result_bundle="$1"
+expected_test_count="${2:-}"
+if [[ -n "$expected_test_count" && ! "$expected_test_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: expected test count must be a positive integer: $expected_test_count" >&2
+  exit 2
+fi
 
 if [[ ! -d "$result_bundle" ]]; then
   echo "error: xcresult bundle not found: $result_bundle" >&2
@@ -57,6 +62,11 @@ fi
 
 if (( total_tests <= 0 )); then
   echo "error: xcresult reports zero tests; refusing a false-success test run" >&2
+  exit 1
+fi
+
+if [[ -n "$expected_test_count" ]] && (( total_tests != expected_test_count )); then
+  echo "error: expected $expected_test_count tests, found $total_tests" >&2
   exit 1
 fi
 

--- a/scripts/test_assert_xcresult_tests.py
+++ b/scripts/test_assert_xcresult_tests.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class AssertXCResultTestsTests(unittest.TestCase):
+    def test_rejects_result_bundle_with_wrong_expected_test_count(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            result_bundle = root / "result.xcresult"
+            result_bundle.mkdir()
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            xcrun = bin_directory / "xcrun"
+            xcrun.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' '{\"result\":\"Passed\",\"totalTestCount\":1,\"failedTests\":0}'\n"
+            )
+            xcrun.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = f"{bin_directory}:{environment['PATH']}"
+
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "scripts/assert-xcresult-tests.sh",
+                    str(result_bundle),
+                    "2",
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+                text=True,
+            )
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("expected 2 tests, found 1", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -170,15 +170,41 @@ nonisolated private final class NamedPipeWatcher: @unchecked Sendable {
   }
 }
 
+nonisolated private final class NamedPipeSender {
+  private let descriptor: Int32
+
+  init(url: URL) throws {
+    let path = url.path(percentEncoded: false)
+    guard mkfifo(path, 0o600) == 0 else { throw NamedPipeWatcherError.creationFailed }
+    let descriptor = open(path, O_RDWR | O_CLOEXEC)
+    guard descriptor >= 0 else { throw NamedPipeWatcherError.openFailed }
+    self.descriptor = descriptor
+  }
+
+  deinit {
+    Darwin.close(descriptor)
+  }
+
+  func send(_ value: String) throws {
+    let data = Data(value.utf8)
+    let count = data.withUnsafeBytes {
+      Darwin.write(descriptor, $0.baseAddress, $0.count)
+    }
+    guard count == data.count else { throw NamedPipeWatcherError.writeFailed }
+  }
+}
+
 nonisolated private enum NamedPipeWatcherError: Error {
   case creationFailed
   case openFailed
+  case writeFailed
 }
 
 private struct ShellCancellationFixture {
   let root: URL
   let readyURL: URL
   let resultURL: URL
+  let watchdogURL: URL
   let executableURL = URL(fileURLWithPath: "/usr/bin/python3")
   let arguments: [String]
 
@@ -191,6 +217,7 @@ private struct ShellCancellationFixture {
     let scriptURL = root.appending(path: "fixture.py", directoryHint: .notDirectory)
     let readyURL = root.appending(path: "ready", directoryHint: .notDirectory)
     let resultURL = root.appending(path: "result", directoryHint: .notDirectory)
+    let watchdogURL = root.appending(path: "watchdog", directoryHint: .notDirectory)
     try """
     import pathlib
     import signal
@@ -198,6 +225,7 @@ private struct ShellCancellationFixture {
 
     ready = pathlib.Path(sys.argv[1])
     result = pathlib.Path(sys.argv[2])
+    watchdog = pathlib.Path(sys.argv[3])
 
     def publish(path, value):
         with path.open("w") as stream:
@@ -209,18 +237,21 @@ private struct ShellCancellationFixture {
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, lambda *_: finish("terminated"))
-    # Bound a broken cancellation path without measuring host-side wall-clock latency.
+    # Arm the fallback only after the Swift consumer has observed cancellation.
     signal.signal(signal.SIGALRM, lambda *_: finish("natural"))
     publish(ready, "ready")
-    signal.alarm(20)
+    with watchdog.open("r") as stream:
+        stream.read(3)
+    signal.alarm(5)
     signal.pause()
     """.write(to: scriptURL, atomically: true, encoding: .utf8)
     self.root = root
     self.readyURL = readyURL
     self.resultURL = resultURL
+    self.watchdogURL = watchdogURL
     arguments = [
       scriptURL.path(percentEncoded: false), readyURL.path(percentEncoded: false),
-      resultURL.path(percentEncoded: false),
+      resultURL.path(percentEncoded: false), watchdogURL.path(percentEncoded: false),
     ]
   }
 }
@@ -334,6 +365,7 @@ struct ShellClientStreamingTests {
       url: fixture.readyURL,
       onCompletion: { if $0 == "ready" { readyCancellation.signalReady() } }
     )
+    let watchdog = try NamedPipeSender(url: fixture.watchdogURL)
     let resultEvent = AsyncStream<String>.makeStream()
     let resultWatcher = try NamedPipeWatcher(
       url: fixture.resultURL,
@@ -359,9 +391,10 @@ struct ShellClientStreamingTests {
 
     await consumer.value
     try #require(readyCancellation.cancellationWasIssued)
+    try watchdog.send("arm")
     var resultIterator = resultEvent.stream.makeAsyncIterator()
     let result = try #require(await resultIterator.next())
-    withExtendedLifetime((readyWatcher, resultWatcher)) {}
+    withExtendedLifetime((readyWatcher, resultWatcher, watchdog)) {}
 
     #expect(result == "terminated")
   }
@@ -374,6 +407,7 @@ struct ShellClientStreamingTests {
       url: fixture.readyURL,
       onCompletion: { if $0 == "ready" { readyCancellation.signalReady() } }
     )
+    let watchdog = try NamedPipeSender(url: fixture.watchdogURL)
     let resultEvent = AsyncStream<String>.makeStream()
     let resultWatcher = try NamedPipeWatcher(
       url: fixture.resultURL,
@@ -393,9 +427,10 @@ struct ShellClientStreamingTests {
 
     _ = await runTask.result
     try #require(readyCancellation.cancellationWasIssued)
+    try watchdog.send("arm")
     var resultIterator = resultEvent.stream.makeAsyncIterator()
     let result = try #require(await resultIterator.next())
-    withExtendedLifetime((readyWatcher, resultWatcher)) {}
+    withExtendedLifetime((readyWatcher, resultWatcher, watchdog)) {}
 
     #expect(result == "terminated")
   }

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -58,6 +59,169 @@ nonisolated final class TerminationCallRecorder: @unchecked Sendable {
     lock.lock()
     defer { lock.unlock() }
     return countValue
+  }
+}
+
+nonisolated private final class ProcessReadyCancellation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancellation: (@Sendable () -> Void)?
+  private var ready = false
+  private var didCancel = false
+
+  func installCancellation(_ cancellation: @escaping @Sendable () -> Void) {
+    let action: (@Sendable () -> Void)?
+    lock.lock()
+    self.cancellation = cancellation
+    action = takeCancellationLocked()
+    lock.unlock()
+    action?()
+  }
+
+  func signalReady() {
+    let action: (@Sendable () -> Void)?
+    lock.lock()
+    ready = true
+    action = takeCancellationLocked()
+    lock.unlock()
+    action?()
+  }
+
+  var cancellationWasIssued: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return didCancel
+  }
+
+  private func takeCancellationLocked() -> (@Sendable () -> Void)? {
+    guard ready, !didCancel, let cancellation else { return nil }
+    didCancel = true
+    return cancellation
+  }
+}
+
+nonisolated private final class NamedPipeState: @unchecked Sendable {
+  private static let cancellationByte: UInt8 = 0
+
+  private let lock = NSLock()
+  private var descriptor: Int32
+
+  init(descriptor: Int32) {
+    self.descriptor = descriptor
+  }
+
+  func read() -> String? {
+    let descriptor = lock.withLock { self.descriptor }
+    guard descriptor >= 0 else { return nil }
+    var buffer = [UInt8](repeating: 0, count: 64)
+    let count = buffer.withUnsafeMutableBytes { bytes -> Int in
+      while true {
+        let count = Darwin.read(descriptor, bytes.baseAddress, bytes.count)
+        if count < 0, errno == EINTR { continue }
+        return count
+      }
+    }
+    closeDescriptor()
+    guard count > 0, buffer[0] != Self.cancellationByte else { return nil }
+    return String(bytes: buffer.prefix(count), encoding: .utf8)
+  }
+
+  func cancel() {
+    lock.withLock {
+      guard descriptor >= 0 else { return }
+      var byte = Self.cancellationByte
+      _ = Darwin.write(descriptor, &byte, 1)
+    }
+  }
+
+  private func closeDescriptor() {
+    lock.withLock {
+      guard descriptor >= 0 else { return }
+      Darwin.close(descriptor)
+      descriptor = -1
+    }
+  }
+}
+
+/// Uses a dedicated OS thread so a loaded cooperative or Dispatch pool cannot delay
+/// the process-ready cancellation signal.
+nonisolated private final class NamedPipeWatcher: @unchecked Sendable {
+  private let state: NamedPipeState
+
+  init(
+    url: URL,
+    onCompletion: @escaping @Sendable (String?) -> Void
+  ) throws {
+    let path = url.path(percentEncoded: false)
+    guard mkfifo(path, 0o600) == 0 else { throw NamedPipeWatcherError.creationFailed }
+    let descriptor = open(path, O_RDWR | O_CLOEXEC)
+    guard descriptor >= 0 else { throw NamedPipeWatcherError.openFailed }
+    let state = NamedPipeState(descriptor: descriptor)
+    self.state = state
+    let thread = Thread {
+      onCompletion(state.read())
+    }
+    thread.name = "Prowl shell cancellation fixture"
+    thread.qualityOfService = .userInitiated
+    thread.start()
+  }
+
+  deinit {
+    state.cancel()
+  }
+}
+
+nonisolated private enum NamedPipeWatcherError: Error {
+  case creationFailed
+  case openFailed
+}
+
+private struct ShellCancellationFixture {
+  let root: URL
+  let readyURL: URL
+  let resultURL: URL
+  let executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+  let arguments: [String]
+
+  init(name: String) throws {
+    let root = FileManager.default.temporaryDirectory.appending(
+      path: "prowl-tests-shell-cancellation-\(name)-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let scriptURL = root.appending(path: "fixture.py", directoryHint: .notDirectory)
+    let readyURL = root.appending(path: "ready", directoryHint: .notDirectory)
+    let resultURL = root.appending(path: "result", directoryHint: .notDirectory)
+    try """
+    import pathlib
+    import signal
+    import sys
+
+    ready = pathlib.Path(sys.argv[1])
+    result = pathlib.Path(sys.argv[2])
+
+    def publish(path, value):
+        with path.open("w") as stream:
+            stream.write(value)
+            stream.flush()
+
+    def finish(value):
+        publish(result, value)
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, lambda *_: finish("terminated"))
+    # Bound a broken cancellation path without measuring host-side wall-clock latency.
+    signal.signal(signal.SIGALRM, lambda *_: finish("natural"))
+    publish(ready, "ready")
+    signal.alarm(20)
+    signal.pause()
+    """.write(to: scriptURL, atomically: true, encoding: .utf8)
+    self.root = root
+    self.readyURL = readyURL
+    self.resultURL = resultURL
+    arguments = [
+      scriptURL.path(percentEncoded: false), readyURL.path(percentEncoded: false),
+      resultURL.path(percentEncoded: false),
+    ]
   }
 }
 
@@ -162,67 +326,78 @@ struct ShellClientStreamingTests {
     #expect(streamedLines.contains(expectedStderrLine))
   }
 
-  @Test func cancellingRunStreamConsumerTerminatesProcessQuickly() async throws {
-    let shell = ShellClient.liveValue
-    let commandURL = URL(fileURLWithPath: "/bin/sleep")
-    let stream = shell.runStream(commandURL, ["30"], nil)
-
+  @Test func cancellingRunStreamConsumerTerminatesProcessAfterItIsReady() async throws {
+    let fixture = try ShellCancellationFixture(name: "stream")
+    defer { try? FileManager.default.removeItem(at: fixture.root) }
+    let readyCancellation = ProcessReadyCancellation()
+    let readyWatcher = try NamedPipeWatcher(
+      url: fixture.readyURL,
+      onCompletion: { if $0 == "ready" { readyCancellation.signalReady() } }
+    )
+    let resultEvent = AsyncStream<String>.makeStream()
+    let resultWatcher = try NamedPipeWatcher(
+      url: fixture.resultURL,
+      onCompletion: {
+        if let value = $0 { resultEvent.continuation.yield(value) }
+        resultEvent.continuation.finish()
+      }
+    )
+    let stream = ShellClient.liveValue.runStream(
+      fixture.executableURL,
+      fixture.arguments,
+      nil
+    )
     let consumer = Task {
-      var lines: [ShellStreamLine] = []
       do {
-        for try await event in stream {
-          if case .line(let line) = event {
-            lines.append(line)
-          }
-        }
+        for try await _ in stream {}
       } catch {
         // CancellationError or ShellClientError after SIGTERM both indicate
-        // the cancellation pathway is connected.
+        // that the consumer observed process teardown.
       }
-      return lines
     }
+    readyCancellation.installCancellation { consumer.cancel() }
 
-    // The coordinator unit test covers cancellation before process registration.
-    // Yield once to exercise the usual already-running stream path without a timing sleep.
-    await Task.yield()
+    await consumer.value
+    try #require(readyCancellation.cancellationWasIssued)
+    var resultIterator = resultEvent.stream.makeAsyncIterator()
+    let result = try #require(await resultIterator.next())
+    withExtendedLifetime((readyWatcher, resultWatcher)) {}
 
-    let start = ContinuousClock.now
-    consumer.cancel()
-    _ = await consumer.value
-    let elapsed = ContinuousClock.now - start
-
-    // The assertion distinguishes "cancellation worked" from "waited out the
-    // process's 30-second natural exit". Loaded CI runners have pushed the
-    // full cancel → SIGTERM → pipe-EOF → finish chain past 10s while suite
-    // tests run in parallel, so the budget leaves headroom without blurring
-    // that distinction.
-    #expect(
-      elapsed < .seconds(20),
-      "consumer cancellation must not wait for the process's 30-second natural exit; took \(elapsed)"
-    )
+    #expect(result == "terminated")
   }
 
-  @Test func runReturnsQuicklyWhenCallingTaskIsCancelled() async {
-    let shell = ShellClient.liveValue
-    let commandURL = URL(fileURLWithPath: "/bin/sleep")
-
-    let runTask = Task {
-      try await shell.run(commandURL, ["30"], nil)
-    }
-
-    // Cancellation before process registration is covered deterministically above.
-    await Task.yield()
-
-    let start = ContinuousClock.now
-    runTask.cancel()
-    _ = await runTask.result
-    let elapsed = ContinuousClock.now - start
-
-    // Same budget rationale as cancellingRunStreamConsumerTerminatesProcessQuickly.
-    #expect(
-      elapsed < .seconds(20),
-      "run() cancellation must not wait for the process's 30-second natural exit; took \(elapsed)"
+  @Test func runTerminatesReadyProcessWhenCallingTaskIsCancelled() async throws {
+    let fixture = try ShellCancellationFixture(name: "run")
+    defer { try? FileManager.default.removeItem(at: fixture.root) }
+    let readyCancellation = ProcessReadyCancellation()
+    let readyWatcher = try NamedPipeWatcher(
+      url: fixture.readyURL,
+      onCompletion: { if $0 == "ready" { readyCancellation.signalReady() } }
     )
+    let resultEvent = AsyncStream<String>.makeStream()
+    let resultWatcher = try NamedPipeWatcher(
+      url: fixture.resultURL,
+      onCompletion: {
+        if let value = $0 { resultEvent.continuation.yield(value) }
+        resultEvent.continuation.finish()
+      }
+    )
+    let runTask = Task {
+      try await ShellClient.liveValue.run(
+        fixture.executableURL,
+        fixture.arguments,
+        nil
+      )
+    }
+    readyCancellation.installCancellation { runTask.cancel() }
+
+    _ = await runTask.result
+    try #require(readyCancellation.cancellationWasIssued)
+    var resultIterator = resultEvent.stream.makeAsyncIterator()
+    let result = try #require(await resultIterator.next())
+    withExtendedLifetime((readyWatcher, resultWatcher)) {}
+
+    #expect(result == "terminated")
   }
 
   @Test func runStreamSucceedsForShortLivedProcessAfterCancellationFixes() async throws {


### PR DESCRIPTION
## Summary

- replace two wall-clock shell cancellation assertions with process-ready semantic handshakes
- use dedicated named-pipe reader threads so cancellation is not delayed by Swift or Dispatch executor contention
- arm the child watchdog only after the canceled Swift task returns, distinguishing `SIGTERM` from a bounded natural exit without executor-starvation false negatives
- run the two process-lifecycle integration tests separately from the 2500+ parallel app suite using the same build products
- require the isolated xcresult to contain exactly both selected tests

## Motivation

The previous tests used `Task.yield()` as a process-readiness proxy and measured cancellation against a 20-second latency budget. Under the full parallel suite they could report 36+ second elapsed times despite passing immediately in isolation. The budget had already been widened from 2 to 5 to 10 to 20 seconds.

The new fixture publishes readiness only after installing its signal handlers, then reports either `terminated` or `natural`. Assertions now test cancellation semantics rather than runner load. The process-lifecycle cases are isolated from the highly parallel app batch while still using `test-without-building`, so there is no second compilation.

## CI follow-up

The first CI run showed that canceling an `AsyncThrowingStream` consumer still requires the consumer Task to regain its Swift executor before `onTermination` runs. Under the fully concurrent CI workload this happened after the child watchdog expired. The watchdog now starts only after the consumer/calling Task has returned, and `make test-app` executes these two integration tests in a separate phase. A script-level regression requires that phase's xcresult to contain exactly two tests, preventing silently unmatched Swift Testing selectors.

## Validation

- captured original RED: both prior tests failed in the loaded parallel suite at approximately 36.5 seconds
- captured CI RED: stream cancellation fixture reported `natural` after executor starvation
- replacement tests: 10 repetitions each, passed, average 0.032 seconds
- `make test-app`: 2547 tests in the parallel phase, then exactly 2 isolated tests; zero failures
- `make check`: 35 script tests plus format/lint passed
- `make build-app`
