### PR TITLE
Add prowl skills and the shared symlink installer (065 K2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,13 @@ test-cli-smoke: build-cli # Smoke test CLI executable
 	socket="$$tmp_dir/cli.sock"; \
 	response="$$tmp_dir/response.json"; \
 	PROWL_CLI_SOCKET="$$socket" "$$bin" list --json >"$$response" || true; \
-	jq -e '.error.code == "APP_NOT_RUNNING"' "$$response" >/dev/null
+	jq -e '.error.code == "APP_NOT_RUNNING"' "$$response" >/dev/null; \
+	mkdir -p "$$tmp_dir/skills/prowl-cli" "$$tmp_dir/home"; \
+	cp "$(CURRENT_MAKEFILE_DIR)/skills/prowl-cli/SKILL.md" "$$tmp_dir/skills/prowl-cli/SKILL.md"; \
+	skills_response="$$tmp_dir/skills.json"; \
+	PROWL_CLI_SOCKET="$$socket" PROWL_SKILLS_DIR="$$tmp_dir/skills" HOME="$$tmp_dir/home" \
+		"$$bin" skills list --json >"$$skills_response"; \
+	jq -e '.ok and .data.action == "list" and (.data.skills | map(.id)) == ["prowl-cli"]' "$$skills_response" >/dev/null
 
 test-cli-unit: # Run CLI unit tests via SwiftPM
 	@test_list="$$(swift test list)"; \

--- a/ProwlCLI/Commands/ProwlCommand.swift
+++ b/ProwlCLI/Commands/ProwlCommand.swift
@@ -15,6 +15,7 @@ struct ProwlCommand: ParsableCommand {
       ListCommand.self,
       AgentsCommand.self,
       ProfilesCommand.self,
+      SkillsCommand.self,
       FocusCommand.self,
       SendCommand.self,
       KeyCommand.self,

--- a/ProwlCLI/Commands/ProwlCommand.swift
+++ b/ProwlCLI/Commands/ProwlCommand.swift
@@ -9,6 +9,12 @@ struct ProwlCommand: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "prowl",
     abstract: "Control a running Prowl instance from the command line.",
+    discussion: """
+      Prowl bundles agent skills, including prowl-cli, which teaches a coding agent this CLI. \
+      Run `prowl skills install` once to link them into your agents' skill folders \
+      (~/.claude/skills, ~/.codex/skills, ~/.agents/skills); `prowl skills list` shows the status. \
+      The skills commands work locally and do not need the app to be running.
+      """,
     version: ProwlVersion.current,
     subcommands: [
       OpenCommand.self,

--- a/ProwlCLI/Commands/SkillsCommand.swift
+++ b/ProwlCLI/Commands/SkillsCommand.swift
@@ -1,0 +1,161 @@
+// ProwlCLI/Commands/SkillsCommand.swift
+// Local-only management of Prowl's bundled agent skills. Never opens the socket.
+
+import ArgumentParser
+import Foundation
+import ProwlCLIShared
+
+struct SkillsCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "skills",
+    abstract: "Link Prowl's bundled agent skills into agent skill folders.",
+    discussion: """
+      Runs locally against the skills bundled with this Prowl app; it never contacts or launches \
+      the app. Targets: claude (~/.claude/skills), codex (~/.codex/skills), agents (~/.agents/skills).
+      """,
+    subcommands: [
+      SkillsListCommand.self,
+      SkillsInstallCommand.self,
+      SkillsUninstallCommand.self,
+      SkillsPathCommand.self,
+    ]
+  )
+}
+
+struct SkillsChangeRequest: Equatable {
+  var skillIDs: [String] = []
+  var targetIDs: [String] = []
+  var scope: ProwlSkillScope = .user
+  var projectPath: String?
+}
+
+struct SkillsChangeOptions: ParsableArguments {
+  enum Scope: String, ExpressibleByArgument {
+    case user
+    case project
+
+    var value: ProwlSkillScope {
+      switch self {
+      case .user: .user
+      case .project: .project
+      }
+    }
+  }
+
+  @Argument(help: "Bundled skill ids. Defaults to every user-installable bundled skill.")
+  var skills: [String] = []
+
+  @Option(
+    name: .long,
+    parsing: .singleValue,
+    help: "Target id (repeatable): claude, codex, or agents. Defaults to every detected target."
+  )
+  var target: [String] = []
+
+  @Option(name: .long, help: "Scope: user (default) or project.")
+  var scope: Scope = .user
+
+  @Option(name: .long, help: "Project root for --scope project. Defaults to the Git root of the current directory.")
+  var path: String?
+
+  func makeRequest() throws -> SkillsChangeRequest {
+    if path != nil, scope != .project {
+      throw ExitError(code: CLIErrorCode.invalidArgument, message: "--path requires --scope project.")
+    }
+    return SkillsChangeRequest(skillIDs: skills, targetIDs: target, scope: scope.value, projectPath: path)
+  }
+}
+
+struct SkillsListCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list",
+    abstract: "List bundled skills with their install status per target."
+  )
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try SkillsCommandRunner.run(options: options) { executor in
+      try executor.list()
+    }
+  }
+}
+
+struct SkillsInstallCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "install",
+    abstract: "Link bundled skills into agent skill folders."
+  )
+
+  @OptionGroup var change: SkillsChangeOptions
+  @OptionGroup var options: GlobalOptions
+
+  func makeRequest() throws -> SkillsChangeRequest {
+    try change.makeRequest()
+  }
+
+  mutating func run() throws {
+    try SkillsCommandRunner.run(options: options) { executor in
+      try executor.install(try makeRequest())
+    }
+  }
+}
+
+struct SkillsUninstallCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "uninstall",
+    abstract: "Remove bundled skill links from agent skill folders."
+  )
+
+  @OptionGroup var change: SkillsChangeOptions
+  @OptionGroup var options: GlobalOptions
+
+  func makeRequest() throws -> SkillsChangeRequest {
+    try change.makeRequest()
+  }
+
+  mutating func run() throws {
+    try SkillsCommandRunner.run(options: options) { executor in
+      try executor.uninstall(try makeRequest())
+    }
+  }
+}
+
+struct SkillsPathCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "path",
+    abstract: "Print the bundled directory of a skill (any audience)."
+  )
+
+  @Argument(help: "Bundled skill id.")
+  var skill: String
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try SkillsCommandRunner.run(options: options) { executor in
+      try executor.path(skillID: skill)
+    }
+  }
+}
+
+enum SkillsCommandRunner {
+  static let commandName = "skills"
+
+  static func run(
+    options: GlobalOptions,
+    _ body: (SkillsCommandExecutor) throws -> SkillsCommandPayload
+  ) throws {
+    try CLIExecution.run(command: commandName, output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let executor = try SkillsCommandExecutor.current()
+      let payload = try body(executor)
+      let response = CommandResponse(
+        ok: true,
+        command: commandName,
+        schemaVersion: SkillsCommandPayload.schemaVersion,
+        data: try RawJSON(encoding: payload)
+      )
+      OutputRenderer.render(response, mode: options.outputMode)
+    }
+  }
+}

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -432,10 +432,11 @@ enum OutputRenderer {
       var lines = ["\(skill.id.bold)  \(skill.name)  \(audience)"]
       for target in skill.targets {
         let detected = target.detected ? "" : "  \("(target not detected)".dim)"
+        let destination = target.destination.map { "  \("→ \($0)".dim)" } ?? ""
         lines.append(
           "  \(target.id.padding(toLength: 7, withPad: " ", startingAt: 0))  "
-            + "\(skillsStatusLabel(target.status))  "
-            + "\(target.path.dim)\(detected)"
+            + "\(skillsStatusLabel(target))  "
+            + "\(target.path.dim)\(destination)\(detected)"
         )
       }
       return lines.joined(separator: "\n")
@@ -465,11 +466,12 @@ enum OutputRenderer {
     FileHandle.standardError.write(Data("note: \(note)\n".utf8))
   }
 
-  private static func skillsStatusLabel(_ status: SkillsCommandStatus) -> String {
-    switch status {
+  private static func skillsStatusLabel(_ target: SkillsCommandTargetStatus) -> String {
+    switch target.status {
     case .installed: skillsColumn("installed").green
     case .notInstalled: skillsColumn("not installed").dim
-    case .installedDifferentSource: skillsColumn("installed (different source)").yellow
+    case .installedDifferentSource where target.destination != nil: skillsColumn("linked elsewhere").yellow
+    case .installedDifferentSource: skillsColumn("real file or directory").yellow
     case .broken: skillsColumn("broken link").red
     }
   }

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -116,6 +116,14 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "skills",
+         let data = response.data,
+         let payload = try? data.decode(as: SkillsCommandPayload.self)
+      {
+        renderSkills(payload)
+        return
+      }
+
       if response.command == "focus",
          let data = response.data,
          let payload = try? data.decode(as: FocusCommandPayload.self)
@@ -397,6 +405,78 @@ enum OutputRenderer {
       let reason = profile.availability.reason.map { "  \($0.dim)" } ?? ""
       return "\(profile.name.bold)  \(profile.runtime)  \(enabled)  \(availability)  \(profile.id.dim)\(reason)"
     }.joined(separator: "\n")
+  }
+
+  private static func renderSkills(_ payload: SkillsCommandPayload) {
+    switch payload {
+    case .list(let list):
+      print(skillsListText(list))
+    case .install(let change):
+      print(skillsChangeText(change, removing: false))
+      renderSkillsNote(change)
+    case .uninstall(let change):
+      print(skillsChangeText(change, removing: true))
+      renderSkillsNote(change)
+    case .path(let path):
+      print(path.skill.path)
+    }
+  }
+
+  static func skillsListText(_ payload: SkillsListPayload) -> String {
+    guard !payload.skills.isEmpty else { return "No bundled skills found." }
+    return payload.skills.map { skill in
+      let audience =
+        skill.audience == .workflow
+        ? "[workflow — not installable]".yellow
+        : "[user]".dim
+      var lines = ["\(skill.id.bold)  \(skill.name)  \(audience)"]
+      for target in skill.targets {
+        let detected = target.detected ? "" : "  \("(target not detected)".dim)"
+        lines.append(
+          "  \(target.id.padding(toLength: 7, withPad: " ", startingAt: 0))  "
+            + "\(skillsStatusLabel(target.status))  "
+            + "\(target.path.dim)\(detected)"
+        )
+      }
+      return lines.joined(separator: "\n")
+    }.joined(separator: "\n\n")
+  }
+
+  static func skillsChangeText(_ payload: SkillsChangePayload, removing: Bool) -> String {
+    guard !payload.results.isEmpty else {
+      return removing ? "Nothing to remove." : "Nothing to install."
+    }
+    return payload.results.map { result in
+      let verb: String
+      switch (removing, result.before) {
+      case (true, .notInstalled): verb = skillsColumn("not installed").dim
+      case (true, _): verb = skillsColumn("removed").green
+      case (false, .installed): verb = skillsColumn("unchanged").dim
+      case (false, .broken): verb = skillsColumn("repaired").green
+      case (false, .installedDifferentSource): verb = skillsColumn("replaced").green
+      case (false, .notInstalled): verb = skillsColumn("installed").green
+      }
+      return "\(verb)  \(result.skill.bold) → \(result.target)  \(result.path.dim)"
+    }.joined(separator: "\n")
+  }
+
+  private static func renderSkillsNote(_ payload: SkillsChangePayload) {
+    guard let note = payload.note else { return }
+    FileHandle.standardError.write(Data("note: \(note)\n".utf8))
+  }
+
+  private static func skillsStatusLabel(_ status: SkillsCommandStatus) -> String {
+    switch status {
+    case .installed: skillsColumn("installed").green
+    case .notInstalled: skillsColumn("not installed").dim
+    case .installedDifferentSource: skillsColumn("installed (different source)").yellow
+    case .broken: skillsColumn("broken link").red
+    }
+  }
+
+  /// Pads before coloring so ANSI escapes do not skew column alignment.
+  private static func skillsColumn(_ text: String) -> String {
+    text.padding(toLength: 28, withPad: " ", startingAt: 0)
   }
 
   private static func renderAgentsRead(_ payload: AgentReadCommandPayload) {

--- a/ProwlCLI/Skills/SkillsCommandExecutor.swift
+++ b/ProwlCLI/Skills/SkillsCommandExecutor.swift
@@ -161,6 +161,17 @@ struct SkillsCommandExecutor {
         )
       }
     }
+    if scope == .project {
+      let escaping = targets.compactMap { ProwlSkillInstaller.projectBoundaryViolation(target: $0, root: root) }
+      guard escaping.isEmpty else {
+        throw ExitError(
+          code: CLIErrorCode.installConflict,
+          message: "Refusing to follow a symlinked target directory outside the project: "
+            + escaping.joined(separator: ", ")
+            + ". Project-scope links stay inside the repository; nothing was changed."
+        )
+      }
+    }
     let conflicts = pairs.filter { SymlinkInstaller.hasConflict(linkPath: $0.before.linkPath) }
     guard conflicts.isEmpty else {
       throw ExitError(
@@ -232,6 +243,7 @@ struct SkillsCommandExecutor {
     case .user:
       return userRoot
     case .project:
+      let start: URL
       if let projectPath = request.projectPath {
         let url = URL(filePath: projectPath, directoryHint: .isDirectory, relativeTo: currentDirectory)
           .standardizedFileURL
@@ -244,12 +256,17 @@ struct SkillsCommandExecutor {
           throw ExitError(
             code: CLIErrorCode.pathNotDirectory, message: "Project path is not a directory: \(displayPath(url))")
         }
-        return url
+        start = url
+      } else {
+        start = currentDirectory
       }
-      guard let root = GitRootLocator.root(containing: currentDirectory) else {
+      // Both spellings name a repository: an explicit path inside a repository resolves to its
+      // root, exactly like the current directory does, so links land where runtimes look.
+      guard let root = GitRootLocator.root(containing: start) else {
         throw ExitError(
           code: CLIErrorCode.pathNotFound,
-          message: "No Git repository contains \(displayPath(currentDirectory)); pass --path <repo>."
+          message: "No Git repository contains \(displayPath(start)); project scope needs a repository "
+            + "(pass --path <repo> or run inside one)."
         )
       }
       return root

--- a/ProwlCLI/Skills/SkillsCommandExecutor.swift
+++ b/ProwlCLI/Skills/SkillsCommandExecutor.swift
@@ -1,0 +1,291 @@
+// ProwlCLI/Skills/SkillsCommandExecutor.swift
+// Pure local execution of `prowl skills`: bundle lookup, target selection, link changes.
+
+import Foundation
+import ProwlCLIShared
+
+struct SkillsCommandExecutor {
+  let skills: [BundledSkill]
+  let userRoot: URL
+  let currentDirectory: URL
+
+  static let projectScopeNote =
+    "Project-scope skill links are absolute paths specific to this Mac. Prowl never edits Git state; "
+    + "exclude them yourself (for example in .git/info/exclude) if they should stay out of version control."
+
+  /// Resolves the bundle next to the running executable (or `PROWL_SKILLS_DIR`) and the user root.
+  static func current(environment: [String: String] = ProcessInfo.processInfo.environment) throws -> Self {
+    let skills: [BundledSkill]
+    do {
+      skills = try ProwlSkills.bundledForCLI(executableURL: currentExecutableURL(), environment: environment)
+    } catch let error as ProwlSkillsError {
+      throw ExitError(code: error.code.rawValue, message: error.localizedDescription)
+    }
+    let home: URL
+    if let override = environment["HOME"], !override.isEmpty {
+      home = URL(filePath: override, directoryHint: .isDirectory)
+    } else {
+      home = FileManager.default.homeDirectoryForCurrentUser
+    }
+    return Self(
+      skills: skills,
+      userRoot: home.standardizedFileURL,
+      currentDirectory: URL(filePath: FileManager.default.currentDirectoryPath, directoryHint: .isDirectory)
+    )
+  }
+
+  /// The executable as invoked (possibly a symlink such as `/usr/local/bin/prowl`); the registry
+  /// resolves it to the app bundle. `argv[0]` alone may be a bare name and is not used.
+  private static func currentExecutableURL() -> URL {
+    Bundle.main.executableURL ?? URL(filePath: CommandLine.arguments[0])
+  }
+
+  // MARK: - Commands
+
+  func list() throws -> SkillsCommandPayload {
+    let listed = skills.map { skill in
+      SkillsCommandSkill(
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+        audience: skill.audience,
+        path: ProwlSkillInstaller.sourcePath(skill),
+        targets: SkillInstallTarget.all.map { target in
+          let status = ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: userRoot)
+          return SkillsCommandTargetStatus(
+            id: target.id,
+            detected: status.detected,
+            path: status.linkPath,
+            status: SkillsCommandStatus(status.status)
+          )
+        }
+      )
+    }
+    return .list(SkillsListPayload(skills: listed))
+  }
+
+  func install(_ request: SkillsChangeRequest) throws -> SkillsCommandPayload {
+    let root = try resolveRoot(request)
+    let selectedSkills = try resolveSkills(request.skillIDs, installing: true)
+    let targets = try resolveTargets(request.targetIDs, scope: request.scope, root: root, requireDetected: true)
+    let pairs = try prepare(skills: selectedSkills, targets: targets, scope: request.scope, root: root)
+
+    let results = try pairs.map { pair in
+      let after: SkillTargetStatus
+      do {
+        after = try ProwlSkillInstaller.install(
+          skill: pair.skill, target: pair.target, scope: request.scope, root: root)
+      } catch {
+        throw ExitError(
+          code: CLIErrorCode.skillsFailed,
+          message: "Failed to link \(pair.skill.id) into \(pair.before.linkPath): \(error.localizedDescription)"
+        )
+      }
+      return SkillsCommandResult(
+        skill: pair.skill.id,
+        target: pair.target.id,
+        path: pair.before.linkPath,
+        before: SkillsCommandStatus(pair.before.status),
+        after: SkillsCommandStatus(after.status)
+      )
+    }
+    return .install(changePayload(scope: request.scope, root: root, results: results))
+  }
+
+  func uninstall(_ request: SkillsChangeRequest) throws -> SkillsCommandPayload {
+    let root = try resolveRoot(request)
+    let selectedSkills = try resolveSkills(request.skillIDs, installing: false)
+    let targets = try resolveTargets(request.targetIDs, scope: request.scope, root: root, requireDetected: false)
+    let pairs = try prepare(skills: selectedSkills, targets: targets, scope: request.scope, root: root)
+
+    let results = try pairs.map { pair in
+      var after = pair.before
+      if pair.before.status != .notInstalled {
+        do {
+          after = try ProwlSkillInstaller.uninstall(
+            skill: pair.skill, target: pair.target, scope: request.scope, root: root)
+        } catch {
+          throw ExitError(
+            code: CLIErrorCode.skillsFailed,
+            message: "Failed to remove \(pair.before.linkPath): \(error.localizedDescription)"
+          )
+        }
+      }
+      return SkillsCommandResult(
+        skill: pair.skill.id,
+        target: pair.target.id,
+        path: pair.before.linkPath,
+        before: SkillsCommandStatus(pair.before.status),
+        after: SkillsCommandStatus(after.status)
+      )
+    }
+    return .uninstall(changePayload(scope: request.scope, root: root, results: results))
+  }
+
+  func path(skillID: String) throws -> SkillsCommandPayload {
+    let skill = try bundledSkill(id: skillID)
+    return .path(
+      SkillsPathPayload(
+        skill: SkillsCommandSkillReference(
+          id: skill.id,
+          name: skill.name,
+          audience: skill.audience,
+          path: ProwlSkillInstaller.sourcePath(skill)
+        )
+      )
+    )
+  }
+
+  // MARK: - Selection
+
+  private struct Pair {
+    let skill: BundledSkill
+    let target: SkillInstallTarget
+    let before: SkillTargetStatus
+  }
+
+  /// Computes every skill × target slot and refuses the whole operation when any slot is a real
+  /// file or directory, so a conflict never leaves a partial result.
+  private func prepare(
+    skills: [BundledSkill],
+    targets: [SkillInstallTarget],
+    scope: ProwlSkillScope,
+    root: URL
+  ) throws -> [Pair] {
+    let pairs = skills.flatMap { skill in
+      targets.map { target in
+        Pair(
+          skill: skill,
+          target: target,
+          before: ProwlSkillInstaller.status(skill: skill, target: target, scope: scope, root: root)
+        )
+      }
+    }
+    let conflicts = pairs.filter { SymlinkInstaller.hasConflict(linkPath: $0.before.linkPath) }
+    guard conflicts.isEmpty else {
+      throw ExitError(
+        code: CLIErrorCode.installConflict,
+        message: "Refusing to touch a real file or directory (only symlinks are managed): "
+          + conflicts.map(\.before.linkPath).joined(separator: ", ")
+          + ". Remove it manually or choose other targets; nothing was changed."
+      )
+    }
+    return pairs
+  }
+
+  private func resolveSkills(_ ids: [String], installing: Bool) throws -> [BundledSkill] {
+    guard !ids.isEmpty else {
+      return skills.filter { $0.audience == .user }
+    }
+    let requested = try ids.map { id in try bundledSkill(id: id) }
+    if installing, let workflowSkill = requested.first(where: { $0.audience == .workflow }) {
+      throw ExitError(
+        code: CLIErrorCode.skillNotInstallable,
+        message: "'\(workflowSkill.id)' is a workflow skill: Prowl materializes it for workflow runs and does not "
+          + "install it into agent skill folders. Use 'prowl skills path \(workflowSkill.id)' to locate it."
+      )
+    }
+    let requestedIDs = Set(requested.map(\.id))
+    return skills.filter { requestedIDs.contains($0.id) }
+  }
+
+  private func bundledSkill(id: String) throws -> BundledSkill {
+    guard let skill = skills.first(where: { $0.id == id }) else {
+      throw ExitError(
+        code: CLIErrorCode.skillNotFound,
+        message: "No bundled skill named '\(id)'. Run 'prowl skills list' to see the bundled skills."
+      )
+    }
+    return skill
+  }
+
+  private func resolveTargets(
+    _ ids: [String],
+    scope: ProwlSkillScope,
+    root: URL,
+    requireDetected: Bool
+  ) throws -> [SkillInstallTarget] {
+    guard !ids.isEmpty else {
+      let detected = SkillInstallTarget.all.filter { $0.isDetected(scope: scope, root: root) }
+      if requireDetected, detected.isEmpty {
+        throw ExitError(
+          code: CLIErrorCode.targetNotFound,
+          message: "No agent skill directories detected under \(displayPath(root)). "
+            + "Pass --target <claude|codex|agents> to create one."
+        )
+      }
+      return detected
+    }
+    let requested = Set(ids)
+    if let unknown = ids.first(where: { SkillInstallTarget.target(id: $0) == nil }) {
+      throw ExitError(
+        code: CLIErrorCode.targetNotFound,
+        message: "Unknown target '\(unknown)'. Supported targets: "
+          + SkillInstallTarget.all.map(\.id).joined(separator: ", ") + "."
+      )
+    }
+    return SkillInstallTarget.all.filter { requested.contains($0.id) }
+  }
+
+  private func resolveRoot(_ request: SkillsChangeRequest) throws -> URL {
+    switch request.scope {
+    case .user:
+      return userRoot
+    case .project:
+      if let projectPath = request.projectPath {
+        let url = URL(filePath: projectPath, directoryHint: .isDirectory, relativeTo: currentDirectory)
+          .standardizedFileURL
+        var isDirectory: ObjCBool = false
+        // A trailing slash makes fileExists(atPath:) reject a regular file, hiding PATH_NOT_DIRECTORY.
+        guard FileManager.default.fileExists(atPath: displayPath(url), isDirectory: &isDirectory) else {
+          throw ExitError(code: CLIErrorCode.pathNotFound, message: "Project path not found: \(displayPath(url))")
+        }
+        guard isDirectory.boolValue else {
+          throw ExitError(
+            code: CLIErrorCode.pathNotDirectory, message: "Project path is not a directory: \(displayPath(url))")
+        }
+        return url
+      }
+      guard let root = GitRootLocator.root(containing: currentDirectory) else {
+        throw ExitError(
+          code: CLIErrorCode.pathNotFound,
+          message: "No Git repository contains \(displayPath(currentDirectory)); pass --path <repo>."
+        )
+      }
+      return root
+    }
+  }
+
+  private func changePayload(scope: ProwlSkillScope, root: URL, results: [SkillsCommandResult]) -> SkillsChangePayload {
+    SkillsChangePayload(
+      scope: scope,
+      root: displayPath(root),
+      results: results,
+      note: scope == .project ? Self.projectScopeNote : nil
+    )
+  }
+
+  private func displayPath(_ url: URL) -> String {
+    url.path(percentEncoded: false).trimmingTrailingPathSeparator()
+  }
+}
+
+/// Finds the nearest ancestor (including the start) that contains a `.git` entry. A worktree's
+/// `.git` is a file, so both kinds count; no Git process is involved.
+enum GitRootLocator {
+  static func root(containing directory: URL) -> URL? {
+    var current = directory.standardizedFileURL
+    while true {
+      let marker = current.appending(path: ".git", directoryHint: .notDirectory).path(percentEncoded: false)
+      if FileManager.default.fileExists(atPath: marker) {
+        return current
+      }
+      // Stop at the filesystem root: deletingLastPathComponent() of "/" yields "/.." rather than "/".
+      let path = current.path(percentEncoded: false).trimmingTrailingPathSeparator()
+      guard path != "/", !path.isEmpty else {
+        return nil
+      }
+      current = current.deletingLastPathComponent().standardizedFileURL
+    }
+  }
+}

--- a/ProwlCLI/Skills/SkillsCommandExecutor.swift
+++ b/ProwlCLI/Skills/SkillsCommandExecutor.swift
@@ -56,7 +56,8 @@ struct SkillsCommandExecutor {
             id: target.id,
             detected: status.detected,
             path: status.linkPath,
-            status: SkillsCommandStatus(status.status)
+            status: SkillsCommandStatus(status.status),
+            destination: status.status.destination
           )
         }
       )

--- a/ProwlCLI/Skills/SkillsCommandExecutor.swift
+++ b/ProwlCLI/Skills/SkillsCommandExecutor.swift
@@ -72,21 +72,29 @@ struct SkillsCommandExecutor {
     let pairs = try prepare(skills: selectedSkills, targets: targets, scope: request.scope, root: root)
 
     let results = try pairs.map { pair in
-      let after: SkillTargetStatus
-      do {
-        after = try ProwlSkillInstaller.install(
-          skill: pair.skill, target: pair.target, scope: request.scope, root: root)
-      } catch {
-        throw ExitError(
-          code: CLIErrorCode.skillsFailed,
-          message: "Failed to link \(pair.skill.id) into \(pair.before.linkPath): \(error.localizedDescription)"
-        )
+      // Re-read the slot right before acting: targets whose skills directories alias the same
+      // folder (synced ~/.claude/skills and ~/.codex/skills) share one link, so an earlier pair
+      // may already have installed it.
+      let before = ProwlSkillInstaller.status(skill: pair.skill, target: pair.target, scope: request.scope, root: root)
+      var after = before
+      if case .installed = before.status {
+        // Already linked to this bundle; relinking would only churn the shared slot.
+      } else {
+        do {
+          after = try ProwlSkillInstaller.install(
+            skill: pair.skill, target: pair.target, scope: request.scope, root: root)
+        } catch {
+          throw ExitError(
+            code: CLIErrorCode.skillsFailed,
+            message: "Failed to link \(pair.skill.id) into \(before.linkPath): \(error.localizedDescription)"
+          )
+        }
       }
       return SkillsCommandResult(
         skill: pair.skill.id,
         target: pair.target.id,
-        path: pair.before.linkPath,
-        before: SkillsCommandStatus(pair.before.status),
+        path: before.linkPath,
+        before: SkillsCommandStatus(before.status),
         after: SkillsCommandStatus(after.status)
       )
     }
@@ -100,23 +108,25 @@ struct SkillsCommandExecutor {
     let pairs = try prepare(skills: selectedSkills, targets: targets, scope: request.scope, root: root)
 
     let results = try pairs.map { pair in
-      var after = pair.before
-      if pair.before.status != .notInstalled {
+      // Re-read the slot right before acting; an aliased target may already be empty.
+      let before = ProwlSkillInstaller.status(skill: pair.skill, target: pair.target, scope: request.scope, root: root)
+      var after = before
+      if before.status != .notInstalled {
         do {
           after = try ProwlSkillInstaller.uninstall(
             skill: pair.skill, target: pair.target, scope: request.scope, root: root)
         } catch {
           throw ExitError(
             code: CLIErrorCode.skillsFailed,
-            message: "Failed to remove \(pair.before.linkPath): \(error.localizedDescription)"
+            message: "Failed to remove \(before.linkPath): \(error.localizedDescription)"
           )
         }
       }
       return SkillsCommandResult(
         skill: pair.skill.id,
         target: pair.target.id,
-        path: pair.before.linkPath,
-        before: SkillsCommandStatus(pair.before.status),
+        path: before.linkPath,
+        before: SkillsCommandStatus(before.status),
         after: SkillsCommandStatus(after.status)
       )
     }

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -32,6 +32,9 @@
       "$ref": "#/$defs/profilesResponse"
     },
     {
+      "$ref": "#/$defs/skillsResponse"
+    },
+    {
       "$ref": "#/$defs/focusResponse"
     },
     {
@@ -2711,6 +2714,284 @@
             },
             "schema_version": {
               "const": "prowl.cli.profiles.v1"
+            },
+            "error": {
+              "$ref": "#/$defs/error"
+            }
+          }
+        }
+      ]
+    },
+    "skillStatus": {
+      "enum": [
+        "not_installed",
+        "installed",
+        "installed_different_source",
+        "broken"
+      ]
+    },
+    "skillAudience": {
+      "enum": [
+        "user",
+        "workflow"
+      ]
+    },
+    "skillTargetStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "detected",
+        "path",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "enum": [
+            "claude",
+            "codex",
+            "agents"
+          ]
+        },
+        "detected": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/$defs/skillStatus"
+        }
+      }
+    },
+    "skillsListSkill": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "description",
+        "audience",
+        "path",
+        "targets"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "audience": {
+          "$ref": "#/$defs/skillAudience"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/skillTargetStatus"
+          }
+        }
+      }
+    },
+    "skillsListData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "skills"
+      ],
+      "properties": {
+        "action": {
+          "const": "list"
+        },
+        "skills": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/skillsListSkill"
+          }
+        }
+      }
+    },
+    "skillsChangeResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "skill",
+        "target",
+        "path",
+        "before",
+        "after"
+      ],
+      "properties": {
+        "skill": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "enum": [
+            "claude",
+            "codex",
+            "agents"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "before": {
+          "$ref": "#/$defs/skillStatus"
+        },
+        "after": {
+          "$ref": "#/$defs/skillStatus"
+        }
+      }
+    },
+    "skillsChangeData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "scope",
+        "root",
+        "results"
+      ],
+      "properties": {
+        "action": {
+          "enum": [
+            "install",
+            "uninstall"
+          ]
+        },
+        "scope": {
+          "enum": [
+            "user",
+            "project"
+          ]
+        },
+        "root": {
+          "type": "string",
+          "minLength": 1
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/skillsChangeResult"
+          }
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "skillsPathData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "skill"
+      ],
+      "properties": {
+        "action": {
+          "const": "path"
+        },
+        "skill": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "audience",
+            "path"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "audience": {
+              "$ref": "#/$defs/skillAudience"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "skillsData": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/skillsListData"
+        },
+        {
+          "$ref": "#/$defs/skillsChangeData"
+        },
+        {
+          "$ref": "#/$defs/skillsPathData"
+        }
+      ]
+    },
+    "skillsResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "data"
+          ],
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "command": {
+              "const": "skills"
+            },
+            "schema_version": {
+              "const": "prowl.cli.skills.v1"
+            },
+            "data": {
+              "$ref": "#/$defs/skillsData"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "error"
+          ],
+          "properties": {
+            "ok": {
+              "const": false
+            },
+            "command": {
+              "const": "skills"
+            },
+            "schema_version": {
+              "const": "prowl.cli.skills.v1"
             },
             "error": {
               "$ref": "#/$defs/error"

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -2762,6 +2762,10 @@
         },
         "status": {
           "$ref": "#/$defs/skillStatus"
+        },
+        "destination": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -2737,37 +2737,107 @@
       ]
     },
     "skillTargetStatus": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "id",
