### PR TITLE
Rename Settings page to CLI & Skills

### DIFF
--- a/.agents/skills/prowl-cli
+++ b/.agents/skills/prowl-cli
@@ -1,1 +1,0 @@
-../../skills/prowl-cli

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -22,7 +22,7 @@ inside a repo, and not for how-to questions about Prowl's settings.
 
 ## Install
 
-From the app: **Settings → Agents → Command Line Tool → Install**, or Command
+From the app: **Settings → Agents → CLI & Skills → Install**, or Command
 Palette → "Install Command Line Tool". This symlinks `prowl` into
 `/usr/local/bin` (prompting for admin if needed). The Settings page also shows
 the local Unix socket path `prowl` uses to reach the app (`PROWL_CLI_SOCKET`
@@ -414,7 +414,7 @@ and `targets[]` (`id`, `detected`, `path`, `status`, optional `destination`); `i
 `.data.scope`, `.data.root`, `.data.results[]` (`skill`, `target`, `path`, `before`,
 `after`) and, for project scope, `.data.note`; `path` → `.data.skill.{id,name,audience,path}`.
 `PROWL_SKILLS_DIR` points the command at a different skills root for development.
-Settings › Agents › Command Line Tool › **Agent Skills** offers the same user-scope actions
+Settings › Agents › CLI & Skills › **Agent Skills** offers the same user-scope actions
 from the GUI (Install / Remove / Repair / Replace per skill × detected target) and shows
 the same status as `prowl skills list` — see [settings](settings.md#agent-skills).
 

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -3,7 +3,7 @@
 > The Settings window (`⌘,`): what each tab controls. For the exhaustive
 > field-by-field list, see [`reference/settings-fields.md`](../reference/settings-fields.md).
 
-**Keywords:** settings, preferences, ⌘comma, general, notifications, shortcuts, worktree, updates, advanced, github, agents, agent profiles, command line tool, cli, agent skills, skills install, repo settings, appearance
+**Keywords:** settings, preferences, ⌘comma, general, notifications, shortcuts, worktree, updates, advanced, github, agents, agent profiles, cli & skills, command line tool, cli, agent skills, skills install, repo settings, appearance
 
 **Related:** [reference/settings-fields](../reference/settings-fields.md) · [custom-actions](custom-actions.md) · [updates](updates.md) · [notifications](notifications.md)
 
@@ -34,7 +34,7 @@ and opens that section's root.
 | **Commands** | Global Custom Commands. Enabled commands appear in the window toolbar; each repo can independently hide a Global command. → [custom-actions](custom-actions.md) |
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout. |
 | **Agents → Profiles** | Named launch presets for supported agent runtimes (model, effort, execution mode, tab/split placement, extra arguments, opt-in dedicated home for a separate account) with a live launch preview. List order is the recommendation fallback. → [agent-profiles](agent-profiles.md) |
-| **Agents → Command Line Tool** | Install/status for the bundled `prowl` CLI, the local socket path it uses to reach the app, and the **Agent Skills** section that links the bundled skills into your agents' skill folders. → [cli](cli.md) |
+| **Agents → CLI & Skills** | Install/status for the bundled `prowl` CLI, the local socket path it uses to reach the app, and the **Agent Skills** section that links the bundled skills into your agents' skill folders. → [cli](cli.md) |
 | **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, Global-command visibility, **Default Agent Profile**, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
 
 ## Where settings live on disk
@@ -49,13 +49,13 @@ Legacy `~/.supacode` is migrated to `~/.prowl` on first launch.
 
 ## Install the CLI from here
 
-**Agents → Command Line Tool → Install** symlinks `prowl` into `/usr/local/bin`
+**Agents → CLI & Skills → Install** symlinks `prowl` into `/usr/local/bin`
 (prompting for admin rights if needed). Also available via Command Palette →
 "Install Command Line Tool". See [cli](cli.md).
 
 ## Agent Skills
 
-**Agents → Command Line Tool → Agent Skills** lists the user-installable skills bundled in
+**Agents → CLI & Skills → Agent Skills** lists the user-installable skills bundled in
 the app (`Prowl.app/Contents/Resources/skills/`, today `prowl-cli`) and links them into
 your agents' skill folders so every agent reads the version that matches the installed
 app. It is the GUI for [`prowl skills`](cli.md#prowl-skills) in user scope and shows the

--- a/supacode/Features/Settings/Reducer/AgentSkillsFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentSkillsFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import Foundation
 
-/// Settings → Agents → Command Line Tool → Agent Skills (docs-ai 065): the `user`-audience
+/// Settings → Agents → CLI & Skills → Agent Skills (docs-ai 065): the `user`-audience
 /// skills bundled in this app, one status chip per detected user target, and one explicit
 /// action per skill × target link. Statuses come from the shared installer, so the section
 /// always agrees with `prowl skills list`.

--- a/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
+++ b/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-/// Settings → Agents → Command Line Tool → Agent Skills: one row per bundled `user`
+/// Settings → Agents → CLI & Skills → Agent Skills: one row per bundled `user`
 /// skill, with one full-width line per detected target (status, link folder, action).
 /// Link behavior stays in `AgentSkillsFeature`; this view only presents it.
 struct AgentSkillsSectionView: View {

--- a/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
+++ b/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-/// Settings → Agents → Command Line Tool: install/status for the bundled `prowl`
+/// Settings → Agents → CLI & Skills: install/status for the bundled `prowl`
 /// CLI, the socket it reaches the app through, and the bundled agent skills
 /// (`AgentSkillsFeature`). Installation behavior stays in the reducers; this view
 /// only presents it.

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
         Section("Agents") {
           Label("Profiles", systemImage: "person.crop.circle")
             .tag(SettingsSection.profiles)
-          Label("Command Line Tool", systemImage: "terminal")
+          Label("CLI & Skills", systemImage: "terminal")
             .tag(SettingsSection.commandLineTool)
         }
 
@@ -122,7 +122,7 @@ struct SettingsView: View {
       case .commandLineTool:
         SettingsDetailView {
           CommandLineToolSettingsView(store: settingsStore)
-            .navigationTitle("Command Line Tool")
+            .navigationTitle("CLI & Skills")
         }
       case .repository(let repositoryID):
         if let repository = repositories[id: repositoryID] {

--- a/supacodeTests/AppFeatureAgentSkillsTests.swift
+++ b/supacodeTests/AppFeatureAgentSkillsTests.swift
@@ -35,7 +35,7 @@ struct AppFeatureAgentSkillsTests {
     }
   }
 
-  /// Leaving the Command Line Tool page removes the child state; the in-flight link effect must be
+  /// Leaving the CLI & Skills page removes the child state; the in-flight link effect must be
   /// cancelled with it, or its completion lands on nil state and the outcome is never reported.
   @Test(.dependencies, arguments: [AgentSkillsFeatureTests.LinkAction.install, .remove])
   func switchingSectionsCancelsAnInFlightLinkEffect(action: AgentSkillsFeatureTests.LinkAction) async throws {


### PR DESCRIPTION
## Summary

- rename the Settings sidebar item and detail title from **Command Line Tool** to **CLI & Skills**
- update current user documentation and code comments to match the new navigation path
- remove the obsolete repository-local `.agents/skills/prowl-cli` symlink

## Validation

- `make check`
- `make build-app`
