### PR TITLE
Bundle Prowl's official skills and add the shared registry (K1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: ./.github/actions/setup-macos
       - run: make lint
       - name: Stage debug app resources
-        run: make embed-cli-debug embed-docs
+        run: make embed-cli-debug embed-docs embed-skills
       - name: Build app and run tests in parallel
         shell: bash
         run: |
@@ -53,7 +53,7 @@ jobs:
           pid_app=$!
           run_task cli-smoke make test-cli-smoke &
           pid_smoke=$!
-          run_task cli-integration make test-cli-integration &
+          run_task cli-tests make test-cli-unit test-cli-integration &
           pid_cli=$!
           run_task scripts make test-scripts &
           pid_scripts=$!

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ Frameworks/GhosttyKit.xcframework
 Resources/ghostty
 Resources/terminfo
 Resources/docs
+Resources/skills
 .ghostty_hash
 .ghostty_build_stamp
 .build_settings_cache.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ make capture-spike               # Sample the running Prowl Debug app when CPU c
 make measure-titles              # Black-box check that animated tab titles stay coalesced (~1 change/s)
 make log-stream                  # Stream app logs (subsystem: com.onevcat.prowl)
 make build-cli                   # Build CLI (prowl) via SwiftPM
-make test-cli-smoke              # Run CLI smoke tests (unit-level)
+make test-cli-smoke              # Run CLI executable smoke tests
+make test-cli-unit               # Run CLI unit tests
 make test-cli-integration        # Run CLI integration tests (socket round-trip)
 make bump-version                # Bump version (date-based YYYY.M.DD) and create git tag; used by release.sh
 ```
@@ -144,7 +145,7 @@ Reducer ← .terminalEvent(Event) ← AsyncStream<Event>
 ## Rules
 
 - After a task, ensure the app builds: `make build-app`
-- When working on CLI code (`ProwlCLI/`, `ProwlCLITests/`, `Package.swift`), run `make build-cli`, `make test-cli-smoke`, and `make test-cli-integration` before committing.
+- When working on CLI code (`ProwlCLI/`, `ProwlCLITests/`, `Package.swift`), run `make build-cli`, `make test-cli-smoke`, `make test-cli-unit`, and `make test-cli-integration` before committing.
 - When you change user-facing behavior (keyboard shortcuts, settings, the `prowl` CLI, or a feature's UX), update the matching file under `docs/` in the same change. For a full audit, run the `sync-docs` skill.
 - `docs-ai/` is curated, durable product/design documentation — never a working-note archive. Use the `write-ai-doc` skill only for a substantial feature or a non-trivial fix whose design and result must guide future implementation. Do not create entries for reviews, audits, routine research or investigations, status reports, test runs, or docs-only work unless onevcat explicitly asks for a `docs-ai/` record. When uncertain, do not create an entry. For qualifying work, create `docs-ai/NNN-<slug>/000-plan.md` before coding and complete `001-action.md` after implementation. Follow-up work on the same topic amends the existing entry (see `docs-ai/README.md`).
 - When implementing a new feature or fixing a bug that is unrelated to the current branch's active work, first create a dedicated branch from the latest `origin/main`; then work, commit, push, and open a PR from that branch.

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ TEST_SIGNING_ARGS := CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_
 endif
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs embed-skills run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs embed-skills run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-unit test-cli-integration benchmark-build bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -405,6 +405,16 @@ test-cli-smoke: build-cli # Smoke test CLI executable
 	response="$$tmp_dir/response.json"; \
 	PROWL_CLI_SOCKET="$$socket" "$$bin" list --json >"$$response" || true; \
 	jq -e '.error.code == "APP_NOT_RUNNING"' "$$response" >/dev/null
+
+test-cli-unit: # Run CLI unit tests via SwiftPM
+	@test_list="$$(swift test list)"; \
+	matching_test_count="$$(printf '%s\n' "$$test_list" | grep -Evc '$(CLI_INTEGRATION_TEST_FILTER)' || true)"; \
+	if [ "$$matching_test_count" -eq 0 ]; then \
+		echo "error: CLI unit filter matched zero tests" >&2; \
+		exit 1; \
+	fi; \
+	echo "CLI unit filter matched $$matching_test_count test(s)."; \
+	swift test --skip-build --skip '$(CLI_INTEGRATION_TEST_FILTER)'
 
 test-cli-integration: # Run CLI integration tests via SwiftPM
 	@test_list="$$(swift test list)"; \

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ TEST_SIGNING_ARGS := CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_
 endif
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs embed-skills run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-scripts test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -128,7 +128,15 @@ embed-docs: # Stage docs/ into Resources for bundling into the app (.app/Content
 	rsync -a --delete --exclude '.sync-meta.json' "$$src/" "$$dst/"; \
 	echo "embedded docs at $$dst"
 
-build-app: ensure-ghostty embed-cli-debug embed-docs # Build the macOS app (Debug)
+embed-skills: # Stage skills/ into Resources for bundling into the app (.app/Contents/Resources/skills)
+	@set -euo pipefail; \
+	src="$(CURRENT_MAKEFILE_DIR)/skills"; \
+	dst="$(CURRENT_MAKEFILE_DIR)/Resources/skills"; \
+	mkdir -p "$$dst"; \
+	rsync -a --delete "$$src/" "$$dst/"; \
+	echo "embedded skills at $$dst"
+
+build-app: ensure-ghostty embed-cli-debug embed-docs embed-skills # Build the macOS app (Debug)
 	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental $(DEBUG_SIGNING_ARGS) 2>&1 | mise exec -- xcsift -w --format toon'
 
 sync-cli-version: # Sync app MARKETING_VERSION into ProwlCLIShared/ProwlVersion.swift
@@ -335,13 +343,13 @@ install-release: build-ghostty-xcframework # Build Release, sign locally, instal
 	ditto "$$APP_PATH" "$$DST"; \
 	echo "installed $$DST (Release build, locally signed)"
 
-archive: build-ghostty-xcframework embed-cli embed-docs # Archive Release build for distribution
+archive: build-ghostty-xcframework embed-cli embed-docs embed-skills # Archive Release build for distribution
 	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Release -archivePath build/supacode.xcarchive archive CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="$$APPLE_TEAM_ID" CODE_SIGN_IDENTITY="$$DEVELOPER_ID_IDENTITY_SHA" OTHER_CODE_SIGN_FLAGS="--timestamp" PROWL_SENTRY_DSN="$(PROWL_SENTRY_DSN)" PROWL_POSTHOG_API_KEY="$(PROWL_POSTHOG_API_KEY)" PROWL_POSTHOG_HOST="$(PROWL_POSTHOG_HOST)" -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) $(XCODEBUILD_FLAGS) 2>&1 | mise exec -- xcsift -qw --format toon'
 
 export-archive: # Export xarchive
 	bash -o pipefail -c 'xcodebuild -exportArchive -archivePath build/supacode.xcarchive -exportPath build/export -exportOptionsPlist build/ExportOptions.plist 2>&1 | mise exec -- xcsift -qw --format toon'
 
-test: ensure-ghostty embed-cli-debug embed-docs test-app
+test: ensure-ghostty embed-cli-debug embed-docs embed-skills test-app
 
 test-scripts: # Run tests for the repository's Python scripts
 	@python3 -m unittest discover -s "$(CURRENT_MAKEFILE_DIR)/scripts" -p 'test_*.py'
@@ -408,13 +416,13 @@ test-cli-integration: # Run CLI integration tests via SwiftPM
 	echo "CLI integration filter matched $$matching_test_count test(s)."; \
 	swift test --skip-build --filter '$(CLI_INTEGRATION_TEST_FILTER)'
 
-benchmark-build: ensure-ghostty embed-cli-debug embed-docs # Benchmark clean and compilation-cache build/test time
+benchmark-build: ensure-ghostty embed-cli-debug embed-docs embed-skills # Benchmark clean and compilation-cache build/test time
 	@BUILD_BENCHMARK_ROOT="$(CURRENT_MAKEFILE_DIR)/.build-benchmark/build-time" \
 		SPM_CACHE_DIR="$(SPM_CACHE_DIR)" \
 		bash "$(CURRENT_MAKEFILE_DIR)/scripts/benchmark-build.sh" \
 		"$(BUILD_BENCHMARK_SCENARIO)" "$(BUILD_BENCHMARK_SAMPLES)"
 
-bench: ensure-ghostty embed-cli-debug embed-docs # Run performance benchmarks optimized (-O); append absolute medians to the bench log
+bench: ensure-ghostty embed-cli-debug embed-docs embed-skills # Run performance benchmarks optimized (-O); append absolute medians to the bench log
 	@set -euo pipefail; \
 	bench_log_dir="$$HOME/Library/Logs/Prowl/measurements/bench"; \
 	mkdir -p "$$bench_log_dir"; \

--- a/ProwlCLITests/ProwlSkillsTests.swift
+++ b/ProwlCLITests/ProwlSkillsTests.swift
@@ -167,8 +167,82 @@ final class ProwlSkillsTests: XCTestCase {
         frontmatter: """
           ---
           name: Invalid
+          description: Invalid audience.
           metadata:
             prowl-install: everywhere
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      XCTAssertThrowsError(try ProwlSkills.bundled(resourcesURL: resources)) { error in
+        guard let skillsError = error as? ProwlSkillsError,
+          case .invalidFrontmatter(_, let reason) = skillsError
+        else {
+          return XCTFail("Expected invalid skill frontmatter")
+        }
+        XCTAssertEqual(reason, "metadata.prowl-install must be user or workflow")
+      }
+    }
+  }
+
+  func testBundledRejectsTopLevelProwlInstallMetadata() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "invalid",
+        frontmatter: """
+          ---
+          name: Invalid
+          description: Invalid audience nesting.
+          metadata:
+          prowl-install: workflow
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      XCTAssertThrowsError(try ProwlSkills.bundled(resourcesURL: resources)) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .invalidFrontmatter)
+      }
+    }
+  }
+
+  func testBundledRejectsNestedProwlInstallMetadata() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "invalid",
+        frontmatter: """
+          ---
+          name: Invalid
+          description: Invalid audience nesting.
+          metadata:
+            vendor:
+              prowl-install: workflow
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      XCTAssertThrowsError(try ProwlSkills.bundled(resourcesURL: resources)) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .invalidFrontmatter)
+      }
+    }
+  }
+
+  func testBundledRejectsInconsistentlyIndentedMetadataFields() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "invalid",
+        frontmatter: """
+          ---
+          name: Invalid
+          description: Invalid metadata indentation.
+          metadata:
+            vendor: scalar
+              nested: value
           ---
           """,
         resourcesURL: resources

--- a/ProwlCLITests/ProwlSkillsTests.swift
+++ b/ProwlCLITests/ProwlSkillsTests.swift
@@ -1,0 +1,332 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class ProwlSkillsTests: XCTestCase {
+  func testBundledParsesPlainDescriptionAndDefaultsAudienceToUser() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      let skillDirectory = try writeSkill(
+        id: "plain",
+        frontmatter: """
+          ---
+          name: Plain Skill
+          description: A plain description: with punctuation.
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      let skills = try ProwlSkills.bundled(resourcesURL: resources)
+
+      XCTAssertEqual(
+        skills,
+        [
+          BundledSkill(
+            id: "plain",
+            name: "Plain Skill",
+            description: "A plain description: with punctuation.",
+            audience: .user,
+            directoryURL: skillDirectory
+          )
+        ]
+      )
+    }
+  }
+
+  func testBundledParsesFoldedDescriptionAndAudienceMetadata() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "reviewer",
+        frontmatter: """
+          ---
+          name: Reviewer
+          description: >-
+            Review a proposed change and
+            report actionable findings.
+
+            Preserve paragraph boundaries.
+          metadata:
+            prowl-install: workflow
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      let skill = try XCTUnwrap(ProwlSkills.bundled(resourcesURL: resources).first)
+
+      XCTAssertEqual(
+        skill.description,
+        "Review a proposed change and report actionable findings.\nPreserve paragraph boundaries."
+      )
+      XCTAssertEqual(skill.audience, .workflow)
+    }
+  }
+
+  func testBundledParsesExplicitUserAndWorkflowAudiences() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "global",
+        frontmatter: """
+          ---
+          name: Global
+          description: Globally installable.
+          metadata:
+            prowl-install: user
+          ---
+          """,
+        resourcesURL: resources
+      )
+      _ = try writeSkill(
+        id: "workflow",
+        frontmatter: """
+          ---
+          name: Workflow
+          description: Workflow only.
+          metadata:
+            prowl-install: workflow
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      let skills = try ProwlSkills.bundled(resourcesURL: resources)
+
+      XCTAssertEqual(skills.map(\.audience), [.user, .workflow])
+    }
+  }
+
+  func testBundledSortsSkillsByStableID() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      for id in ["zeta", "alpha", "middle"] {
+        _ = try writeSkill(
+          id: id,
+          frontmatter: """
+            ---
+            name: \(id)
+            description: \(id) description.
+            ---
+            """,
+          resourcesURL: resources
+        )
+      }
+
+      XCTAssertEqual(
+        try ProwlSkills.bundled(resourcesURL: resources).map(\.id),
+        ["alpha", "middle", "zeta"]
+      )
+    }
+  }
+
+  func testSkillLooksUpByIDAndReturnsNilForUnknownID() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "prowl-cli",
+        frontmatter: """
+          ---
+          name: Prowl CLI
+          description: Control Prowl.
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      XCTAssertEqual(
+        try ProwlSkills.skill(id: "prowl-cli", resourcesURL: resources)?.name,
+        "Prowl CLI"
+      )
+      XCTAssertNil(try ProwlSkills.skill(id: "missing", resourcesURL: resources))
+      XCTAssertNil(try ProwlSkills.skill(id: "../prowl-cli", resourcesURL: resources))
+    }
+  }
+
+  func testBundledRejectsMissingFrontmatter() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "invalid",
+        frontmatter: "# Missing frontmatter\n",
+        resourcesURL: resources
+      )
+
+      XCTAssertThrowsError(try ProwlSkills.bundled(resourcesURL: resources)) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .invalidFrontmatter)
+      }
+    }
+  }
+
+  func testBundledRejectsInvalidFrontmatter() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(path: "Resources", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "invalid",
+        frontmatter: """
+          ---
+          name: Invalid
+          metadata:
+            prowl-install: everywhere
+          ---
+          """,
+        resourcesURL: resources
+      )
+
+      XCTAssertThrowsError(try ProwlSkills.bundled(resourcesURL: resources)) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .invalidFrontmatter)
+      }
+    }
+  }
+
+  func testCLIOverrideTakesPrecedenceOverExecutableBundle() throws {
+    try withTemporaryDirectory { root in
+      let bundledResources = root.appending(
+        path: "Prowl.app/Contents/Resources", directoryHint: .isDirectory)
+      let executable = bundledResources.appending(
+        path: "prowl-cli/prowl", directoryHint: .notDirectory)
+      try writeFile("binary", to: executable)
+      _ = try writeSkill(
+        id: "bundled",
+        frontmatter: validFrontmatter(name: "Bundled"),
+        resourcesURL: bundledResources
+      )
+
+      let overrideSkills = root.appending(path: "override-skills", directoryHint: .isDirectory)
+      _ = try writeSkill(
+        id: "override",
+        frontmatter: validFrontmatter(name: "Override"),
+        skillsURL: overrideSkills
+      )
+
+      let skills = try ProwlSkills.bundledForCLI(
+        executableURL: executable,
+        environment: ["PROWL_SKILLS_DIR": overrideSkills.path(percentEncoded: false)]
+      )
+
+      XCTAssertEqual(skills.map(\.id), ["override"])
+    }
+  }
+
+  func testCLIInvalidOverrideDoesNotFallBackToExecutableBundle() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(
+        path: "Prowl.app/Contents/Resources", directoryHint: .isDirectory)
+      let executable = resources.appending(path: "prowl-cli/prowl", directoryHint: .notDirectory)
+      try writeFile("binary", to: executable)
+      _ = try writeSkill(
+        id: "bundled",
+        frontmatter: validFrontmatter(name: "Bundled"),
+        resourcesURL: resources
+      )
+      let missingOverride = root.appending(path: "missing-skills", directoryHint: .isDirectory)
+
+      XCTAssertThrowsError(
+        try ProwlSkills.bundledForCLI(
+          executableURL: executable,
+          environment: ["PROWL_SKILLS_DIR": missingOverride.path(percentEncoded: false)]
+        )
+      ) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .bundleNotFound)
+      }
+    }
+  }
+
+  func testCLIResolvesBundleThroughExecutableSymlink() throws {
+    try withTemporaryDirectory { root in
+      let resources = root.appending(
+        path: "Prowl.app/Contents/Resources", directoryHint: .isDirectory)
+      let bundledExecutable = resources.appending(
+        path: "prowl-cli/prowl", directoryHint: .notDirectory)
+      try writeFile("binary", to: bundledExecutable)
+      _ = try writeSkill(
+        id: "prowl-cli",
+        frontmatter: validFrontmatter(name: "Prowl CLI"),
+        resourcesURL: resources
+      )
+
+      let executableSymlink = root.appending(path: "bin/prowl", directoryHint: .notDirectory)
+      try FileManager.default.createDirectory(
+        at: executableSymlink.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try FileManager.default.createSymbolicLink(
+        at: executableSymlink,
+        withDestinationURL: bundledExecutable
+      )
+
+      let skills = try ProwlSkills.bundledForCLI(
+        executableURL: executableSymlink,
+        environment: [:]
+      )
+
+      XCTAssertEqual(skills.map(\.id), ["prowl-cli"])
+      XCTAssertEqual(
+        skills.first?.directoryURL,
+        resources.appending(path: "skills/prowl-cli", directoryHint: .isDirectory)
+      )
+    }
+  }
+
+  func testCLIReturnsBundleNotFoundWhenNoBundleOrOverrideExists() throws {
+    try withTemporaryDirectory { root in
+      let executable = root.appending(path: "bin/prowl", directoryHint: .notDirectory)
+      try writeFile("binary", to: executable)
+
+      XCTAssertThrowsError(
+        try ProwlSkills.bundledForCLI(executableURL: executable, environment: [:])
+      ) { error in
+        XCTAssertEqual((error as? ProwlSkillsError)?.code, .bundleNotFound)
+      }
+    }
+  }
+
+  private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-skills-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try operation(root)
+  }
+
+  @discardableResult
+  private func writeSkill(
+    id: String,
+    frontmatter: String,
+    resourcesURL: URL
+  ) throws -> URL {
+    try writeSkill(
+      id: id,
+      frontmatter: frontmatter,
+      skillsURL: resourcesURL.appending(path: "skills", directoryHint: .isDirectory)
+    )
+  }
+
+  @discardableResult
+  private func writeSkill(
+    id: String,
+    frontmatter: String,
+    skillsURL: URL
+  ) throws -> URL {
+    let directory = skillsURL.appending(path: id, directoryHint: .isDirectory)
+    try writeFile(
+      frontmatter, to: directory.appending(path: "SKILL.md", directoryHint: .notDirectory))
+    return directory
+  }
+
+  private func writeFile(_ contents: String, to url: URL) throws {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data(contents.utf8).write(to: url)
+  }
+
+  private func validFrontmatter(name: String) -> String {
+    """
+    ---
+    name: \(name)
+    description: A bundled skill.
+    ---
+    """
+  }
+}

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ make log-stream            # Stream app logs (subsystem: com.onevcat.prowl)
 ```bash
 make build-cli             # Build `prowl` CLI via SwiftPM
 make test-cli-smoke        # Quick CLI smoke checks