-        "detected",
-        "path",
-        "status"
-      ],
-      "properties": {
-        "id": {
-          "enum": [
-            "claude",
-            "codex",
-            "agents"
-          ]
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "detected",
+            "path",
+            "status"
+          ],
+          "properties": {
+            "id": {
+              "enum": [
+                "claude",
+                "codex",
+                "agents"
+              ]
+            },
+            "detected": {
+              "type": "boolean"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "status": {
+              "enum": [
+                "not_installed",
+                "installed"
+              ]
+            }
+          }
         },
-        "detected": {
-          "type": "boolean"
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "detected",
+            "path",
+            "status"
+          ],
+          "properties": {
+            "id": {
+              "enum": [
+                "claude",
+                "codex",
+                "agents"
+              ]
+            },
+            "detected": {
+              "type": "boolean"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "status": {
+              "const": "installed_different_source"
+            },
+            "destination": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         },
-        "path": {
-          "type": "string",
-          "minLength": 1
-        },
-        "status": {
-          "$ref": "#/$defs/skillStatus"
-        },
-        "destination": {
-          "type": "string",
-          "minLength": 1
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "detected",
+            "path",
+            "status",
+            "destination"
+          ],
+          "properties": {
+            "id": {
+              "enum": [
+                "claude",
+                "codex",
+                "agents"
+              ]
+            },
+            "detected": {
+              "type": "boolean"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "status": {
+              "const": "broken"
+            },
+            "destination": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
-      }
+      ]
     },
     "skillsListSkill": {
       "type": "object",

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1,13 +1,14 @@
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Foundation
 import JSONSchema
 import ProwlCLIContracts
 import ProwlCLIShared
 import XCTest
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
 
 final class ProwlCLIIntegrationTests: XCTestCase {
   private var repoRoot: URL {
@@ -42,6 +43,10 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(help.stdout.contains("create"))
     XCTAssertTrue(help.stdout.contains("close"))
     XCTAssertTrue(help.stdout.contains("skills"))
+    XCTAssertTrue(
+      help.stdout.contains("prowl skills install"),
+      "Root help should tell users and agents how to link the bundled skills"
+    )
   }
 
   func testNativeHookBridgeIsHiddenSilentAndFailOpenWithoutListener() throws {
@@ -159,7 +164,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     let notifierArgv = ["/usr/bin/python3", script.path, "space value", "", "秘密-like"]
     try JSONSerialization.data(withJSONObject: notifierArgv).write(to: record, options: .atomic)
     try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: record.path)
-    let payload = #"{"type":"agent-turn-complete","thread-id":"thread-1","turn-id":"turn-1","cwd":"/tmp/project","last-assistant-message":"excluded"}"#
+    let payload =
+      #"{"type":"agent-turn-complete","thread-id":"thread-1","turn-id":"turn-1","cwd":"/tmp/project","last-assistant-message":"excluded"}"#
 
     let result = try runProwl(
       args: ["agents", "_hook", "codex", "agent-turn-complete", payload],
@@ -224,7 +230,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(error["code"] as? String, CLIErrorCode.socketPermissionDenied)
     let message = try XCTUnwrap(error["message"] as? String)
     XCTAssertTrue(message.contains("EACCES"), "Message should include errno name: \(message)")
-    XCTAssertTrue(message.localizedCaseInsensitiveContains("sandbox"), "Message should guide agent recovery: \(message)")
+    XCTAssertTrue(
+      message.localizedCaseInsensitiveContains("sandbox"), "Message should guide agent recovery: \(message)")
   }
 
   func testListReportsTransportFailedWhenSocketPathIsNotASocket() throws {
@@ -261,7 +268,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     let error = try XCTUnwrap(payload["error"] as? [String: Any])
     XCTAssertEqual(error["code"] as? String, CLIErrorCode.transportFailed)
     let message = try XCTUnwrap(error["message"] as? String)
-    XCTAssertTrue(message.localizedCaseInsensitiveContains("too long"), "Message should identify path length: \(message)")
+    XCTAssertTrue(
+      message.localizedCaseInsensitiveContains("too long"), "Message should identify path length: \(message)")
   }
 
   func testAgentsCommandRoundTripsOverSocket() throws {
@@ -625,14 +633,15 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "open",
       schemaVersion: "prowl.cli.open.v1",
-      data: RawJSON(encoding: OpenResponseData(
-        invocation: "open-subcommand",
-        requestedPath: repoRoot.path,
-        resolvedPath: repoRoot.path,
-        resolution: "exact-root",
-        appLaunched: false,
-        broughtToFront: true
-      ))
+      data: RawJSON(
+        encoding: OpenResponseData(
+          invocation: "open-subcommand",
+          requestedPath: repoRoot.path,
+          resolvedPath: repoRoot.path,
+          resolution: "exact-root",
+          appLaunched: false,
+          broughtToFront: true
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -665,14 +674,15 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "open",
       schemaVersion: "prowl.cli.open.v1",
-      data: RawJSON(encoding: OpenResponseData(
-        invocation: "implicit-open",
-        requestedPath: repoRoot.path,
-        resolvedPath: repoRoot.path,
-        resolution: "exact-root",
-        appLaunched: false,
-        broughtToFront: true
-      ))
+      data: RawJSON(
+        encoding: OpenResponseData(
+          invocation: "implicit-open",
+          requestedPath: repoRoot.path,
+          resolvedPath: repoRoot.path,
+          resolution: "exact-root",
+          appLaunched: false,
+          broughtToFront: true
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1112,7 +1122,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       XCTAssertNil(installData["note"])
       let installResults = try XCTUnwrap(installData["results"] as? [[String: Any]])
       XCTAssertEqual(installResults.map { $0["target"] as? String }, ["claude", "codex", "agents"])
-      XCTAssertEqual(installResults.map { $0["before"] as? String }, ["not_installed", "not_installed", "not_installed"])
+      XCTAssertEqual(
+        installResults.map { $0["before"] as? String }, ["not_installed", "not_installed", "not_installed"])
       XCTAssertEqual(installResults.map { $0["after"] as? String }, ["installed", "installed", "installed"])
       for target in [".claude", ".codex", ".agents"] {
         let link = fixture.home.appending(path: "\(target)/skills/prowl-cli").path(percentEncoded: false)
@@ -1133,7 +1144,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       XCTAssertEqual(uninstallData["action"] as? String, "uninstall")
       let uninstallResults = try XCTUnwrap(uninstallData["results"] as? [[String: Any]])
       XCTAssertEqual(uninstallResults.map { $0["target"] as? String }, ["claude", "codex", "agents"])
-      XCTAssertEqual(uninstallResults.map { $0["after"] as? String }, ["not_installed", "not_installed", "not_installed"])
+      XCTAssertEqual(
+        uninstallResults.map { $0["after"] as? String }, ["not_installed", "not_installed", "not_installed"])
       for target in [".claude", ".codex", ".agents"] {
         let link = fixture.home.appending(path: "\(target)/skills/prowl-cli").path(percentEncoded: false)
         XCTAssertNil(try? FileManager.default.attributesOfItem(atPath: link))
@@ -1168,7 +1180,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       let conflictError = try XCTUnwrap(try jsonObject(from: conflict.stdout)["error"] as? [String: Any])
       XCTAssertEqual(conflictError["code"] as? String, "INSTALL_CONFLICT")
       XCTAssertEqual(try Data(contentsOf: realDirectory.appending(path: "SKILL.md")), Data("keep".utf8))
-      XCTAssertNil(try? FileManager.default.destinationOfSymbolicLink(atPath: realDirectory.path(percentEncoded: false)))
+      XCTAssertNil(
+        try? FileManager.default.destinationOfSymbolicLink(atPath: realDirectory.path(percentEncoded: false)))
 
       let unknownTarget = try runProwl(
         args: ["skills", "install", "--target", "cursor", "--json"], environment: fixture.environment)
@@ -1568,31 +1581,32 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "focus",
       schemaVersion: "prowl.cli.focus.v1",
-      data: RawJSON(encoding: FocusResponseData(
-        requested: FocusRequested(selector: "pane", value: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764"),
-        resolvedVia: "pane",
-        broughtToFront: true,
-        target: FocusResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Users/onevcat/Projects/Prowl",
-            name: "Prowl",
-            path: "/Users/onevcat/Projects/Prowl",
-            rootPath: "/Users/onevcat/Projects/Prowl",
-            kind: "git"
-          ),
-          tab: FocusResponseTab(
-            id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
-            title: "Prowl 1",
-            selected: true
-          ),
-          pane: FocusResponsePane(
-            id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-            title: "zsh",
-            cwd: "/Users/onevcat/Projects/Prowl",
-            focused: true
+      data: RawJSON(
+        encoding: FocusResponseData(
+          requested: FocusRequested(selector: "pane", value: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764"),
+          resolvedVia: "pane",
+          broughtToFront: true,
+          target: FocusResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Users/onevcat/Projects/Prowl",
+              name: "Prowl",
+              path: "/Users/onevcat/Projects/Prowl",
+              rootPath: "/Users/onevcat/Projects/Prowl",
+              kind: "git"
+            ),
+            tab: FocusResponseTab(
+              id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
+              title: "Prowl 1",
+              selected: true
+            ),
+            pane: FocusResponsePane(
+              id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+              title: "zsh",
+              cwd: "/Users/onevcat/Projects/Prowl",
+              focused: true
+            )
           )
-        )
-      ))
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1608,41 +1622,41 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(result.stdout.contains("tab: Prowl 1"), "Missing tab field: \(result.stdout)")
   }
 
-
   func testListCommandTextRenderingFromSocket() throws {
     let socketPath = temporarySocketPath(suffix: "list-text")
     let response = try CommandResponse(
       ok: true,
       command: "list",
       schemaVersion: "prowl.cli.list.v1",
-      data: RawJSON(encoding: ListResponseData(
-        count: 1,
-        items: [
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "Prowl:/Users/onevcat/Projects/Prowl",
-              name: "Prowl",
-              path: "/Users/onevcat/Projects/Prowl",
-              rootPath: "/Users/onevcat/Projects/Prowl",
-              kind: "git"
-            ),
-            tab: ListTab(
-              id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
-              handle: 7,
-              title: "Prowl 1",
-              selected: true
-            ),
-            pane: ListPane(
-              id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-              handle: 8,
-              title: "zsh",
-              cwd: "/Users/onevcat/Projects/Prowl",
-              focused: true
-            ),
-            task: ListTask(status: "running")
-          )
-        ]
-      ))
+      data: RawJSON(
+        encoding: ListResponseData(
+          count: 1,
+          items: [
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "Prowl:/Users/onevcat/Projects/Prowl",
+                name: "Prowl",
+                path: "/Users/onevcat/Projects/Prowl",
+                rootPath: "/Users/onevcat/Projects/Prowl",
+                kind: "git"
+              ),
+              tab: ListTab(
+                id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
+                handle: 7,
+                title: "Prowl 1",
+                selected: true
+              ),
+              pane: ListPane(
+                id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+                handle: 8,
+                title: "zsh",
+                cwd: "/Users/onevcat/Projects/Prowl",
+                focused: true
+              ),
+              task: ListTask(status: "running")
+            )
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1685,43 +1699,44 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "agents",
       schemaVersion: "prowl.cli.agents.v1",
-      data: RawJSON(encoding: AgentsResponseData(
-        count: 3,
-        agents: [
-          makeAgentResponse(
-            id: "done-pane",
-            name: "codex",
-            status: "done",
-            projectName: "Prowl",
-            branch: "main",
-            tabTitle: "Done tab",
-            detectionReason: "legacy.detector",
-            session: AgentsResponseSession(
-              id: "019f4e9e-1234-4567-89ab-0123456789ab",
-              path: "/Users/me/.codex/sessions/rollout.jsonl",
-              confidence: "exact",
-              source: "open_file"
-            )
-          ),
-          makeAgentResponse(
-            id: "blocked-pane",
-            handle: 3,
-            name: "omp",
-            status: "blocked",
-            projectName: "Prowl",
-            branch: "feature/cli-agents",
-            tabTitle: "issue 330"
-          ),
-          makeAgentResponse(
-            id: "working-pane",
-            name: "claude",
-            status: "working",
-            projectName: "Notes",
-            branch: "main",
-            tabTitle: "review"
-          ),
-        ]
-      ))
+      data: RawJSON(
+        encoding: AgentsResponseData(
+          count: 3,
+          agents: [
+            makeAgentResponse(
+              id: "done-pane",
+              name: "codex",
+              status: "done",
+              projectName: "Prowl",
+              branch: "main",
+              tabTitle: "Done tab",
+              detectionReason: "legacy.detector",
+              session: AgentsResponseSession(
+                id: "019f4e9e-1234-4567-89ab-0123456789ab",
+                path: "/Users/me/.codex/sessions/rollout.jsonl",
+                confidence: "exact",
+                source: "open_file"
+              )
+            ),
+            makeAgentResponse(
+              id: "blocked-pane",
+              handle: 3,
+              name: "omp",
+              status: "blocked",
+              projectName: "Prowl",
+              branch: "feature/cli-agents",
+              tabTitle: "issue 330"
+            ),
+            makeAgentResponse(
+              id: "working-pane",
+              name: "claude",
+              status: "working",
+              projectName: "Notes",
+              branch: "main",
+              tabTitle: "review"
+            ),
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1770,29 +1785,30 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "list",
       schemaVersion: "prowl.cli.list.v1",
-      data: RawJSON(encoding: ListResponseData(
-        count: 2,
-        items: [
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/Alpha", rootPath: "/Projects/Alpha", kind: "git"
+      data: RawJSON(
+        encoding: ListResponseData(
+          count: 2,
+          items: [
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/Alpha", rootPath: "/Projects/Alpha", kind: "git"
+              ),
+              tab: ListTab(id: "t1", title: "Tab A", selected: true),
+              pane: ListPane(id: "p1", title: "zsh", cwd: "/Projects/Alpha", focused: true),
+              task: ListTask(status: "running")
             ),
-            tab: ListTab(id: "t1", title: "Tab A", selected: true),
-            pane: ListPane(id: "p1", title: "zsh", cwd: "/Projects/Alpha", focused: true),
-            task: ListTask(status: "running")
-          ),
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-2", name: "develop",
-              path: "/Projects/Beta", rootPath: "/Projects/Beta", kind: "git"
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-2", name: "develop",
+                path: "/Projects/Beta", rootPath: "/Projects/Beta", kind: "git"
+              ),
+              tab: ListTab(id: "t2", title: "Tab B", selected: true),
+              pane: ListPane(id: "p2", title: "zsh", cwd: "/Projects/Beta", focused: false),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "t2", title: "Tab B", selected: true),
-            pane: ListPane(id: "p2", title: "zsh", cwd: "/Projects/Beta", focused: false),
-            task: ListTask(status: "idle")
-          ),
-        ]
-      ))
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1817,29 +1833,30 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "list",
       schemaVersion: "prowl.cli.list.v1",
-      data: RawJSON(encoding: ListResponseData(
-        count: 2,
-        items: [
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+      data: RawJSON(
+        encoding: ListResponseData(
+          count: 2,
+          items: [
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "t1", title: "Tab 1", selected: true),
+              pane: ListPane(id: "p-same", title: "zsh", cwd: "/Projects/App", focused: true),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "t1", title: "Tab 1", selected: true),
-            pane: ListPane(id: "p-same", title: "zsh", cwd: "/Projects/App", focused: true),
-            task: ListTask(status: "idle")
-          ),
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "t1", title: "Tab 1", selected: true),
+              pane: ListPane(id: "p-diff", title: "zsh", cwd: "/Users/onevcat", focused: false),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "t1", title: "Tab 1", selected: true),
-            pane: ListPane(id: "p-diff", title: "zsh", cwd: "/Users/onevcat", focused: false),
-            task: ListTask(status: "idle")
-          ),
-        ]
-      ))
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1868,38 +1885,39 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "list",
       schemaVersion: "prowl.cli.list.v1",
-      data: RawJSON(encoding: ListResponseData(
-        count: 3,
-        items: [
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+      data: RawJSON(
+        encoding: ListResponseData(
+          count: 3,
+          items: [
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "tab-a", title: "Tab A", selected: false),
+              pane: ListPane(id: "pa1", title: "zsh", cwd: "/Projects/App", focused: false),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "tab-a", title: "Tab A", selected: false),
-            pane: ListPane(id: "pa1", title: "zsh", cwd: "/Projects/App", focused: false),
-            task: ListTask(status: "idle")
-          ),
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "tab-b", title: "Tab B", selected: true),
+              pane: ListPane(id: "pb1", title: "vim", cwd: "/Projects/App", focused: true),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "tab-b", title: "Tab B", selected: true),
-            pane: ListPane(id: "pb1", title: "vim", cwd: "/Projects/App", focused: true),
-            task: ListTask(status: "idle")
-          ),
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "tab-b", title: "Tab B", selected: true),
+              pane: ListPane(id: "pb2", title: "htop", cwd: "/Projects/App", focused: false),
+              task: ListTask(status: "idle")
             ),
-            tab: ListTab(id: "tab-b", title: "Tab B", selected: true),
-            pane: ListPane(id: "pb2", title: "htop", cwd: "/Projects/App", focused: false),
-            task: ListTask(status: "idle")
-          ),
-        ]
-      ))
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1921,20 +1939,21 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "list",
       schemaVersion: "prowl.cli.list.v1",
-      data: RawJSON(encoding: ListResponseData(
-        count: 1,
-        items: [
-          ListResponseItem(
-            worktree: ListWorktree(
-              id: "wt-1", name: "main",
-              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
-            ),
-            tab: ListTab(id: "t1", title: "Tab A", selected: true),
-            pane: ListPane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true),
-            task: ListTask(status: "running")
-          ),
-        ]
-      ))
+      data: RawJSON(
+        encoding: ListResponseData(
+          count: 1,
+          items: [
+            ListResponseItem(
+              worktree: ListWorktree(
+                id: "wt-1", name: "main",
+                path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+              ),
+              tab: ListTab(id: "t1", title: "Tab A", selected: true),
+              pane: ListPane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true),
+              task: ListTask(status: "running")
+            )
+          ]
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -1956,22 +1975,23 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "send",
       schemaVersion: "prowl.cli.send.v1",
-      data: RawJSON(encoding: SendResponseData(
-        target: SendResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl", name: "Prowl",
-            path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
+      data: RawJSON(
+        encoding: SendResponseData(
+          target: SendResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl", name: "Prowl",
+              path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
+            ),
+            tab: SendResponseTab(id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0", title: "Prowl 1", selected: true),
+            pane: SendResponsePane(
+              id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+              title: "zsh", cwd: "/Projects/Prowl", focused: true
+            )
           ),
-          tab: SendResponseTab(id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0", title: "Prowl 1", selected: true),
-          pane: SendResponsePane(
-            id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-            title: "zsh", cwd: "/Projects/Prowl", focused: true
-          )
-        ),
-        input: SendResponseInput(source: "argv", characters: 10, bytes: 10, trailingEnterSent: true),
-        createdTab: false,
-        wait: SendResponseWait(exitCode: 0, durationMs: 1234)
-      ))
+          input: SendResponseInput(source: "argv", characters: 10, bytes: 10, trailingEnterSent: true),
+          createdTab: false,
+          wait: SendResponseWait(exitCode: 0, durationMs: 1234)
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -2006,19 +2026,20 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "send",
       schemaVersion: "prowl.cli.send.v1",
-      data: RawJSON(encoding: SendResponseData(
-        target: SendResponseTarget(
-          worktree: ListWorktree(
-            id: "wt-1", name: "main",
-            path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+      data: RawJSON(
+        encoding: SendResponseData(
+          target: SendResponseTarget(
+            worktree: ListWorktree(
+              id: "wt-1", name: "main",
+              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ),
+            tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
+            pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
           ),
-          tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
-          pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
-        ),
-        input: SendResponseInput(source: "argv", characters: 5, bytes: 5, trailingEnterSent: true),
-        createdTab: false,
-        wait: nil
-      ))
+          input: SendResponseInput(source: "argv", characters: 5, bytes: 5, trailingEnterSent: true),
+          createdTab: false,
+          wait: nil
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -2046,19 +2067,20 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "send",
       schemaVersion: "prowl.cli.send.v1",
-      data: RawJSON(encoding: SendResponseData(
-        target: SendResponseTarget(
-          worktree: ListWorktree(
-            id: "wt-1", name: "main",
-            path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+      data: RawJSON(
+        encoding: SendResponseData(
+          target: SendResponseTarget(
+            worktree: ListWorktree(
+              id: "wt-1", name: "main",
+              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ),
+            tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
+            pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
           ),
-          tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
-          pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
-        ),
-        input: SendResponseInput(source: "argv", characters: 10, bytes: 10, trailingEnterSent: true),
-        createdTab: false,
-        wait: SendResponseWait(exitCode: 0, durationMs: 350)
-      ))
+          input: SendResponseInput(source: "argv", characters: 10, bytes: 10, trailingEnterSent: true),
+          createdTab: false,
+          wait: SendResponseWait(exitCode: 0, durationMs: 350)
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2080,19 +2102,20 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "send",
       schemaVersion: "prowl.cli.send.v1",
-      data: RawJSON(encoding: SendResponseData(
-        target: SendResponseTarget(
-          worktree: ListWorktree(
-            id: "wt-1", name: "main",
-            path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+      data: RawJSON(
+        encoding: SendResponseData(
+          target: SendResponseTarget(
+            worktree: ListWorktree(
+              id: "wt-1", name: "main",
+              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ),
+            tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
+            pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
           ),
-          tab: SendResponseTab(id: "t1", title: "Tab 1", selected: true),
-          pane: SendResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
-        ),
-        input: SendResponseInput(source: "argv", characters: 5, bytes: 5, trailingEnterSent: true),
-        createdTab: false,
-        wait: SendResponseWait(exitCode: 0, durationMs: 100)
-      ))
+          input: SendResponseInput(source: "argv", characters: 5, bytes: 5, trailingEnterSent: true),
+          createdTab: false,
+          wait: SendResponseWait(exitCode: 0, durationMs: 100)
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2132,22 +2155,23 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "key",
       schemaVersion: "prowl.cli.key.v1",
-      data: RawJSON(encoding: KeyResponseData(
-        requested: KeyResponseRequested(token: "enter", repeat: 1),
-        key: KeyResponseKey(normalized: "enter", category: "editing"),
-        delivery: KeyResponseDelivery(attempted: 1, delivered: 1, mode: "keyDownUp"),
-        target: KeyResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl", name: "Prowl",
-            path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
-          ),
-          tab: KeyResponseTab(id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0", title: "Prowl 1", selected: true),
-          pane: KeyResponsePane(
-            id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-            title: "zsh", cwd: "/Projects/Prowl", focused: true
+      data: RawJSON(
+        encoding: KeyResponseData(
+          requested: KeyResponseRequested(token: "enter", repeat: 1),
+          key: KeyResponseKey(normalized: "enter", category: "editing"),
+          delivery: KeyResponseDelivery(attempted: 1, delivered: 1, mode: "keyDownUp"),
+          target: KeyResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl", name: "Prowl",
+              path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
+            ),
+            tab: KeyResponseTab(id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0", title: "Prowl 1", selected: true),
+            pane: KeyResponsePane(
+              id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+              title: "zsh", cwd: "/Projects/Prowl", focused: true
+            )
           )
-        )
-      ))
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -2315,19 +2339,20 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "key",
       schemaVersion: "prowl.cli.key.v1",
-      data: RawJSON(encoding: KeyResponseData(
-        requested: KeyResponseRequested(token: "Ctrl+C", repeat: 3),
-        key: KeyResponseKey(normalized: "ctrl-c", category: "control"),
-        delivery: KeyResponseDelivery(attempted: 3, delivered: 3, mode: "keyDownUp"),
-        target: KeyResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl", name: "Prowl",
-            path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
-          ),
-          tab: KeyResponseTab(id: "t1", title: "Prowl 1", selected: true),
-          pane: KeyResponsePane(id: "p1", title: "Claude", cwd: "/Projects/Prowl", focused: true)
-        )
-      ))
+      data: RawJSON(
+        encoding: KeyResponseData(
+          requested: KeyResponseRequested(token: "Ctrl+C", repeat: 3),
+          key: KeyResponseKey(normalized: "ctrl-c", category: "control"),
+          delivery: KeyResponseDelivery(attempted: 3, delivered: 3, mode: "keyDownUp"),
+          target: KeyResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl", name: "Prowl",
+              path: "/Projects/Prowl", rootPath: "/Projects/Prowl", kind: "git"
+            ),
+            tab: KeyResponseTab(id: "t1", title: "Prowl 1", selected: true),
+            pane: KeyResponsePane(id: "p1", title: "Claude", cwd: "/Projects/Prowl", focused: true)
+          )
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2354,19 +2379,20 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "key",
       schemaVersion: "prowl.cli.key.v1",
-      data: RawJSON(encoding: KeyResponseData(
-        requested: KeyResponseRequested(token: "esc", repeat: 1),
-        key: KeyResponseKey(normalized: "esc", category: "control"),
-        delivery: KeyResponseDelivery(attempted: 1, delivered: 1, mode: "keyDownUp"),
-        target: KeyResponseTarget(
-          worktree: ListWorktree(
-            id: "wt-1", name: "main",
-            path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
-          ),
-          tab: KeyResponseTab(id: "t1", title: "Tab 1", selected: true),
-          pane: KeyResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
-        )
-      ))
+      data: RawJSON(
+        encoding: KeyResponseData(
+          requested: KeyResponseRequested(token: "esc", repeat: 1),
+          key: KeyResponseKey(normalized: "esc", category: "control"),
+          delivery: KeyResponseDelivery(attempted: 1, delivered: 1, mode: "keyDownUp"),
+          target: KeyResponseTarget(
+            worktree: ListWorktree(
+              id: "wt-1", name: "main",
+              path: "/Projects/App", rootPath: "/Projects/App", kind: "git"
+            ),
+            tab: KeyResponseTab(id: "t1", title: "Tab 1", selected: true),
+            pane: KeyResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
+          )
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2469,7 +2495,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     ]
 
     for (raw, normalized) in tokenCases {
-      let socketPath = temporarySocketPath(suffix: "key-expanded-\(normalized.replacingOccurrences(of: "-", with: "_"))")
+      let socketPath = temporarySocketPath(
+        suffix: "key-expanded-\(normalized.replacingOccurrences(of: "-", with: "_"))")
       let response = CommandResponse(
         ok: true,
         command: "key",
@@ -2511,34 +2538,35 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "read",
       schemaVersion: "prowl.cli.read.v1",
-      data: RawJSON(encoding: ReadResponseData(
-        target: ReadResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl",
-            name: "Prowl",
-            path: "/Projects/Prowl",
-            rootPath: "/Projects/Prowl",
-            kind: "git"
+      data: RawJSON(
+        encoding: ReadResponseData(
+          target: ReadResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl",
+              name: "Prowl",
+              path: "/Projects/Prowl",
+              rootPath: "/Projects/Prowl",
+              kind: "git"
+            ),
+            tab: ReadResponseTab(
+              id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
+              title: "Prowl 1",
+              selected: true
+            ),
+            pane: ReadResponsePane(
+              id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+              title: "zsh",
+              cwd: "/Projects/Prowl",
+              focused: true
+            )
           ),
-          tab: ReadResponseTab(
-            id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
-            title: "Prowl 1",
-            selected: true
-          ),
-          pane: ReadResponsePane(
-            id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-            title: "zsh",
-            cwd: "/Projects/Prowl",
-            focused: true
-          )
-        ),
-        mode: "last",
-        last: 5,
-        source: "scrollback",
-        truncated: false,
-        lineCount: 5,
-        text: "1\n2\n3\n4\n5"
-      ))
+          mode: "last",
+          last: 5,
+          source: "scrollback",
+          truncated: false,
+          lineCount: 5,
+          text: "1\n2\n3\n4\n5"
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -2569,25 +2597,26 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "read",
       schemaVersion: "prowl.cli.read.v1",
-      data: RawJSON(encoding: ReadResponseData(
-        target: ReadResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl",
-            name: "Prowl",
-            path: "/Projects/Prowl",
-            rootPath: "/Projects/Prowl",
-            kind: "git"
+      data: RawJSON(
+        encoding: ReadResponseData(
+          target: ReadResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl",
+              name: "Prowl",
+              path: "/Projects/Prowl",
+              rootPath: "/Projects/Prowl",
+              kind: "git"
+            ),
+            tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+            pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
           ),
-          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
-          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
-        ),
-        mode: "snapshot",
-        last: nil,
-        source: "detection",
-        truncated: false,
-        lineCount: 2,
-        text: "active-line-1\nactive-line-2"
-      ))
+          mode: "snapshot",
+          last: nil,
+          source: "detection",
+          truncated: false,
+          lineCount: 2,
+          text: "active-line-1\nactive-line-2"
+        ))
     )
 
     let (requestData, result) = try runWithMockServer(
@@ -2615,25 +2644,26 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "read",
       schemaVersion: "prowl.cli.read.v1",
-      data: RawJSON(encoding: ReadResponseData(
-        target: ReadResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl",
-            name: "Prowl",
-            path: "/Projects/Prowl",
-            rootPath: "/Projects/Prowl",
-            kind: "git"
+      data: RawJSON(
+        encoding: ReadResponseData(
+          target: ReadResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl",
+              name: "Prowl",
+              path: "/Projects/Prowl",
+              rootPath: "/Projects/Prowl",
+              kind: "git"
+            ),
+            tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+            pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
           ),
-          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
-          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
-        ),
-        mode: "snapshot",
-        last: nil,
-        source: "screen",
-        truncated: false,
-        lineCount: 1,
-        text: "viewport"
-      ))
+          mode: "snapshot",
+          last: nil,
+          source: "screen",
+          truncated: false,
+          lineCount: 1,
+          text: "viewport"
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2656,25 +2686,26 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "read",
       schemaVersion: "prowl.cli.read.v1",
-      data: RawJSON(encoding: ReadResponseData(
-        target: ReadResponseTarget(
-          worktree: ListWorktree(
-            id: "Prowl:/Projects/Prowl",
-            name: "Prowl",
-            path: "/Projects/Prowl",
-            rootPath: "/Projects/Prowl",
-            kind: "git"
+      data: RawJSON(
+        encoding: ReadResponseData(
+          target: ReadResponseTarget(
+            worktree: ListWorktree(
+              id: "Prowl:/Projects/Prowl",
+              name: "Prowl",
+              path: "/Projects/Prowl",
+              rootPath: "/Projects/Prowl",
+              kind: "git"
+            ),
+            tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+            pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
           ),
-          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
-          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
-        ),
-        mode: "snapshot",
-        last: nil,
-        source: "screen",
-        truncated: false,
-        lineCount: 1,
-        text: "private viewport text"
-      ))
+          mode: "snapshot",
+          last: nil,
+          source: "screen",
+          truncated: false,
+          lineCount: 1,
+          text: "private viewport text"
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -2742,25 +2773,26 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "read",
       schemaVersion: "prowl.cli.read.v1",
-      data: RawJSON(encoding: ReadResponseData(
-        target: ReadResponseTarget(
-          worktree: ListWorktree(
-            id: "wt-1",
-            name: "main",
-            path: "/Projects/App",
-            rootPath: "/Projects/App",
-            kind: "git"
+      data: RawJSON(
+        encoding: ReadResponseData(
+          target: ReadResponseTarget(
+            worktree: ListWorktree(
+              id: "wt-1",
+              name: "main",
+              path: "/Projects/App",
+              rootPath: "/Projects/App",
+              kind: "git"
+            ),
+            tab: ReadResponseTab(id: "t1", title: "Tab 1", selected: true),
+            pane: ReadResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
           ),
-          tab: ReadResponseTab(id: "t1", title: "Tab 1", selected: true),
-          pane: ReadResponsePane(id: "p1", title: "zsh", cwd: "/Projects/App", focused: true)
-        ),
-        mode: "last",
-        last: 3,
-        source: "scrollback",
-        truncated: false,
-        lineCount: 3,
-        text: "a\nb\nc"
-      ))
+          mode: "last",
+          last: 3,
+          source: "scrollback",
+          truncated: false,
+          lineCount: 3,
+          text: "a\nb\nc"
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -3008,36 +3040,38 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "handoff",
       schemaVersion: "prowl.cli.handoff.v2",
-      data: RawJSON(encoding: HandoffCommandPayload(
-        action: .toAgent,
-        artifactPath: "/Projects/App/.prowl/handoff/current.md",
-        outgoingAgent: "codex",
-        toAgent: "claude",
-        repos: [
-          HandoffRepoPayload(name: "App", branch: "feature", isGit: true, changedFileCount: 3, insertions: 120, deletions: 14)
-        ],
-        changedFileCount: 3,
-        archivedPath: "handoff/archive/2026-06-12T1430-codex-to-claude.md",
-        sessionContext: HandoffSessionPayload(
-          agent: "codex",
-          sessionID: "codex-session",
-          paneID: "pane-0",
-          paneTitle: "codex",
-          source: "terminal-scrollback",
-          confidence: "fallback",
-          excerptPath: "handoff/sessions/2026-06-12T1430-pane-0.md",
-          transcriptPath: "/tmp/codex.jsonl"
-        ),
-        briefing: "inline",
-        hasBriefing: true,
-        launchedPane: HandoffPanePayload(
-          worktreeID: "App:/Projects/App",
-          worktreeName: "App",
-          tabID: "tab-1",
-          paneID: "pane-9",
-          paneTitle: "claude"
-        )
-      ))
+      data: RawJSON(
+        encoding: HandoffCommandPayload(
+          action: .toAgent,
+          artifactPath: "/Projects/App/.prowl/handoff/current.md",
+          outgoingAgent: "codex",
+          toAgent: "claude",
+          repos: [
+            HandoffRepoPayload(
+              name: "App", branch: "feature", isGit: true, changedFileCount: 3, insertions: 120, deletions: 14)
+          ],
+          changedFileCount: 3,
+          archivedPath: "handoff/archive/2026-06-12T1430-codex-to-claude.md",
+          sessionContext: HandoffSessionPayload(
+            agent: "codex",
+            sessionID: "codex-session",
+            paneID: "pane-0",
+            paneTitle: "codex",
+            source: "terminal-scrollback",
+            confidence: "fallback",
+            excerptPath: "handoff/sessions/2026-06-12T1430-pane-0.md",
+            transcriptPath: "/tmp/codex.jsonl"
+          ),
+          briefing: "inline",
+          hasBriefing: true,
+          launchedPane: HandoffPanePayload(
+            worktreeID: "App:/Projects/App",
+            worktreeName: "App",
+            tabID: "tab-1",
+            paneID: "pane-9",
+            paneTitle: "claude"
+          )
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -3061,13 +3095,14 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: true,
       command: "handoff",
       schemaVersion: "prowl.cli.handoff.v2",
-      data: RawJSON(encoding: HandoffCommandPayload(
-        action: .toAgent,
-        artifactPath: "/Projects/App/.prowl/handoff/current.md",
-        outgoingAgent: "codex",
-        toAgent: "claude",
-        archivedPath: "handoff/archive/2026-06-12T1430-codex-to-claude.md"
-      ))
+      data: RawJSON(
+        encoding: HandoffCommandPayload(
+          action: .toAgent,
+          artifactPath: "/Projects/App/.prowl/handoff/current.md",
+          outgoingAgent: "codex",
+          toAgent: "claude",
+          archivedPath: "handoff/archive/2026-06-12T1430-codex-to-claude.md"
+        ))
     )
 
     let (_, result) = try runWithMockServer(
@@ -3283,7 +3318,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       domain: "ProwlCLITests",
       code: 1,
       userInfo: [
-        NSLocalizedDescriptionKey: "Could not find prowl binary. Checked: \(candidates.joined(separator: ", "))",
+        NSLocalizedDescriptionKey: "Could not find prowl binary. Checked: \(candidates.joined(separator: ", "))"
       ]
     )
   }
@@ -3417,7 +3452,6 @@ private struct OpenResponsePane: Encodable {
   let title: String
   let cwd: String?
 }
-
 
 private struct ListResponseData: Encodable {
   let count: Int

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -41,6 +41,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(help.stdout.contains("USAGE:"))
     XCTAssertTrue(help.stdout.contains("create"))
     XCTAssertTrue(help.stdout.contains("close"))
+    XCTAssertTrue(help.stdout.contains("skills"))
   }
 
   func testNativeHookBridgeIsHiddenSilentAndFailOpenWithoutListener() throws {
@@ -1061,6 +1062,247 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(result.exitCode, 0)
     XCTAssertTrue(result.stdout.contains("Reviewer  claude  disabled  unknown"), result.stdout)
     XCTAssertTrue(result.stdout.contains("Availability check has not completed"), result.stdout)
+  }
+
+  // MARK: - skills (local-only)
+
+  func testSkillsListIsLocalOnlyAndValidatesAgainstSchema() throws {
+    try withSkillsFixture { fixture in
+      let result = try runProwl(args: ["skills", "list", "--json"], environment: fixture.environment)
+
+      XCTAssertEqual(result.exitCode, 0, result.stderr)
+      XCTAssertEqual(result.stderr, "")
+      try assertResponseMatchesSchema(Data(result.stdout.utf8))
+      let output = try jsonObject(from: result.stdout)
+      XCTAssertEqual(output["command"] as? String, "skills")
+      XCTAssertEqual(output["schema_version"] as? String, "prowl.cli.skills.v1")
+      let data = try XCTUnwrap(output["data"] as? [String: Any])
+      XCTAssertEqual(data["action"] as? String, "list")
+      let skills = try XCTUnwrap(data["skills"] as? [[String: Any]])
+      XCTAssertEqual(skills.map { $0["id"] as? String }, ["prowl-cli", "reviewer"])
+      XCTAssertEqual(skills.map { $0["audience"] as? String }, ["user", "workflow"])
+      let targets = try XCTUnwrap(skills[0]["targets"] as? [[String: Any]])
+      XCTAssertEqual(targets.map { $0["id"] as? String }, ["claude", "codex", "agents"])
+      XCTAssertEqual(targets.map { $0["detected"] as? Bool }, [true, false, true])
+      XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.socketPath), "The command never touches the socket")
+
+      let text = try runProwl(args: ["skills", "list", "--no-color"], environment: fixture.environment)
+      XCTAssertEqual(text.exitCode, 0, text.stderr)
+      XCTAssertTrue(text.stdout.contains("prowl-cli"))
+      XCTAssertTrue(text.stdout.contains("workflow"))
+      XCTAssertTrue(text.stdout.contains("not installed"))
+    }
+  }
+
+  func testSkillsInstallStatusUninstallRoundTripAcrossAllTargets() throws {
+    try withSkillsFixture { fixture in
+      let install = try runProwl(
+        args: [
+          "skills", "install", "prowl-cli", "--target", "claude", "--target", "codex", "--target", "agents", "--json",
+        ],
+        environment: fixture.environment
+      )
+      XCTAssertEqual(install.exitCode, 0, install.stderr)
+      XCTAssertEqual(install.stderr, "")
+      try assertResponseMatchesSchema(Data(install.stdout.utf8))
+      let installData = try XCTUnwrap(try jsonObject(from: install.stdout)["data"] as? [String: Any])
+      XCTAssertEqual(installData["action"] as? String, "install")
+      XCTAssertEqual(installData["scope"] as? String, "user")
+      XCTAssertEqual(installData["root"] as? String, fixture.home.path(percentEncoded: false))
+      XCTAssertNil(installData["note"])
+      let installResults = try XCTUnwrap(installData["results"] as? [[String: Any]])
+      XCTAssertEqual(installResults.map { $0["target"] as? String }, ["claude", "codex", "agents"])
+      XCTAssertEqual(installResults.map { $0["before"] as? String }, ["not_installed", "not_installed", "not_installed"])
+      XCTAssertEqual(installResults.map { $0["after"] as? String }, ["installed", "installed", "installed"])
+      for target in [".claude", ".codex", ".agents"] {
+        let link = fixture.home.appending(path: "\(target)/skills/prowl-cli").path(percentEncoded: false)
+        XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: link), fixture.skillPath("prowl-cli"))
+      }
+
+      let list = try runProwl(args: ["skills", "list", "--json"], environment: fixture.environment)
+      XCTAssertEqual(list.exitCode, 0, list.stderr)
+      let listData = try XCTUnwrap(try jsonObject(from: list.stdout)["data"] as? [String: Any])
+      let listed = try XCTUnwrap(listData["skills"] as? [[String: Any]])
+      let statuses = try XCTUnwrap(listed[0]["targets"] as? [[String: Any]]).map { $0["status"] as? String }
+      XCTAssertEqual(statuses, ["installed", "installed", "installed"])
+
+      let uninstall = try runProwl(args: ["skills", "uninstall", "--json"], environment: fixture.environment)
+      XCTAssertEqual(uninstall.exitCode, 0, uninstall.stderr)
+      try assertResponseMatchesSchema(Data(uninstall.stdout.utf8))
+      let uninstallData = try XCTUnwrap(try jsonObject(from: uninstall.stdout)["data"] as? [String: Any])
+      XCTAssertEqual(uninstallData["action"] as? String, "uninstall")
+      let uninstallResults = try XCTUnwrap(uninstallData["results"] as? [[String: Any]])
+      XCTAssertEqual(uninstallResults.map { $0["target"] as? String }, ["claude", "codex", "agents"])
+      XCTAssertEqual(uninstallResults.map { $0["after"] as? String }, ["not_installed", "not_installed", "not_installed"])
+      for target in [".claude", ".codex", ".agents"] {
+        let link = fixture.home.appending(path: "\(target)/skills/prowl-cli").path(percentEncoded: false)
+        XCTAssertNil(try? FileManager.default.attributesOfItem(atPath: link))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.home.appending(path: "\(target)/skills").path()))
+      }
+      XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.skillPath("prowl-cli") + "/SKILL.md"))
+    }
+  }
+
+  func testSkillsInstallRefusesWorkflowSkillsAndRealDirectoriesInBothOutputModes() throws {
+    try withSkillsFixture { fixture in
+      let workflow = try runProwl(args: ["skills", "install", "reviewer", "--json"], environment: fixture.environment)
+      XCTAssertNotEqual(workflow.exitCode, 0)
+      try assertResponseMatchesSchema(Data(workflow.stdout.utf8))
+      let workflowError = try XCTUnwrap(try jsonObject(from: workflow.stdout)["error"] as? [String: Any])
+      XCTAssertEqual(workflowError["code"] as? String, "SKILL_NOT_INSTALLABLE")
+
+      let workflowText = try runProwl(args: ["skills", "install", "reviewer"], environment: fixture.environment)
+      XCTAssertNotEqual(workflowText.exitCode, 0)
+      XCTAssertEqual(workflowText.stdout, "")
+      XCTAssertTrue(workflowText.stderr.contains("error [SKILL_NOT_INSTALLABLE]"))
+
+      let realDirectory = fixture.home.appending(path: ".claude/skills/prowl-cli")
+      try FileManager.default.createDirectory(at: realDirectory, withIntermediateDirectories: true)
+      try Data("keep".utf8).write(to: realDirectory.appending(path: "SKILL.md"))
+      let conflict = try runProwl(
+        args: ["skills", "install", "prowl-cli", "--target", "claude", "--json"],
+        environment: fixture.environment
+      )
+      XCTAssertNotEqual(conflict.exitCode, 0)
+      try assertResponseMatchesSchema(Data(conflict.stdout.utf8))
+      let conflictError = try XCTUnwrap(try jsonObject(from: conflict.stdout)["error"] as? [String: Any])
+      XCTAssertEqual(conflictError["code"] as? String, "INSTALL_CONFLICT")
+      XCTAssertEqual(try Data(contentsOf: realDirectory.appending(path: "SKILL.md")), Data("keep".utf8))
+      XCTAssertNil(try? FileManager.default.destinationOfSymbolicLink(atPath: realDirectory.path(percentEncoded: false)))
+
+      let unknownTarget = try runProwl(
+        args: ["skills", "install", "--target", "cursor", "--json"], environment: fixture.environment)
+      XCTAssertNotEqual(unknownTarget.exitCode, 0)
+      let unknownTargetError = try XCTUnwrap(try jsonObject(from: unknownTarget.stdout)["error"] as? [String: Any])
+      XCTAssertEqual(unknownTargetError["code"] as? String, "TARGET_NOT_FOUND")
+
+      let unknownSkill = try runProwl(args: ["skills", "path", "missing", "--json"], environment: fixture.environment)
+      XCTAssertNotEqual(unknownSkill.exitCode, 0)
+      let unknownSkillError = try XCTUnwrap(try jsonObject(from: unknownSkill.stdout)["error"] as? [String: Any])
+      XCTAssertEqual(unknownSkillError["code"] as? String, "SKILL_NOT_FOUND")
+    }
+  }
+
+  func testSkillsProjectScopePrintsHygieneNoteOnceAndNeverTouchesGit() throws {
+    try withSkillsFixture { fixture in
+      let repo = fixture.root.appending(path: "repo", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: repo.appending(path: ".git/info"), withIntermediateDirectories: true)
+      try Data("ref: refs/heads/main\n".utf8).write(to: repo.appending(path: ".git/HEAD"))
+      try FileManager.default.createDirectory(at: repo.appending(path: ".claude"), withIntermediateDirectories: true)
+      let gitBefore = try gitEntries(repo)
+
+      let text = try runProwl(
+        args: ["skills", "install", "--scope", "project", "--path", repo.path(percentEncoded: false), "--no-color"],
+        environment: fixture.environment
+      )
+      XCTAssertEqual(text.exitCode, 0, text.stderr)
+      XCTAssertEqual(text.stderr.components(separatedBy: ".git/info/exclude").count - 1, 1, text.stderr)
+      XCTAssertFalse(text.stdout.contains(".git/info/exclude"))
+      XCTAssertTrue(text.stdout.contains("claude"))
+      let link = repo.appending(path: ".claude/skills/prowl-cli").path(percentEncoded: false)
+      XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: link), fixture.skillPath("prowl-cli"))
+
+      let json = try runProwl(
+        args: ["skills", "uninstall", "--scope", "project", "--path", repo.path(percentEncoded: false), "--json"],
+        environment: fixture.environment
+      )
+      XCTAssertEqual(json.exitCode, 0, json.stderr)
+      XCTAssertEqual(json.stderr, "")
+      try assertResponseMatchesSchema(Data(json.stdout.utf8))
+      let data = try XCTUnwrap(try jsonObject(from: json.stdout)["data"] as? [String: Any])
+      XCTAssertEqual(data["scope"] as? String, "project")
+      XCTAssertEqual(data["root"] as? String, repo.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      let note = try XCTUnwrap(data["note"] as? String)
+      XCTAssertEqual(note.components(separatedBy: ".git/info/exclude").count - 1, 1)
+      XCTAssertNil(try? FileManager.default.attributesOfItem(atPath: link))
+      XCTAssertEqual(try gitEntries(repo), gitBefore)
+    }
+  }
+
+  func testSkillsPathPrintsBundledDirectoryAndFailsClosedWithoutBundle() throws {
+    try withSkillsFixture { fixture in
+      let path = try runProwl(args: ["skills", "path", "reviewer"], environment: fixture.environment)
+      XCTAssertEqual(path.exitCode, 0, path.stderr)
+      XCTAssertEqual(path.stdout, fixture.skillPath("reviewer") + "\n")
+      XCTAssertEqual(path.stderr, "")
+
+      let pathJSON = try runProwl(args: ["skills", "path", "reviewer", "--json"], environment: fixture.environment)
+      XCTAssertEqual(pathJSON.exitCode, 0, pathJSON.stderr)
+      try assertResponseMatchesSchema(Data(pathJSON.stdout.utf8))
+      let data = try XCTUnwrap(try jsonObject(from: pathJSON.stdout)["data"] as? [String: Any])
+      let skill = try XCTUnwrap(data["skill"] as? [String: Any])
+      XCTAssertEqual(skill["path"] as? String, fixture.skillPath("reviewer"))
+      XCTAssertEqual(skill["audience"] as? String, "workflow")
+
+      var brokenEnvironment = fixture.environment
+      brokenEnvironment["PROWL_SKILLS_DIR"] = fixture.root.appending(path: "missing-skills").path(percentEncoded: false)
+      let missing = try runProwl(args: ["skills", "list", "--json"], environment: brokenEnvironment)
+      XCTAssertNotEqual(missing.exitCode, 0)
+      try assertResponseMatchesSchema(Data(missing.stdout.utf8))
+      let error = try XCTUnwrap(try jsonObject(from: missing.stdout)["error"] as? [String: Any])
+      XCTAssertEqual(error["code"] as? String, "BUNDLE_NOT_FOUND")
+
+      let missingText = try runProwl(args: ["skills", "list"], environment: brokenEnvironment)
+      XCTAssertNotEqual(missingText.exitCode, 0)
+      XCTAssertEqual(missingText.stdout, "")
+      XCTAssertTrue(missingText.stderr.contains("error [BUNDLE_NOT_FOUND]"))
+    }
+  }
+
+  private struct SkillsFixture {
+    let root: URL
+    let home: URL
+    let skillsRoot: URL
+    let socketPath: String
+
+    var environment: [String: String] {
+      [
+        ProwlSocket.environmentKey: socketPath,
+        "PROWL_SKILLS_DIR": skillsRoot.path(percentEncoded: false),
+        "HOME": home.path(percentEncoded: false),
+      ]
+    }
+
+    func skillPath(_ id: String) -> String {
+      skillsRoot.appending(path: id, directoryHint: .notDirectory).path(percentEncoded: false)
+    }
+  }
+
+  private func withSkillsFixture(_ body: (SkillsFixture) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-skills-cli-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = root.appending(path: "home", directoryHint: .notDirectory)
+    try FileManager.default.createDirectory(at: home.appending(path: ".claude"), withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: home.appending(path: ".agents"), withIntermediateDirectories: true)
+
+    let skillsRoot = root.appending(path: "skills", directoryHint: .isDirectory)
+    for (id, extra) in [("prowl-cli", ""), ("reviewer", "metadata:\n  prowl-install: workflow\n")] {
+      let directory = skillsRoot.appending(path: id, directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      try Data("---\nname: \(id)\ndescription: \(id) description.\n\(extra)---\n".utf8)
+        .write(to: directory.appending(path: "SKILL.md"))
+    }
+
+    let fixture = SkillsFixture(
+      root: root,
+      home: home,
+      skillsRoot: skillsRoot,
+      socketPath: root.appending(path: "missing.sock").path(percentEncoded: false)
+    )
+    try body(fixture)
+  }
+
+  private func gitEntries(_ repo: URL) throws -> [String] {
+    let enumerator = FileManager.default.enumerator(atPath: repo.appending(path: ".git").path(percentEncoded: false))
+    var entries: [String] = []
+    while let entry = enumerator?.nextObject() as? String {
+      entries.append(entry)
+    }
+    return entries.sorted()
   }
 
   func testCreatePaneCommandRendersAnchorAndDirection() throws {

--- a/ProwlCLITests/SkillInstallTargetTests.swift
+++ b/ProwlCLITests/SkillInstallTargetTests.swift
@@ -118,6 +118,40 @@ final class SkillInstallTargetTests: XCTestCase {
     }
   }
 
+  func testInstallerRefusesProjectTargetsThatResolveOutsideTheRoot() throws {
+    try withTemporaryDirectory { root in
+      let repo = root.appending(path: "repo", directoryHint: .isDirectory)
+      let external = root.appending(path: "external", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+      try FileManager.default.createSymbolicLink(at: repo.appending(path: ".codex"), withDestinationURL: external)
+      let skill = try makeSkill(root: root, id: "prowl-cli")
+      let target = try XCTUnwrap(SkillInstallTarget.target(id: "codex"))
+      let escapingPath = repo.appending(path: ".codex", directoryHint: .notDirectory).path(percentEncoded: false)
+
+      XCTAssertEqual(
+        ProwlSkillInstaller.projectBoundaryViolation(target: target, root: repo),
+        escapingPath
+      )
+      XCTAssertNil(
+        ProwlSkillInstaller.projectBoundaryViolation(
+          target: try XCTUnwrap(SkillInstallTarget.target(id: "claude")), root: repo)
+      )
+      XCTAssertThrowsError(
+        try ProwlSkillInstaller.install(skill: skill, target: target, scope: .project, root: repo)
+      ) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: escapingPath))
+      }
+      XCTAssertThrowsError(
+        try ProwlSkillInstaller.uninstall(skill: skill, target: target, scope: .project, root: repo)
+      ) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: escapingPath))
+      }
+      XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: external.path(percentEncoded: false)), [])
+      XCTAssertNoThrow(try ProwlSkillInstaller.install(skill: skill, target: target, scope: .user, root: repo))
+    }
+  }
+
   // MARK: - Helpers
 
   private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {

--- a/ProwlCLITests/SkillInstallTargetTests.swift
+++ b/ProwlCLITests/SkillInstallTargetTests.swift
@@ -102,7 +102,7 @@ final class SkillInstallTargetTests: XCTestCase {
 
       XCTAssertEqual(
         ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: home).status,
-        .broken(path: linkPath)
+        .broken(path: linkPath, destination: root.appending(path: "gone").path(percentEncoded: false))
       )
 
       try FileManager.default.removeItem(atPath: linkPath)
@@ -113,7 +113,7 @@ final class SkillInstallTargetTests: XCTestCase {
 
       XCTAssertEqual(
         ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: home).status,
-        .installedDifferentSource(path: linkPath)
+        .installedDifferentSource(path: linkPath, destination: other.path(percentEncoded: false))
       )
     }
   }

