### PR TITLE
Drive RepositoriesFeature delays with an injected clock

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -902,7 +902,7 @@ extension RepositoriesFeature {
         return .cancel(id: CancelID.toastAutoDismiss)
       case .success, .warning:
         return .run { send in
-          try? await ContinuousClock().sleep(for: .seconds(3))
+          try? await clock.sleep(for: .seconds(3))
           await send(.dismissToast)
         }
         .cancellable(id: CancelID.toastAutoDismiss, cancelInFlight: true)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -902,7 +902,7 @@ extension RepositoriesFeature {
         return .cancel(id: CancelID.toastAutoDismiss)
       case .success, .warning:
         return .run { send in
-          try? await clock.sleep(for: .seconds(3))
+          try? await ContinuousClock().sleep(for: .seconds(3))
           await send(.dismissToast)
         }
         .cancellable(id: CancelID.toastAutoDismiss, cancelInFlight: true)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -71,7 +71,7 @@ extension RepositoriesFeature {
       let repositoryRootURL = worktree.repositoryRootURL
       let worktreeIDs = repository.worktrees.map(\.id)
       return .run { send in
-        try? await clock.sleep(for: .seconds(2))
+        try? await ContinuousClock().sleep(for: .seconds(2))
         await send(
           .worktreeInfoEvent(
             .repositoryPullRequestRefresh(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -71,7 +71,7 @@ extension RepositoriesFeature {
       let repositoryRootURL = worktree.repositoryRootURL
       let worktreeIDs = repository.worktrees.map(\.id)
       return .run { send in
-        try? await ContinuousClock().sleep(for: .seconds(2))
+        try? await clock.sleep(for: .seconds(2))
         await send(
           .worktreeInfoEvent(
             .repositoryPullRequestRefresh(
@@ -181,7 +181,7 @@ extension RepositoriesFeature {
         clearAllPullRequestRefreshTracking(state: &state)
         return .run { send in
           while !Task.isCancelled {
-            try? await ContinuousClock().sleep(for: githubIntegrationRecoveryInterval)
+            try? await clock.sleep(for: githubIntegrationRecoveryInterval)
             guard !Task.isCancelled else {
               return
             }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -556,6 +556,7 @@ struct RepositoriesFeature {
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence
   @Dependency(ShellClient.self) var shellClient
   @Dependency(\.date.now) var now
+  @Dependency(\.continuousClock) var clock
   @Dependency(BranchNameSuggestionClient.self) var branchNameSuggestionClient
   @Dependency(\.uuid) var uuid
   @Dependency(\.repositoryIconDetector) var repositoryIconDetector

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1752,6 +1752,8 @@ struct RepositoriesFeatureTests {
     initialState.workspaceCreationPrompt?.isCreating = true
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
     }
     store.exhaustivity = .off
 
@@ -1820,6 +1822,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.date.now = Date(timeIntervalSince1970: 1_700_000_000)
       $0.shellClient.runLoginImpl = { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
@@ -5967,6 +5970,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, number, _, _ in
@@ -6021,6 +6025,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, _, strategy, _ in
@@ -6065,6 +6070,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { root in
         #expect(root == URL(fileURLWithPath: repoRoot))
@@ -6100,6 +6106,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6133,6 +6140,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6166,6 +6174,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6272,6 +6281,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.closePullRequest = { _, _, number, _ in
@@ -6479,6 +6489,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { false }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("remoteInfo should not be requested when GitHub integration is unavailable")
@@ -6614,6 +6625,8 @@ struct RepositoriesFeatureTests {
       )
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
     }
 
     await store.send(.githubIntegration(.githubIntegrationAvailabilityUpdated(false))) {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1752,8 +1752,6 @@ struct RepositoriesFeatureTests {
     initialState.workspaceCreationPrompt?.isCreating = true
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
-    } withDependencies: {
-      $0.continuousClock = TestClock()
     }
     store.exhaustivity = .off
 
@@ -1822,7 +1820,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.date.now = Date(timeIntervalSince1970: 1_700_000_000)
       $0.shellClient.runLoginImpl = { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
@@ -5970,7 +5967,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, number, _, _ in
@@ -6025,7 +6021,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, _, strategy, _ in
@@ -6070,7 +6065,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { root in
         #expect(root == URL(fileURLWithPath: repoRoot))
@@ -6106,7 +6100,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6140,7 +6133,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6174,7 +6166,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: fixture.state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("git remoteInfo should not run when PR URL resolves")
@@ -6281,7 +6272,6 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.closePullRequest = { _, _, number, _ in


### PR DESCRIPTION
## Problem

`RepositoriesFeatureTests/worktreeInfoEventRepositoryPullRequestRefreshQueuesWhileAvailabilityUnknown`
fails intermittently in CI with:

```
Must handle 2 received actions before sending an action.
Unhandled actions: [refreshGithubIntegrationAvailability, githubIntegrationAvailabilityUpdated(false)]
```

It passes locally and in isolation (10/10), so it read as noise — but it is a real
non-deterministic-clock defect, not flakiness.

## Root cause

The GitHub-integration recovery loop sleeps on a real `ContinuousClock()` and re-emits
`refreshGithubIntegrationAvailability` every `githubIntegrationRecoveryInterval` (15s). A `TestStore`
cannot control a real clock, so under the full parallel CI run a test's window between starting the
recovery loop (on `githubIntegrationAvailabilityUpdated(false)`) and cancelling it (on
`setGithubIntegrationEnabled(false)`) can exceed 15s of wall-clock — the real clock then fires an
extra `refreshGithubIntegrationAvailability` → `githubIntegrationAvailabilityUpdated` pair right as
the test sends its next action, exactly the two unhandled actions above.

## Fix

Inject `@Dependency(\.continuousClock)` and sleep on it in the recovery loop. The two tests that
reach the recovery path now provide a `TestClock` that is never advanced, so the loop suspends and
never fires during the test — deterministic regardless of CI load, aligning with the repo rule
"in unit tests, never use `Task.sleep`; use `TestClock`."

The one-shot delayed PR refresh (2s) and toast auto-dismiss (3s) keep their original real clock:
they are not the flake, and injecting them would force every test embedding `RepositoriesFeature`
that triggers a toast or delayed refresh (e.g. `AppFeature*Tests`) to supply a clock. Scoping the
change to the recovery loop keeps the blast radius to exactly the two recovery-path tests.

## Verification

`make check`, `make test` (zero failures), `make build-app`. `RepositoriesFeatureTests`: 251 passed;
the three `AppFeature*` toast tests that a broad injection had broken pass unchanged. The
previously-flaky test is now deterministic (the recovery effect cannot fire without a clock advance).

https://claude.ai/code/session_01AQ4X2bx8DnU74wwThhV9D8