+make test-cli-unit         # CLI unit tests
 make test-cli-integration  # End-to-end CLI socket integration tests
 ```
 

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -24,7 +24,7 @@ that 063-B3 consumes; 064-S3 attaches launch-scoped hooks through 063-A2's launc
 PRs merge to `main` one at a time (each keeps `main` shippable); engine PRs without a
 user-facing surface may merge before "their" release and stay dormant. Three releases:
 
-### Current R1 status (2026-08-26)
+### Current R1 status (2026-08-27)
 
 | Slice(s) | State | PR / next action |
 | --- | --- | --- |
@@ -34,17 +34,17 @@ user-facing surface may merge before "their" release and stay dormant. Three rel
 | A2 | Merged | #714 |
 | S1 | Merged | #715: bus, multicast observer, `agents signal` |
 | S2 | Merged | #718: paired dispatch receipt, strict ID wait, generic evidence wait; [action record](../064-agent-completion-signals/005-s2-action.md) |
-| S3 wave 1 | S3a merged (#721, #723); S3b merged (#725); S3c in review | S3c = #728 ([064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md)); the slice is complete when #728 merges |
+| S3 wave 1 | Complete | Merged in #721/#723/#725/#728; S3c plan [064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md) |
 | 065-S0/K1 | Planned, parallel | Skill-target spike + bundled-skill registry |
 | 065-K2/K3 | Planned | Follow S0/K1 inside R1 |
 
-A2 completes 063's R1 implementation work, and S1/S2/S3a/S3b are on `main`. The last orchestration
-critical-path slice is S3c; 065-S0/K1 may proceed independently in parallel.
+A2 completes 063's R1 implementation work, and S1/S2/S3 wave 1 are on `main`. The remaining
+R1 work is 065 bundled skill distribution: S0 is complete, followed by K1–K3.
 
 #### S3 wave 1 PR breakdown
 
-S3 wave 1 remains one R1 release slice but lands as three sequential, independently
-reviewable PRs. The slice is complete only after S3c:
+S3 wave 1 is one complete R1 release slice that landed as three sequential, independently
+reviewable PR scopes:
 
 | PR | Runtime scope | Foundation / closure scope | Depends |
 | --- | --- | --- | --- |
@@ -122,6 +122,8 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-08-27 — S3c merged (#728), completing S3 wave 1 across #721/#723/#725/#728.
+  The remaining R1 work is 065 bundled skill distribution.
 - 2026-08-26 — S3b merged (#725). S3c started on `feat/agent-signal-hooks-s3c` after a
   live re-attestation of Pi 0.84.3, Oh My Pi 18.0.6, and OpenCode 1.18.23; the Active Agents
   exact-channel badge was removed from S3c without commitment. Plan:

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -35,11 +35,11 @@ user-facing surface may merge before "their" release and stay dormant. Three rel
 | S1 | Merged | #715: bus, multicast observer, `agents signal` |
 | S2 | Merged | #718: paired dispatch receipt, strict ID wait, generic evidence wait; [action record](../064-agent-completion-signals/005-s2-action.md) |
 | S3 wave 1 | Complete | Merged in #721/#723/#725/#728; S3c plan [064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md) |
-| 065-S0/K1 | Planned, parallel | Skill-target spike + bundled-skill registry |
+| 065-S0/K1 | S0 complete; K1 implemented | K1 PR pending; [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md) |
 | 065-K2/K3 | Planned | Follow S0/K1 inside R1 |
 
 A2 completes 063's R1 implementation work, and S1/S2/S3 wave 1 are on `main`. The remaining
-R1 work is 065 bundled skill distribution: S0 is complete, followed by K1–K3.
+R1 work is 065 bundled skill distribution: S0 is complete, K1 is implemented, and K2/K3 follow.
 
 #### S3 wave 1 PR breakdown
 
@@ -122,6 +122,8 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-08-27 — 065-S0 completed its target verification and K1 implemented the bundled-skill
+  foundation; K2/K3 remain in R1. Record: [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md).
 - 2026-08-27 — S3c merged (#728), completing S3 wave 1 across #721/#723/#725/#728.
   The remaining R1 work is 065 bundled skill distribution.
 - 2026-08-26 — S3b merged (#725). S3c started on `feat/agent-signal-hooks-s3c` after a

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — S1 #715, S2 #718, S3a #721/#723, S3b #725 merged; S3c (Pi/OMP/OpenCode) in progress |
+| **Status** | In progress — S1 #715, S2 #718, and S3 wave 1 #721/#723/#725/#728 merged; S4/S5 planned |
 | **Anchor date** | 2026-08-22 |
 | **Primary PRs** | #715 (S1); #718 (S2); #721, #723 (S3a); #725 (S3b); #728 (S3c) |
 | **Related** | [063 agent-workflows](../063-agent-workflows/000-plan.md) (consumer; defines the `ObservedAgentState` observer this entry feeds), [030 agent-status-detection](../030-agent-status-detection/000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [#473](https://github.com/onevcat/Prowl/issues/473), [#676](https://github.com/onevcat/Prowl/issues/676), `docs/components/agent-detection.md`, `docs/components/cli.md` |
@@ -245,6 +245,8 @@ opencode; partial for qodercli/qwen/amp; docs/bundle for the rest). Key conclusi
 
 ## Amendments
 
+- Updated 2026-08-27: S3c merged (#728), completing S3 wave 1 across
+  #721/#723/#725/#728. S4 and S5 remain planned.
 - Updated 2026-08-26: S3b merged (#725); planned S3c for Pi, Oh My Pi, and OpenCode after a
   live re-attestation (Pi 0.84.3, OMP 18.0.6, OpenCode 1.18.23) — extensions relay native event
   names in the Claude-shaped envelope, OMP maps `session_stop`, OpenCode is non-announcing with a

--- a/docs-ai/064-agent-completion-signals/006-s3-wave1-plan.md
+++ b/docs-ai/064-agent-completion-signals/006-s3-wave1-plan.md
@@ -2,12 +2,13 @@
 
 ## Status
 
-Owner-approved plan; S3a merged in [#721](https://github.com/onevcat/Prowl/pull/721) (hardened
+Complete. S3a merged in [#721](https://github.com/onevcat/Prowl/pull/721) (hardened
 in [#723](https://github.com/onevcat/Prowl/pull/723)). Implementation record:
 [007-s3a-action.md](007-s3a-action.md). S3b merged in [#725](https://github.com/onevcat/Prowl/pull/725) (plan
-[008-s3b-plan.md](008-s3b-plan.md), record [009-s3b-action.md](009-s3b-action.md)). S3c is
-implemented in [#728](https://github.com/onevcat/Prowl/pull/728) (plan
-[010-s3c-plan.md](010-s3c-plan.md), record [011-s3c-action.md](011-s3c-action.md)).
+[008-s3b-plan.md](008-s3b-plan.md), record [009-s3b-action.md](009-s3b-action.md)). S3c merged
+in [#728](https://github.com/onevcat/Prowl/pull/728) (plan
+[010-s3c-plan.md](010-s3c-plan.md), record [011-s3c-action.md](011-s3c-action.md)), completing
+S3 wave 1.
 
 - Planning branch: `feat/agent-signal-hooks-s3a`
 - Prerequisites: 063-A2, 064-S1, and 064-S2 are merged.
@@ -20,8 +21,8 @@ implemented in [#728](https://github.com/onevcat/Prowl/pull/728) (plan
 
 ## S3 wave 1 PR breakdown
 
-S3 wave 1 remains one R1 release slice, delivered as three sequential merge-safe PRs. The
-slice is not complete until S3c passes its complete tier-A gate.
+S3 wave 1 is one complete R1 release slice, delivered as three sequential merge-safe PR
+scopes. S3c passed the complete tier-A gate in #728.
 
 | PR | Runtime scope | Foundation / closure scope | Depends |
 | --- | --- | --- | --- |
@@ -29,8 +30,7 @@ slice is not complete until S3c passes its complete tier-A gate.
 | **S3b** | Copilot, Droid, Qoder | Plugin/settings adapters and fixtures on the S3a foundation | S3a |
 | **S3c** | Pi, OMP, OpenCode | Extension/plugin adapters, complete docs and tier-A live verification (the exact-channel badge was dropped on 2026-08-26) | S3b |
 
-Every PR keeps `main` shippable. Partial runtime support may exist on `main` between these PRs,
-but release documentation must not call S3 wave 1 complete before S3c.
+Every PR kept `main` shippable. S3c completed the tier-A runtime set and closed the wave.
 
 ## S3a objective
 

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -2,9 +2,9 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — S0 complete; K1–K3 planned |
+| **Status** | In progress — S0 and K1 complete; K2–K3 planned |
 | **Anchor date** | 2026-08-22 |
-| **Primary PRs** | #712 (plan), K1–K3 to fill in |
+| **Primary PRs** | #712 (plan); K1 pending; K2–K3 to fill in |
 | **Related** | [063-agent-workflows](../063-agent-workflows/000-plan.md) (D1 `skill:` materialization, D1–D3 new skills), [060-prowl-cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md) (four-layer CLI rule), [013-prowl-cli](../013-prowl-cli/000-plan.md), `docs/components/cli.md`, `skills/prowl-cli/SKILL.md` |
 
 ## Background
@@ -137,7 +137,7 @@ depends on it); K2 and K3 follow inside R1 so the R1 user can `prowl skills inst
 | Slice | Contents | Depends |
 | --- | --- | --- |
 | **S0** spike | **Complete** — verified Codex per-directory links and `.codex/skills`, mapped installed `.agents/skills` readers, and confirmed dangling links do not block discovery. Copy mode stays out of K2. See [002-s0-skill-targets.md](002-s0-skill-targets.md). | — |