--- a/ProwlCLITests/SkillInstallTargetTests.swift
+++ b/ProwlCLITests/SkillInstallTargetTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class SkillInstallTargetTests: XCTestCase {
+  func testExactV1TargetDefinitions() {
+    XCTAssertEqual(SkillInstallTarget.all.map(\.id), ["claude", "codex", "agents"])
+    XCTAssertEqual(
+      SkillInstallTarget.all.map(\.userDirectory),
+      [".claude/skills", ".codex/skills", ".agents/skills"]
+    )
+    XCTAssertEqual(
+      SkillInstallTarget.all.map(\.projectDirectory),
+      [".claude/skills", ".codex/skills", ".agents/skills"]
+    )
+    XCTAssertEqual(SkillInstallTarget.target(id: "codex")?.displayName, "Codex")
+    XCTAssertNil(SkillInstallTarget.target(id: "cursor"))
+  }
+
+  func testSkillsDirectoryResolvesUnderTheScopeRoot() throws {
+    let home = URL(filePath: "/tmp/home", directoryHint: .isDirectory)
+    let repo = URL(filePath: "/tmp/repo", directoryHint: .isDirectory)
+    let target = try XCTUnwrap(SkillInstallTarget.target(id: "claude"))
+
+    XCTAssertEqual(
+      target.skillsDirectoryURL(scope: .user, root: home).path(percentEncoded: false).trimmingTrailingPathSeparator(),
+      "/tmp/home/.claude/skills"
+    )
+    XCTAssertEqual(
+      target.skillsDirectoryURL(scope: .project, root: repo).path(percentEncoded: false)
+        .trimmingTrailingPathSeparator(),
+      "/tmp/repo/.claude/skills"
+    )
+  }
+
+  func testDetectionRequiresTheParentDirectoryOnly() throws {
+    try withTemporaryDirectory { home in
+      try FileManager.default.createDirectory(
+        at: home.appending(path: ".claude"), withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(
+        at: home.appending(path: ".agents/skills"), withIntermediateDirectories: true)
+      try Data().write(to: home.appending(path: ".codex"))
+
+      let detected = SkillInstallTarget.all.filter { $0.isDetected(scope: .user, root: home) }.map(\.id)
+
+      XCTAssertEqual(detected, ["claude", "agents"])
+    }
+  }
+
+  func testDetectionAppliesTheSameParentRuleToProjectScope() throws {
+    try withTemporaryDirectory { repo in
+      try FileManager.default.createDirectory(
+        at: repo.appending(path: ".codex"), withIntermediateDirectories: true)
+
+      let detected = SkillInstallTarget.all.filter { $0.isDetected(scope: .project, root: repo) }.map(\.id)
+
+      XCTAssertEqual(detected, ["codex"])
+    }
+  }
+
+  func testInstallerCreatesTargetDirectoryAndRoundTrips() throws {
+    try withTemporaryDirectory { root in
+      let home = root.appending(path: "home", directoryHint: .isDirectory)
+      let skill = try makeSkill(root: root, id: "prowl-cli")
+      let target = try XCTUnwrap(SkillInstallTarget.target(id: "codex"))
+      let linkPath = home.appending(path: ".codex/skills/prowl-cli").path(percentEncoded: false)
+
+      let before = ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: home)
+      XCTAssertEqual(
+        before, SkillTargetStatus(target: target, detected: false, linkPath: linkPath, status: .notInstalled))
+
+      let installed = try ProwlSkillInstaller.install(skill: skill, target: target, scope: .user, root: home)
+      XCTAssertEqual(installed.status, .installed(path: linkPath))
+      XCTAssertTrue(installed.detected)
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(atPath: linkPath),
+        root.appending(path: "skills/prowl-cli", directoryHint: .notDirectory).path(percentEncoded: false)
+      )
+
+      let removed = try ProwlSkillInstaller.uninstall(skill: skill, target: target, scope: .user, root: home)
+      XCTAssertEqual(removed.status, .notInstalled)
+      XCTAssertFalse(FileManager.default.fileExists(atPath: linkPath))
+      XCTAssertTrue(
+        FileManager.default.fileExists(atPath: home.appending(path: ".codex/skills").path(percentEncoded: false)),
+        "Uninstall removes the link only, never the target directory"
+      )
+    }
+  }
+
+  func testInstallerReportsBrokenAndDifferentSourceLinks() throws {
+    try withTemporaryDirectory { root in
+      let home = root.appending(path: "home", directoryHint: .isDirectory)
+      let skill = try makeSkill(root: root, id: "prowl-cli")
+      let target = try XCTUnwrap(SkillInstallTarget.target(id: "claude"))
+      let skillsDirectory = home.appending(path: ".claude/skills")
+      try FileManager.default.createDirectory(at: skillsDirectory, withIntermediateDirectories: true)
+      let linkPath = skillsDirectory.appending(path: "prowl-cli").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(
+        atPath: linkPath,
+        withDestinationPath: root.appending(path: "gone").path(percentEncoded: false)
+      )
+
+      XCTAssertEqual(
+        ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: home).status,
+        .broken(path: linkPath)
+      )
+
+      try FileManager.default.removeItem(atPath: linkPath)
+      let other = root.appending(path: "other")
+      try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+      try FileManager.default.createSymbolicLink(
+        atPath: linkPath, withDestinationPath: other.path(percentEncoded: false))
+
+      XCTAssertEqual(
+        ProwlSkillInstaller.status(skill: skill, target: target, scope: .user, root: home).status,
+        .installedDifferentSource(path: linkPath)
+      )
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-skill-targets-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try operation(root)
+  }
+
+  private func makeSkill(root: URL, id: String) throws -> BundledSkill {
+    let directory = root.appending(path: "skills/\(id)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data("---\nname: \(id)\ndescription: \(id).\n---\n".utf8)
+      .write(to: directory.appending(path: "SKILL.md"))
+    return BundledSkill(id: id, name: id, description: "\(id).", audience: .user, directoryURL: directory)
+  }
+}

--- a/ProwlCLITests/SkillsCommandExecutorTests.swift
+++ b/ProwlCLITests/SkillsCommandExecutorTests.swift
@@ -197,6 +197,41 @@ final class SkillsCommandExecutorTests: XCTestCase {
     }
   }
 
+  func testAliasedTargetsShareOneSlotWithoutFailingOrDoubleLinking() throws {
+    try withFixture { fixture in
+      // Synced dotfiles: ~/.claude/skills and ~/.codex/skills are symlinks to one shared folder.
+      let shared = fixture.root.appending(path: "skills-shared", directoryHint: .isDirectory)
+      try fixture.makeDirectory(shared)
+      try fixture.makeDirectory(fixture.home.appending(path: ".codex"))
+      for target in [".claude", ".codex"] {
+        try FileManager.default.createSymbolicLink(
+          at: fixture.home.appending(path: "\(target)/skills"), withDestinationURL: shared)
+      }
+
+      let install = try fixture.executor.install(SkillsChangeRequest(skillIDs: ["prowl-cli"]))
+      guard case .install(let installed) = install else { return XCTFail("Expected install payload") }
+      XCTAssertEqual(installed.results.map(\.target), ["claude", "codex", "agents"])
+      XCTAssertEqual(installed.results.map(\.before), [.notInstalled, .installed, .notInstalled])
+      XCTAssertEqual(installed.results.map(\.after), [.installed, .installed, .installed])
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(atPath: shared.appending(path: "prowl-cli").path()),
+        fixture.skillDirectory("prowl-cli")
+      )
+
+      let uninstall = try fixture.executor.uninstall(SkillsChangeRequest(skillIDs: ["prowl-cli"]))
+      guard case .uninstall(let removed) = uninstall else { return XCTFail("Expected uninstall payload") }
+      XCTAssertEqual(removed.results.map(\.target), ["claude", "codex", "agents"])
+      XCTAssertEqual(removed.results.map(\.before), [.installed, .notInstalled, .installed])
+      XCTAssertEqual(removed.results.map(\.after), [.notInstalled, .notInstalled, .notInstalled])
+      XCTAssertNil(try? FileManager.default.attributesOfItem(atPath: shared.appending(path: "prowl-cli").path()))
+      XCTAssertNil(
+        try? FileManager.default.attributesOfItem(
+          atPath: fixture.home.appending(path: ".agents/skills/prowl-cli").path()),
+        "Every slot is removed even though two of them alias the same link"
+      )
+    }
+  }
+
   // MARK: - uninstall
 
   func testUninstallRemovesLinksAndSkipsAbsentOnes() throws {

--- a/ProwlCLITests/SkillsCommandExecutorTests.swift
+++ b/ProwlCLITests/SkillsCommandExecutorTests.swift
@@ -147,10 +147,10 @@ final class SkillsCommandExecutorTests: XCTestCase {
   func testInstallRejectsUnknownSkillAndTarget() throws {
     try withFixture { fixture in
       assertExitError(code: CLIErrorCode.skillNotFound) {
-        try fixture.executor.install(SkillsChangeRequest(skillIDs: ["missing"]))
+        _ = try fixture.executor.install(SkillsChangeRequest(skillIDs: ["missing"]))
       }
       assertExitError(code: CLIErrorCode.targetNotFound) {
-        try fixture.executor.install(SkillsChangeRequest(targetIDs: ["cursor"]))
+        _ = try fixture.executor.install(SkillsChangeRequest(targetIDs: ["cursor"]))
       }
       XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")))
     }
@@ -159,7 +159,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
   func testInstallRefusesWorkflowAudienceSkills() throws {
     try withFixture { fixture in
       assertExitError(code: CLIErrorCode.skillNotInstallable) {
-        try fixture.executor.install(SkillsChangeRequest(skillIDs: ["prowl-cli", "reviewer"]))
+        _ = try fixture.executor.install(SkillsChangeRequest(skillIDs: ["prowl-cli", "reviewer"]))
       }
       XCTAssertFalse(
         FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")),
@@ -174,7 +174,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       try FileManager.default.removeItem(at: fixture.home.appending(path: ".agents"))
 
       assertExitError(code: CLIErrorCode.targetNotFound) {
-        try fixture.executor.install(SkillsChangeRequest())
+        _ = try fixture.executor.install(SkillsChangeRequest())
       }
     }
   }
@@ -186,7 +186,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       try Data("keep".utf8).write(to: realDirectory.appending(path: "SKILL.md"))
 
       assertExitError(code: CLIErrorCode.installConflict) {
-        try fixture.executor.install(SkillsChangeRequest())
+        _ = try fixture.executor.install(SkillsChangeRequest())
       }
 
       XCTAssertFalse(
@@ -266,7 +266,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       try fixture.makeDirectory(fixture.home.appending(path: ".agents/skills/prowl-cli"))
 
       assertExitError(code: CLIErrorCode.installConflict) {
-        try fixture.executor.uninstall(SkillsChangeRequest())
+        _ = try fixture.executor.uninstall(SkillsChangeRequest())
       }
       XCTAssertTrue(
         fixture.isSymlink(fixture.linkPath(target: ".claude", skill: "prowl-cli")),
@@ -292,7 +292,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       XCTAssertEqual(workflow.skill.audience, .workflow)
 
       assertExitError(code: CLIErrorCode.skillNotFound) {
-        try fixture.executor.path(skillID: "../prowl-cli")
+        _ = try fixture.executor.path(skillID: "../prowl-cli")
       }
     }
   }
@@ -393,7 +393,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       try fixture.makeDirectory(repo.appending(path: ".claude"))
 
       assertExitError(code: CLIErrorCode.installConflict) {
-        try fixture.executor.install(
+        _ = try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: repo.path(percentEncoded: false)))
       }
 
@@ -421,8 +421,8 @@ final class SkillsCommandExecutorTests: XCTestCase {
         skillIDs: ["prowl-cli"], targetIDs: ["codex"], scope: .project,
         projectPath: repo.path(percentEncoded: false))
 
-      assertExitError(code: CLIErrorCode.installConflict) { try fixture.executor.install(request) }
-      assertExitError(code: CLIErrorCode.installConflict) { try fixture.executor.uninstall(request) }
+      assertExitError(code: CLIErrorCode.installConflict) { _ = try fixture.executor.install(request) }
+      assertExitError(code: CLIErrorCode.installConflict) { _ = try fixture.executor.uninstall(request) }
 
       XCTAssertEqual(
         try FileManager.default.destinationOfSymbolicLink(atPath: external.appending(path: "prowl-cli").path()),
@@ -460,21 +460,21 @@ final class SkillsCommandExecutorTests: XCTestCase {
       try fixture.makeDirectory(plain)
 
       assertExitError(code: CLIErrorCode.pathNotFound) {
-        try fixture.executor(currentDirectory: plain).install(SkillsChangeRequest(scope: .project))
+        _ = try fixture.executor(currentDirectory: plain).install(SkillsChangeRequest(scope: .project))
       }
       assertExitError(code: CLIErrorCode.pathNotFound) {
-        try fixture.executor.install(
+        _ = try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: plain.path(percentEncoded: false)))
       }
       XCTAssertFalse(FileManager.default.fileExists(atPath: plain.appending(path: ".claude").path()))
       assertExitError(code: CLIErrorCode.pathNotFound) {
-        try fixture.executor.install(
+        _ = try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: fixture.root.appending(path: "missing").path()))
       }
       let file = fixture.root.appending(path: "file")
       try Data().write(to: file)
       assertExitError(code: CLIErrorCode.pathNotDirectory) {
-        try fixture.executor.install(
+        _ = try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: file.path(percentEncoded: false)))
       }
     }
@@ -485,7 +485,7 @@ final class SkillsCommandExecutorTests: XCTestCase {
       let repo = try fixture.makeRepository(name: "repo")
 
       assertExitError(code: CLIErrorCode.targetNotFound) {
-        try fixture.executor.install(
+        _ = try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: repo.path(percentEncoded: false)))
       }
       XCTAssertFalse(FileManager.default.fileExists(atPath: repo.appending(path: ".claude").path()))

--- a/ProwlCLITests/SkillsCommandExecutorTests.swift
+++ b/ProwlCLITests/SkillsCommandExecutorTests.swift
@@ -308,6 +308,97 @@ final class SkillsCommandExecutorTests: XCTestCase {
     }
   }
 
+  func testExplicitProjectPathResolvesToTheContainingGitRoot() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      let nested = repo.appending(path: "src/deep", directoryHint: .isDirectory)
+      try fixture.makeDirectory(nested)
+
+      let payload = try fixture.executor.install(
+        SkillsChangeRequest(
+          skillIDs: ["prowl-cli"], targetIDs: ["codex"], scope: .project,
+          projectPath: nested.path(percentEncoded: false)))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.root, repo.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      XCTAssertEqual(
+        change.results.map(\.path),
+        [repo.appending(path: ".codex/skills/prowl-cli").path(percentEncoded: false)]
+      )
+      XCTAssertFalse(FileManager.default.fileExists(atPath: nested.appending(path: ".codex").path()))
+    }
+  }
+
+  func testProjectScopeRefusesTargetParentsThatEscapeTheRepository() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      let external = fixture.root.appending(path: "external", directoryHint: .isDirectory)
+      try fixture.makeDirectory(external)
+      try FileManager.default.createSymbolicLink(at: repo.appending(path: ".agents"), withDestinationURL: external)
+      try fixture.makeDirectory(repo.appending(path: ".claude"))
+
+      assertExitError(code: CLIErrorCode.installConflict) {
+        try fixture.executor.install(
+          SkillsChangeRequest(scope: .project, projectPath: repo.path(percentEncoded: false)))
+      }
+
+      XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: external.path(percentEncoded: false)), [])
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: repo.appending(path: ".claude/skills/prowl-cli").path()),
+        "A boundary violation on one target leaves the others untouched"
+      )
+    }
+  }
+
+  func testProjectScopeRefusesSkillsDirectoriesThatEscapeTheRepositoryOnInstallAndUninstall() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      let external = fixture.root.appending(path: "external", directoryHint: .isDirectory)
+      try fixture.makeDirectory(external)
+      try fixture.makeDirectory(repo.appending(path: ".codex"))
+      try FileManager.default.createSymbolicLink(
+        at: repo.appending(path: ".codex/skills"), withDestinationURL: external)
+      try FileManager.default.createSymbolicLink(
+        atPath: external.appending(path: "prowl-cli").path(percentEncoded: false),
+        withDestinationPath: fixture.skillDirectory("prowl-cli")
+      )
+      let request = SkillsChangeRequest(
+        skillIDs: ["prowl-cli"], targetIDs: ["codex"], scope: .project,
+        projectPath: repo.path(percentEncoded: false))
+
+      assertExitError(code: CLIErrorCode.installConflict) { try fixture.executor.install(request) }
+      assertExitError(code: CLIErrorCode.installConflict) { try fixture.executor.uninstall(request) }
+
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(atPath: external.appending(path: "prowl-cli").path()),
+        fixture.skillDirectory("prowl-cli"),
+        "The external link is never replaced or removed"
+      )
+    }
+  }
+
+  func testProjectScopeAcceptsSymlinksThatStayInsideTheRepository() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      try fixture.makeDirectory(repo.appending(path: ".claude"))
+      try FileManager.default.createSymbolicLink(
+        atPath: repo.appending(path: ".agents").path(percentEncoded: false), withDestinationPath: ".claude")
+
+      let payload = try fixture.executor.install(
+        SkillsChangeRequest(
+          skillIDs: ["prowl-cli"], targetIDs: ["agents"], scope: .project,
+          projectPath: repo.path(percentEncoded: false)))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.results.map(\.after), [.installed])
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(
+          atPath: repo.appending(path: ".claude/skills/prowl-cli").path(percentEncoded: false)),
+        fixture.skillDirectory("prowl-cli")
+      )
+    }
+  }
+
   func testProjectScopeWithoutAGitRootOrWithABadPathFails() throws {
     try withFixture { fixture in
       let plain = fixture.root.appending(path: "plain", directoryHint: .isDirectory)
@@ -316,6 +407,11 @@ final class SkillsCommandExecutorTests: XCTestCase {
       assertExitError(code: CLIErrorCode.pathNotFound) {
         try fixture.executor(currentDirectory: plain).install(SkillsChangeRequest(scope: .project))
       }
+      assertExitError(code: CLIErrorCode.pathNotFound) {
+        try fixture.executor.install(
+          SkillsChangeRequest(scope: .project, projectPath: plain.path(percentEncoded: false)))
+      }
+      XCTAssertFalse(FileManager.default.fileExists(atPath: plain.appending(path: ".claude").path()))
       assertExitError(code: CLIErrorCode.pathNotFound) {
         try fixture.executor.install(
           SkillsChangeRequest(scope: .project, projectPath: fixture.root.appending(path: "missing").path()))

--- a/ProwlCLITests/SkillsCommandExecutorTests.swift
+++ b/ProwlCLITests/SkillsCommandExecutorTests.swift
@@ -1,0 +1,443 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+@testable import prowl
+
+final class SkillsCommandExecutorTests: XCTestCase {
+  // MARK: - list
+
+  func testListReportsEverySkillAcrossEveryTargetWithDetectionAndAudience() throws {
+    try withFixture { fixture in
+      let payload = try fixture.executor.list()
+      guard case .list(let list) = payload else { return XCTFail("Expected list payload") }
+
+      XCTAssertEqual(list.skills.map(\.id), ["prowl-cli", "reviewer"])
+      XCTAssertEqual(list.skills.map(\.audience), [.user, .workflow])
+      XCTAssertEqual(list.skills[0].path, fixture.skillDirectory("prowl-cli"))
+      XCTAssertEqual(list.skills[0].targets.map(\.id), ["claude", "codex", "agents"])
+      XCTAssertEqual(list.skills[0].targets.map(\.detected), [true, false, true])
+      XCTAssertEqual(list.skills[0].targets.map(\.status), [.notInstalled, .notInstalled, .notInstalled])
+      XCTAssertEqual(list.skills[0].targets[0].path, fixture.linkPath(target: ".claude", skill: "prowl-cli"))
+    }
+  }
+
+  func testListReportsAllFourStatuses() throws {
+    try withFixture { fixture in
+      try fixture.link(target: ".claude", skill: "prowl-cli", to: fixture.skillDirectory("prowl-cli"))
+      try fixture.link(target: ".agents", skill: "prowl-cli", to: fixture.root.appending(path: "gone").path())
+      try fixture.makeDirectory(fixture.home.appending(path: ".codex/skills/prowl-cli"))
+
+      let payload = try fixture.executor.list()
+      guard case .list(let list) = payload else { return XCTFail("Expected list payload") }
+
+      XCTAssertEqual(
+        list.skills[0].targets.map(\.status),
+        [.installed, .installedDifferentSource, .broken]
+      )
+      XCTAssertEqual(list.skills[1].targets.map(\.status), [.notInstalled, .notInstalled, .notInstalled])
+    }
+  }
+
+  // MARK: - install
+
+  func testBareInstallLinksUserSkillsIntoDetectedTargetsOnly() throws {
+    try withFixture { fixture in
+      let payload = try fixture.executor.install(SkillsChangeRequest())
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.scope, .user)
+      XCTAssertEqual(change.root, fixture.home.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      XCTAssertNil(change.note)
+      XCTAssertEqual(
+        change.results,
+        [
+          SkillsCommandResult(
+            skill: "prowl-cli", target: "claude",
+            path: fixture.linkPath(target: ".claude", skill: "prowl-cli"),
+            before: .notInstalled, after: .installed),
+          SkillsCommandResult(
+            skill: "prowl-cli", target: "agents",
+            path: fixture.linkPath(target: ".agents", skill: "prowl-cli"),
+            before: .notInstalled, after: .installed),
+        ]
+      )
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(
+          atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")),
+        fixture.skillDirectory("prowl-cli")
+      )
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: fixture.home.appending(path: ".codex").path()),
+        "A bare install never creates an undetected target"
+      )
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "reviewer")),
+        "Workflow-audience skills are never installed by a bare install"
+      )
+    }
+  }
+
+  func testExplicitTargetCreatesUndetectedTargetDirectory() throws {
+    try withFixture { fixture in
+      let payload = try fixture.executor.install(
+        SkillsChangeRequest(skillIDs: ["prowl-cli"], targetIDs: ["codex"]))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.results.map(\.target), ["codex"])
+      XCTAssertEqual(change.results.map(\.after), [.installed])
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(
+          atPath: fixture.linkPath(target: ".codex", skill: "prowl-cli")),
+        fixture.skillDirectory("prowl-cli")
+      )
+    }
+  }
+
+  func testInstallOrdersAndDeduplicatesExplicitSkillsAndTargets() throws {
+    try withFixture { fixture in
+      let payload = try fixture.executor.install(
+        SkillsChangeRequest(
+          skillIDs: ["prowl-cli", "prowl-cli"],
+          targetIDs: ["agents", "claude", "agents"]))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.results.map { "\($0.skill)→\($0.target)" }, ["prowl-cli→claude", "prowl-cli→agents"])
+    }
+  }
+
+  func testInstallRepairsBrokenLinksAndLeavesInstalledLinksUnchanged() throws {
+    try withFixture { fixture in
+      try fixture.link(target: ".claude", skill: "prowl-cli", to: fixture.root.appending(path: "gone").path())
+      try fixture.link(target: ".agents", skill: "prowl-cli", to: fixture.skillDirectory("prowl-cli"))
+
+      let payload = try fixture.executor.install(SkillsChangeRequest(skillIDs: ["prowl-cli"]))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.results.map(\.before), [.broken, .installed])
+      XCTAssertEqual(change.results.map(\.after), [.installed, .installed])
+      XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(
+          atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")),
+        fixture.skillDirectory("prowl-cli")
+      )
+    }
+  }
+
+  func testInstallRejectsUnknownSkillAndTarget() throws {
+    try withFixture { fixture in
+      assertExitError(code: CLIErrorCode.skillNotFound) {
+        try fixture.executor.install(SkillsChangeRequest(skillIDs: ["missing"]))
+      }
+      assertExitError(code: CLIErrorCode.targetNotFound) {
+        try fixture.executor.install(SkillsChangeRequest(targetIDs: ["cursor"]))
+      }
+      XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")))
+    }
+  }
+
+  func testInstallRefusesWorkflowAudienceSkills() throws {
+    try withFixture { fixture in
+      assertExitError(code: CLIErrorCode.skillNotInstallable) {
+        try fixture.executor.install(SkillsChangeRequest(skillIDs: ["prowl-cli", "reviewer"]))
+      }
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")),
+        "Refusal happens before any link is created"
+      )
+    }
+  }
+
+  func testBareInstallWithoutDetectedTargetsFailsWithTargetNotFound() throws {
+    try withFixture { fixture in
+      try FileManager.default.removeItem(at: fixture.home.appending(path: ".claude"))
+      try FileManager.default.removeItem(at: fixture.home.appending(path: ".agents"))
+
+      assertExitError(code: CLIErrorCode.targetNotFound) {
+        try fixture.executor.install(SkillsChangeRequest())
+      }
+    }
+  }
+
+  func testInstallConflictIsDetectedBeforeAnyChange() throws {
+    try withFixture { fixture in
+      let realDirectory = fixture.home.appending(path: ".agents/skills/prowl-cli")
+      try fixture.makeDirectory(realDirectory)
+      try Data("keep".utf8).write(to: realDirectory.appending(path: "SKILL.md"))
+
+      assertExitError(code: CLIErrorCode.installConflict) {
+        try fixture.executor.install(SkillsChangeRequest())
+      }
+
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: fixture.linkPath(target: ".claude", skill: "prowl-cli")),
+        "The conflict-free target must not be modified when another target conflicts"
+      )
+      XCTAssertEqual(try Data(contentsOf: realDirectory.appending(path: "SKILL.md")), Data("keep".utf8))
+    }
+  }
+
+  // MARK: - uninstall
+
+  func testUninstallRemovesLinksAndSkipsAbsentOnes() throws {
+    try withFixture { fixture in
+      try fixture.link(target: ".claude", skill: "prowl-cli", to: fixture.skillDirectory("prowl-cli"))
+      try fixture.link(target: ".agents", skill: "prowl-cli", to: fixture.root.appending(path: "gone").path())
+
+      let payload = try fixture.executor.uninstall(SkillsChangeRequest())
+      guard case .uninstall(let change) = payload else { return XCTFail("Expected uninstall payload") }
+
+      XCTAssertEqual(change.results.map(\.target), ["claude", "agents"])
+      XCTAssertEqual(change.results.map(\.before), [.installed, .broken])
+      XCTAssertEqual(change.results.map(\.after), [.notInstalled, .notInstalled])
+      XCTAssertFalse(fixture.isSymlink(fixture.linkPath(target: ".claude", skill: "prowl-cli")))
+      XCTAssertFalse(fixture.isSymlink(fixture.linkPath(target: ".agents", skill: "prowl-cli")))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.skillDirectory("prowl-cli")))
+
+      let again = try fixture.executor.uninstall(SkillsChangeRequest(skillIDs: ["prowl-cli"], targetIDs: ["codex"]))
+      guard case .uninstall(let unchanged) = again else { return XCTFail("Expected uninstall payload") }
+      XCTAssertEqual(unchanged.results.map(\.before), [.notInstalled])
+      XCTAssertEqual(unchanged.results.map(\.after), [.notInstalled])
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: fixture.home.appending(path: ".codex").path()),
+        "Uninstall never creates target directories"
+      )
+    }
+  }
+
+  func testUninstallRefusesRealDirectories() throws {
+    try withFixture { fixture in
+      try fixture.link(target: ".claude", skill: "prowl-cli", to: fixture.skillDirectory("prowl-cli"))
+      try fixture.makeDirectory(fixture.home.appending(path: ".agents/skills/prowl-cli"))
+
+      assertExitError(code: CLIErrorCode.installConflict) {
+        try fixture.executor.uninstall(SkillsChangeRequest())
+      }
+      XCTAssertTrue(
+        fixture.isSymlink(fixture.linkPath(target: ".claude", skill: "prowl-cli")),
+        "A conflict elsewhere leaves other links untouched"
+      )
+    }
+  }
+
+  // MARK: - path
+
+  func testPathResolvesAnyAudienceAndRejectsUnknownSkills() throws {
+    try withFixture { fixture in
+      guard case .path(let user) = try fixture.executor.path(skillID: "prowl-cli") else {
+        return XCTFail("Expected path payload")
+      }
+      XCTAssertEqual(user.skill.path, fixture.skillDirectory("prowl-cli"))
+      XCTAssertEqual(user.skill.audience, .user)
+
+      guard case .path(let workflow) = try fixture.executor.path(skillID: "reviewer") else {
+        return XCTFail("Expected path payload")
+      }
+      XCTAssertEqual(workflow.skill.path, fixture.skillDirectory("reviewer"))
+      XCTAssertEqual(workflow.skill.audience, .workflow)
+
+      assertExitError(code: CLIErrorCode.skillNotFound) {
+        try fixture.executor.path(skillID: "../prowl-cli")
+      }
+    }
+  }
+
+  // MARK: - project scope
+
+  func testProjectScopeUsesExplicitPathAndPrintsHygieneNoteOnce() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      try fixture.makeDirectory(repo.appending(path: ".claude"))
+      let gitEntriesBefore = try fixture.gitEntries(repo)
+
+      let payload = try fixture.executor.install(
+        SkillsChangeRequest(scope: .project, projectPath: repo.path(percentEncoded: false)))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.scope, .project)
+      XCTAssertEqual(change.root, repo.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      XCTAssertEqual(change.results.map(\.target), ["claude"])
+      XCTAssertEqual(
+        change.results.map(\.path),
+        [repo.appending(path: ".claude/skills/prowl-cli").path(percentEncoded: false)]
+      )
+      let note = try XCTUnwrap(change.note)
+      XCTAssertTrue(note.contains(".git/info/exclude"))
+      XCTAssertTrue(note.contains("absolute"))
+      XCTAssertEqual(try fixture.gitEntries(repo), gitEntriesBefore, "Prowl never edits Git state")
+    }
+  }
+
+  func testProjectScopeResolvesTheGitRootFromTheCurrentDirectory() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+      let nested = repo.appending(path: "src/deep", directoryHint: .isDirectory)
+      try fixture.makeDirectory(nested)
+
+      let executor = fixture.executor(currentDirectory: nested)
+      let payload = try executor.install(
+        SkillsChangeRequest(skillIDs: ["prowl-cli"], targetIDs: ["codex"], scope: .project))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.root, repo.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      XCTAssertEqual(
+        change.results.map(\.path),
+        [repo.appending(path: ".codex/skills/prowl-cli").path(percentEncoded: false)]
+      )
+    }
+  }
+
+  func testProjectScopeTreatsAWorktreeGitFileAsTheRoot() throws {
+    try withFixture { fixture in
+      let main = try fixture.makeRepository(name: "main")
+      let worktree = fixture.root.appending(path: "worktree", directoryHint: .isDirectory)
+      try fixture.makeDirectory(worktree.appending(path: "nested"))
+      try Data("gitdir: \(main.path(percentEncoded: false)).git/worktrees/wt\n".utf8)
+        .write(to: worktree.appending(path: ".git"))
+
+      let executor = fixture.executor(currentDirectory: worktree.appending(path: "nested"))
+      let payload = try executor.install(
+        SkillsChangeRequest(skillIDs: ["prowl-cli"], targetIDs: ["agents"], scope: .project))
+      guard case .install(let change) = payload else { return XCTFail("Expected install payload") }
+
+      XCTAssertEqual(change.root, worktree.path(percentEncoded: false).trimmingTrailingPathSeparator())
+      XCTAssertEqual(
+        try Data(contentsOf: worktree.appending(path: ".git")),
+        Data("gitdir: \(main.path(percentEncoded: false)).git/worktrees/wt\n".utf8)
+      )
+    }
+  }
+
+  func testProjectScopeWithoutAGitRootOrWithABadPathFails() throws {
+    try withFixture { fixture in
+      let plain = fixture.root.appending(path: "plain", directoryHint: .isDirectory)
+      try fixture.makeDirectory(plain)
+
+      assertExitError(code: CLIErrorCode.pathNotFound) {
+        try fixture.executor(currentDirectory: plain).install(SkillsChangeRequest(scope: .project))
+      }
+      assertExitError(code: CLIErrorCode.pathNotFound) {
+        try fixture.executor.install(
+          SkillsChangeRequest(scope: .project, projectPath: fixture.root.appending(path: "missing").path()))
+      }
+      let file = fixture.root.appending(path: "file")
+      try Data().write(to: file)
+      assertExitError(code: CLIErrorCode.pathNotDirectory) {
+        try fixture.executor.install(
+          SkillsChangeRequest(scope: .project, projectPath: file.path(percentEncoded: false)))
+      }
+    }
+  }
+
+  func testProjectScopeBareInstallWithoutDetectedTargetsFails() throws {
+    try withFixture { fixture in
+      let repo = try fixture.makeRepository(name: "repo")
+
+      assertExitError(code: CLIErrorCode.targetNotFound) {
+        try fixture.executor.install(
+          SkillsChangeRequest(scope: .project, projectPath: repo.path(percentEncoded: false)))
+      }
+      XCTAssertFalse(FileManager.default.fileExists(atPath: repo.appending(path: ".claude").path()))
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func assertExitError(
+    code: String,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: () throws -> Void
+  ) {
+    XCTAssertThrowsError(try body(), file: file, line: line) { error in
+      XCTAssertEqual((error as? ExitError)?.code, code, "\(error)", file: file, line: line)
+    }
+  }
+
+  private struct Fixture {
+    let root: URL
+    let home: URL
+    let skills: [BundledSkill]
+
+    var executor: SkillsCommandExecutor {
+      executor(currentDirectory: root)
+    }
+
+    func executor(currentDirectory: URL) -> SkillsCommandExecutor {
+      SkillsCommandExecutor(skills: skills, userRoot: home, currentDirectory: currentDirectory)
+    }
+
+    func skillDirectory(_ id: String) -> String {
+      root.appending(path: "skills/\(id)", directoryHint: .notDirectory).path(percentEncoded: false)
+    }
+
+    func linkPath(target: String, skill: String) -> String {
+      home.appending(path: "\(target)/skills/\(skill)").path(percentEncoded: false)
+    }
+
+    func link(target: String, skill: String, to destination: String) throws {
+      let skillsDirectory = home.appending(path: "\(target)/skills", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: skillsDirectory, withIntermediateDirectories: true)
+      try FileManager.default.createSymbolicLink(
+        atPath: linkPath(target: target, skill: skill), withDestinationPath: destination)
+    }
+
+    func makeDirectory(_ url: URL) throws {
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func makeRepository(name: String) throws -> URL {
+      let repo = root.appending(path: name, directoryHint: .isDirectory)
+      try makeDirectory(repo.appending(path: ".git/info"))
+      try Data("ref: refs/heads/main\n".utf8).write(to: repo.appending(path: ".git/HEAD"))
+      return repo
+    }
+
+    func gitEntries(_ repo: URL) throws -> [String] {
+      let enumerator = FileManager.default.enumerator(atPath: repo.appending(path: ".git").path(percentEncoded: false))
+      var entries: [String] = []
+      while let entry = enumerator?.nextObject() as? String {
+        entries.append(entry)
+      }
+      return entries.sorted()
+    }
+
+    func isSymlink(_ path: String) -> Bool {
+      (try? FileManager.default.attributesOfItem(atPath: path))?[.type] as? FileAttributeType
+        == .typeSymbolicLink
+    }
+  }
+
+  private func withFixture(_ operation: (Fixture) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-skills-executor-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = root.appending(path: "home", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: home.appending(path: ".claude"), withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: home.appending(path: ".agents"), withIntermediateDirectories: true)
+
+    let skillsRoot = root.appending(path: "skills", directoryHint: .isDirectory)
+    try writeSkill(id: "prowl-cli", name: "Prowl CLI", audience: nil, skillsRoot: skillsRoot)
+    try writeSkill(id: "reviewer", name: "Reviewer", audience: "workflow", skillsRoot: skillsRoot)
+    let skills = try ProwlSkills.bundledForCLI(
+      executableURL: root.appending(path: "prowl"),
+      environment: ["PROWL_SKILLS_DIR": skillsRoot.path(percentEncoded: false)]
+    )
+
+    try operation(Fixture(root: root, home: home, skills: skills))
+  }
+
+  private func writeSkill(id: String, name: String, audience: String?, skillsRoot: URL) throws {
+    let directory = skillsRoot.appending(path: id, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    var frontmatter = "---\nname: \(name)\ndescription: \(name) description.\n"
+    if let audience {
+      frontmatter += "metadata:\n  prowl-install: \(audience)\n"
+    }
+    frontmatter += "---\n"
+    try Data(frontmatter.utf8).write(to: directory.appending(path: "SKILL.md"))
+  }
+}

--- a/ProwlCLITests/SkillsCommandExecutorTests.swift
+++ b/ProwlCLITests/SkillsCommandExecutorTests.swift
@@ -35,7 +35,27 @@ final class SkillsCommandExecutorTests: XCTestCase {
         list.skills[0].targets.map(\.status),
         [.installed, .installedDifferentSource, .broken]
       )
+      XCTAssertEqual(
+        list.skills[0].targets.map(\.destination),
+        [nil, nil, fixture.root.appending(path: "gone").path(percentEncoded: false)],
+        "A real directory has no destination; a dangling link names where the app used to be"
+      )
       XCTAssertEqual(list.skills[1].targets.map(\.status), [.notInstalled, .notInstalled, .notInstalled])
+    }
+  }
+
+  func testListNamesTheOtherSourceOfAForeignLink() throws {
+    try withFixture { fixture in
+      let debugBuild = fixture.root.appending(path: "DerivedData/skills/prowl-cli", directoryHint: .isDirectory)
+      try fixture.makeDirectory(debugBuild)
+      let debugPath = debugBuild.path(percentEncoded: false).trimmingTrailingPathSeparator()
+      try fixture.link(target: ".claude", skill: "prowl-cli", to: debugPath)
+
+      let payload = try fixture.executor.list()
+      guard case .list(let list) = payload else { return XCTFail("Expected list payload") }
+
+      XCTAssertEqual(list.skills[0].targets[0].status, .installedDifferentSource)
+      XCTAssertEqual(list.skills[0].targets[0].destination, debugPath)
     }
   }
 

--- a/ProwlCLITests/SkillsCommandParsingTests.swift
+++ b/ProwlCLITests/SkillsCommandParsingTests.swift
@@ -1,0 +1,49 @@
+import ProwlCLIShared
+import XCTest
+
+@testable import prowl
+
+final class SkillsCommandParsingTests: XCTestCase {
+  func testRootRoutesSkillsLeaves() throws {
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["skills", "list", "--json"]) is SkillsListCommand)
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["skills", "install"]) is SkillsInstallCommand)
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["skills", "uninstall", "prowl-cli"]) is SkillsUninstallCommand)
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["skills", "path", "prowl-cli"]) is SkillsPathCommand)
+  }
+
+  func testInstallParsesRepeatedSkillsAndTargetsWithScopeAndPath() throws {
+    let command = try SkillsInstallCommand.parse([
+      "prowl-cli", "other", "--target", "claude", "--target", "codex", "--scope", "project", "--path", "/tmp/repo",
+    ])
+
+    XCTAssertEqual(
+      try command.makeRequest(),
+      SkillsChangeRequest(
+        skillIDs: ["prowl-cli", "other"],
+        targetIDs: ["claude", "codex"],
+        scope: .project,
+        projectPath: "/tmp/repo"
+      )
+    )
+  }
+
+  func testBareInstallAndUninstallDefaultToUserScope() throws {
+    XCTAssertEqual(try SkillsInstallCommand.parse([]).makeRequest(), SkillsChangeRequest())
+    XCTAssertEqual(try SkillsUninstallCommand.parse([]).makeRequest(), SkillsChangeRequest())
+  }
+
+  func testPathRequiresProjectScope() throws {
+    let command = try SkillsUninstallCommand.parse(["--path", "/tmp/repo"])
+
+    XCTAssertThrowsError(try command.makeRequest()) { error in
+      XCTAssertEqual((error as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
+  }
+
+  func testRejectsInvalidScopeAndMissingValues() {
+    XCTAssertThrowsError(try SkillsInstallCommand.parse(["--scope", "global"]))
+    XCTAssertThrowsError(try SkillsInstallCommand.parse(["--target"]))
+    XCTAssertThrowsError(try SkillsPathCommand.parse([]))
+    XCTAssertThrowsError(try SkillsListCommand.parse(["prowl-cli"]))
+  }
+}

--- a/ProwlCLITests/SkillsSchemaTests.swift
+++ b/ProwlCLITests/SkillsSchemaTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import JSONSchema
+import ProwlCLIContracts
+import ProwlCLIShared
+import XCTest
+
+final class SkillsSchemaTests: XCTestCase {
+  private let target =
+    #"{"id":"claude","detected":true,"path":"/Users/me/.claude/skills/prowl-cli","status":"installed"}"#
+
+  func testSchemaAcceptsEveryActionAndStatus() throws {
+    let statuses = ["not_installed", "installed", "installed_different_source", "broken"]
+    let targets = zip(["claude", "codex", "agents", "claude"], statuses).map { id, status in
+      #"{"id":"\#(id)","detected":false,"path":"/Users/me/.\#(id)/skills/prowl-cli","status":"\#(status)"}"#
+    }.joined(separator: ",")
+    let list =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"list","skills":[{"id":"prowl-cli","name":"prowl-cli","description":"Drive Prowl.","audience":"user","path":"/Applications/Prowl.app/Contents/Resources/skills/prowl-cli","targets":[\#(targets)]}]}}"#
+    let install =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"install","scope":"user","root":"/Users/me","results":[{"skill":"prowl-cli","target":"claude","path":"/Users/me/.claude/skills/prowl-cli","before":"broken","after":"installed"}]}}"#
+    let uninstall =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"uninstall","scope":"project","root":"/Projects/App","results":[{"skill":"prowl-cli","target":"codex","path":"/Projects/App/.codex/skills/prowl-cli","before":"installed","after":"not_installed"}],"note":"Links carry absolute paths; consider .git/info/exclude."}}"#
+    let path =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"path","skill":{"id":"reviewer","name":"Reviewer","audience":"workflow","path":"/Applications/Prowl.app/Contents/Resources/skills/reviewer"}}}"#
+    let error =
+      #"{"ok":false,"command":"skills","schema_version":"prowl.cli.skills.v1","error":{"code":"SKILL_NOT_INSTALLABLE","message":"reviewer is a workflow skill."}}"#
+
+    for instance in [list, install, uninstall, path, error] {
+      try assertValidity(instance, expected: true)
+    }
+  }
+
+  func testSchemaRejectsUnknownFieldsInvalidStatusesAndCrossActionFields() throws {
+    let unknownField =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"list","skills":[{"id":"prowl-cli","name":"prowl-cli","description":"Drive Prowl.","audience":"user","path":"/skills/prowl-cli","targets":[\#(target)],"extra":true}]}}"#
+    let invalidStatus =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"install","scope":"user","root":"/Users/me","results":[{"skill":"prowl-cli","target":"claude","path":"/x","before":"missing","after":"installed"}]}}"#
+    let crossAction =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"path","skill":{"id":"prowl-cli","name":"prowl-cli","audience":"user","path":"/x"},"results":[]}}"#
+    let invalidAudience =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"path","skill":{"id":"prowl-cli","name":"prowl-cli","audience":"everyone","path":"/x"}}}"#
+    let wrongVersion =
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v2","data":{"action":"list","skills":[]}}"#
+
+    for instance in [unknownField, invalidStatus, crossAction, invalidAudience, wrongVersion] {
+      try assertValidity(instance, expected: false)
+    }
+  }
+
+  func testPayloadRoundTripsThroughCodable() throws {
+    let payload = SkillsCommandPayload.install(
+      SkillsChangePayload(
+        scope: .project,
+        root: "/Projects/App",
+        results: [
+          SkillsCommandResult(
+            skill: "prowl-cli", target: "claude", path: "/Projects/App/.claude/skills/prowl-cli",
+            before: .notInstalled, after: .installed)
+        ],
+        note: "note"
+      )
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(payload)
+    let text = String(decoding: data, as: UTF8.self)
+
+    XCTAssertTrue(text.hasPrefix(#"{"action":"install""#))
+    XCTAssertEqual(try JSONDecoder().decode(SkillsCommandPayload.self, from: data), payload)
+
+    let listData = try encoder.encode(SkillsCommandPayload.list(SkillsListPayload(skills: [])))
+    XCTAssertEqual(String(decoding: listData, as: UTF8.self), #"{"action":"list","skills":[]}"#)
+    let response = CommandResponse(
+      ok: true, command: "skills", schemaVersion: "prowl.cli.skills.v1",
+      data: try RawJSON(encoding: SkillsCommandPayload.list(SkillsListPayload(skills: [])))
+    )
+    try assertValidity(String(decoding: try encoder.encode(response), as: UTF8.self), expected: true)
+  }
+
+  private func assertValidity(_ instance: String, expected: Bool) throws {
+    let schemaText = try XCTUnwrap(String(data: ProwlCLIContractBundle.schemaData, encoding: .utf8))
+    let result = try Schema(instance: schemaText).validate(instance: instance)
+    XCTAssertEqual(result.isValid, expected, "Schema errors for \(instance): \(result.errors ?? [])")
+  }
+}

--- a/ProwlCLITests/SkillsSchemaTests.swift
+++ b/ProwlCLITests/SkillsSchemaTests.swift
@@ -13,6 +13,7 @@ final class SkillsSchemaTests: XCTestCase {
     let targets = zip(["claude", "codex", "agents", "claude"], statuses).map { id, status in
       #"{"id":"\#(id)","detected":false,"path":"/Users/me/.\#(id)/skills/prowl-cli","status":"\#(status)"}"#
     }.joined(separator: ",")
+      + #",{"id":"codex","detected":true,"path":"/Users/me/.codex/skills/prowl-cli","status":"broken","destination":"/Volumes/Old/Prowl.app/Contents/Resources/skills/prowl-cli"}"#
     let list =
       #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"list","skills":[{"id":"prowl-cli","name":"prowl-cli","description":"Drive Prowl.","audience":"user","path":"/Applications/Prowl.app/Contents/Resources/skills/prowl-cli","targets":[\#(targets)]}]}}"#
     let install =
@@ -47,6 +48,21 @@ final class SkillsSchemaTests: XCTestCase {
   }
 
   func testPayloadRoundTripsThroughCodable() throws {
+    let listed = SkillsCommandPayload.list(
+      SkillsListPayload(skills: [
+        SkillsCommandSkill(
+          id: "prowl-cli", name: "prowl-cli", description: "d", audience: .user, path: "/bundle/prowl-cli",
+          targets: [
+            SkillsCommandTargetStatus(id: "claude", detected: true, path: "/h/.claude/skills/prowl-cli", status: .installed),
+            SkillsCommandTargetStatus(
+              id: "codex", detected: true, path: "/h/.codex/skills/prowl-cli", status: .installedDifferentSource,
+              destination: "/dd/skills/prowl-cli"),
+          ])
+      ]))
+    let listedJSON = String(decoding: try JSONEncoder().encode(listed), as: UTF8.self)
+    XCTAssertEqual(listedJSON.components(separatedBy: "\"destination\"").count - 1, 1, "destination is omitted when nil")
+    XCTAssertEqual(try JSONDecoder().decode(SkillsCommandPayload.self, from: Data(listedJSON.utf8)), listed)
+
     let payload = SkillsCommandPayload.install(
       SkillsChangePayload(
         scope: .project,

--- a/ProwlCLITests/SkillsSchemaTests.swift
+++ b/ProwlCLITests/SkillsSchemaTests.swift
@@ -9,11 +9,13 @@ final class SkillsSchemaTests: XCTestCase {
     #"{"id":"claude","detected":true,"path":"/Users/me/.claude/skills/prowl-cli","status":"installed"}"#
 
   func testSchemaAcceptsEveryActionAndStatus() throws {
-    let statuses = ["not_installed", "installed", "installed_different_source", "broken"]
-    let targets = zip(["claude", "codex", "agents", "claude"], statuses).map { id, status in
-      #"{"id":"\#(id)","detected":false,"path":"/Users/me/.\#(id)/skills/prowl-cli","status":"\#(status)"}"#
-    }.joined(separator: ",")
-      + #",{"id":"codex","detected":true,"path":"/Users/me/.codex/skills/prowl-cli","status":"broken","destination":"/Volumes/Old/Prowl.app/Contents/Resources/skills/prowl-cli"}"#
+    let targets = [
+      #"{"id":"claude","detected":false,"path":"/Users/me/.claude/skills/prowl-cli","status":"not_installed"}"#,
+      #"{"id":"codex","detected":true,"path":"/Users/me/.codex/skills/prowl-cli","status":"installed"}"#,
+      #"{"id":"agents","detected":true,"path":"/Users/me/.agents/skills/prowl-cli","status":"installed_different_source"}"#,
+      #"{"id":"agents","detected":true,"path":"/Users/me/.agents/skills/prowl-cli","status":"installed_different_source","destination":"/DerivedData/Prowl.app/Contents/Resources/skills/prowl-cli"}"#,
+      #"{"id":"codex","detected":true,"path":"/Users/me/.codex/skills/prowl-cli","status":"broken","destination":"/Volumes/Old/Prowl.app/Contents/Resources/skills/prowl-cli"}"#,
+    ].joined(separator: ",")
     let list =
       #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"list","skills":[{"id":"prowl-cli","name":"prowl-cli","description":"Drive Prowl.","audience":"user","path":"/Applications/Prowl.app/Contents/Resources/skills/prowl-cli","targets":[\#(targets)]}]}}"#
     let install =
@@ -43,6 +45,24 @@ final class SkillsSchemaTests: XCTestCase {
       #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v2","data":{"action":"list","skills":[]}}"#
 
     for instance in [unknownField, invalidStatus, crossAction, invalidAudience, wrongVersion] {
+      try assertValidity(instance, expected: false)
+    }
+  }
+
+  func testSchemaTiesDestinationToTheStatusesThatCanCarryIt() throws {
+    func list(_ target: String) -> String {
+      #"{"ok":true,"command":"skills","schema_version":"prowl.cli.skills.v1","data":{"action":"list","skills":[{"id":"prowl-cli","name":"prowl-cli","description":"Drive Prowl.","audience":"user","path":"/skills/prowl-cli","targets":[\#(target)]}]}}"#
+    }
+    let installedWithDestination = list(
+      #"{"id":"claude","detected":true,"path":"/h/.claude/skills/prowl-cli","status":"installed","destination":"/x"}"#)
+    let notInstalledWithDestination = list(
+      #"{"id":"claude","detected":true,"path":"/h/.claude/skills/prowl-cli","status":"not_installed","destination":"/x"}"#)
+    let brokenWithoutDestination = list(
+      #"{"id":"claude","detected":true,"path":"/h/.claude/skills/prowl-cli","status":"broken"}"#)
+    let emptyDestination = list(
+      #"{"id":"claude","detected":true,"path":"/h/.claude/skills/prowl-cli","status":"broken","destination":""}"#)
+
+    for instance in [installedWithDestination, notInstalledWithDestination, brokenWithoutDestination, emptyDestination] {
       try assertValidity(instance, expected: false)
     }
   }

--- a/ProwlCLITests/SymlinkInstallerTests.swift
+++ b/ProwlCLITests/SymlinkInstallerTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class SymlinkInstallerTests: XCTestCase {
+  func testStatusIsNotInstalledWhenNothingExists() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let link = root.appending(path: "bin/link").path(percentEncoded: false)
+
+      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .notInstalled)
+    }
+  }
+
+  func testStatusIsInstalledForSymlinkToExpectedSource() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let link = root.appending(path: "link").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: source)
+
+      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .installed(path: link))
+    }
+  }
+
+  func testStatusIsDifferentSourceForSymlinkToAnotherLiveSource() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let other = try makeDirectory(root.appending(path: "other"))
+      let link = root.appending(path: "link").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: other)
+
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: link, source: source),
+        .installedDifferentSource(path: link)
+      )
+    }
+  }
+
+  func testStatusIsDifferentSourceForRegularFileAndRealDirectory() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let file = root.appending(path: "file").path(percentEncoded: false)
+      try Data("contents".utf8).write(to: URL(filePath: file))
+      let directory = try makeDirectory(root.appending(path: "directory"))
+
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: file, source: source),
+        .installedDifferentSource(path: file)
+      )
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: directory, source: source),
+        .installedDifferentSource(path: directory)
+      )
+    }
+  }
+
+  func testStatusIsBrokenForDanglingSymlink() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let missing = root.appending(path: "missing").path(percentEncoded: false)
+      let link = root.appending(path: "link").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: missing)
+
+      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .broken(path: link))
+    }
+  }
+
+  func testStatusIsBrokenForDanglingSymlinkThatNamesTheExpectedSource() throws {
+    try withTemporaryDirectory { root in
+      let source = root.appending(path: "moved-away").path(percentEncoded: false)
+      let link = root.appending(path: "link").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: source)
+
+      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .broken(path: link))
+    }
+  }
+
+  func testInstallCreatesParentDirectoriesAndLink() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let link = root.appending(path: "a/b/c/link").path(percentEncoded: false)
+
+      try SymlinkInstaller.install(source: source, linkPath: link)
+
+      XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: link), source)
+      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .installed(path: link))
+    }
+  }
+
+  func testInstallReplacesLiveAndDanglingSymlinks() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let other = try makeDirectory(root.appending(path: "other"))
+      let liveLink = root.appending(path: "live").path(percentEncoded: false)
+      let danglingLink = root.appending(path: "dangling").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: liveLink, withDestinationPath: other)
+      try FileManager.default.createSymbolicLink(
+        atPath: danglingLink,
+        withDestinationPath: root.appending(path: "missing").path(percentEncoded: false)
+      )
+
+      try SymlinkInstaller.install(source: source, linkPath: liveLink)
+      try SymlinkInstaller.install(source: source, linkPath: danglingLink)
+
+      XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: liveLink), source)
+      XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: danglingLink), source)
+      XCTAssertTrue(FileManager.default.fileExists(atPath: other), "Replacing a link must not touch its old target")
+    }
+  }
+
+  func testInstallRefusesRegularFileAndRealDirectoryWithoutModifyingThem() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let file = root.appending(path: "file").path(percentEncoded: false)
+      try Data("existing".utf8).write(to: URL(filePath: file))
+      let directory = try makeDirectory(root.appending(path: "directory"))
+      let marker = URL(filePath: directory).appending(path: "marker")
+      try Data("keep".utf8).write(to: marker)
+
+      XCTAssertThrowsError(try SymlinkInstaller.install(source: source, linkPath: file)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: file))
+      }
+      XCTAssertThrowsError(try SymlinkInstaller.install(source: source, linkPath: directory)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: directory))
+      }
+
+      XCTAssertEqual(FileManager.default.contents(atPath: file), Data("existing".utf8))
+      XCTAssertEqual(try Data(contentsOf: marker), Data("keep".utf8))
+      XCTAssertFalse(isSymlink(file))
+      XCTAssertFalse(isSymlink(directory))
+    }
+  }
+
+  func testInstallRejectsMissingSource() throws {
+    try withTemporaryDirectory { root in
+      let source = root.appending(path: "missing-source").path(percentEncoded: false)
+      let link = root.appending(path: "link").path(percentEncoded: false)
+
+      XCTAssertThrowsError(try SymlinkInstaller.install(source: source, linkPath: link)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .sourceNotFound(path: source))
+      }
+      XCTAssertFalse(FileManager.default.fileExists(atPath: link))
+    }
+  }
+
+  func testUninstallRemovesLiveAndDanglingSymlinks() throws {
+    try withTemporaryDirectory { root in
+      let target = try makeDirectory(root.appending(path: "target"))
+      let liveLink = root.appending(path: "live").path(percentEncoded: false)
+      let danglingLink = root.appending(path: "dangling").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: liveLink, withDestinationPath: target)
+      try FileManager.default.createSymbolicLink(
+        atPath: danglingLink,
+        withDestinationPath: root.appending(path: "missing").path(percentEncoded: false)
+      )
+
+      try SymlinkInstaller.uninstall(linkPath: liveLink)
+      try SymlinkInstaller.uninstall(linkPath: danglingLink)
+
+      XCTAssertFalse(isSymlink(liveLink))
+      XCTAssertFalse(isSymlink(danglingLink))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: target), "Uninstall must not follow the link")
+    }
+  }
+
+  func testUninstallRefusesRegularFileAndRealDirectory() throws {
+    try withTemporaryDirectory { root in
+      let file = root.appending(path: "file").path(percentEncoded: false)
+      try Data("existing".utf8).write(to: URL(filePath: file))
+      let directory = try makeDirectory(root.appending(path: "directory"))
+
+      XCTAssertThrowsError(try SymlinkInstaller.uninstall(linkPath: file)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: file))
+      }
+      XCTAssertThrowsError(try SymlinkInstaller.uninstall(linkPath: directory)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .conflict(path: directory))
+      }
+      XCTAssertEqual(FileManager.default.contents(atPath: file), Data("existing".utf8))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: directory))
+    }
+  }
+
+  func testUninstallReportsNotInstalledWhenNothingExists() throws {
+    try withTemporaryDirectory { root in
+      let link = root.appending(path: "link").path(percentEncoded: false)
+
+      XCTAssertThrowsError(try SymlinkInstaller.uninstall(linkPath: link)) { error in
+        XCTAssertEqual(error as? SymlinkInstallError, .notInstalled(path: link))
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-symlink-installer-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try operation(root)
+  }
+
+  @discardableResult
+  private func makeDirectory(_ url: URL) throws -> String {
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url.path(percentEncoded: false)
+  }
+
+  private func isSymlink(_ path: String) -> Bool {
+    (try? FileManager.default.attributesOfItem(atPath: path))?[.type] as? FileAttributeType == .typeSymbolicLink
+  }
+}

--- a/ProwlCLITests/SymlinkInstallerTests.swift
+++ b/ProwlCLITests/SymlinkInstallerTests.swift
@@ -31,7 +31,21 @@ final class SymlinkInstallerTests: XCTestCase {
 
       XCTAssertEqual(
         SymlinkInstaller.status(linkPath: link, source: source),
-        .installedDifferentSource(path: link)
+        .installedDifferentSource(path: link, destination: other)
+      )
+    }
+  }
+
+  func testStatusResolvesARelativeDifferentSourceAgainstTheLinkDirectory() throws {
+    try withTemporaryDirectory { root in
+      let source = try makeDirectory(root.appending(path: "source"))
+      let other = try makeDirectory(root.appending(path: "bin/other"))
+      let link = root.appending(path: "bin/link").path(percentEncoded: false)
+      try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: "other")
+
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: link, source: source),
+        .installedDifferentSource(path: link, destination: other)
       )
     }
   }