-| **K1** | `embed-skills`, `Resources/skills` folder reference, `ProwlSkills` registry + frontmatter parser (incl. `metadata.prowl-install`), tests; 063 plan cross-link. | — |
+| **K1** | **Complete** — `embed-skills`, `Resources/skills` folder reference, Foundation-only `ProwlSkills` registry + typed errors and frontmatter parser, CLI bundle resolution, tests. See [003-k1-bundle-registry.md](003-k1-bundle-registry.md). | — |
 | **K2** | Shared `SymlinkInstaller` extracted from `CLIInstallClient`, `prowl skills list\|install\|uninstall\|path`, contract, `cli.md`, `prowl-cli` skill line, smoke + integration tests (temp dirs, `PROWL_SKILLS_DIR`). | S0, K1 |
 | **K3** | Agent Skills section on the Command Line Tool page, `AgentSkillsFeature` + `SkillInstallClient`, reducer tests, `docs/components/settings.md`. | K2 |
 
@@ -214,6 +214,10 @@ Decisions below were taken in the 2026-08-22 plan review (#712):
 
 ## Amendments
 
+- Updated 2026-08-27: Implemented and verified K1: skills are staged into the app bundle;
+  the shared registry parses audience metadata, resolves app/CLI bundle locations, and fails
+  with typed errors; no installation behavior was added — see
+  [003-k1-bundle-registry.md](003-k1-bundle-registry.md).
 - Updated 2026-08-27: Completed S0 with temporary homes/projects only. Claude Code and
   Codex follow per-skill directory links; Codex project scope is `.codex/skills`; the
   installed `.agents/skills` reader matrix is recorded; dangling links do not block other

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -214,6 +214,10 @@ Decisions below were taken in the 2026-08-22 plan review (#712):
 
 ## Amendments
 
+- Updated 2026-08-27 during K1 review: clean CI now stages the ignored skills resource and
+  executes a dedicated CLI unit-test target; the frontmatter parser rejects top-level, nested,
+  or inconsistently indented `prowl-install` metadata before audience defaulting — see
+  [003-k1-bundle-registry.md](003-k1-bundle-registry.md).
 - Updated 2026-08-27: Implemented and verified K1: skills are staged into the app bundle;
   the shared registry parses audience metadata, resolves app/CLI bundle locations, and fails
   with typed errors; no installation behavior was added — see

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
+| **Status** | In progress — S0 complete; K1–K3 planned |
 | **Anchor date** | 2026-08-22 |
 | **Primary PRs** | #712 (plan), K1–K3 to fill in |
 | **Related** | [063-agent-workflows](../063-agent-workflows/000-plan.md) (D1 `skill:` materialization, D1–D3 new skills), [060-prowl-cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md) (four-layer CLI rule), [013-prowl-cli](../013-prowl-cli/000-plan.md), `docs/components/cli.md`, `skills/prowl-cli/SKILL.md` |
@@ -63,17 +63,21 @@ skills; the app passes `Bundle.main.resourceURL`, the CLI resolves its own execu
 Not run from a bundle and no override → `BUNDLE_NOT_FOUND`.
 
 **Install targets (declarative, verified per runtime).** `SkillInstallTarget { id,
-displayName, userDirectory, projectDirectory?, runtimes }`. V1 table — entries marked
-*verify* are confirmed (directory, symlink following) by spike S0 before K2 builds on them:
+displayName, userDirectory, projectDirectory?, runtimes }`. S0 confirmed the V1 table before
+K2 builds on it; per-runtime evidence strength and the remaining Cursor credential boundary
+are recorded in [002-s0-skill-targets.md](002-s0-skill-targets.md):
 
-| Target id | User dir | Project dir | Read by |
-| --- | --- | --- | --- |
-| `claude` | `~/.claude/skills` | `.claude/skills` | Claude Code (follows symlinked skill directories — this repo's `.claude/skills/prowl-cli` link loads) |
-| `codex` | `~/.codex/skills` | *verify* | Codex (follows a symlinked skills root; per-directory symlink *verify*) |
-| `agents` | `~/.agents/skills` | `.agents/skills` | cross-agent convention (agentskills.io); *verify* which installed runtimes honour it |
+| Target id | User dir | Project dir | Read by | Directory symlink / dangling link |
+| --- | --- | --- | --- | --- |
+| `claude` | `~/.claude/skills` | `.claude/skills` | Claude Code | Followed; dangling link omitted |
+| `codex` | `~/.codex/skills` | `.codex/skills` | Codex | Followed; dangling link omitted |
+| `agents` | `~/.agents/skills` | `.agents/skills` | Codex, Gemini CLI, Cursor Agent, OpenCode, Copilot CLI, Kimi CLI, Droid, Amp, Qoder CLI, Pi, OMP, Grok Build | Followed by locally exercised readers; dangling link omitted (Droid logs a warning); Cursor location documented but authentication blocked its black-box run |
 
-Other `AgentProfileRuntime` cases (gemini, copilot, cursor, opencode, amp, droid, …) join the
-table as their skill directories are verified; unknown ones stay out rather than guessed.
+S0 verified the local target behavior and records the evidence level for each installed
+runtime in [002-s0-skill-targets.md](002-s0-skill-targets.md). Cline and Qwen Code do not
+read `.agents/skills` by default; Claude Code uses the separate `claude` target. Other
+`AgentProfileRuntime` cases join the table only after their directories and symlink behavior
+are verified; unknown ones stay out rather than guessed.
 A user target counts as *detected* when its parent (`~/.claude`, `~/.codex`, `~/.agents`)
 exists; undetected targets are listed but never chosen by default, and an explicit
 `--target` creates the directory.
@@ -132,7 +136,7 @@ depends on it); K2 and K3 follow inside R1 so the R1 user can `prowl skills inst
 
 | Slice | Contents | Depends |
 | --- | --- | --- |
-| **S0** spike | Verify the target table: Codex per-directory symlink following and project dir, `.agents/skills` readers among installed runtimes, how each runtime treats a dangling symlink. Use a temporary `CODEX_HOME` / project, never the user's live skill folders. Record results in this plan. | — |
+| **S0** spike | **Complete** — verified Codex per-directory links and `.codex/skills`, mapped installed `.agents/skills` readers, and confirmed dangling links do not block discovery. Copy mode stays out of K2. See [002-s0-skill-targets.md](002-s0-skill-targets.md). | — |
 | **K1** | `embed-skills`, `Resources/skills` folder reference, `ProwlSkills` registry + frontmatter parser (incl. `metadata.prowl-install`), tests; 063 plan cross-link. | — |
 | **K2** | Shared `SymlinkInstaller` extracted from `CLIInstallClient`, `prowl skills list\|install\|uninstall\|path`, contract, `cli.md`, `prowl-cli` skill line, smoke + integration tests (temp dirs, `PROWL_SKILLS_DIR`). | S0, K1 |
 | **K3** | Agent Skills section on the Command Line Tool page, `AgentSkillsFeature` + `SkillInstallClient`, reducer tests, `docs/components/settings.md`. | K2 |
@@ -175,8 +179,10 @@ Decisions below were taken in the 2026-08-22 plan review (#712):
 
 ## Risks
 
-- A runtime may not follow directory symlinks for skills → S0 verifies before K2; if any V1
-  target refuses symlinks, copy mode is promoted from open question to K2 scope.
+- A runtime may regress directory-symlink discovery → S0 found no V1 target that refuses
+  the direct-link shape; the verified matrix and evidence boundary live in
+  [002-s0-skill-targets.md](002-s0-skill-targets.md). Keep copy mode deferred unless a
+  supported runtime demonstrably regresses.
 - Debug builds: links point into DerivedData and show as `installedDifferentSource` in a
   Release app (and vice versa). Acceptable; the status text names the other source.
 - Runtimes move their skill directories → the table is declarative and small; unknown
@@ -201,10 +207,15 @@ Decisions below were taken in the 2026-08-22 plan review (#712):
 
 ## Open questions
 
-- Copy mode (`--copy`) in V1 or later? Needed only if S0 finds a symlink-averse runtime.
+- Copy mode (`--copy`) is deferred. S0 found no symlink-averse V1 target; reconsider only
+  for a demonstrated supported-runtime regression.
 - Should 063-D1's Workflows “ask your agent” prompt instruct `prowl skills install` first?
 - Settings project-scope UI (per-repository section in Repo Settings) — V2 if asked.
 
 ## Amendments
 
-(append `- Updated 2026-MM-DD: ... — see [00N-topic.md](00N-topic.md)` lines here)
+- Updated 2026-08-27: Completed S0 with temporary homes/projects only. Claude Code and
+  Codex follow per-skill directory links; Codex project scope is `.codex/skills`; the
+  installed `.agents/skills` reader matrix is recorded; dangling links do not block other
+  skills; copy mode remains deferred. The record also fixes K1's planned shared interface
+  boundary before implementation — see [002-s0-skill-targets.md](002-s0-skill-targets.md).

--- a/docs-ai/065-bundled-agent-skills/002-s0-skill-targets.md
+++ b/docs-ai/065-bundled-agent-skills/002-s0-skill-targets.md
@@ -1,0 +1,218 @@
+# 065 S0 — Skill install target verification
+
+| | |
+| --- | --- |
+| **Status** | Complete |
+| **Verified** | 2026-08-27 |
+| **Scope** | `claude`, `codex`, and `agents` install targets only; no production skill directories were modified |
+
+## Outcome
+
+The V1 target table is viable with one symlink per skill directory. Claude Code and Codex
+both follow a skill-directory symlink into an external canonical directory. The shared
+`.agents/skills` target is read by most Agent Profile runtimes installed on the verification
+host. Every locally exercised reader followed the directory-symlink shape. Cursor remains a
+location-only result because its CLI stops before discovery without account authentication;
+that residual gap is not evidence of refusal, so copy mode does **not** move into K2.
+
+The three target ids describe install locations, not mutually exclusive runtimes:
+
+- `claude` is Claude Code's native user/project location.
+- `codex` is Codex's native/legacy-compatible user/project location.
+- `agents` is the cross-runtime location. Codex also reads it, as do multiple other
+  installed runtimes.
+
+Installing the same bundled skill into both `codex` and `agents` is therefore expected. The
+links resolve to the same canonical bundle directory; target status and removal remain
+independent at skill × target granularity.
+
+## Safety and method
+
+All probes used temporary roots created by `mktemp`:
+
+- a temporary `HOME` for shared user paths;
+- a temporary `CLAUDE_CONFIG_DIR`;
+- a temporary `CODEX_HOME`;
+- initialized throwaway Git repositories for project discovery; and
+- canonical marker skills outside the runtime discovery roots, linked into each target.
+
+Each discovery root contained one valid absolute directory symlink and one dangling absolute
+directory symlink. The live `~/.claude/skills`, `~/.codex/skills`, and `~/.agents/skills`
+paths were neither read as test inputs nor modified. Runtime credentials were not copied into
+the temporary homes.
+
+Evidence is labelled below as:
+
+- **black-box** — the installed runtime's own list/inspect/debug surface returned the marker;
+- **installed source** — the exact installed version's loader was invoked or inspected
+  without a model request; or
+- **documented** — the installed CLI could not complete isolated discovery without
+  authentication/model configuration, so its official runtime documentation confirms the
+  location only. These cases are not reported as directory-symlink or authenticated
+  end-to-end verification unless installed source supplied that additional evidence.
+
+## Target results
+
+### `claude`
+
+| Field | Verified value |
+| --- | --- |
+| User directory | `~/.claude/skills` (`$CLAUDE_CONFIG_DIR/skills` under an override) |
+| Project directory | `.claude/skills` |
+| Runtime | Claude Code 2.1.246 |
+| Directory symlink | Followed at user and project scope |
+| Dangling symlink | Omitted from discovery; other skills continue loading |
+| Evidence | Black-box startup/debug log under a temporary `CLAUDE_CONFIG_DIR` |
+
+The probe started headless Claude Code without credentials. It exited with `Not logged in`
+after local initialization, but its debug log reported the temporary user and project roots
+and `Loaded 2 unique skills (… user: 1, project: 1 …)`: exactly the two valid linked marker
+skills. The two dangling links were not counted. No model call or live credential was needed.
+
+### `codex`
+
+| Field | Verified value |
+| --- | --- |
+| User directory | `~/.codex/skills` (`$CODEX_HOME/skills` under an override) |
+| Project directory | `.codex/skills` |
+| Additional compatible directories | `~/.agents/skills`, `.agents/skills` |
+| Runtime | Codex CLI 0.149.1 |
+| Directory symlink | Followed in all four roots |
+| Dangling symlink | Omitted; `skills/list` returned an empty `errors` array |
+| Evidence | Black-box App Server `skills/list` under temporary `HOME` and `CODEX_HOME` |
+
+The App Server handshake (`initialize` → `initialized` → `skills/list`) returned one marker
+from each root. In particular, `.codex/skills` was returned with `scope: repo`, resolving the
+plan's project-directory question. Returned paths pointed to each symlink's canonical target.
+
+### `agents`
+
+| Field | Verified value |
+| --- | --- |
+| User directory | `~/.agents/skills` |
+| Project directory | `.agents/skills` |
+| Directory symlink | Supported by the locally exercised readers below; documented/source-only readers are marked |
+| Dangling symlink | Ignored by locally exercised readers; Droid additionally logs a warning |
+
+Installed-runtime matrix:
+
+| Runtime/version | User | Project | Evidence | Dangling-link behavior |
+| --- | --- | --- | --- | --- |
+| Codex CLI 0.149.1 | Yes | Yes | Black-box `skills/list` | Silently omitted |
+| Gemini CLI 0.46.0 | Yes | Yes | Black-box `gemini skills list` | Omitted |
+| Cursor Agent 2026.05.09 | Yes | Yes | Documented location; isolated CLI stopped at authentication | Not black-box verified in S0 |
+| OpenCode 1.18.23 | Yes | Yes | Black-box `opencode debug skill` | Silently omitted |
+| GitHub Copilot CLI 1.0.80 | Yes | Yes | Black-box `copilot skill list --json` | Silently omitted |
+| Kimi CLI 1.41.0 | Yes | Yes | Installed loader via `resolve_skills_roots` | Silently omitted |
+| Droid 0.204.0 | Yes | Yes | Installed discovery during `droid exec --list-tools`; official location docs | Skipped with `Skipping unresolvable path during discovery` warning |
+| Amp 0.0.1783746383 | Yes | Yes | Black-box `amp skill list --json` with a non-secret placeholder key | Silently omitted; returned `errors: []` |
+| Qoder CLI 1.1.31 | Yes | Yes | Black-box `qodercli skills list` | Silently omitted |
+| Pi 0.84.3 | Yes | Yes | Installed `loadSkills` implementation | Silently omitted |
+| Oh My Pi 18.0.6 | Yes | Yes | Black-box RPC `get_available_commands` with a non-secret placeholder key | Silently omitted; stderr remained empty |
+| Grok Build 0.2.118 | Yes | Yes | Black-box `grok inspect --json` | Silently omitted |
+| Claude Code 2.1.246 | No | No | Native directories verified separately above | N/A for this target |
+| Cline CLI 3.0.56 | No by default | No by default | Official paths are `~/.cline/skills` / `.cline/skills` | N/A for this target |
+| Qwen Code 0.21.3 | No by default | No by default | Official paths are `~/.qwen/skills` / `.qwen/skills`; custom directories are configurable | N/A for this target |
+
+The V1 `agents` target should list only these established readers. A later runtime may join
+when its installed behavior or authoritative documentation confirms both location and
+symlink handling; Prowl should not infer support from `AgentProfileRuntime` membership alone.
+
+## Cursor and Amp custom-model feasibility
+
+Cursor Agent CLI cannot use a custom provider to close its remaining black-box gap. In the
+installed 2026.05.09 CLI, `--api-key` is Cursor account authentication and `--model` selects
+from that account's model catalog. There is no provider/base-URL option. Cursor IDE's BYOK
+and OpenAI base-URL override do not carry over to Agent CLI. Without a valid Cursor account
+credential, S0 can record only the official `.agents/skills` location support; it does not
+claim an authenticated directory-symlink run.
+
+Amp 0.0.1783746383 does expose a real custom-provider surface:
+
+```text
+amp config model-providers add-router openai-compatible
+  --base-url <https-url>
+  --api-key-env <variable>
+  --model-mapping <patterns>
+  --personal|--workspace
+```
+
+This can route inference away from Amp credits, but creating the personal/workspace router
+still requires Amp account authentication and mutates account configuration. It was neither
+needed nor used for S0: `amp skill list --json` completed locally with a non-secret
+placeholder key, returned both linked marker skills, omitted both dangling links, and
+reported `errors: []` without a model request.
+
+## Plan impact
+
+1. Keep all three target ids and their existing detection rule: the target is detected when
+   its parent directory exists; explicit `--target` may create it.
+2. Set Codex project scope to `.codex/skills`.
+3. Describe `agents` as the shared target read by the verified runtime set above, not as a
+   fourth runtime.
+4. Keep direct absolute bundle links. No compatibility copy is required in K2.
+5. Keep `broken` as an installer status even though runtimes omit dangling links: Prowl must
+   surface and repair a moved/removed bundle instead of inheriting each runtime's mostly
+   silent behavior.
+6. Keep authenticated K2 manual verification focused on Claude Code and Codex as planned.
+   Cursor remains a location-only result and does not become a claim of authenticated
+   end-to-end testing.
+
+## K1 implementation boundary
+
+K1 remains foundation-only: it bundles and locates skills but does not install them. The
+planned shared surface in `ProwlCLIShared` is:
+
+```swift
+public enum ProwlSkillAudience: String, Sendable {
+  case user
+  case workflow
+}
+
+public struct BundledSkill: Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let description: String
+  public let audience: ProwlSkillAudience
+  public let directoryURL: URL
+}
+
+public enum ProwlSkills {
+  public static func bundled(resourcesURL: URL) throws -> [BundledSkill]
+  public static func skill(id: String, resourcesURL: URL) throws -> BundledSkill?
+  public static func bundledForCLI(
+    executableURL: URL,
+    environment: [String: String]
+  ) throws -> [BundledSkill]
+}
+```
+
+The semantic contract is fixed even if red tests motivate a smaller helper split:
+
+- `bundled(resourcesURL:)` enumerates `<resourcesURL>/skills/*/SKILL.md` in stable id order.
+- `skill(id:resourcesURL:)` is the 063 runner lookup and never searches third-party roots.
+- `bundledForCLI` uses `PROWL_SKILLS_DIR` first; otherwise it resolves the executable symlink
+  and finds `../skills` beside the bundled `prowl-cli` directory.
+- A missing override/bundle maps to `BUNDLE_NOT_FOUND` for the future K2 command surface.
+- The parser accepts only `name`, plain or folded `description`, and
+  `metadata.prowl-install`; absent audience defaults to `user`.
+
+K1 tests should be red first for plain/folded descriptions, audience default/override,
+stable enumeration, id lookup, executable-symlink resolution, override precedence, and the
+missing-bundle error.
+
+## References
+
+- [Claude Code skills](https://code.claude.com/docs/en/slash-commands)
+- [Codex App Server `skills/list`](https://developers.openai.com/codex/app-server/)
+- [Gemini CLI skills](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/using-agent-skills.md)
+- [GitHub Copilot agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
+- [Kimi CLI skills](https://github.com/MoonshotAI/kimi-cli/blob/main/docs/en/customization/skills.md)
+- [Factory Droid skills](https://docs.factory.ai/harness/skills)
+- [Amp skills](https://ampcode.com/docs/customize/skills)
+- [Amp modes and model routing](https://ampcode.com/docs/models-and-subagents)
+- [Cursor Agent CLI authentication](https://docs.cursor.com/en/cli/reference/authentication)
+- [OpenCode skills](https://opencode.ai/docs/skills)
+- [Pi skills](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/skills.md)
+- [Oh My Pi skills](https://github.com/can1357/oh-my-pi/blob/main/docs/skills.md)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
+++ b/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
@@ -28,6 +28,8 @@ installing or modifying any skill in a user or project directory.
   the executable symlink and locates `../skills` beside the bundled `prowl-cli` directory.
 - `ProwlSkillsError` provides typed `BUNDLE_NOT_FOUND` and invalid-frontmatter failures for the
   later K2 command layer to map without parsing localized text.
+- Clean CI stages `embed-skills` before parallel app tests, and the dedicated `test-cli-unit`
+  target executes all non-integration SwiftPM tests before the socket integration suite.
 
 ## Decisions and boundaries
 
@@ -41,15 +43,33 @@ installing or modifying any skill in a user or project directory.
 - Malformed audience metadata never defaults to `user`, preventing a typo from making a future
   workflow-only skill globally installable.
 
+## Review hardening
+
+- Clean CI originally staged only the CLI and docs before invoking `test-app`; because
+  `Resources/skills` is ignored, the Xcode resource input was absent. The staging step now
+  includes `embed-skills`.
+- The CI integration filter compiled the registry tests but executed only socket integration
+  tests. `test-cli-unit` now runs every non-integration CLI test and is part of the same CI task.
+- Audience metadata now requires `prowl-install` to be a direct child of `metadata` and every
+  metadata field to use one consistent direct-child indentation. Top-level, nested, and
+  inconsistently indented forms fail before an audience can default or change.
+- The invalid-audience fixture now includes an otherwise valid description and asserts the
+  specific audience failure reason, so another invalid field cannot make the regression test
+  pass accidentally.
+
 ## Verification
 
 - TDD RED: the focused SwiftPM suite failed with 21 expected missing-symbol errors before the
   shared registry types existed.
-- TDD GREEN: `ProwlSkillsTests` passed 11 tests covering plain and folded descriptions, default
-  and explicit audiences, invalid/missing frontmatter, stable sorting, safe ID lookup, override
-  precedence and invalid-override behavior, executable-symlink resolution, and
-  `BUNDLE_NOT_FOUND`.
+- Review RED: two focused tests reproduced top-level audience metadata silently defaulting to
+  `user` and nested audience metadata being accepted; 11 existing tests passed while both new
+  tests failed for the expected reason.
+- TDD GREEN: `ProwlSkillsTests` passed 14 tests covering plain and folded descriptions, default
+  and explicit audiences, invalid/missing frontmatter, strict metadata hierarchy, stable
+  sorting, safe ID lookup, override precedence and invalid-override behavior,
+  executable-symlink resolution, and `BUNDLE_NOT_FOUND`.
 - `make build-cli` and `make test-cli-smoke` passed.
+- `make test-cli-unit` passed 75 unit tests, including all 14 registry tests.
 - `make test-cli-integration` passed 97 integration tests.
 - `make test` passed and the xcresult checks verified 2,621 main app tests plus 2 isolated shell
   cancellation tests with zero failures.

--- a/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
+++ b/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
@@ -1,0 +1,67 @@
+# 065.003 — Bundled Skills Foundation (K1)
+
+## Context
+
+S0 confirmed that Prowl can distribute its own skills as direct directory symlinks, but the
+shipped app still had no canonical skills bundle or shared registry. K1 establishes that
+foundation for the later CLI installer, Settings UI, and 063 workflow materialization without
+installing or modifying any skill in a user or project directory.
+
+## Change
+
+- `Makefile` now stages `skills/` into the ignored `Resources/skills/` directory through an
+  `embed-skills` target using `rsync -a --delete`.
+- `build-app`, `test`, `archive`, `benchmark-build`, and `bench` depend on `embed-skills`,
+  matching the existing `embed-docs` lifecycle.
+- `Resources/skills` is an Xcode folder reference in the app Resources build phase, so each
+  shipped skill keeps its directory and `SKILL.md` layout under
+  `Prowl.app/Contents/Resources/skills/<id>/`.
+- `ProwlCLIShared` now exposes the Foundation-only `ProwlSkillAudience`, `BundledSkill`, and
+  `ProwlSkills` registry. `bundled(resourcesURL:)` enumerates immediate skill directories in
+  stable ID order, while `skill(id:resourcesURL:)` searches that enumeration instead of
+  constructing an input-derived path.
+- The minimal frontmatter parser reads required `name` and plain or `>-` folded `description`
+  fields plus the nested `metadata.prowl-install` audience. Missing audience defaults to
+  `user`; explicit `user` and `workflow` are accepted; any other value fails closed.
+- `bundledForCLI(executableURL:environment:)` treats `PROWL_SKILLS_DIR` as a direct skills-root
+  override. A present but invalid override does not fall back. Without the override, it resolves
+  the executable symlink and locates `../skills` beside the bundled `prowl-cli` directory.
+- `ProwlSkillsError` provides typed `BUNDLE_NOT_FOUND` and invalid-frontmatter failures for the
+  later K2 command layer to map without parsing localized text.
+
+## Decisions and boundaries
+
+- K1 remains synchronous and Foundation-only. It adds no YAML dependency, installer, target
+  detection, CLI command, socket behavior, Settings state, or write into an agent skill folder.
+- Registry IDs are immediate directory names. Lookup filters the parsed registry, so values such
+  as `../prowl-cli` cannot traverse out of the bundle.
+- `PROWL_SKILLS_DIR` points directly at a skills root, whereas `bundled(resourcesURL:)` receives
+  the app Resources root and appends `skills/`. The private common enumerator keeps this
+  distinction explicit.
+- Malformed audience metadata never defaults to `user`, preventing a typo from making a future
+  workflow-only skill globally installable.
+
+## Verification
+
+- TDD RED: the focused SwiftPM suite failed with 21 expected missing-symbol errors before the
+  shared registry types existed.
+- TDD GREEN: `ProwlSkillsTests` passed 11 tests covering plain and folded descriptions, default
+  and explicit audiences, invalid/missing frontmatter, stable sorting, safe ID lookup, override
+  precedence and invalid-override behavior, executable-symlink resolution, and
+  `BUNDLE_NOT_FOUND`.
+- `make build-cli` and `make test-cli-smoke` passed.
+- `make test-cli-integration` passed 97 integration tests.
+- `make test` passed and the xcresult checks verified 2,621 main app tests plus 2 isolated shell
+  cancellation tests with zero failures.
+- `make check` passed, including strict Swift formatting, SwiftLint, and 44 script tests.
+- `make build-app` passed with zero errors or warnings.
+- The final Debug app contains
+  `Contents/Resources/skills/prowl-cli/SKILL.md`; it is byte-for-byte identical to
+  `skills/prowl-cli/SKILL.md`.
+
+## Refs
+
+- Slice: 065-K1
+- Branch: `feat/bundled-skills-k1`
+- PR: pending
+- Depends on: [002-s0-skill-targets.md](002-s0-skill-targets.md)

--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D6A1CB362F1F4ACB004FDABD /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A1CB342F1F4AC2004FDABD /* Carbon.framework */; };
 		D6CLI0012F99000100000001 /* prowl-cli in Resources */ = {isa = PBXBuildFile; fileRef = D6CLI0022F99000100000001 /* prowl-cli */; };
 		D6DOC0012F99000300000001 /* docs in Resources */ = {isa = PBXBuildFile; fileRef = D6DOC0022F99000300000001 /* docs */; };
+		D6SKL0012F99000500000001 /* skills in Resources */ = {isa = PBXBuildFile; fileRef = D6SKL0022F99000500000001 /* skills */; };
 		D6HOK0012F99000400000001 /* agent-hooks in Resources */ = {isa = PBXBuildFile; fileRef = D6HOK0022F99000400000001 /* agent-hooks */; };
 		D6D054282F2E3EBF00D70ED5 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = D6D054272F2E3EBF00D70ED5 /* PostHog */; };
 		DFE570C142184CC387C1BC78 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B5698573F7354B14B940EA60 /* Sparkle */; };
@@ -45,6 +46,7 @@
 		D6A1CB342F1F4AC2004FDABD /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		D6CLI0022F99000100000001 /* prowl-cli */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "prowl-cli"; path = "Resources/prowl-cli"; sourceTree = "<group>"; };
 		D6DOC0022F99000300000001 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = "Resources/docs"; sourceTree = "<group>"; };
+		D6SKL0022F99000500000001 /* skills */ = {isa = PBXFileReference; lastKnownFileType = folder; name = skills; path = "Resources/skills"; sourceTree = "<group>"; };
 		D6HOK0022F99000400000001 /* agent-hooks */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "agent-hooks"; path = "Resources/agent-hooks"; sourceTree = "<group>"; };
 		D6F821012F1FCBC1004B4174 /* supacodeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = supacodeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -111,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				D6DOC0022F99000300000001 /* docs */,
+				D6SKL0022F99000500000001 /* skills */,
 				D64162AD2F23CAF100260CA3 /* ghostty */,
 				D64162AF2F23CAF100260CA3 /* git-wt */,
 				D6CLI0022F99000100000001 /* prowl-cli */,
@@ -255,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6DOC0012F99000300000001 /* docs in Resources */,
+				D6SKL0012F99000500000001 /* skills in Resources */,
 				D64162B02F23CAF100260CA3 /* ghostty in Resources */,
 				D64162B12F23CAF100260CA3 /* terminfo in Resources */,
 				D64162B22F23CAF100260CA3 /* git-wt in Resources */,

--- a/supacode/CLIService/Shared/ProwlSkills.swift
+++ b/supacode/CLIService/Shared/ProwlSkills.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+nonisolated public enum ProwlSkillAudience: String, Equatable, Sendable {
+  case user
+  case workflow
+}
+
+nonisolated public struct BundledSkill: Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let description: String
+  public let audience: ProwlSkillAudience
+  public let directoryURL: URL
+
+  public init(
+    id: String,
+    name: String,
+    description: String,
+    audience: ProwlSkillAudience,
+    directoryURL: URL
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.audience = audience
+    self.directoryURL = directoryURL
+  }
+}
+
+nonisolated public enum ProwlSkillsError: Error, Equatable, Sendable, LocalizedError {
+  public enum Code: String, Equatable, Sendable {
+    case bundleNotFound = "BUNDLE_NOT_FOUND"
+    case invalidFrontmatter = "INVALID_SKILL_FRONTMATTER"
+  }
+
+  case bundleNotFound(path: String)
+  case invalidFrontmatter(path: String, reason: String)
+
+  public var code: Code {
+    switch self {
+    case .bundleNotFound:
+      .bundleNotFound
+    case .invalidFrontmatter:
+      .invalidFrontmatter
+    }
+  }
+
+  public var errorDescription: String? {
+    switch self {
+    case .bundleNotFound(let path):
+      "Bundled skills were not found at \(path)."
+    case .invalidFrontmatter(let path, let reason):
+      "Invalid skill frontmatter at \(path): \(reason)"
+    }
+  }
+}
+
+nonisolated public enum ProwlSkills {
+  public static func bundled(resourcesURL: URL) throws -> [BundledSkill] {
+    try bundled(
+      skillsURL: resourcesURL.appending(path: "skills", directoryHint: .isDirectory)
+    )
+  }
+
+  public static func skill(id: String, resourcesURL: URL) throws -> BundledSkill? {
+    try bundled(resourcesURL: resourcesURL).first { $0.id == id }
+  }
+
+  public static func bundledForCLI(
+    executableURL: URL,
+    environment: [String: String]
+  ) throws -> [BundledSkill] {
+    if let overridePath = environment["PROWL_SKILLS_DIR"] {
+      guard !overridePath.isEmpty else {
+        throw ProwlSkillsError.bundleNotFound(path: overridePath)
+      }
+      return try bundled(
+        skillsURL: URL(filePath: overridePath, directoryHint: .isDirectory)
+      )
+    }
+
+    let resolvedExecutableURL = executableURL.standardizedFileURL.resolvingSymlinksInPath()
+    let executableDirectory = resolvedExecutableURL.deletingLastPathComponent()
+    guard resolvedExecutableURL.lastPathComponent == "prowl",
+      executableDirectory.lastPathComponent == "prowl-cli"
+    else {
+      throw ProwlSkillsError.bundleNotFound(
+        path: resolvedExecutableURL.path(percentEncoded: false)
+      )
+    }
+    return try bundled(resourcesURL: executableDirectory.deletingLastPathComponent())
+  }
+
+  private static func bundled(skillsURL: URL) throws -> [BundledSkill] {
+    let standardizedSkillsURL = skillsURL.standardizedFileURL
+    let skillsPath = standardizedSkillsURL.path(percentEncoded: false)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: skillsPath, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      throw ProwlSkillsError.bundleNotFound(path: skillsPath)
+    }
+
+    let contents: [URL]
+    do {
+      contents = try FileManager.default.contentsOfDirectory(
+        at: standardizedSkillsURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+      )
+    } catch {
+      throw ProwlSkillsError.bundleNotFound(path: skillsPath)
+    }
+
+    let directories =
+      contents
+      .filter { url in
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+      }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+    return try directories.compactMap { directoryURL in
+      let skillFileURL = directoryURL.appending(path: "SKILL.md", directoryHint: .notDirectory)
+      guard FileManager.default.fileExists(atPath: skillFileURL.path(percentEncoded: false)) else {
+        return nil
+      }
+      return try parseSkill(
+        id: directoryURL.lastPathComponent,
+        directoryURL: directoryURL.standardizedFileURL,
+        skillFileURL: skillFileURL
+      )
+    }
+  }
+
+  private static func parseSkill(
+    id: String,
+    directoryURL: URL,
+    skillFileURL: URL
+  ) throws -> BundledSkill {
+    let skillPath = skillFileURL.path(percentEncoded: false)
+    let data: Data
+    do {
+      data = try Data(contentsOf: skillFileURL)
+    } catch {
+      throw ProwlSkillsError.invalidFrontmatter(
+        path: skillPath,
+        reason: "SKILL.md could not be read"
+      )
+    }
+    guard let source = String(data: data, encoding: .utf8) else {
+      throw ProwlSkillsError.invalidFrontmatter(
+        path: skillPath,
+        reason: "SKILL.md is not valid UTF-8"
+      )
+    }
+
+    let frontmatter = try parseFrontmatter(source, path: skillPath)
+    return BundledSkill(
+      id: id,
+      name: frontmatter.name,
+      description: frontmatter.description,
+      audience: frontmatter.audience,
+      directoryURL: directoryURL
+    )
+  }
+
+  private static func parseFrontmatter(_ source: String, path: String) throws -> ParsedFrontmatter {
+    let normalizedSource =
+      source
+      .replacing("\r\n", with: "\n")
+      .replacing("\r", with: "\n")
+    let lines = normalizedSource.split(separator: "\n", omittingEmptySubsequences: false).map(
+      String.init)
+    guard lines.first == "---",
+      let closingIndex = lines.indices.dropFirst().first(where: { lines[$0] == "---" })
+    else {
+      throw invalidFrontmatter(path: path, reason: "missing frontmatter delimiters")
+    }
+
+    let frontmatterLines = Array(lines[1..<closingIndex])
+    var name: String?
+    var description: String?
+    var audience = ProwlSkillAudience.user
+    var audienceWasSet = false
+    var index = 0
+
+    while index < frontmatterLines.count {
+      let line = frontmatterLines[index]
+      if line.trimmingCharacters(in: .whitespaces).isEmpty {
+        index += 1
+        continue
+      }
+      guard indentation(of: line) == 0,
+        let (key, value) = keyValue(in: line),
+        !key.isEmpty
+      else {
+        throw invalidFrontmatter(path: path, reason: "malformed top-level field")
+      }
+
+      switch key {
+      case "name":
+        guard name == nil, !value.isEmpty else {
+          throw invalidFrontmatter(path: path, reason: "name must be a non-empty scalar")
+        }
+        name = value
+        index += 1
+
+      case "description":
+        guard description == nil else {
+          throw invalidFrontmatter(path: path, reason: "description is duplicated")
+        }
+        if value == ">-" {
+          let result = try foldedDescription(
+            lines: frontmatterLines,
+            startIndex: index + 1,
+            path: path
+          )
+          description = result.value
+          index = result.nextIndex
+        } else {
+          guard !value.isEmpty else {
+            throw invalidFrontmatter(
+              path: path, reason: "description must be a non-empty scalar or >- block")
+          }
+          description = value
+          index += 1
+        }
+
+      case "metadata":
+        guard value.isEmpty else {
+          throw invalidFrontmatter(path: path, reason: "metadata must be a map")
+        }
+        let result = try audienceMetadata(
+          lines: frontmatterLines,
+          startIndex: index + 1,
+          currentAudience: audience,
+          audienceWasSet: audienceWasSet,
+          path: path
+        )
+        audience = result.audience
+        audienceWasSet = result.wasSet
+        index = result.nextIndex
+
+      default:
+        index += 1
+      }
+    }
+
+    guard let name else {
+      throw invalidFrontmatter(path: path, reason: "name is missing")
+    }
+    guard let description else {
+      throw invalidFrontmatter(path: path, reason: "description is missing")
+    }
+    return ParsedFrontmatter(name: name, description: description, audience: audience)
+  }
+
+  private static func foldedDescription(
+    lines: [String],
+    startIndex: Int,
+    path: String
+  ) throws -> (value: String, nextIndex: Int) {
+    var index = startIndex
+    var blockLines: [String] = []
+    while index < lines.count {
+      let line = lines[index]
+      if !line.trimmingCharacters(in: .whitespaces).isEmpty, indentation(of: line) == 0 {
+        break
+      }
+      blockLines.append(line)
+      index += 1
+    }
+
+    let nonEmptyLines = blockLines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    guard let blockIndent = nonEmptyLines.compactMap(indentation).min(), blockIndent > 0 else {
+      throw invalidFrontmatter(path: path, reason: "folded description is empty or malformed")
+    }
+
+    var paragraphs: [String] = []
+    var paragraphLines: [String] = []
+    for line in blockLines {
+      let stripped = String(line.dropFirst(min(blockIndent, line.count)))
+        .trimmingCharacters(in: .whitespaces)
+      if stripped.isEmpty {
+        if !paragraphLines.isEmpty {
+          paragraphs.append(paragraphLines.joined(separator: " "))
+          paragraphLines.removeAll(keepingCapacity: true)
+        }
+      } else {
+        paragraphLines.append(stripped)
+      }
+    }
+    if !paragraphLines.isEmpty {
+      paragraphs.append(paragraphLines.joined(separator: " "))
+    }
+
+    let value = paragraphs.joined(separator: "\n")
+    guard !value.isEmpty else {
+      throw invalidFrontmatter(path: path, reason: "folded description is empty")
+    }
+    return (value, index)
+  }
+
+  private static func audienceMetadata(
+    lines: [String],
+    startIndex: Int,
+    currentAudience: ProwlSkillAudience,
+    audienceWasSet: Bool,
+    path: String
+  ) throws -> ParsedAudienceMetadata {
+    var audience = currentAudience
+    var wasSet = audienceWasSet
+    var index = startIndex
+
+    while index < lines.count {
+      let line = lines[index]
+      if line.trimmingCharacters(in: .whitespaces).isEmpty {
+        index += 1
+        continue
+      }
+      guard let fieldIndent = indentation(of: line) else {
+        throw invalidFrontmatter(path: path, reason: "metadata uses invalid indentation")
+      }
+      if fieldIndent == 0 {
+        break
+      }
+      guard let (key, value) = keyValue(in: line), !key.isEmpty else {
+        throw invalidFrontmatter(path: path, reason: "metadata contains a malformed field")
+      }
+      if key == "prowl-install" {
+        guard !wasSet, let parsedAudience = ProwlSkillAudience(rawValue: value) else {
+          throw invalidFrontmatter(
+            path: path, reason: "metadata.prowl-install must be user or workflow")
+        }
+        audience = parsedAudience
+        wasSet = true
+      }
+      index += 1
+    }
+
+    return ParsedAudienceMetadata(audience: audience, wasSet: wasSet, nextIndex: index)
+  }
+
+  private static func keyValue(in line: String) -> (key: String, value: String)? {
+    guard let separator = line.firstIndex(of: ":") else {
+      return nil
+    }
+    let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+    let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+    return (key, value)
+  }
+
+  private static func indentation(of line: String) -> Int? {
+    var indentation = 0
+    for character in line {
+      switch character {
+      case " ":
+        indentation += 1
+      case "\t":
+        return nil
+      default:
+        return indentation
+      }
+    }
+    return indentation
+  }
+
+  private static func invalidFrontmatter(path: String, reason: String) -> ProwlSkillsError {
+    .invalidFrontmatter(path: path, reason: reason)
+  }
+}
+
+nonisolated private struct ParsedFrontmatter {
+  let name: String
+  let description: String
+  let audience: ProwlSkillAudience
+}
+
+nonisolated private struct ParsedAudienceMetadata {
+  let audience: ProwlSkillAudience
+  let wasSet: Bool
+  let nextIndex: Int
+}

--- a/supacode/CLIService/Shared/ProwlSkills.swift
+++ b/supacode/CLIService/Shared/ProwlSkills.swift
@@ -197,6 +197,8 @@ nonisolated public enum ProwlSkills {
         throw invalidFrontmatter(path: path, reason: "malformed top-level field")
       }
 
+      try validateTopLevelKey(key, path: path)
+
       switch key {
       case "name":
         guard name == nil, !value.isEmpty else {
@@ -310,6 +312,7 @@ nonisolated public enum ProwlSkills {
   ) throws -> ParsedAudienceMetadata {
     var audience = currentAudience
     var wasSet = audienceWasSet
+    var directFieldIndent: Int?
     var index = startIndex
 
     while index < lines.count {
@@ -323,6 +326,15 @@ nonisolated public enum ProwlSkills {
       }
       if fieldIndent == 0 {
         break
+      }
+      if directFieldIndent == nil {
+        directFieldIndent = fieldIndent
+      }
+      guard let directFieldIndent, fieldIndent == directFieldIndent else {
+        throw invalidFrontmatter(
+          path: path,
+          reason: "metadata fields must use consistent direct-child indentation"
+        )
       }
       guard let (key, value) = keyValue(in: line), !key.isEmpty else {
         throw invalidFrontmatter(path: path, reason: "metadata contains a malformed field")
@@ -339,6 +351,15 @@ nonisolated public enum ProwlSkills {
     }
 
     return ParsedAudienceMetadata(audience: audience, wasSet: wasSet, nextIndex: index)
+  }
+
+  private static func validateTopLevelKey(_ key: String, path: String) throws {
+    guard key != "prowl-install" else {
+      throw invalidFrontmatter(
+        path: path,
+        reason: "prowl-install must be a direct child of metadata"
+      )
+    }
   }
 
   private static func keyValue(in line: String) -> (key: String, value: String)? {


### PR DESCRIPTION
## Summary

- record the completed S0 install-target and directory-symlink verification without touching live skill folders
- stage Prowl's official skills into the app bundle across Debug, test, archive, and benchmark build paths
- add the Foundation-only shared skills registry with minimal frontmatter parsing, stable lookup, audience metadata, typed errors, bundle resolution, and development override support
- record completion of S3 wave 1 and the 065 K1 slice

## Scope

K1 is foundation-only. It does not install skills, detect install targets, add CLI commands, change Settings, manage third-party skills, or write into user/project skill directories.

## Verification

- focused registry tests: 11 passed after the expected RED run
- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration` — 97 passed
- `make test` — 2,621 main tests plus 2 isolated cancellation tests verified
- `make check` — formatting, lint, and 44 script tests passed
- `make build-app` — zero errors and warnings
- verified the built app's `Contents/Resources/skills/prowl-cli/SKILL.md` is byte-for-byte identical to the source skill