@@ -45,11 +59,11 @@ final class SymlinkInstallerTests: XCTestCase {
 
       XCTAssertEqual(
         SymlinkInstaller.status(linkPath: file, source: source),
-        .installedDifferentSource(path: file)
+        .installedDifferentSource(path: file, destination: nil)
       )
       XCTAssertEqual(
         SymlinkInstaller.status(linkPath: directory, source: source),
-        .installedDifferentSource(path: directory)
+        .installedDifferentSource(path: directory, destination: nil)
       )
     }
   }
@@ -61,7 +75,10 @@ final class SymlinkInstallerTests: XCTestCase {
       let link = root.appending(path: "link").path(percentEncoded: false)
       try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: missing)
 
-      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .broken(path: link))
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: link, source: source),
+        .broken(path: link, destination: missing)
+      )
     }
   }
 
@@ -71,7 +88,10 @@ final class SymlinkInstallerTests: XCTestCase {
       let link = root.appending(path: "link").path(percentEncoded: false)
       try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: source)
 
-      XCTAssertEqual(SymlinkInstaller.status(linkPath: link, source: source), .broken(path: link))
+      XCTAssertEqual(
+        SymlinkInstaller.status(linkPath: link, source: source),
+        .broken(path: link, destination: source)
+      )
     }
   }
 

--- a/docs-ai/013-prowl-cli/contracts/input.md
+++ b/docs-ai/013-prowl-cli/contracts/input.md
@@ -9,7 +9,7 @@ and the executable [schema bundle](schema.md).
 ```text
 prowl [path]
 prowl open [path]
-prowl list | agents [read|signal] | profiles | focus | read | send | key | handoff | create | close
+prowl list | agents [read|signal] | profiles | skills | focus | read | send | key | handoff | create | close
 ```
 
 Bare path forms (`/`, `./`, `../`, `~/`, `file://`, `.`, `..`) enter `open`.
@@ -59,6 +59,19 @@ is a read-only global snapshot and accepts no target. `close` requires a pane-or
 shipped release. They keep their legacy parser/transport behavior while emitting a
 stderr warning; new automation must use the lifecycle grammar above.
 
+## Local skills grammar
+
+```bash
+prowl skills list
+prowl skills install [<skill>...] [--target <claude|codex|agents>]... [--scope user|project] [--path <dir>]
+prowl skills uninstall [<skill>...] [--target <claude|codex|agents>]... [--scope user|project] [--path <dir>]
+prowl skills path <skill>
+```
+
+`skills` is local-only: it resolves the bundle beside the executable (or `PROWL_SKILLS_DIR`)
+and never opens the socket. `--target` is repeatable; `--path` requires `--scope project`
+(`INVALID_ARGUMENT`); `path` requires exactly one skill id. See [skills.md](skills.md).
+
 ## Agent signal grammar
 
 ```bash
@@ -80,6 +93,8 @@ See [agents-signal.md](agents-signal.md).
   socket peer process ancestry, never UI focus or `PROWL_PANE_ID`.
 - `handoff` defaults to the calling pane, not UI focus.
 - `list`, `agents`, and `profiles list` are global discovery commands with no target selector.
+- `skills` accepts no target selector and never contacts the app; it acts on the local
+  filesystem only.
 - `open` consumes a path rather than a target.
 
 ## Transport request model

--- a/docs-ai/013-prowl-cli/contracts/schema.md
+++ b/docs-ai/013-prowl-cli/contracts/schema.md
@@ -17,6 +17,7 @@ The bundle has one versioned success-or-error response schema for every wire com
 | `agents.read` | `#/$defs/agentsReadResponse` |
 | `agents.signal` | `#/$defs/agentsSignalResponse` |
 | `profiles` | `#/$defs/profilesResponse` |
+| `skills` (local-only) | `#/$defs/skillsResponse` |
 | `focus` | `#/$defs/focusResponse` |
 | `send` | `#/$defs/sendResponse` |
 | `key` | `#/$defs/keyResponse` |
@@ -28,15 +29,18 @@ The bundle has one versioned success-or-error response schema for every wire com
 | `handoff` | `#/$defs/handoffResponse` |
 
 The bundle root is a `oneOf` across these responses and is valid for any complete
-socket response.
+socket response. `skills` never crosses the socket; its responses are produced locally by
+the CLI on the same envelope and are validated from real command runs.
 
 ## Executable verification
 
 `ProwlCLITests/ProwlCLIIntegrationTests.swift` loads the bundle through the
 `ProwlCLIContracts` SwiftPM target and validates every mock socket response that
 contains a command payload or error with the Draft 2020-12 `JSONSchema` validator.
-Those are raw socket bytes, not decoded model assertions. `make test-cli-integration`
-is therefore the contract verification command.
+Those are raw socket bytes, not decoded model assertions. The same suite runs `prowl skills`
+against a temporary `PROWL_SKILLS_DIR`, home, and Git repository with an unavailable socket
+and validates its stdout envelopes the same way. `make test-cli-integration` is therefore the
+contract verification command.
 
 A public wire command is incomplete until its versioned response definition,
 socket fixture, parser/handler test, user manual, and command contract change in the

--- a/docs-ai/013-prowl-cli/contracts/skills.md
+++ b/docs-ai/013-prowl-cli/contracts/skills.md
@@ -1,0 +1,190 @@
+# `prowl skills` Contract
+
+## Status
+
+Current version: `prowl.cli.skills.v1`.
+
+`skills` manages the agent skills bundled inside the Prowl app: it links them into agent skill
+folders so every runtime reads the version that matches the installed app. The whole command
+group is **local-only**: it never opens the CLI socket, never launches or contacts a running
+app, and works with Prowl closed. Every response uses `command: "skills"` and one closed
+`data` object discriminated by `action`.
+
+## Input
+
+```bash
+prowl skills list [--json]
+prowl skills install [<skill>...] [--target <id>]... [--scope user|project] [--path <dir>] [--json]
+prowl skills uninstall [<skill>...] [--target <id>]... [--scope user|project] [--path <dir>] [--json]
+prowl skills path <skill> [--json]
+```
+
+### Bundle resolution
+
+- `PROWL_SKILLS_DIR`, when set, is a skills root (`<dir>/<id>/SKILL.md`) and wins. A present but
+  invalid value fails with `BUNDLE_NOT_FOUND`; it never falls back to the app bundle.
+- Otherwise the CLI resolves its own executable — following symlinks such as
+  `/usr/local/bin/prowl` — to `Prowl.app/Contents/Resources/prowl-cli/prowl` and reads the
+  sibling `Contents/Resources/skills/`. A CLI that is not inside an app bundle fails with
+  `BUNDLE_NOT_FOUND`; a skill with malformed frontmatter fails with `INVALID_SKILL_FRONTMATTER`.
+- Skill ids are bundled directory names, enumerated in stable id order. `audience` is `user`
+  (installable) or `workflow` (materialized by workflow runs, never installed).
+
+### Targets
+
+| id | User directory | Project directory | Read by |
+| --- | --- | --- | --- |
+| `claude` | `~/.claude/skills` | `<root>/.claude/skills` | Claude Code |
+| `codex` | `~/.codex/skills` | `<root>/.codex/skills` | Codex |
+| `agents` | `~/.agents/skills` | `<root>/.agents/skills` | Codex, Gemini CLI, Cursor Agent, OpenCode, Copilot CLI, Kimi CLI, Droid, Amp, Qoder CLI, Pi, Oh My Pi, Grok Build |
+
+A target is **detected** when the parent of its skills directory (`~/.claude`, `~/.codex`,
+`~/.agents`, or the same names under a project root) exists as a directory. `--target` is
+repeatable and accepts only the ids above; any other id fails with `TARGET_NOT_FOUND` before
+any change. An explicit `--target` selects exactly those targets and `install` creates their
+skills directory when it is missing, detected or not. `uninstall` never creates directories.
+
+### Scope and roots
+
+- `--scope` defaults to `user`. The user root is `$HOME` (an explicit `HOME` override is
+  honored so verification can use a temporary home).
+- `--scope project` uses `--path <dir>` as the project root, or the nearest ancestor of the
+  current directory (including itself) that contains a `.git` entry — a directory or, for a
+  worktree, a file. `--path` requires `--scope project` (`INVALID_ARGUMENT`); a missing path
+  is `PATH_NOT_FOUND`, a non-directory is `PATH_NOT_DIRECTORY`, and a current directory
+  outside any Git repository is `PATH_NOT_FOUND`. Prowl never reads or edits Git state.
+- `list` reports user scope only.
+
+### Selection and defaults
+
+- Skills: with no ids, `install` and `uninstall` act on every `user`-audience bundled skill.
+  Explicit ids must be bundled (`SKILL_NOT_FOUND`). Naming a `workflow`-audience skill in
+  `install` fails with `SKILL_NOT_INSTALLABLE` before any change; `uninstall` and `path` accept
+  any bundled id.
+- Targets: with no `--target`, `install` acts on every detected target and fails with
+  `TARGET_NOT_FOUND` when none is detected; `uninstall` acts on every detected target and
+  succeeds with an empty `results` array when none is detected.
+- Results are ordered skills (bundle order) × targets (table order). Repeated ids are
+  collapsed; input order does not affect output order.
+
+### Link semantics
+
+- One absolute directory symlink per skill × target: `<skills dir>/<skill id>` → the bundled
+  skill directory. The target's skills directory is created when missing.
+- An existing symlink is replaced whether it is live or dangling, so `install` doubles as the
+  repair for `broken`. A real file or directory is never replaced or removed: every selected
+  slot is checked first and one conflicting slot fails the whole command with
+  `INSTALL_CONFLICT` and no change.
+- `uninstall` removes only symlinks, dangling ones included, regardless of where they point.
+  A `not_installed` slot is reported unchanged.
+- An unexpected filesystem failure after the conflict check fails with `SKILLS_FAILED`; slots
+  processed before the failure keep their new state, so re-run the command after fixing the
+  cause.
+
+### Status values
+
+| `status` | Meaning |
+| --- | --- |
+| `not_installed` | Nothing occupies the slot. |
+| `installed` | A symlink that resolves to this app's bundled skill directory. |
+| `installed_different_source` | A symlink to another live location (for example a Debug build), or a real file/directory. |
+| `broken` | A dangling symlink; the app was moved or removed. `install` repairs it. |
+
+## Success: `list`
+
+```json
+{
+  "ok": true,
+  "command": "skills",
+  "schema_version": "prowl.cli.skills.v1",
+  "data": {
+    "action": "list",
+    "skills": [
+      {
+        "id": "prowl-cli",
+        "name": "prowl-cli",
+        "description": "Use the Prowl CLI (`prowl`) to inspect or control a running Prowl GUI app…",
+        "audience": "user",
+        "path": "/Applications/Prowl.app/Contents/Resources/skills/prowl-cli",
+        "targets": [
+          { "id": "claude", "detected": true, "path": "/Users/me/.claude/skills/prowl-cli", "status": "installed" },
+          { "id": "codex", "detected": true, "path": "/Users/me/.codex/skills/prowl-cli", "status": "broken" },
+          { "id": "agents", "detected": false, "path": "/Users/me/.agents/skills/prowl-cli", "status": "not_installed" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`path` is the canonical bundled directory; each target `path` is the link slot for that
+skill. `workflow`-audience skills are listed with their status so a manual link is visible,
+but they are never selected for installation.
+
+## Success: `install` and `uninstall`
+
+```json
+{
+  "ok": true,
+  "command": "skills",
+  "schema_version": "prowl.cli.skills.v1",
+  "data": {
+    "action": "install",
+    "scope": "project",
+    "root": "/Projects/App",
+    "results": [
+      {
+        "skill": "prowl-cli",
+        "target": "claude",
+        "path": "/Projects/App/.claude/skills/prowl-cli",
+        "before": "broken",
+        "after": "installed"
+      }
+    ],
+    "note": "Project-scope skill links are absolute paths specific to this Mac. Prowl never edits Git state; exclude them yourself (for example in .git/info/exclude) if they should stay out of version control."
+  }
+}
+```
+
+`root` is the scope root (`$HOME` for `user`, the project root for `project`). `before` and
+`after` are the slot status before and after the change; an `uninstall` result ends in
+`not_installed`. `note` is present only for project scope, exactly once per response.
+
+## Success: `path`
+
+```json
+{
+  "ok": true,
+  "command": "skills",
+  "schema_version": "prowl.cli.skills.v1",
+  "data": {
+    "action": "path",
+    "skill": {
+      "id": "reviewer",
+      "name": "Reviewer",
+      "audience": "workflow",
+      "path": "/Applications/Prowl.app/Contents/Resources/skills/reviewer"
+    }
+  }
+}
+```
+
+## Text output
+
+- `list` prints one block per skill (id, name, audience tag) with one line per target:
+  status, link slot, and `(target not detected)` when applicable.
+- `install` / `uninstall` print one line per result: `installed`, `repaired`, `replaced`,
+  `unchanged`, `removed`, or `not installed`, followed by `skill → target` and the slot path.
+- `path` prints exactly the bundled directory followed by a newline, for `$(…)` use.
+- The project-scope note is written once to stderr, prefixed `note:`, in text mode only. JSON
+  mode keeps it in `data.note` and writes nothing to stderr, so stdout stays one envelope.
+- Errors follow the common text form `error [CODE]: message` on stderr with empty stdout.
+
+## Errors
+
+`SKILL_NOT_FOUND`, `SKILL_NOT_INSTALLABLE`, `TARGET_NOT_FOUND`, `INSTALL_CONFLICT`,
+`BUNDLE_NOT_FOUND`, `INVALID_SKILL_FRONTMATTER`, `INVALID_ARGUMENT`, `PATH_NOT_FOUND`,
+`PATH_NOT_DIRECTORY`, and `SKILLS_FAILED` use the common error envelope with
+`schema_version: "prowl.cli.skills.v1"`. Because the command never uses the socket,
+`APP_NOT_RUNNING`, `SOCKET_PERMISSION_DENIED`, and `TRANSPORT_FAILED` cannot occur. See
+[`cli-output-schema.json`](../../../ProwlCLIContracts/Resources/cli-output-schema.json).

--- a/docs-ai/013-prowl-cli/contracts/skills.md
+++ b/docs-ai/013-prowl-cli/contracts/skills.md
@@ -96,9 +96,10 @@ skills directory when it is missing, detected or not. `uninstall` never creates 
 | `installed_different_source` | A symlink to another live location (for example a Debug build) — `destination` names it — or a real file/directory (`destination` absent). |
 | `broken` | A dangling symlink; `destination` names where the app used to be. `install` repairs it. |
 
-`destination` is the link target resolved against the link's directory; it is present only for
-the two statuses above and never for a real file or directory, so its absence under
-`installed_different_source` identifies a non-symlink occupant.
+`destination` is the link target resolved against the link's directory. The schema ties it to
+the status: it is required for `broken`, optional for `installed_different_source` (present
+for a foreign symlink, absent for a real file or directory, so its absence identifies a
+non-symlink occupant), and forbidden for `installed` and `not_installed`.
 
 ## Success: `list`
 

--- a/docs-ai/013-prowl-cli/contracts/skills.md
+++ b/docs-ai/013-prowl-cli/contracts/skills.md
@@ -83,6 +83,11 @@ skills directory when it is missing, detected or not. `uninstall` never creates 
   `INSTALL_CONFLICT` and no change.
 - `uninstall` removes only symlinks, dangling ones included, regardless of where they point.
   A `not_installed` slot is reported unchanged.
+- Each slot is re-read immediately before it is acted on. Targets whose skills directories
+  alias the same folder (for example `~/.claude/skills` and `~/.codex/skills` both symlinked to
+  one synced directory) therefore share one link: the first pair installs or removes it and the
+  later pair reports `before == after` (`installed` / `not_installed`) instead of failing or
+  relinking. `before` in each result is that per-slot reading, not the pre-command listing.
 - An unexpected filesystem failure after the conflict check fails with `SKILLS_FAILED`; slots
   processed before the failure keep their new state, so re-run the command after fixing the
   cause.

--- a/docs-ai/013-prowl-cli/contracts/skills.md
+++ b/docs-ai/013-prowl-cli/contracts/skills.md
@@ -93,8 +93,12 @@ skills directory when it is missing, detected or not. `uninstall` never creates 
 | --- | --- |
 | `not_installed` | Nothing occupies the slot. |
 | `installed` | A symlink that resolves to this app's bundled skill directory. |
-| `installed_different_source` | A symlink to another live location (for example a Debug build), or a real file/directory. |
-| `broken` | A dangling symlink; the app was moved or removed. `install` repairs it. |
+| `installed_different_source` | A symlink to another live location (for example a Debug build) — `destination` names it — or a real file/directory (`destination` absent). |
+| `broken` | A dangling symlink; `destination` names where the app used to be. `install` repairs it. |
+
+`destination` is the link target resolved against the link's directory; it is present only for
+the two statuses above and never for a real file or directory, so its absence under
+`installed_different_source` identifies a non-symlink occupant.
 
 ## Success: `list`
 
@@ -114,7 +118,7 @@ skills directory when it is missing, detected or not. `uninstall` never creates 
         "path": "/Applications/Prowl.app/Contents/Resources/skills/prowl-cli",
         "targets": [
           { "id": "claude", "detected": true, "path": "/Users/me/.claude/skills/prowl-cli", "status": "installed" },
-          { "id": "codex", "detected": true, "path": "/Users/me/.codex/skills/prowl-cli", "status": "broken" },
+          { "id": "codex", "detected": true, "path": "/Users/me/.codex/skills/prowl-cli", "status": "broken", "destination": "/Volumes/Old/Prowl.app/Contents/Resources/skills/prowl-cli" },
           { "id": "agents", "detected": false, "path": "/Users/me/.agents/skills/prowl-cli", "status": "not_installed" }
         ]
       }
@@ -178,7 +182,9 @@ but they are never selected for installation.
 ## Text output
 
 - `list` prints one block per skill (id, name, audience tag) with one line per target:
-  status, link slot, and `(target not detected)` when applicable.
+  status (`installed`, `not installed`, `linked elsewhere`, `real file or directory`,
+  `broken link`), link slot, `→ <destination>` for a foreign or dangling link, and
+  `(target not detected)` when applicable.
 - `install` / `uninstall` print one line per result: `installed`, `repaired`, `replaced`,
   `unchanged`, `removed`, or `not installed`, followed by `skill → target` and the slot path.
 - `path` prints exactly the bundled directory followed by a newline, for `$(…)` use.

--- a/docs-ai/013-prowl-cli/contracts/skills.md
+++ b/docs-ai/013-prowl-cli/contracts/skills.md
@@ -48,11 +48,17 @@ skills directory when it is missing, detected or not. `uninstall` never creates 
 
 - `--scope` defaults to `user`. The user root is `$HOME` (an explicit `HOME` override is
   honored so verification can use a temporary home).
-- `--scope project` uses `--path <dir>` as the project root, or the nearest ancestor of the
-  current directory (including itself) that contains a `.git` entry — a directory or, for a
-  worktree, a file. `--path` requires `--scope project` (`INVALID_ARGUMENT`); a missing path
-  is `PATH_NOT_FOUND`, a non-directory is `PATH_NOT_DIRECTORY`, and a current directory
-  outside any Git repository is `PATH_NOT_FOUND`. Prowl never reads or edits Git state.
+- `--scope project` acts on a repository. The root is the nearest ancestor (including the
+  start itself) that contains a `.git` entry — a directory or, for a worktree, a file — of
+  `--path <dir>` when given, otherwise of the current directory. `--path` requires
+  `--scope project` (`INVALID_ARGUMENT`); a missing path is `PATH_NOT_FOUND`, a non-directory
+  is `PATH_NOT_DIRECTORY`, and a start point outside any Git repository is `PATH_NOT_FOUND`.
+  Prowl never reads or edits Git state.
+- Project-scope links stay inside the repository. If a target's parent directory
+  (`<root>/.codex`) or skills directory (`<root>/.codex/skills`) exists and resolves outside
+  the canonical root — for example a committed symlink to a shared folder — every command that
+  would use it fails with `INSTALL_CONFLICT` before any change. User scope deliberately follows
+  such symlinks because synced `~/.claude/skills`-style setups are supported.
 - `list` reports user scope only.
 
 ### Selection and defaults

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -36,7 +36,7 @@ user-facing surface may merge before "their" release and stay dormant. Three rel
 | S2 | Merged | #718: paired dispatch receipt, strict ID wait, generic evidence wait; [action record](../064-agent-completion-signals/005-s2-action.md) |
 | S3 wave 1 | Complete | Merged in #721/#723/#725/#728; S3c plan [064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md) |
 | 065-S0/K1 | Merged | #729; [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md) |
-| 065-K2 | Implemented | PR pending from `feat/bundled-skills-k2`; [065.004](../065-bundled-agent-skills/004-k2-skill-installer-cli.md) |
+| 065-K2 | In review | #730; [065.004](../065-bundled-agent-skills/004-k2-skill-installer-cli.md) |
 | 065-K3 | Planned | Follows K2 inside R1 |
 
 A2 completes 063's R1 implementation work, and S1/S2/S3 wave 1 are on `main`. The remaining
@@ -125,7 +125,7 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 ## Change log
 
 - 2026-08-27 — 065-K1 merged in #729. K2 (shared `SymlinkInstaller` + `prowl skills`) was
-  implemented on `feat/bundled-skills-k2` and awaits review; K3 remains planned inside R1.
+  implemented on `feat/bundled-skills-k2` and opened as #730; K3 remains planned inside R1.
   Record: [065.004](../065-bundled-agent-skills/004-k2-skill-installer-cli.md).
 - 2026-08-27 — 065-S0 completed its target verification and K1 implemented the bundled-skill
   foundation; K2/K3 remain in R1. Record: [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md).

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -36,11 +36,12 @@ user-facing surface may merge before "their" release and stay dormant. Three rel
 | S2 | Merged | #718: paired dispatch receipt, strict ID wait, generic evidence wait; [action record](../064-agent-completion-signals/005-s2-action.md) |
 | S3 wave 1 | Complete | Merged in #721/#723/#725/#728; S3c plan [064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md) |
 | 065-S0/K1 | Merged | #729; [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md) |
-| 065-K2 | In progress | Next 065 slice on `feat/bundled-skills-k2`: shared `SymlinkInstaller` + `prowl skills` |
+| 065-K2 | Implemented | PR pending from `feat/bundled-skills-k2`; [065.004](../065-bundled-agent-skills/004-k2-skill-installer-cli.md) |
 | 065-K3 | Planned | Follows K2 inside R1 |
 
 A2 completes 063's R1 implementation work, and S1/S2/S3 wave 1 are on `main`. The remaining
-R1 work is 065 bundled skill distribution: S0 and K1 are merged (#729); K2 is next, then K3.
+R1 work is 065 bundled skill distribution: S0 and K1 are merged (#729), K2 is implemented and
+awaiting review, and K3 follows.
 
 #### S3 wave 1 PR breakdown
 
@@ -123,8 +124,9 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
-- 2026-08-27 — 065-K1 merged in #729. K2 (shared `SymlinkInstaller` + `prowl skills`) started on
-  `feat/bundled-skills-k2`; K3 remains planned inside R1.
+- 2026-08-27 — 065-K1 merged in #729. K2 (shared `SymlinkInstaller` + `prowl skills`) was
+  implemented on `feat/bundled-skills-k2` and awaits review; K3 remains planned inside R1.
+  Record: [065.004](../065-bundled-agent-skills/004-k2-skill-installer-cli.md).
 - 2026-08-27 — 065-S0 completed its target verification and K1 implemented the bundled-skill
   foundation; K2/K3 remain in R1. Record: [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md).
 - 2026-08-27 — S3c merged (#728), completing S3 wave 1 across #721/#723/#725/#728.

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -35,11 +35,12 @@ user-facing surface may merge before "their" release and stay dormant. Three rel
 | S1 | Merged | #715: bus, multicast observer, `agents signal` |
 | S2 | Merged | #718: paired dispatch receipt, strict ID wait, generic evidence wait; [action record](../064-agent-completion-signals/005-s2-action.md) |
 | S3 wave 1 | Complete | Merged in #721/#723/#725/#728; S3c plan [064.010](../064-agent-completion-signals/010-s3c-plan.md), record [064.011](../064-agent-completion-signals/011-s3c-action.md) |
-| 065-S0/K1 | S0 complete; K1 implemented | K1 PR pending; [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md) |
-| 065-K2/K3 | Planned | Follow S0/K1 inside R1 |
+| 065-S0/K1 | Merged | #729; [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md) |
+| 065-K2 | In progress | Next 065 slice on `feat/bundled-skills-k2`: shared `SymlinkInstaller` + `prowl skills` |
+| 065-K3 | Planned | Follows K2 inside R1 |
 
 A2 completes 063's R1 implementation work, and S1/S2/S3 wave 1 are on `main`. The remaining
-R1 work is 065 bundled skill distribution: S0 is complete, K1 is implemented, and K2/K3 follow.
+R1 work is 065 bundled skill distribution: S0 and K1 are merged (#729); K2 is next, then K3.
 
 #### S3 wave 1 PR breakdown
 
@@ -122,6 +123,8 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-08-27 — 065-K1 merged in #729. K2 (shared `SymlinkInstaller` + `prowl skills`) started on
+  `feat/bundled-skills-k2`; K3 remains planned inside R1.
 - 2026-08-27 — 065-S0 completed its target verification and K1 implemented the bundled-skill
   foundation; K2/K3 remain in R1. Record: [065.003](../065-bundled-agent-skills/003-k1-bundle-registry.md).
 - 2026-08-27 — S3c merged (#728), completing S3 wave 1 across #721/#723/#725/#728.

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | In progress — S0 and K1 complete; K2–K3 planned |
 | **Anchor date** | 2026-08-22 |
-| **Primary PRs** | #712 (plan); K1 pending; K2–K3 to fill in |
+| **Primary PRs** | #712 (plan); #729 (K1); K2–K3 to fill in |
 | **Related** | [063-agent-workflows](../063-agent-workflows/000-plan.md) (D1 `skill:` materialization, D1–D3 new skills), [060-prowl-cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md) (four-layer CLI rule), [013-prowl-cli](../013-prowl-cli/000-plan.md), `docs/components/cli.md`, `skills/prowl-cli/SKILL.md` |
 
 ## Background
@@ -137,7 +137,7 @@ depends on it); K2 and K3 follow inside R1 so the R1 user can `prowl skills inst
 | Slice | Contents | Depends |
 | --- | --- | --- |
 | **S0** spike | **Complete** — verified Codex per-directory links and `.codex/skills`, mapped installed `.agents/skills` readers, and confirmed dangling links do not block discovery. Copy mode stays out of K2. See [002-s0-skill-targets.md](002-s0-skill-targets.md). | — |
-| **K1** | **Complete** — `embed-skills`, `Resources/skills` folder reference, Foundation-only `ProwlSkills` registry + typed errors and frontmatter parser, CLI bundle resolution, tests. See [003-k1-bundle-registry.md](003-k1-bundle-registry.md). | — |
+| **K1** | **Complete (#729)** — `embed-skills`, `Resources/skills` folder reference, Foundation-only `ProwlSkills` registry + typed errors and frontmatter parser, CLI bundle resolution, tests. See [003-k1-bundle-registry.md](003-k1-bundle-registry.md). | — |
 | **K2** | Shared `SymlinkInstaller` extracted from `CLIInstallClient`, `prowl skills list\|install\|uninstall\|path`, contract, `cli.md`, `prowl-cli` skill line, smoke + integration tests (temp dirs, `PROWL_SKILLS_DIR`). | S0, K1 |
 | **K3** | Agent Skills section on the Command Line Tool page, `AgentSkillsFeature` + `SkillInstallClient`, reducer tests, `docs/components/settings.md`. | K2 |
 

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -2,9 +2,9 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — S0 and K1 complete; K2–K3 planned |
+| **Status** | In progress — S0, K1, and K2 complete; K3 planned |
 | **Anchor date** | 2026-08-22 |
-| **Primary PRs** | #712 (plan); #729 (K1); K2–K3 to fill in |
+| **Primary PRs** | #712 (plan); #729 (K1); K2 pending; K3 to fill in |
 | **Related** | [063-agent-workflows](../063-agent-workflows/000-plan.md) (D1 `skill:` materialization, D1–D3 new skills), [060-prowl-cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md) (four-layer CLI rule), [013-prowl-cli](../013-prowl-cli/000-plan.md), `docs/components/cli.md`, `skills/prowl-cli/SKILL.md` |
 
 ## Background
@@ -138,7 +138,7 @@ depends on it); K2 and K3 follow inside R1 so the R1 user can `prowl skills inst
 | --- | --- | --- |
 | **S0** spike | **Complete** — verified Codex per-directory links and `.codex/skills`, mapped installed `.agents/skills` readers, and confirmed dangling links do not block discovery. Copy mode stays out of K2. See [002-s0-skill-targets.md](002-s0-skill-targets.md). | — |
 | **K1** | **Complete (#729)** — `embed-skills`, `Resources/skills` folder reference, Foundation-only `ProwlSkills` registry + typed errors and frontmatter parser, CLI bundle resolution, tests. See [003-k1-bundle-registry.md](003-k1-bundle-registry.md). | — |
-| **K2** | Shared `SymlinkInstaller` extracted from `CLIInstallClient`, `prowl skills list\|install\|uninstall\|path`, contract, `cli.md`, `prowl-cli` skill line, smoke + integration tests (temp dirs, `PROWL_SKILLS_DIR`). | S0, K1 |
+| **K2** | **Complete** — shared `SymlinkInstaller` extracted from `CLIInstallClient`, declarative targets, `prowl skills list\|install\|uninstall\|path`, contract, schema, `cli.md`, `prowl-cli` skill line, unit + integration tests (temp dirs, `PROWL_SKILLS_DIR`). See [004-k2-skill-installer-cli.md](004-k2-skill-installer-cli.md). | S0, K1 |
 | **K3** | Agent Skills section on the Command Line Tool page, `AgentSkillsFeature` + `SkillInstallClient`, reducer tests, `docs/components/settings.md`. | K2 |
 
 ## Alternatives & decisions
@@ -214,6 +214,10 @@ Decisions below were taken in the 2026-08-22 plan review (#712):
 
 ## Amendments
 
+- Updated 2026-08-27: Implemented and verified K2: one shared symlink installer with a
+  `broken` status now backs both the CLI installer and skill links; `prowl skills` is
+  local-only with the four contract layers; project scope prints its Git-hygiene note once and
+  never edits Git state — see [004-k2-skill-installer-cli.md](004-k2-skill-installer-cli.md).
 - Updated 2026-08-27 during K1 review: clean CI now stages the ignored skills resource and
   executes a dedicated CLI unit-test target; the frontmatter parser rejects top-level, nested,
   or inconsistently indented `prowl-install` metadata before audience defaulting — see

--- a/docs-ai/065-bundled-agent-skills/000-plan.md
+++ b/docs-ai/065-bundled-agent-skills/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | In progress — S0, K1, and K2 complete; K3 planned |
 | **Anchor date** | 2026-08-22 |
-| **Primary PRs** | #712 (plan); #729 (K1); K2 pending; K3 to fill in |
+| **Primary PRs** | #712 (plan); #729 (K1); #730 (K2); K3 to fill in |
 | **Related** | [063-agent-workflows](../063-agent-workflows/000-plan.md) (D1 `skill:` materialization, D1–D3 new skills), [060-prowl-cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md) (four-layer CLI rule), [013-prowl-cli](../013-prowl-cli/000-plan.md), `docs/components/cli.md`, `skills/prowl-cli/SKILL.md` |
 
 ## Background

--- a/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
+++ b/docs-ai/065-bundled-agent-skills/003-k1-bundle-registry.md
@@ -83,5 +83,5 @@ installing or modifying any skill in a user or project directory.
 
 - Slice: 065-K1
 - Branch: `feat/bundled-skills-k1`
-- PR: pending
+- PR: #729
 - Depends on: [002-s0-skill-targets.md](002-s0-skill-targets.md)

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -85,6 +85,12 @@ Adversarial review round 1 (sibling Pi agent, brief and findings kept outside th
   detected targets and points at `--target`. `INVALID_SKILL_FRONTMATTER` joined the manual's
   error table.
 
+Round 2 found no P0/P1 and one P2: `installedDifferentSource` and `broken` dropped the link's
+actual destination, so neither the CLI nor K3 could name the other source the plan promises for
+Debug/Release switches. The shared status now carries `destination` (resolved against the link
+directory; nil for a real file or directory), `list` exposes it as an optional `destination`
+field and `→ path` in text, and the contract, schema, and manual document it.
+
 ## Verification
 
 - TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -1,0 +1,103 @@
+# 065.004 — Shared Symlink Installer and `prowl skills` (K2)
+
+## Context
+
+K1 (#729) put Prowl's official skills into the app bundle and gave the app, the CLI, and the
+future workflow runner one registry, but nothing could yet link a bundled skill into an agent's
+skill folder. The only symlink installer in the codebase was the `/usr/local/bin/prowl` logic
+inside the TCA `CLIInstallClient`, and it could not see a dangling link (`fileExists` follows
+symlinks). K2 extracts that logic into a shared Foundation-only installer, adds the three
+verified S0 targets as declarative data, and ships the local-only `prowl skills` command group
+with its contract, schema, manual, and skill line. Settings UI stays in K3.
+
+## Change
+
+- `SymlinkInstaller` (`ProwlCLIShared`) owns status/install/uninstall for one link slot. Status
+  is `notInstalled` / `installed` / `installedDifferentSource` / `broken`; the slot is inspected
+  with `attributesOfItem` (lstat) so a dangling link is `broken` instead of invisible. `install`
+  creates parents, replaces live or dangling links, and refuses a real file or directory with
+  `SymlinkInstallError.conflict` before any mutation; `uninstall` removes symlinks only.
+  Filesystem errors other than the typed cases propagate unchanged.
+- `CLIInstallClient` now delegates to the shared installer. `CLIInstallStatus` is a typealias
+  of the shared enum; the user-facing messages, the osascript privilege fallback, and every
+  existing `CLIInstallClientTests` case are unchanged. A dangling `/usr/local/bin/prowl` used to
+  fail installation with a raw `EEXIST`; it is now reported as a broken link and repaired by
+  Install. The Command Line Tool page gained the matching `broken` row (Repair button) because
+  the shared enum is exhaustive; no other Settings work.
+- `SkillInstallTarget.all` declares exactly `claude`, `codex`, and `agents` with their user and
+  project directories. Detection is "the parent of the skills directory exists"; the same rule
+  applies under a project root. `ProwlSkillInstaller` composes target + skill into one link
+  slot (`<skills dir>/<skill id>` → bundled directory) for the CLI now and Settings in K3.
+- `prowl skills list | install | uninstall | path` (`SkillsCommand` + `SkillsCommandExecutor`)
+  runs entirely locally: it resolves the bundle through `ProwlSkills.bundledForCLI` from
+  `Bundle.main.executableURL` (never bare `argv[0]`), reads the user root from `HOME`, and never
+  touches `AppLauncher` or the socket. Bare `install` = every `user`-audience skill × every
+  detected target; repeated `--target` selects and creates targets; `workflow` skills fail
+  `SKILL_NOT_INSTALLABLE`; every slot is conflict-checked before any change so
+  `INSTALL_CONFLICT` leaves nothing half-done; `uninstall` skips `not_installed` slots.
+  Project scope takes `--path <repo>` or walks up from the cwd to the nearest `.git` entry (a
+  worktree's `.git` file counts) and emits the absolute-path / `.git/info/exclude` note exactly
+  once — `data.note` in JSON, one `note:` line on stderr in text mode.
+- Contract layers: `prowl.cli.skills.v1` with `command: "skills"` and `data.action` as the
+  discriminator (same shape as `create`/`handoff`), closed definitions in
+  `cli-output-schema.json`, `docs-ai/013-prowl-cli/contracts/skills.md`, `input.md` and
+  `schema.md` rows, a `prowl skills` section and error rows in `docs/components/cli.md`, and one
+  line in `skills/prowl-cli/SKILL.md` telling an agent that `prowl skills install prowl-cli`
+  keeps it current.
+
+## Decisions and boundaries
+
+- One installer, not two: the CLI installer keeps only message mapping and privilege
+  escalation. The shared status compares the raw link text with the expected source and, when
+  that differs, their resolved real paths, so a link written through `/private/tmp` still counts
+  as installed.
+- Roots are injected (`userRoot`, `currentDirectory`) rather than read from
+  `homeDirectoryForCurrentUser`, so unit tests, integration tests, and manual verification run
+  against temporary homes and throwaway repositories; no test or verification step touched a
+  live skill folder.
+- `--path` requires `--scope project` (`INVALID_ARGUMENT`), mirroring `--prompt` requiring
+  `--profile`. Missing/invalid roots reuse the existing `PATH_NOT_FOUND` /
+  `PATH_NOT_DIRECTORY` codes; unexpected filesystem failures use `SKILLS_FAILED` following the
+  `*_FAILED` convention. A bare `install` that detects no target fails with
+  `TARGET_NOT_FOUND` instead of succeeding with nothing installed; a bare `uninstall` in the same
+  situation succeeds with empty results.
+- `list` reports user scope only; project-scope status is visible through the `install` /
+  `uninstall` `before` field. Runtime reader labels for the `agents` target live in the
+  contract and manual, not in the declarative target data.
+- Not in K2: Settings Agent Skills section, `AgentSkillsFeature`, `SkillInstallClient`, copy
+  mode, third-party skills, auto-install after updates, Git mutations, new targets.
+
+## Verification
+
+- TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared
+  types existed; one hang exposed a `GitRootLocator` loop past `/` (`deletingLastPathComponent`
+  of `/` yields `/..`), fixed by stopping at the filesystem root.
+- `make build-cli` and `make test-cli-smoke` pass; the smoke target now also runs
+  `skills list --json` against a temporary skills root and home with the socket unavailable.
+  `make test-cli-unit` passed 120 tests and `make test-cli-integration` passed 102. New
+  coverage: 13 installer, 6 target, 18 executor, 5 parser, 3 schema, and 5 integration tests;
+  the integration tests run the real binary with an unavailable `PROWL_CLI_SOCKET`, a temporary
+  `PROWL_SKILLS_DIR`, a temporary `HOME`, and a throwaway Git repository, and validate every
+  JSON envelope against the schema bundle.
+- App: `CLIInstallClientTests` (existing cases plus dangling-link status, live install repair,
+  and live uninstall of a dangling link) and `SettingsFeatureCLIInstallTests` passed (18 tests
+  in the focused run). `make test` verified 2,624 main app tests plus 2 isolated tests with zero
+  failures; `make check` passed (strict formatting, SwiftLint, 44 script tests); `make build-app`
+  passed and the Debug app contains `Contents/Resources/skills/prowl-cli/SKILL.md`, identical
+  to the source file.
+- Manual: a temporary `Prowl.app/Contents/Resources` layout with the CLI symlinked from a
+  temporary `bin/` on `PATH`; bare-name invocation resolved to the real executable
+  (`BUNDLE_NOT_FOUND` names the resolved path); list → bare install (detected only) →
+  explicit `--target codex` creation → workflow refusal → real-directory conflict with the
+  conflict-free target untouched → project-scope install from a nested directory of a `git
+  init` repo with the note once on stderr and `git status` showing only an untracked
+  `.codex/` → JSON uninstall with zero stderr bytes → user-scope uninstall of all three
+  targets. The live `~/.claude/skills`, `~/.codex/skills`, and `~/.agents/skills` were not
+  read as inputs or modified.
+
+## Refs
+
+- Slice: 065-K2
+- Branch: `feat/bundled-skills-k2`
+- PR: pending
+- Depends on: [003-k1-bundle-registry.md](003-k1-bundle-registry.md)

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -67,6 +67,24 @@ with its contract, schema, manual, and skill line. Settings UI stays in K3.
 - Not in K2: Settings Agent Skills section, `AgentSkillsFeature`, `SkillInstallClient`, copy
   mode, third-party skills, auto-install after updates, Git mutations, new targets.
 
+## Review hardening
+
+Adversarial review round 1 (sibling Pi agent, brief and findings kept outside the repository):
+
+- Project-scope commands followed repository-controlled symlinks: a committed `.agents ->
+  /elsewhere` link let `--scope project` write into (or remove links from) a folder outside the
+  repository while reporting an in-repository path. `ProwlSkillInstaller.projectBoundaryViolation`
+  now refuses a target whose parent or skills directory resolves outside the canonical root, the
+  executor pre-checks every selected target before any change (`INSTALL_CONFLICT`), and the
+  shared `install`/`uninstall` enforce the same rule so K3 cannot bypass it. User scope still
+  follows symlinks on purpose. Symlinks that resolve inside the repository remain accepted.
+- An explicit `--path` accepted any directory, including a non-repository or a nested folder
+  that runtimes never read. Both spellings now resolve to the Git root containing the start
+  point, and a start point outside a repository is `PATH_NOT_FOUND`.
+- The `prowl-cli` skill line implied that all three user targets are always linked; it now says
+  detected targets and points at `--target`. `INVALID_SKILL_FRONTMATTER` joined the manual's
+  error table.
+
 ## Verification
 
 - TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared
@@ -75,7 +93,7 @@ with its contract, schema, manual, and skill line. Settings UI stays in K3.
 - `make build-cli` and `make test-cli-smoke` pass; the smoke target now also runs
   `skills list --json` against a temporary skills root and home with the socket unavailable.
   `make test-cli-unit` passed 120 tests and `make test-cli-integration` passed 102. New
-  coverage: 13 installer, 6 target, 18 executor, 5 parser, 3 schema, and 5 integration tests;
+  coverage: 13 installer, 6 target, 18 executor, 5 parser, 3 schema, and 5 integration tests (review round 1 added 5 boundary/explicit-path tests);
   the integration tests run the real binary with an unavailable `PROWL_CLI_SOCKET`, a temporary
   `PROWL_SKILLS_DIR`, a temporary `HOME`, and a throwaway Git repository, and validate every
   JSON envelope against the schema bundle.

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -99,6 +99,9 @@ xcodebuild's exit code, so its "pass" was wrong — and that the schema accepted
 `destination` required for `broken`, optional for `installed_different_source`, forbidden
 otherwise, with negative fixtures for each invalid combination.
 
+Round 4 re-verified every earlier fix and reported no findings at any level; the review loop
+closed there.
+
 ## Verification
 
 - TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared
@@ -106,17 +109,19 @@ otherwise, with negative fixtures for each invalid combination.
   of `/` yields `/..`), fixed by stopping at the filesystem root.
 - `make build-cli` and `make test-cli-smoke` pass; the smoke target now also runs
   `skills list --json` against a temporary skills root and home with the socket unavailable.
-  `make test-cli-unit` passed 120 tests and `make test-cli-integration` passed 102. New
-  coverage: 13 installer, 6 target, 18 executor, 5 parser, 3 schema, and 5 integration tests (review round 1 added 5 boundary/explicit-path tests);
+  After the review rounds, `make test-cli-unit` passed 128 tests and `make test-cli-integration`
+  passed 102. New coverage: 14 installer, 7 target, 22 executor, 5 parser, 4 schema, and 5
+  integration tests;
   the integration tests run the real binary with an unavailable `PROWL_CLI_SOCKET`, a temporary
   `PROWL_SKILLS_DIR`, a temporary `HOME`, and a throwaway Git repository, and validate every
   JSON envelope against the schema bundle.
 - App: `CLIInstallClientTests` (existing cases plus dangling-link status, live install repair,
   and live uninstall of a dangling link) and `SettingsFeatureCLIInstallTests` passed (18 tests
-  in the focused run). `make test` verified 2,624 main app tests plus 2 isolated tests with zero
-  failures; `make check` passed (strict formatting, SwiftLint, 44 script tests); `make build-app`
-  passed and the Debug app contains `Contents/Resources/skills/prowl-cli/SKILL.md`, identical
-  to the source file.
+  in the focused run, re-run after the round-3 fix). `make test` on the fixed tree verified
+  2,624 main app tests plus 2 isolated tests with zero failures; `make check` passed (strict
+  formatting, SwiftLint, 44 script tests); `make build-app` passed and the Debug app contains
+  `Contents/Resources/skills/prowl-cli/SKILL.md`, identical to the source file, and its bundled
+  `prowl-cli/prowl` resolves the skills beside itself.
 - Manual: a temporary `Prowl.app/Contents/Resources` layout with the CLI symlinked from a
   temporary `bin/` on `PATH`; bare-name invocation resolved to the real executable
   (`BUNDLE_NOT_FOUND` names the resolved path); list → bare install (detected only) →
@@ -131,5 +136,5 @@ otherwise, with negative fixtures for each invalid combination.
 
 - Slice: 065-K2
 - Branch: `feat/bundled-skills-k2`
-- PR: pending
+- PR: #730
 - Depends on: [003-k1-bundle-registry.md](003-k1-bundle-registry.md)

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -91,6 +91,14 @@ Debug/Release switches. The shared status now carries `destination` (resolved ag
 directory; nil for a real file or directory), `list` exposes it as an optional `destination`
 field and `→ path` in text, and the contract, schema, and manual document it.
 
+Round 3 found the app test target no longer compiled after the status change (a hand-rolled
+status closure in `CLIInstallClientTests`; it now delegates to `SymlinkInstaller.status`) — the
+focused Xcode run before the round-2 commit had been read through a pipeline that hid
+xcodebuild's exit code, so its "pass" was wrong — and that the schema accepted
+`destination` on every status. `skillTargetStatus` is now a status-discriminated `oneOf`:
+`destination` required for `broken`, optional for `installed_different_source`, forbidden
+otherwise, with negative fixtures for each invalid combination.
+
 ## Verification
 
 - TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -43,7 +43,8 @@ with its contract, schema, manual, and skill line. Settings UI stays in K3.
   `cli-output-schema.json`, `docs-ai/013-prowl-cli/contracts/skills.md`, `input.md` and
   `schema.md` rows, a `prowl skills` section and error rows in `docs/components/cli.md`, and one
   line in `skills/prowl-cli/SKILL.md` telling an agent that `prowl skills install prowl-cli`
-  keeps it current.
+  keeps it current. The root `prowl --help` discussion also points at `prowl skills install`
+  so a user or an agent discovers the bundled skills before any Settings UI exists.
 
 ## Decisions and boundaries
 

--- a/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
+++ b/docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md
@@ -102,6 +102,16 @@ otherwise, with negative fixtures for each invalid combination.
 Round 4 re-verified every earlier fix and reported no findings at any level; the review loop
 closed there.
 
+Real-environment verification on onevcat's Mac (owner-authorized, restored afterwards) found a
+setup-specific defect the temp-directory tests had not modelled: `~/.claude/skills` and
+`~/.codex/skills` are both symlinks to one synced folder, so the `claude` and `codex` targets
+alias the same link. `uninstall` removed it for `claude`, then hit `notInstalled` for `codex`
+and aborted with `SKILLS_FAILED`, leaving the `agents` link behind; `install` had relinked the
+shared slot and reported `installed` twice. The executor now re-reads each slot right before
+acting on it — an already-installed slot is left alone and an already-empty slot is skipped —
+and the contract documents aliased targets. Pinned by an executor test with two targets
+symlinked to one folder.
+
 ## Verification
 
 - TDD RED: 116 missing-symbol errors across the five new CLI test files before the shared
@@ -122,6 +132,13 @@ closed there.
   formatting, SwiftLint, 44 script tests); `make build-app` passed and the Debug app contains
   `Contents/Resources/skills/prowl-cli/SKILL.md`, identical to the source file, and its bundled
   `prowl-cli/prowl` resolves the skills beside itself.
+- Real environment (owner-authorized): with the Debug app's bundled `prowl-cli/prowl` and no
+  overrides, `skills install prowl-cli` linked the skill into the synced `~/.claude/skills` /
+  `~/.codex/skills` folder and a new `~/.agents/skills`; Codex 0.149.1 `skills/list` returned
+  `prowl-cli` with the bundle path and `errors: []`, and Claude Code 2.1.247 `--debug` reported
+  `user: 29` skills versus `user: 28` after removal — the differential proof that the linked
+  skill was loaded. Everything was uninstalled and the folders restored to their baseline (the
+  synced repository's working tree stayed clean).
 - Manual: a temporary `Prowl.app/Contents/Resources` layout with the CLI symlinked from a
   temporary `bin/` on `PATH`; bare-name invocation resolved to the real executable
   (`BUNDLE_NOT_FOUND` names the resolved path); list → bare install (detected only) →

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -4,7 +4,7 @@
 > an agent) can list panes, read their screens, run commands and capture output,
 > send keystrokes, focus, and open/close tabs and panes programmatically.
 
-**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl agents read, prowl agents signal, prowl profiles list, prowl read, prowl send, prowl key, prowl focus, prowl create, prowl close, prowl open, prowl handoff, pane id, agent, profile, automation, json, capture, socket
+**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl agents read, prowl agents signal, prowl profiles list, prowl skills, skills install, agent skills, prowl read, prowl send, prowl key, prowl focus, prowl create, prowl close, prowl open, prowl handoff, pane id, agent, profile, automation, json, capture, socket
 
 **Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
 
@@ -26,7 +26,9 @@ From the app: **Settings → Agents → Command Line Tool → Install**, or Comm
 Palette → "Install Command Line Tool". This symlinks `prowl` into
 `/usr/local/bin` (prompting for admin if needed). The Settings page also shows
 the local Unix socket path `prowl` uses to reach the app (`PROWL_CLI_SOCKET`
-overrides it for both processes).
+overrides it for both processes). Once `prowl` is installed, `prowl skills install` links
+the bundled `prowl-cli` skill into your agents' skill folders (see
+[`prowl skills`](#prowl-skills)).
 
 ## Global options
 
@@ -329,6 +331,59 @@ Availability is advisory and never blocks launch. Disabled profiles remain visib
 cannot be passed to `create --profile`. Use the Profile UUID for stable automation; an
 exact enabled name also works when unique.
 
+### `prowl skills`
+Link the agent skills bundled inside the Prowl app (`Prowl.app/Contents/Resources/skills/`)
+into agent skill folders as directory symlinks, so every runtime reads the skill version
+that matches the installed app and updates propagate automatically. The whole group is
+**local-only**: it never talks to the socket, never launches the app, and works with Prowl
+closed.
+
+```bash
+prowl skills list [--json]                                   # every bundled skill × target with status
+prowl skills install [<skill>...] [--target <id>]... [--scope user|project] [--path <dir>]
+prowl skills uninstall [<skill>...] [--target <id>]... [--scope user|project] [--path <dir>]
+prowl skills path <skill>                                    # bundled directory, for scripts and workflows
+```
+
+Targets are the verified skill directories; a target is *detected* when its parent
+directory exists:
+
+| `--target` | User scope | Project scope | Read by |
+|---|---|---|---|
+| `claude` | `~/.claude/skills` | `<repo>/.claude/skills` | Claude Code |
+| `codex` | `~/.codex/skills` | `<repo>/.codex/skills` | Codex |
+| `agents` | `~/.agents/skills` | `<repo>/.agents/skills` | Codex, Gemini CLI, Cursor Agent, OpenCode, Copilot CLI, Kimi CLI, Droid, Amp, Qoder CLI, Pi, Oh My Pi, Grok Build |
+
+- A bare `prowl skills install` links every user-installable bundled skill into every
+  detected target; repeat `--target` to pick targets explicitly (an explicit target's
+  directory is created even when it was not detected). Skills tagged `workflow` in `list`
+  belong to workflow runs and refuse installation (`SKILL_NOT_INSTALLABLE`); `path` works
+  for any bundled skill.
+- Statuses: `installed` (link → this app), `not_installed`, `installed_different_source`
+  (a link elsewhere, e.g. a Debug build, or a real directory), `broken` (dangling link —
+  the app moved; `install` repairs it). Existing links are replaced; a real file or
+  directory is never touched and fails the whole command with `INSTALL_CONFLICT` before
+  anything changes. `uninstall` removes links only.
+- `--scope project` uses `--path <repo>` or the Git root of the current directory
+  (worktrees included) and prints one note: the links are absolute, Mac-specific paths and
+  Prowl never edits Git state — use `.git/info/exclude` yourself if they should stay out of
+  version control.
+
+```bash
+prowl skills list
+prowl skills install                                 # all detected user targets
+prowl skills install prowl-cli --target codex        # one skill, one target (creates ~/.codex/skills)
+prowl skills install --scope project --path ~/proj   # project-scoped links
+skill_dir="$(prowl skills path prowl-cli)"
+```
+
+JSON is `prowl.cli.skills.v1` with `data.action` = `list` | `install` | `uninstall` |
+`path`. `list` → `.data.skills[]` with `id`, `name`, `description`, `audience`, `path`,
+and `targets[]` (`id`, `detected`, `path`, `status`); `install`/`uninstall` →
+`.data.scope`, `.data.root`, `.data.results[]` (`skill`, `target`, `path`, `before`,
+`after`) and, for project scope, `.data.note`; `path` → `.data.skill.{id,name,audience,path}`.
+`PROWL_SKILLS_DIR` points the command at a different skills root for development.
+
 ### `prowl read [target]`
 Read a pane's content.
 
@@ -614,16 +669,20 @@ artifacts and terminal excerpts do not appear in `git status`.
 | `AGENT_GONE` | The meaning is mode-specific: a signal caller disappeared, a dispatch worker became terminal, or a generic condition target closed. Inspect `.error.details.mode`; dispatch details retain a record, while condition details retain the requested condition and exact surface observation. |
 | `BLOCKER_UNREADABLE` | A blocked screen was detected but Prowl could not safely extract its current interaction text. Re-run `agents read` or inspect with `read`. |
 | `SESSION_UNRESOLVED` / `RESULT_NOT_FOUND` / `RESULT_INCOMPLETE` / `RESULT_TOO_LARGE` | `agents read --result-only` could not provide one trustworthy complete result. Drop `--result-only` to retain the live snapshot and inspect `.data.result`. |
+| `SKILL_NOT_FOUND` / `TARGET_NOT_FOUND` (`skills`) | No bundled skill or supported target with that id — re-run `prowl skills list`. A bare `skills install` also reports `TARGET_NOT_FOUND` when no target directory is detected; pass `--target`. |
+| `SKILL_NOT_INSTALLABLE` | The skill is a workflow skill; it is materialized by workflow runs, not installed. Use `prowl skills path`. |
+| `INSTALL_CONFLICT` | A real file or directory occupies a skill link slot; nothing was changed. Remove it manually or choose other targets. |
+| `BUNDLE_NOT_FOUND` | The `prowl` binary is not inside a Prowl app bundle and `PROWL_SKILLS_DIR` is unset or invalid — run the installed `prowl` or set the override. |
 | `NO_ACTIVE_PANE` | No pane for focused-target; pass an explicit `--pane`. |
 | `EMPTY_INPUT` | `send` got neither argv nor stdin (or both). |
 | `INVALID_ARGUMENT` | Bad flag/combo (e.g. `--capture --no-wait`) or out-of-range value. |
 | `CAPTURE_UNSUPPORTED` | Target lacks OSC 133 — drop `--capture`, use `read --wait-stable`. |
 | `WAIT_TIMEOUT` | Command didn't finish in time — raise `--timeout` or use `--no-wait`. |
 | `UNSUPPORTED_KEY` / `INVALID_REPEAT` | Check `prowl key --help`. |
-| `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`create tab` path. |
+| `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`create tab` path, or the `skills --scope project` root (`--path`, or run inside a Git repository). |
 | `LAUNCH_FAILED` | App launch or socket wait failed; the message includes the last socket diagnostic when available. |
 | `TRANSPORT_FAILED` | Socket transport failed for a reason other than app availability or permission, such as `ENOTSOCK` or an invalid `PROWL_CLI_SOCKET` path. |
-| `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `PROFILES_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `CREATE_FAILED`, `CLOSE_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`, `HANDOFF_FAILED`) | The action itself failed. |
+| `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `PROFILES_FAILED`, `SKILLS_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `CREATE_FAILED`, `CLOSE_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`, `HANDOFF_FAILED`) | The action itself failed. |
 
 ## Safety & self-targeting
 

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -361,9 +361,11 @@ directory exists:
   for any bundled skill.
 - Statuses: `installed` (link → this app), `not_installed`, `installed_different_source`
   (a link elsewhere, e.g. a Debug build, or a real directory), `broken` (dangling link —
-  the app moved; `install` repairs it). Existing links are replaced; a real file or
-  directory is never touched and fails the whole command with `INSTALL_CONFLICT` before
-  anything changes. `uninstall` removes links only.
+  the app moved; `install` repairs it). For a foreign or dangling link, `list` also names
+  where it points (`destination` in JSON, `→ path` in text), so you can tell which app owns
+  the link before replacing it. Existing links are replaced; a real file or directory is
+  never touched and fails the whole command with `INSTALL_CONFLICT` before anything
+  changes. `uninstall` removes links only.
 - `--scope project` acts on a repository: the Git root containing `--path <dir>` (or the
   current directory; worktrees included). Links never leave the repository — a target folder
   such as `.agents` that is a symlink to somewhere outside it fails with `INSTALL_CONFLICT`.
@@ -381,7 +383,7 @@ skill_dir="$(prowl skills path prowl-cli)"
 
 JSON is `prowl.cli.skills.v1` with `data.action` = `list` | `install` | `uninstall` |
 `path`. `list` → `.data.skills[]` with `id`, `name`, `description`, `audience`, `path`,
-and `targets[]` (`id`, `detected`, `path`, `status`); `install`/`uninstall` →
+and `targets[]` (`id`, `detected`, `path`, `status`, optional `destination`); `install`/`uninstall` →
 `.data.scope`, `.data.root`, `.data.results[]` (`skill`, `target`, `path`, `before`,
 `after`) and, for project scope, `.data.note`; `path` → `.data.skill.{id,name,audience,path}`.
 `PROWL_SKILLS_DIR` points the command at a different skills root for development.

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -364,10 +364,12 @@ directory exists:
   the app moved; `install` repairs it). Existing links are replaced; a real file or
   directory is never touched and fails the whole command with `INSTALL_CONFLICT` before
   anything changes. `uninstall` removes links only.
-- `--scope project` uses `--path <repo>` or the Git root of the current directory
-  (worktrees included) and prints one note: the links are absolute, Mac-specific paths and
-  Prowl never edits Git state — use `.git/info/exclude` yourself if they should stay out of
-  version control.
+- `--scope project` acts on a repository: the Git root containing `--path <dir>` (or the
+  current directory; worktrees included). Links never leave the repository — a target folder
+  such as `.agents` that is a symlink to somewhere outside it fails with `INSTALL_CONFLICT`.
+  The command prints one note: the links are absolute, Mac-specific paths and Prowl never
+  edits Git state — use `.git/info/exclude` yourself if they should stay out of version
+  control.
 
 ```bash
 prowl skills list
@@ -671,15 +673,16 @@ artifacts and terminal excerpts do not appear in `git status`.
 | `SESSION_UNRESOLVED` / `RESULT_NOT_FOUND` / `RESULT_INCOMPLETE` / `RESULT_TOO_LARGE` | `agents read --result-only` could not provide one trustworthy complete result. Drop `--result-only` to retain the live snapshot and inspect `.data.result`. |
 | `SKILL_NOT_FOUND` / `TARGET_NOT_FOUND` (`skills`) | No bundled skill or supported target with that id — re-run `prowl skills list`. A bare `skills install` also reports `TARGET_NOT_FOUND` when no target directory is detected; pass `--target`. |
 | `SKILL_NOT_INSTALLABLE` | The skill is a workflow skill; it is materialized by workflow runs, not installed. Use `prowl skills path`. |
-| `INSTALL_CONFLICT` | A real file or directory occupies a skill link slot; nothing was changed. Remove it manually or choose other targets. |
+| `INSTALL_CONFLICT` | A real file or directory occupies a skill link slot, or a project-scope target folder is a symlink leading outside the repository; nothing was changed. Remove or fix it manually, or choose other targets. |
 | `BUNDLE_NOT_FOUND` | The `prowl` binary is not inside a Prowl app bundle and `PROWL_SKILLS_DIR` is unset or invalid — run the installed `prowl` or set the override. |
+| `INVALID_SKILL_FRONTMATTER` | A bundled (or `PROWL_SKILLS_DIR`) skill's `SKILL.md` frontmatter is malformed — fix the override skill, or reinstall Prowl if the bundle itself is damaged. |
 | `NO_ACTIVE_PANE` | No pane for focused-target; pass an explicit `--pane`. |
 | `EMPTY_INPUT` | `send` got neither argv nor stdin (or both). |
 | `INVALID_ARGUMENT` | Bad flag/combo (e.g. `--capture --no-wait`) or out-of-range value. |
 | `CAPTURE_UNSUPPORTED` | Target lacks OSC 133 — drop `--capture`, use `read --wait-stable`. |
 | `WAIT_TIMEOUT` | Command didn't finish in time — raise `--timeout` or use `--no-wait`. |
 | `UNSUPPORTED_KEY` / `INVALID_REPEAT` | Check `prowl key --help`. |
-| `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`create tab` path, or the `skills --scope project` root (`--path`, or run inside a Git repository). |
+| `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`create tab` path, or the `skills --scope project` start point (`--path` and the current directory must lie inside a Git repository). |
 | `LAUNCH_FAILED` | App launch or socket wait failed; the message includes the last socket diagnostic when available. |
 | `TRANSPORT_FAILED` | Socket transport failed for a reason other than app availability or permission, such as `ENOTSOCK` or an invalid `PROWL_CLI_SOCKET` path. |
 | `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `PROFILES_FAILED`, `SKILLS_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `CREATE_FAILED`, `CLOSE_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`, `HANDOFF_FAILED`) | The action itself failed. |

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -17,6 +17,8 @@ ls "$prowl_docs/components/"   # cli.md, agent-detection.md, handoff.md, …
 
 Other `docs/components/*.md` references below live in that same folder.
 
+This skill ships inside the app: `prowl skills install prowl-cli` links it into `~/.claude/skills`, `~/.codex/skills`, and `~/.agents/skills` so it stays current across app updates (`prowl skills list` shows the status; the command is local and needs no running app).
+
 ## Who You Are
 
 Every Prowl pane exports its own identity to the processes inside it:
@@ -249,4 +251,4 @@ Required sections are `## Objective`, `## Current State`, and `## Next Steps`; o
 
 ## Command Set
 
-`list`, `agents`, `agents read`, `agents signal`, `agents dispatch-complete`, `agents dispatch-abandon`, `agents wait`, `profiles list`, `read`, `send`, `key`, `focus`, `create tab`, `create pane`, `close`, `handoff to`, `handoff save`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with an explicit `close`. `tab create`, `tab close`, and `pane close` remain deprecated aliases for one release.
+`list`, `agents`, `agents read`, `agents signal`, `agents dispatch-complete`, `agents dispatch-abandon`, `agents wait`, `profiles list`, `skills list|install|uninstall|path` (local-only), `read`, `send`, `key`, `focus`, `create tab`, `create pane`, `close`, `handoff to`, `handoff save`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with an explicit `close`. `tab create`, `tab close`, and `pane close` remain deprecated aliases for one release.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -17,7 +17,7 @@ ls "$prowl_docs/components/"   # cli.md, agent-detection.md, handoff.md, …
 
 Other `docs/components/*.md` references below live in that same folder.
 
-This skill ships inside the app: `prowl skills install prowl-cli` links it into `~/.claude/skills`, `~/.codex/skills`, and `~/.agents/skills` so it stays current across app updates (`prowl skills list` shows the status; the command is local and needs no running app).
+This skill ships inside the app: `prowl skills install prowl-cli` links it into every detected agent skill folder (`~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills` — whichever parent directories exist; add `--target <claude|codex|agents>` to pick or create specific ones) so it stays current across app updates. `prowl skills list` shows per-target status; the command is local and needs no running app.
 
 ## Who You Are
 

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -45,6 +45,13 @@ public enum CLIErrorCode {
   // Profiles
   public static let profilesFailed = "PROFILES_FAILED"
 
+  // Skills
+  public static let skillsFailed = "SKILLS_FAILED"
+  public static let skillNotFound = "SKILL_NOT_FOUND"
+  public static let skillNotInstallable = "SKILL_NOT_INSTALLABLE"
+  public static let installConflict = "INSTALL_CONFLICT"
+  public static let bundleNotFound = "BUNDLE_NOT_FOUND"
+
   // Focus
   public static let focusFailed = "FOCUS_FAILED"
 

--- a/supacode/CLIService/Shared/ProwlSkills.swift
+++ b/supacode/CLIService/Shared/ProwlSkills.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated public enum ProwlSkillAudience: String, Equatable, Sendable {
+nonisolated public enum ProwlSkillAudience: String, Codable, Equatable, Sendable {
   case user
   case workflow
 }

--- a/supacode/CLIService/Shared/SkillInstallTarget.swift
+++ b/supacode/CLIService/Shared/SkillInstallTarget.swift
@@ -89,12 +89,14 @@ nonisolated public enum ProwlSkillInstaller {
   }
 
   /// Creates the target directory when missing and links the bundled skill directory.
+  /// In project scope, a target directory that resolves outside the project root is refused.
   public static func install(
     skill: BundledSkill,
     target: SkillInstallTarget,
     scope: ProwlSkillScope,
     root: URL
   ) throws -> SkillTargetStatus {
+    try enforceProjectBoundary(target: target, scope: scope, root: root)
     try SymlinkInstaller.install(
       source: sourcePath(skill),
       linkPath: linkPath(skill: skill, target: target, scope: scope, root: root)
@@ -108,8 +110,40 @@ nonisolated public enum ProwlSkillInstaller {
     scope: ProwlSkillScope,
     root: URL
   ) throws -> SkillTargetStatus {
+    try enforceProjectBoundary(target: target, scope: scope, root: root)
     try SymlinkInstaller.uninstall(linkPath: linkPath(skill: skill, target: target, scope: scope, root: root))
     return status(skill: skill, target: target, scope: scope, root: root)
+  }
+
+  /// The first target path component (`<root>/.codex` or `<root>/.codex/skills`) that exists but
+  /// resolves outside the canonical project root, or `nil` when the slot stays inside the project.
+  /// A repository-controlled symlink must not redirect a project-scoped link into another folder;
+  /// user scope deliberately follows symlinks because synced skill folders are an approved setup.
+  public static func projectBoundaryViolation(target: SkillInstallTarget, root: URL) -> String? {
+    let canonicalRoot = realPath(root)
+    let skillsDirectory = target.skillsDirectoryURL(scope: .project, root: root)
+    for candidate in [skillsDirectory.deletingLastPathComponent(), skillsDirectory] {
+      let path = candidate.path(percentEncoded: false).trimmingTrailingPathSeparator()
+      guard (try? FileManager.default.attributesOfItem(atPath: path)) != nil else { continue }
+      let resolved = realPath(candidate)
+      if resolved != canonicalRoot, !resolved.hasPrefix(canonicalRoot + "/") {
+        return path
+      }
+    }
+    return nil
+  }
+
+  private static func enforceProjectBoundary(
+    target: SkillInstallTarget,
+    scope: ProwlSkillScope,
+    root: URL
+  ) throws {
+    guard scope == .project, let path = projectBoundaryViolation(target: target, root: root) else { return }
+    throw SymlinkInstallError.conflict(path: path)
+  }
+
+  private static func realPath(_ url: URL) -> String {
+    url.standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false).trimmingTrailingPathSeparator()
   }
 
   public static func sourcePath(_ skill: BundledSkill) -> String {

--- a/supacode/CLIService/Shared/SkillInstallTarget.swift
+++ b/supacode/CLIService/Shared/SkillInstallTarget.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+nonisolated public enum ProwlSkillScope: String, Codable, Equatable, Sendable {
+  case user
+  case project
+}
+
+/// One verified agent skill directory (065 S0). Directories are relative to the scope root:
+/// the user's home directory or a project root.
+nonisolated public struct SkillInstallTarget: Equatable, Sendable, Identifiable {
+  public let id: String
+  public let displayName: String
+  public let userDirectory: String
+  public let projectDirectory: String
+
+  public static let all: [SkillInstallTarget] = [
+    SkillInstallTarget(
+      id: "claude",
+      displayName: "Claude Code",
+      userDirectory: ".claude/skills",
+      projectDirectory: ".claude/skills"
+    ),
+    SkillInstallTarget(
+      id: "codex",
+      displayName: "Codex",
+      userDirectory: ".codex/skills",
+      projectDirectory: ".codex/skills"
+    ),
+    SkillInstallTarget(
+      id: "agents",
+      displayName: "Shared agents directory",
+      userDirectory: ".agents/skills",
+      projectDirectory: ".agents/skills"
+    ),
+  ]
+
+  public static func target(id: String) -> SkillInstallTarget? {
+    all.first { $0.id == id }
+  }
+
+  public func skillsDirectoryURL(scope: ProwlSkillScope, root: URL) -> URL {
+    let directory =
+      switch scope {
+      case .user: userDirectory
+      case .project: projectDirectory
+      }
+    return root.appending(path: directory, directoryHint: .isDirectory)
+  }
+
+  /// A target is detected when the parent of its skills directory (for example `~/.codex`)
+  /// exists, so a runtime that was never set up is not selected by default.
+  public func isDetected(scope: ProwlSkillScope, root: URL) -> Bool {
+    let parent = skillsDirectoryURL(scope: scope, root: root).deletingLastPathComponent()
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: parent.path(percentEncoded: false), isDirectory: &isDirectory)
+      && isDirectory.boolValue
+  }
+}
+
+nonisolated public struct SkillTargetStatus: Equatable, Sendable {
+  public let target: SkillInstallTarget
+  public let detected: Bool
+  public let linkPath: String
+  public let status: SymlinkInstallStatus
+
+  public init(target: SkillInstallTarget, detected: Bool, linkPath: String, status: SymlinkInstallStatus) {
+    self.target = target
+    self.detected = detected
+    self.linkPath = linkPath
+    self.status = status
+  }
+}
+
+/// Skill × target link operations shared by `prowl skills` and the Settings UI.
+nonisolated public enum ProwlSkillInstaller {
+  public static func status(
+    skill: BundledSkill,
+    target: SkillInstallTarget,
+    scope: ProwlSkillScope,
+    root: URL
+  ) -> SkillTargetStatus {
+    let linkPath = linkPath(skill: skill, target: target, scope: scope, root: root)
+    return SkillTargetStatus(
+      target: target,
+      detected: target.isDetected(scope: scope, root: root),
+      linkPath: linkPath,
+      status: SymlinkInstaller.status(linkPath: linkPath, source: sourcePath(skill))
+    )
+  }
+
+  /// Creates the target directory when missing and links the bundled skill directory.
+  public static func install(
+    skill: BundledSkill,
+    target: SkillInstallTarget,
+    scope: ProwlSkillScope,
+    root: URL
+  ) throws -> SkillTargetStatus {
+    try SymlinkInstaller.install(
+      source: sourcePath(skill),
+      linkPath: linkPath(skill: skill, target: target, scope: scope, root: root)
+    )
+    return status(skill: skill, target: target, scope: scope, root: root)
+  }
+
+  public static func uninstall(
+    skill: BundledSkill,
+    target: SkillInstallTarget,
+    scope: ProwlSkillScope,
+    root: URL
+  ) throws -> SkillTargetStatus {
+    try SymlinkInstaller.uninstall(linkPath: linkPath(skill: skill, target: target, scope: scope, root: root))
+    return status(skill: skill, target: target, scope: scope, root: root)
+  }
+
+  public static func sourcePath(_ skill: BundledSkill) -> String {
+    skill.directoryURL.path(percentEncoded: false).trimmingTrailingPathSeparator()
+  }
+
+  private static func linkPath(
+    skill: BundledSkill,
+    target: SkillInstallTarget,
+    scope: ProwlSkillScope,
+    root: URL
+  ) -> String {
+    target.skillsDirectoryURL(scope: scope, root: root)
+      .appending(path: skill.id, directoryHint: .notDirectory)
+      .path(percentEncoded: false)
+      .trimmingTrailingPathSeparator()
+  }
+}

--- a/supacode/CLIService/Shared/SkillsCommandPayload.swift
+++ b/supacode/CLIService/Shared/SkillsCommandPayload.swift
@@ -106,12 +106,22 @@ public struct SkillsCommandTargetStatus: Codable, Equatable, Sendable {
   /// The link slot for this skill inside the target's skills directory.
   public let path: String
   public let status: SkillsCommandStatus
+  /// Where a foreign or dangling link points; omitted for `installed`, `not_installed`, and a
+  /// real file or directory occupying the slot.
+  public let destination: String?
 
-  public init(id: String, detected: Bool, path: String, status: SkillsCommandStatus) {
+  public init(
+    id: String,
+    detected: Bool,
+    path: String,
+    status: SkillsCommandStatus,
+    destination: String? = nil
+  ) {
     self.id = id
     self.detected = detected
     self.path = path
     self.status = status
+    self.destination = destination
   }
 }
 

--- a/supacode/CLIService/Shared/SkillsCommandPayload.swift
+++ b/supacode/CLIService/Shared/SkillsCommandPayload.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// `prowl skills` response data, discriminated by `action`.
+public enum SkillsCommandPayload: Codable, Equatable, Sendable {
+  public static let schemaVersion = "prowl.cli.skills.v1"
+
+  case list(SkillsListPayload)
+  case install(SkillsChangePayload)
+  case uninstall(SkillsChangePayload)
+  case path(SkillsPathPayload)
+
+  public var action: SkillsCommandAction {
+    switch self {
+    case .list: .list
+    case .install: .install
+    case .uninstall: .uninstall
+    case .path: .path
+    }
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case action
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    switch try container.decode(SkillsCommandAction.self, forKey: .action) {
+    case .list: self = .list(try SkillsListPayload(from: decoder))
+    case .install: self = .install(try SkillsChangePayload(from: decoder))
+    case .uninstall: self = .uninstall(try SkillsChangePayload(from: decoder))
+    case .path: self = .path(try SkillsPathPayload(from: decoder))
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(action, forKey: .action)
+    switch self {
+    case .list(let payload): try payload.encode(to: encoder)
+    case .install(let payload), .uninstall(let payload): try payload.encode(to: encoder)
+    case .path(let payload): try payload.encode(to: encoder)
+    }
+  }
+}
+
+public enum SkillsCommandAction: String, Codable, Equatable, Sendable {
+  case list
+  case install
+  case uninstall
+  case path
+}
+
+public enum SkillsCommandStatus: String, Codable, Equatable, Sendable {
+  case notInstalled = "not_installed"
+  case installed
+  case installedDifferentSource = "installed_different_source"
+  case broken
+
+  public init(_ status: SymlinkInstallStatus) {
+    switch status {
+    case .notInstalled: self = .notInstalled
+    case .installed: self = .installed
+    case .installedDifferentSource: self = .installedDifferentSource
+    case .broken: self = .broken
+    }
+  }
+}
+
+public struct SkillsListPayload: Codable, Equatable, Sendable {
+  public let skills: [SkillsCommandSkill]
+
+  public init(skills: [SkillsCommandSkill]) {
+    self.skills = skills
+  }
+}
+
+public struct SkillsCommandSkill: Codable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let description: String
+  public let audience: ProwlSkillAudience
+  /// Canonical bundled skill directory.
+  public let path: String
+  public let targets: [SkillsCommandTargetStatus]
+
+  public init(
+    id: String,
+    name: String,
+    description: String,
+    audience: ProwlSkillAudience,
+    path: String,
+    targets: [SkillsCommandTargetStatus]
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.audience = audience
+    self.path = path
+    self.targets = targets
+  }
+}
+
+public struct SkillsCommandTargetStatus: Codable, Equatable, Sendable {
+  public let id: String
+  public let detected: Bool
+  /// The link slot for this skill inside the target's skills directory.
+  public let path: String
+  public let status: SkillsCommandStatus
+
+  public init(id: String, detected: Bool, path: String, status: SkillsCommandStatus) {
+    self.id = id
+    self.detected = detected
+    self.path = path
+    self.status = status
+  }
+}
+
+public struct SkillsChangePayload: Codable, Equatable, Sendable {
+  public let scope: ProwlSkillScope
+  /// The scope root: the home directory for `user`, the project root for `project`.
+  public let root: String
+  public let results: [SkillsCommandResult]
+  /// Project-scope hygiene note; omitted for user scope.
+  public let note: String?
+
+  public init(scope: ProwlSkillScope, root: String, results: [SkillsCommandResult], note: String? = nil) {
+    self.scope = scope
+    self.root = root
+    self.results = results
+    self.note = note
+  }
+}
+
+public struct SkillsCommandResult: Codable, Equatable, Sendable {
+  public let skill: String
+  public let target: String
+  public let path: String
+  public let before: SkillsCommandStatus
+  public let after: SkillsCommandStatus
+
+  public init(skill: String, target: String, path: String, before: SkillsCommandStatus, after: SkillsCommandStatus) {
+    self.skill = skill
+    self.target = target
+    self.path = path
+    self.before = before
+    self.after = after
+  }
+}
+
+public struct SkillsPathPayload: Codable, Equatable, Sendable {
+  public let skill: SkillsCommandSkillReference
+
+  public init(skill: SkillsCommandSkillReference) {
+    self.skill = skill
+  }
+}
+
+public struct SkillsCommandSkillReference: Codable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let audience: ProwlSkillAudience
+  public let path: String
+
+  public init(id: String, name: String, audience: ProwlSkillAudience, path: String) {
+    self.id = id
+    self.name = name
+    self.audience = audience
+    self.path = path
+  }
+}

--- a/supacode/CLIService/Shared/SymlinkInstaller.swift
+++ b/supacode/CLIService/Shared/SymlinkInstaller.swift
@@ -5,10 +5,20 @@ nonisolated public enum SymlinkInstallStatus: Equatable, Sendable {
   case notInstalled
   /// A symlink that resolves to the expected source.
   case installed(path: String)
-  /// A symlink to another live source, or a real file/directory occupying the slot.
-  case installedDifferentSource(path: String)
-  /// A dangling symlink: its destination no longer exists.
-  case broken(path: String)
+  /// A symlink to another live source (`destination` names it, resolved against the link's
+  /// directory), or a real file/directory occupying the slot (`destination` is nil).
+  case installedDifferentSource(path: String, destination: String?)
+  /// A dangling symlink: `destination` no longer exists.
+  case broken(path: String, destination: String)
+
+  /// Where the occupying symlink points, when the slot holds a symlink that is not the expected source.
+  public var destination: String? {
+    switch self {
+    case .installedDifferentSource(_, let destination): destination
+    case .broken(_, let destination): destination
+    case .notInstalled, .installed: nil
+    }
+  }
 }
 
 nonisolated public enum SymlinkInstallError: Error, Equatable, Sendable, LocalizedError {
@@ -40,16 +50,16 @@ nonisolated public enum SymlinkInstaller {
     case .absent:
       return .notInstalled
     case .other:
-      return .installedDifferentSource(path: linkPath)
+      return .installedDifferentSource(path: linkPath, destination: nil)
     case .symlink(let destination):
       let resolvedDestination = resolve(destination, relativeTo: linkPath)
       guard FileManager.default.fileExists(atPath: resolvedDestination) else {
-        return .broken(path: linkPath)
+        return .broken(path: linkPath, destination: resolvedDestination)
       }
       if destination == source || realPath(resolvedDestination) == realPath(source) {
         return .installed(path: linkPath)
       }
-      return .installedDifferentSource(path: linkPath)
+      return .installedDifferentSource(path: linkPath, destination: resolvedDestination)
     }
   }
 

--- a/supacode/CLIService/Shared/SymlinkInstaller.swift
+++ b/supacode/CLIService/Shared/SymlinkInstaller.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Status of one symlink slot shared by the CLI installer (`/usr/local/bin/prowl`) and skill links.
+nonisolated public enum SymlinkInstallStatus: Equatable, Sendable {
+  case notInstalled
+  /// A symlink that resolves to the expected source.
+  case installed(path: String)
+  /// A symlink to another live source, or a real file/directory occupying the slot.
+  case installedDifferentSource(path: String)
+  /// A dangling symlink: its destination no longer exists.
+  case broken(path: String)
+}
+
+nonisolated public enum SymlinkInstallError: Error, Equatable, Sendable, LocalizedError {
+  case sourceNotFound(path: String)
+  /// A real file or directory occupies the slot; it is never replaced or removed.
+  case conflict(path: String)
+  case notInstalled(path: String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .sourceNotFound(let path):
+      "Link source not found at \(path)."
+    case .conflict(let path):
+      "A file already exists at \(path) and is not a symlink. Remove it manually before continuing."
+    case .notInstalled(let path):
+      "No symlink found at \(path)."
+    }
+  }
+}
+
+/// Foundation-only symlink status/install/uninstall used by the app and the standalone CLI.
+///
+/// Real files and directories are never touched: `install` refuses them with `conflict` before
+/// any mutation and `uninstall` removes symlinks only. Filesystem errors other than the typed
+/// cases propagate unchanged so callers can escalate privileges when appropriate.
+nonisolated public enum SymlinkInstaller {
+  public static func status(linkPath: String, source: String) -> SymlinkInstallStatus {
+    switch occupant(at: linkPath) {
+    case .absent:
+      return .notInstalled
+    case .other:
+      return .installedDifferentSource(path: linkPath)
+    case .symlink(let destination):
+      let resolvedDestination = resolve(destination, relativeTo: linkPath)
+      guard FileManager.default.fileExists(atPath: resolvedDestination) else {
+        return .broken(path: linkPath)
+      }
+      if destination == source || realPath(resolvedDestination) == realPath(source) {
+        return .installed(path: linkPath)
+      }
+      return .installedDifferentSource(path: linkPath)
+    }
+  }
+
+  /// Returns `true` when a real file or directory occupies the slot.
+  public static func hasConflict(linkPath: String) -> Bool {
+    if case .other = occupant(at: linkPath) {
+      return true
+    }
+    return false
+  }
+
+  public static func install(source: String, linkPath: String) throws {
+    guard FileManager.default.fileExists(atPath: source) else {
+      throw SymlinkInstallError.sourceNotFound(path: source)
+    }
+    switch occupant(at: linkPath) {
+    case .other:
+      throw SymlinkInstallError.conflict(path: linkPath)
+    case .symlink:
+      try FileManager.default.removeItem(atPath: linkPath)
+    case .absent:
+      break
+    }
+    let directory = (linkPath as NSString).deletingLastPathComponent
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: source)
+  }
+
+  public static func uninstall(linkPath: String) throws {
+    switch occupant(at: linkPath) {
+    case .absent:
+      throw SymlinkInstallError.notInstalled(path: linkPath)
+    case .other:
+      throw SymlinkInstallError.conflict(path: linkPath)
+    case .symlink:
+      try FileManager.default.removeItem(atPath: linkPath)
+    }
+  }
+
+  private enum Occupant {
+    case absent
+    case symlink(destination: String)
+    case other
+  }
+
+  /// Inspects the slot itself without following a symlink, so dangling links are still visible.
+  private static func occupant(at path: String) -> Occupant {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+      return .absent
+    }
+    guard attributes[.type] as? FileAttributeType == .typeSymbolicLink,
+      let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path)
+    else {
+      return .other
+    }
+    return .symlink(destination: destination)
+  }
+
+  private static func resolve(_ destination: String, relativeTo linkPath: String) -> String {
+    guard !destination.hasPrefix("/") else { return destination }
+    let directory = (linkPath as NSString).deletingLastPathComponent
+    return (directory as NSString).appendingPathComponent(destination)
+  }
+
+  private static func realPath(_ path: String) -> String {
+    URL(filePath: path).standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false)
+      .trimmingTrailingPathSeparator()
+  }
+}
+
+extension String {
+  /// Removes trailing path separators so directory URLs and link targets compare as plain paths.
+  nonisolated public func trimmingTrailingPathSeparator() -> String {
+    var value = self
+    while value.count > 1, value.hasSuffix("/") {
+      value.removeLast()
+    }
+    return value
+  }
+}

--- a/supacode/Clients/CLIInstall/CLIInstallClient.swift
+++ b/supacode/Clients/CLIInstall/CLIInstallClient.swift
@@ -1,11 +1,7 @@
 import ComposableArchitecture
 import Foundation
 
-enum CLIInstallStatus: Equatable, Sendable {
-  case notInstalled
-  case installed(path: String)
-  case installedDifferentSource(path: String)
-}
+typealias CLIInstallStatus = SymlinkInstallStatus
 
 struct CLIInstallError: Error, Equatable, Sendable, LocalizedError {
   let message: String
@@ -28,58 +24,24 @@ extension CLIInstallClient: DependencyKey {
       Bundle.main.resourceURL?.appendingPathComponent("prowl-cli/prowl")
     },
     installationStatus: { installPath in
-      let fileManager = FileManager.default
-      let path = installPath.path(percentEncoded: false)
-      guard fileManager.fileExists(atPath: path) else {
-        return .notInstalled
-      }
-      guard let attrs = try? fileManager.attributesOfItem(atPath: path),
-        attrs[.type] as? FileAttributeType == .typeSymbolicLink,
-        let destination = try? fileManager.destinationOfSymbolicLink(atPath: path)
-      else {
-        return .installedDifferentSource(path: path)
-      }
       let bundledURL = Bundle.main.resourceURL?.appendingPathComponent("prowl-cli/prowl")
-      let bundledPath = bundledURL?.path(percentEncoded: false) ?? ""
-      if destination == bundledPath {
-        return .installed(path: path)
-      }
-      return .installedDifferentSource(path: path)
+      return SymlinkInstaller.status(
+        linkPath: installPath.path(percentEncoded: false),
+        source: bundledURL?.path(percentEncoded: false) ?? ""
+      )
     },
     install: { installPath in
-      let fileManager = FileManager.default
       guard let bundledURL = Bundle.main.resourceURL?.appendingPathComponent("prowl-cli/prowl") else {
         throw CLIInstallError(message: "Could not locate bundled CLI binary.")
       }
       let bundledPath = bundledURL.path(percentEncoded: false)
-      guard fileManager.fileExists(atPath: bundledPath) else {
+      guard FileManager.default.fileExists(atPath: bundledPath) else {
         throw CLIInstallError(message: "Bundled CLI binary not found at \(bundledPath).")
       }
-      let destination = installPath.path(percentEncoded: false)
-      if fileManager.fileExists(atPath: destination) {
-        let attrs = try? fileManager.attributesOfItem(atPath: destination)
-        let isSymlink = attrs?[.type] as? FileAttributeType == .typeSymbolicLink
-        guard isSymlink else {
-          throw CLIInstallError(
-            message: "A file already exists at \(destination) and is not a symlink. "
-              + "Remove it manually before installing."
-          )
-        }
-      }
-      try cliSymlinkInstall(source: bundledPath, destination: destination)
+      try cliSymlinkInstall(source: bundledPath, destination: installPath.path(percentEncoded: false))
     },
     uninstall: { installPath in
-      let fileManager = FileManager.default
-      let path = installPath.path(percentEncoded: false)
-      guard fileManager.fileExists(atPath: path) else {
-        throw CLIInstallError(message: "No CLI tool found at \(path).")
-      }
-      guard let attrs = try? fileManager.attributesOfItem(atPath: path),
-        attrs[.type] as? FileAttributeType == .typeSymbolicLink
-      else {
-        throw CLIInstallError(message: "File at \(path) is not a symlink. Refusing to remove for safety.")
-      }
-      try cliSymlinkUninstall(path: path)
+      try cliSymlinkUninstall(path: installPath.path(percentEncoded: false))
     }
   )
 
@@ -93,26 +55,24 @@ extension CLIInstallClient: DependencyKey {
 
 // MARK: - Symlink operations with privilege escalation
 
-/// Attempts to create the CLI symlink. Falls back to osascript privilege escalation on permission failure.
+/// Creates the CLI symlink through the shared installer. Falls back to osascript privilege
+/// escalation on permission failure; conflicts and other typed failures surface as-is.
 private nonisolated func cliSymlinkInstall(source: String, destination: String) throws {
-  let fileManager = FileManager.default
-  let dir = (destination as NSString).deletingLastPathComponent
-
-  // Try direct approach first
   do {
-    if !fileManager.fileExists(atPath: dir) {
-      try fileManager.createDirectory(atPath: dir, withIntermediateDirectories: true)
-    }
-    if fileManager.fileExists(atPath: destination) {
-      try fileManager.removeItem(atPath: destination)
-    }
-    try fileManager.createSymbolicLink(atPath: destination, withDestinationPath: source)
+    try SymlinkInstaller.install(source: source, linkPath: destination)
     return
+  } catch SymlinkInstallError.conflict {
+    throw CLIInstallError(
+      message: "A file already exists at \(destination) and is not a symlink. "
+        + "Remove it manually before installing."
+    )
+  } catch let error as SymlinkInstallError {
+    throw CLIInstallError(message: error.localizedDescription)
   } catch let error as NSError where isPermissionError(error) {
     // Fall through to privilege escalation
   }
 
-  // Privilege escalation via osascript
+  let dir = (destination as NSString).deletingLastPathComponent
   let script =
     "mkdir -p '\(shellEscape(dir))' && "
     + "rm -f '\(shellEscape(destination))' && "
@@ -120,13 +80,18 @@ private nonisolated func cliSymlinkInstall(source: String, destination: String) 
   try runPrivileged(script: script)
 }
 
-/// Attempts to remove the CLI symlink. Falls back to osascript privilege escalation on permission failure.
+/// Removes the CLI symlink through the shared installer. Falls back to osascript privilege
+/// escalation on permission failure; real files are refused before any attempt.
 private nonisolated func cliSymlinkUninstall(path: String) throws {
-  let fileManager = FileManager.default
-
   do {
-    try fileManager.removeItem(atPath: path)
+    try SymlinkInstaller.uninstall(linkPath: path)
     return
+  } catch SymlinkInstallError.notInstalled {
+    throw CLIInstallError(message: "No CLI tool found at \(path).")
+  } catch SymlinkInstallError.conflict {
+    throw CLIInstallError(message: "File at \(path) is not a symlink. Refusing to remove for safety.")
+  } catch let error as SymlinkInstallError {
+    throw CLIInstallError(message: error.localizedDescription)
   } catch let error as NSError where isPermissionError(error) {
     // Fall through to privilege escalation
   }

--- a/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
+++ b/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
@@ -23,6 +23,11 @@ struct CommandLineToolSettingsView: View {
                 .foregroundStyle(.yellow)
                 .accessibilityLabel("Different version")
               Text("A different version exists at \(path)")
+            case .broken(let path):
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+                .accessibilityLabel("Broken link")
+              Text("A broken link exists at \(path)")
             case .notInstalled:
               Image(systemName: "xmark.circle")
                 .foregroundStyle(.secondary)
@@ -55,6 +60,12 @@ struct CommandLineToolSettingsView: View {
                 store.send(.installCLIButtonTapped())
               }
               .help("Replace the existing prowl command with the version bundled in this app")
+              .buttonStyle(.bordered)
+            case .broken:
+              Button("Repair") {
+                store.send(.installCLIButtonTapped())
+              }
+              .help("Replace the broken prowl link with the version bundled in this app")
               .buttonStyle(.bordered)
             }
           }

--- a/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
+++ b/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
@@ -18,12 +18,12 @@ struct CommandLineToolSettingsView: View {
                 .foregroundStyle(.green)
                 .accessibilityLabel("Installed")
               Text("Installed at \(path)")
-            case .installedDifferentSource(let path):
+            case .installedDifferentSource(let path, _):
               Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.yellow)
                 .accessibilityLabel("Different version")
               Text("A different version exists at \(path)")
-            case .broken(let path):
+            case .broken(let path, _):
               Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.yellow)
                 .accessibilityLabel("Broken link")

--- a/supacodeTests/CLIInstallClientTests.swift
+++ b/supacodeTests/CLIInstallClientTests.swift
@@ -94,6 +94,56 @@ struct CLIInstallClientTests {
     #expect(status == .installedDifferentSource(path: installPath.path))
   }
 
+  @Test func statusBrokenWhenSymlinkIsDangling() throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+
+    let installPath = tmp.appendingPathComponent("prowl")
+    try FileManager.default.createSymbolicLink(
+      atPath: installPath.path,
+      withDestinationPath: tmp.appendingPathComponent("moved-away").path
+    )
+
+    let client = CLIInstallClient.liveValue
+    let status = client.installationStatus(installPath)
+
+    #expect(status == .broken(path: installPath.path))
+  }
+
+  @Test func liveInstallReplacesDanglingSymlinkWithBundledCLI() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+
+    let installPath = tmp.appendingPathComponent("prowl")
+    try FileManager.default.createSymbolicLink(
+      atPath: installPath.path,
+      withDestinationPath: tmp.appendingPathComponent("moved-away").path
+    )
+
+    let client = CLIInstallClient.liveValue
+    let bundled = try #require(client.bundledCLIURL())
+    try await client.install(installPath)
+
+    let target = try FileManager.default.destinationOfSymbolicLink(atPath: installPath.path)
+    #expect(target == bundled.path(percentEncoded: false))
+    #expect(client.installationStatus(installPath) == .installed(path: installPath.path))
+  }
+
+  @Test func liveUninstallRemovesDanglingSymlink() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+
+    let installPath = tmp.appendingPathComponent("prowl")
+    try FileManager.default.createSymbolicLink(
+      atPath: installPath.path,
+      withDestinationPath: tmp.appendingPathComponent("moved-away").path
+    )
+
+    try await CLIInstallClient.liveValue.uninstall(installPath)
+
+    #expect((try? FileManager.default.attributesOfItem(atPath: installPath.path)) == nil)
+  }
+
   @Test func installCreatesSymlink() async throws {
     let tmp = try makeTempDir()
     defer { cleanup(tmp) }

--- a/supacodeTests/CLIInstallClientTests.swift
+++ b/supacodeTests/CLIInstallClientTests.swift
@@ -42,17 +42,10 @@ struct CLIInstallClientTests {
     let client = CLIInstallClient(
       bundledCLIURL: { fakeBundledBinary },
       installationStatus: { path in
-        let fileManager = FileManager.default
-        let filePath = path.path(percentEncoded: false)
-        guard fileManager.fileExists(atPath: filePath) else { return .notInstalled }
-        guard let attrs = try? fileManager.attributesOfItem(atPath: filePath),
-          attrs[.type] as? FileAttributeType == .typeSymbolicLink,
-          let destination = try? fileManager.destinationOfSymbolicLink(atPath: filePath)
-        else { return .installedDifferentSource(path: filePath) }
-        if destination == fakeBundledBinary.path(percentEncoded: false) {
-          return .installed(path: filePath)
-        }
-        return .installedDifferentSource(path: filePath)
+        SymlinkInstaller.status(
+          linkPath: path.path(percentEncoded: false),
+          source: fakeBundledBinary.path(percentEncoded: false)
+        )
       },
       install: { _ in },
       uninstall: { _ in }

--- a/supacodeTests/CLIInstallClientTests.swift
+++ b/supacodeTests/CLIInstallClientTests.swift
@@ -78,7 +78,7 @@ struct CLIInstallClientTests {
     let client = CLIInstallClient.liveValue
     let status = client.installationStatus(installPath)
 
-    #expect(status == .installedDifferentSource(path: installPath.path))
+    #expect(status == .installedDifferentSource(path: installPath.path, destination: otherBinary.path))
   }
 
   @Test func statusDifferentSourceWhenRegularFileExists() throws {
@@ -91,7 +91,7 @@ struct CLIInstallClientTests {
     let client = CLIInstallClient.liveValue
     let status = client.installationStatus(installPath)
 
-    #expect(status == .installedDifferentSource(path: installPath.path))
+    #expect(status == .installedDifferentSource(path: installPath.path, destination: nil))
   }
 
   @Test func statusBrokenWhenSymlinkIsDangling() throws {
@@ -107,7 +107,7 @@ struct CLIInstallClientTests {
     let client = CLIInstallClient.liveValue
     let status = client.installationStatus(installPath)
 
-    #expect(status == .broken(path: installPath.path))
+    #expect(status == .broken(path: installPath.path, destination: tmp.appendingPathComponent("moved-away").path))
   }
 
   @Test func liveInstallReplacesDanglingSymlinkWithBundledCLI() async throws {


### PR DESCRIPTION
## Summary

Second slice of docs-ai 065 (Bundled Agent Skills): the shared symlink installer and the local-only `prowl skills` command group. K1 (#729) bundled the skills and the registry; this PR links them into agent skill folders. Settings UI stays in K3.

- **Shared `SymlinkInstaller`** (`ProwlCLIShared`): one status/install/uninstall implementation for `/usr/local/bin/prowl` and skill links. Status is `notInstalled` / `installed` / `installedDifferentSource` / `broken`; the slot is inspected with lstat so a dangling link is `broken` instead of invisible. `install` creates parents, replaces live or dangling links, and refuses real files/directories before any mutation; `uninstall` removes symlinks only.
- **`CLIInstallClient`** now delegates to it. Messages, the osascript privilege fallback, and every existing test are unchanged; a dangling `/usr/local/bin/prowl` used to fail with a raw `EEXIST` and is now reported as broken and repaired by Install (the Command Line Tool page gained the matching Repair row because the enum is exhaustive).
- **Targets**: exactly the S0-verified `claude`, `codex`, `agents` with user/project directories; detected when the parent directory exists; explicit `--target` creates the directory.
- **`prowl skills list | install | uninstall | path`**: never opens the socket or launches the app. Bare `install` = every user-audience skill × every detected target; `workflow` skills fail `SKILL_NOT_INSTALLABLE`; every slot is conflict-checked first so `INSTALL_CONFLICT` changes nothing; project scope uses `--path` or the cwd's Git root (worktree `.git` files included) and prints the absolute-path / `.git/info/exclude` note exactly once (`data.note` in JSON, one stderr line in text). Prowl never edits Git state.
- **Four layers**: `prowl.cli.skills.v1` closed schema definitions, `docs-ai/013-prowl-cli/contracts/skills.md` (+ `input.md`, `schema.md`), a `prowl skills` section in `docs/components/cli.md`, and one line in the `prowl-cli` skill.
- Record: `docs-ai/065-bundled-agent-skills/004-k2-skill-installer-cli.md` (includes the review hardening); plan/release-plan updated (K1 → #729, K2 → #730).
- Project-scope links never leave the repository (a target folder symlinked outside it fails with `INSTALL_CONFLICT`); `--path` resolves to the containing Git root; foreign/dangling links report their `destination`.

## Review rounds

Four adversarial review rounds against this branch (each verified by re-running reproductions on the fix):

1. P0 project-scope symlink escape, P1 explicit `--path` accepting non-repositories/nested dirs, P2 skill wording, P3 manual error row → `5eaea50b`
2. P2 foreign/dangling links did not name their destination → `816ff6b3`
3. P0 app test target no longer compiled, P1 schema did not tie `destination` to status → `05e31cc4`, `719a2d06`
4. Clean at every level.

## Verification

- TDD: five new CLI test files were red (116 missing-symbol errors) before the shared types existed; each review fix started from a failing test. Coverage: 14 installer, 7 target, 22 executor, 5 parser, 4 schema, 5 integration tests — all against temporary directories, a temporary `HOME`, a temporary `PROWL_SKILLS_DIR`, throwaway Git repositories, and an unavailable `PROWL_CLI_SOCKET`. Every JSON envelope is validated against the schema bundle.
- `make build-cli`, `make test-cli-smoke` (now also runs `skills list` locally), `make test-cli-unit` (128), `make test-cli-integration` (102), `make test` (2,624 + 2, zero failures), `make check`, `make build-app` — all pass; the Debug app contains `Contents/Resources/skills/prowl-cli/SKILL.md` and its bundled `prowl-cli/prowl` resolves the skills beside itself.
- App: `CLIInstallClientTests` (existing + dangling-link status, live repair, live uninstall) and `SettingsFeatureCLIInstallTests` pass (18 in the focused run).
- Manual, temp-only: a fake `Prowl.app/Contents/Resources` layout with the CLI symlinked from a temp `bin/` on `PATH` (bare-name invocation resolves the real executable); list → bare install → explicit target creation → workflow refusal → real-directory conflict with other targets untouched → project-scope install from a nested directory with the note once and `git status` showing only untracked `.codex/` → JSON uninstall with zero stderr bytes → user-scope uninstall of all three targets. Live `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills` were neither read as inputs nor modified.

## Not in this PR

Settings Agent Skills section / `AgentSkillsFeature` / `SkillInstallClient` (K3), copy mode, third-party skills, auto-install after updates, Git mutations, new runtime targets.
