### PR TITLE
Align the workflow DSL spec with the shipped dispatch model and plan B1

### DIFF
--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -420,13 +420,13 @@ attaches hooks through A2's launch boundary.
 | **A1** | A | 060 | `prowl create pane` (#699) + target-surface split primitive returning the surface id; CLI four layers. Foundation for every `launch` into a split. |
 | **A1b** | A | A1 | `PROWL_PANE_ID` injected into every pane's environment (beside `PROWL_WORKTREE_PATH` / `PROWL_ROOT_PATH`), documented in `docs/components/cli.md`, and the `prowl-cli` skill's self-identification rewritten around it. Convenience identity only — trusted attribution (064 `agents signal`, `workflow done`) stays on caller-PID resolution. |
 | **A2** | A | A1 | Profile launch boundary (`.prompt`, placement override, anchor, background, synchronous `LaunchedSurface` result) + `prowl create tab/pane --profile --prompt -` + `prowl profiles list`; exposes the seam 064-S3 uses for launch-scoped hooks. Unlocks the CLI-driven route; the runner's `launch` boundary. |
-| **B1** | B | — | Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`. Makes the DSL concrete and authorable (no user-facing surface until R2). |
-| **B2** | B | B1 | Runner core (pure): run state machine incl. `repeat`, run store, template renderer, `WorkflowRequestRegistry`, action registry, watchdog with injected clock — tested against fake boundaries. |
-| **B3** | B | A2, 064-S1, B2 | Runner wiring: `WorkflowRunsFeature` effects, observer consumption via `AppFeature`, CLI preflight, `prowl workflow run/status/done/cancel` + contracts. Engine first powered on. |
+| **B1** | B | — | Definitions: Yams, `AgentWorkflow` model + validator + JSON Schema, three-source discovery, `prowl workflow list/validate/schema`. Makes the DSL concrete and authorable (no user-facing surface until R2). Lives in `ProwlCLIShared` so `validate`/`schema` run without the app; `list` goes through the socket and reads a hidden enabled set (`@Shared`, all enabled until D1's page). Record: [006](006-b1-definitions.md). |
+| **B2** | B | B1 | Runner core (pure): run state machine incl. `repeat`, run store, template renderer, action registry, watchdog with injected clock that consumes exact signals first (064-S5's watchdog part, moved here 2026-08-29) — tested against fake boundaries. Activations live in the shared dispatch store; there is no separate `WorkflowRequestRegistry` (decision 2026-08-29). |
+| **B3** | B | A2, 064-S1, B2, #733 | Runner wiring: `WorkflowRunsFeature` effects, observer consumption via `AppFeature`, CLI preflight, `prowl workflow run/status/done/cancel` + contracts. Engine first powered on. |
 | **C1** | C | B3 | Status center fifth state + run panel + attention triggers + notifications (061 visual verification). Runs become visible. |
 | **C2** | C | B3 | Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu). GUI-initiated runs. |
 | **D1** | D | B1, C2, 065-K1 | `prowl-workflows` authoring skill (registered by adding it to `skills/`; embedding and the registry come from [065](../065-bundled-agent-skills/000-plan.md)), `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group. Distribution and docs. |
-| **D2** | D | A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification; the watchdog consumes exact signals (064-S5 part). Proves the engine on a fresh flow before touching shipped behavior. |
+| **D2** | D | A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification (the exact-signal watchdog's first proof in a real flow). Proves the engine on a fresh flow before touching shipped behavior. |
 | **D3** | D | D2 | `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to\|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill. Migrate the shipped feature last. |
 | **V2** | — | — | observe mode (`expect.status` + `agents read` / hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor. |
 
@@ -596,6 +596,20 @@ attaches hooks through A2's launch boundary.
 
 ## Amendments
 
+- Updated 2026-08-29 (B1 kickoff, grilled): the DSL spec was aligned with what R1 shipped.
+  (1) `expect` activations are records in the shared dispatch store — `launch` via the S2
+  prompted-launch path, `message` via #733's re-dispatch — and `workflow done` is the
+  body-validating completion of that record; the per-activation token stays for correlation
+  only, and the `WorkflowRequestRegistry` of the execution-model section is not built.
+  (2) Model, validator, JSON Schema, and discovery live in `ProwlCLIShared`; `validate`/`schema`
+  work without the app. (3) The watchdog consumes exact signals first (064-S5's watchdog part
+  moves from D2 to B2; `turn_grace` 15 s, floor 5 s, re-check at expiry). (4) `launch.prompt`
+  may be multi-line (A2's prompt carrier; 32 KiB cap); the appended protocol block is the
+  workflow one and `dispatch-complete` on an activation is `WORKFLOW_DELIVERY_REQUIRED`.
+  (5) A `message` step injects only into an idle role (`waitingForRole`); early injection
+  needs a `turn-start` signal and is V2. (6) B1 includes `list` over the socket with a hidden
+  enabled set. Spec: [dsl-spec.md](dsl-spec.md) §4/§5/§9/§10/§12; record:
+  [006-b1-definitions.md](006-b1-definitions.md).
 - Updated 2026-08-29: R1 shipped in v2026.8.29. R2 is split into R2a (B1–C1) and R2b (C2–D2);
   #733 (re-dispatch into an existing pane) and #726 T0 (version attestation) are scheduled in
   R2a as D2 prerequisites, #726 T1 precedes D2 in R2b, and the working cadence is recorded in

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -1,0 +1,110 @@
+# 063.006 — Workflow Definitions (B1): Plan
+
+## Status
+
+Planned (2026-08-29) — first R2a slice. Owner decisions were settled in a grill session on
+2026-08-29 (below) after a re-read of [dsl-spec.md](dsl-spec.md) against what R1 shipped; the
+spec's §4/§5/§9/§10/§12 were amended in the same change. Implementation PR: TBD.
+
+## Context
+
+R1 delivered the primitives the runner needs (A1/A2 launch boundary, 064-S1 observer, S2
+dispatch receipts, S3 hooks on all eight tier-A runtimes, 065 bundled skills), but the DSL
+exists only as a spec. B1 makes it concrete: a file can be parsed, validated, and listed, and
+authoring agents get a machine-readable schema. Nothing runs yet — B2 (runner core) and B3
+(wiring, `run/status/done/cancel`) follow, with #733 re-dispatch landing before B3.
+
+The spec was written before S2/S3 shipped. Re-reading it against `main` surfaced one
+structural overlap (the `expect` completion channel duplicated the dispatch model) and a few
+stale rules; those are settled here so B2/B3 do not inherit them.
+
+## Decisions (grilled with onevcat, 2026-08-29)
+
+| # | Decision | Alternatives rejected |
+| --- | --- | --- |
+| G1 | **Activation = dispatch.** A workflow activation is a record in `AgentDispatchStore`: `launch` steps create it through the S2 prompted-launch path, `message` steps through #733's re-dispatch into an existing surface. `prowl workflow done` resolves the caller pane to its current pending record (peer PID + ancestry, as `dispatch-complete`), requires the activation token to match (correlation only, never trust), validates the body, persists the output, completes the record. `agents wait --dispatch` works on activations. No `WorkflowRequestRegistry`. | A parallel registry + token protocol as first drafted (two "one pending task per pane" mechanisms with drifting semantics). |
+| G2 | **Definitions live in `ProwlCLIShared`.** Model, Yams decoding, validator, JSON Schema, and three-source discovery are compiled into both the CLI and the app; `prowl workflow validate` / `schema` run without the app; `list` needs the app (enabled state, worktree-scoped repo source). | App-only parsing with every subcommand over the socket (authoring agents and CI could not validate without a running Prowl; Settings and CLI could not share one validator). |
+| G3 | **Watchdog is exact-signal-first and ships in B2** (064-S5's watchdog part moves from D2). `needs-input` → attention immediately; `turn-ended` without delivery → `turn_grace` 15 s (floor 5 s, re-check at expiry) → one nudge → `idle_grace` 3 min → attention; heuristic rules only without a channel. | Heuristic-only watchdog in B2, exact signals retrofitted in D2 (pure rework: hooks already cover all tier-A runtimes). Shorter `turn_grace`: below ~5 s the detector cannot have settled (2 s stabilization + 3 s working hold) and OpenCode can fire `session.idle` twice. |
+| G4 | **`launch.prompt` may be multi-line** (A2's `PROWL_LAUNCH_PROMPT` carrier; NUL rejected; 32 KiB cap → `PROMPT_TOO_LARGE`); materialization stays for `message` only. The runner appends the workflow protocol block instead of S2's dispatch block; `dispatch-complete` against an activation fails with `WORKFLOW_DELIVERY_REQUIRED` carrying the exact replacement command. | Keeping the one-line rule; treating a stray `dispatch-complete` as a body-less completion (the step would advance with a missing output). |
+| G5 | **`message` injects only into an idle role** (`waitingForRole`). The shipped signal set has no `turn-start`, so a mid-turn injection makes the next `turn-ended` belong to the previous turn and trips S2's `incomplete` rule; the CLI's #733 refusal is the same rule without an observer. Input queueing is assumed to work on every runtime but is not the deciding factor. | Queue semantics as first drafted, with "ignore the first `turn-ended` after injecting into a working role" (real races around Codex's late `turn-ended`). A `turn-start` signal is the V2 path to early injection. |
+| G6 | **B1 includes `prowl workflow list`** over the socket, reading a hidden enabled set (`@Shared`, everything enabled until D1's Settings page adds the toggle), so the slice has an app-side surface for the end-to-end pass. | Local `validate`/`schema` only, `list` deferred to B3 (a library-only slice verifiable by unit tests alone). |
+
+## Scope
+
+Owned by 063; nothing here changes 064 code.
+
+- **Yams** as a SwiftPM dependency of `ProwlCLIShared` (`Package.swift`) and of the app target
+  (xcodeproj package reference). Pin an exact version. First third-party dependency in the
+  Shared directory: remember that Shared sources are also app sources, so no helper may
+  collide with an app symbol.
+- **Model** (`supacode/CLIService/Shared/WorkflowDefinition.swift` and neighbours):
+  `WorkflowDefinition` (schema, id, name, description, icon, inputs, roles, steps), role
+  sources `current | launch | pick`, launch requirements (`kind`, `agents`, `suggest`, `bind`,
+  `placement`, `direction`, `background`), step verbs (`message`, `launch`, `action`, `notify`,
+  `close`, `repeat`), `expect`, inputs (`integer`, `string`, `enum`). Decoding through Yams
+  into `Codable` types; unknown keys are errors (spec §7).
+- **Validator** (`WorkflowValidator`): every error and warning listed in spec §7, including
+  template-variable whitelist checks, producer-dominates-consumer for `outputs.*` /
+  `actions.*` / `roles.<r>.pane`, `repeat` rules, verdict/`until` consistency, slug patterns,
+  `skill:` resolution against the bundled registry (`ProwlSkills`, 065), and the
+  "spells `prowl workflow done`" warning. Diagnostics carry YAML line/column where Yams
+  provides them.
+- **Action registry (schemas only)**: the V1 native actions `handoff.transition`,
+  `handoff.checkpoint`, `git.context` declared with their typed `with` inputs and output keys
+  so the validator and `schema` can check references. Execution comes with B2.
+- **JSON Schema** (`prowl workflow schema`): generated from the model, checked in under
+  `docs-ai/013-prowl-cli/contracts/` beside the CLI output schema, pinned by a test so the
+  two cannot drift.
+- **Discovery** (`WorkflowDiscovery`): bundle (`Prowl.app/Contents/Resources/workflows/`,
+  absent until the first bundled definition ships with D2 — discovery tolerates a missing
+  folder) < user (`~/.prowl/workflows/*.yaml`) < repo (`<root>/.prowl/workflows/*.yaml`);
+  `prowl.*` ids reserved; repo overrides user for the same non-reserved id. The repo source is
+  resolved per worktree by the app.
+- **CLI** (`ProwlCLI/Commands/WorkflowCommand.swift`): `prowl workflow validate <file>
+  [--json]` and `prowl workflow schema` execute locally (same shape as `SkillsCommandExecutor`);
+  `prowl workflow list [--json]` goes through the socket to a `WorkflowCommandHandler` that
+  merges discovery with the enabled set. Output contract `prowl.cli.workflow.v1` with a
+  `data.action` discriminator (as `prowl.cli.skills.v1`), errors `WORKFLOW_NOT_FOUND`,
+  `WORKFLOW_INVALID`, `INVALID_ARGUMENT`.
+- **Enabled set**: `@Shared` app storage of *disabled* `(scope, id)` pairs — opt-out, so a
+  new file is enabled by default; no UI (D1).
+- **Docs**: `docs/components/cli.md` gains the three commands; contract page
+  `docs-ai/013-prowl-cli/contracts/workflow.md`; `cli-output-schema.json` updated. The
+  `prowl-cli` skill is not taught these commands until B3 makes `run`/`done` real (same rule as
+  064.012 B1: never name unshipped commands to agents).
+
+### Non-goals
+
+`prowl workflow run/status/done/cancel`, the runner and watchdog (B2/B3), Settings › Workflows
+(D1), bundled definitions and skills (`prowl.handoff`, `prowl.adversarial-review`; D2/D3),
+the `Resources/workflows` staging in the Makefile (ships with the first bundled definition).
+
+## Test plan (red first)
+
+- Decoding: the §4 example decodes to the expected model; unknown key, wrong type, and
+  duplicate step id fail with positioned diagnostics.
+- Validator: one test per §7 error and warning; producer-dominance cases (reference before
+  producer, inside vs outside `repeat`); `repeat.max` literal/template bounds; verdict set
+  size and `until` literal membership; slug patterns for every id class; `skill:` unknown id.
+- Schema: generated JSON Schema equals the checked-in file (drift guard); the §4 example
+  validates against it with a JSON Schema validator in the test.
+- Discovery: precedence and reserved-id rules over temp directories; missing bundle folder
+  tolerated; repo scope resolved from a worktree root.
+- CLI: `validate` / `schema` executor tests (JSON and text), `list` socket round trip with a
+  stubbed handler, contract schema conformance for every payload shape.
+
+## Verification
+
+`make check`, `make build-cli`, `make test-cli-unit`, `make test-cli-smoke`,
+`make test-cli-integration`, `make build-app`, the new Swift Testing suites; then the
+end-to-end pass required by the release plan's cadence rules: against an isolated Debug
+instance, drop the §4 example into a scratch user `~/.prowl/workflows/`, run `prowl workflow
+list --json`, `validate` on the example and on a deliberately broken copy, and `schema`,
+driven from the bundled `prowl-cli` skill recipe.
+
+## Open items
+
+- Yams version pin and the xcodeproj package reference (first shared third-party dependency).
+- Whether `list --json` should include per-file validation diagnostics inline or only a
+  status plus a pointer to `validate` (default: status + counts; diagnostics stay with
+  `validate`).

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -4,7 +4,9 @@
 > and the CLI participant protocol. Updated in place as the design settles and the
 > implementation lands; history and rationale live in [000-plan.md](000-plan.md).
 >
-> Status: **draft** (2026-08-21) — not yet implemented. Sections marked *TBD* are open.
+> Status: **draft, revised 2026-08-29** after R1 shipped — B1 (definitions) is next; §4, §5, §9,
+> §10, and §12 were aligned with the shipped dispatch model (064-S2/S3, #733) on 2026-08-29
+> (decisions in [006-b1-definitions.md](006-b1-definitions.md)). Sections marked *TBD* are open.
 
 ## 1. Principles
 
@@ -140,8 +142,8 @@ steps:
 
 | Verb | Payload keys | Allowed target | Notes |
 | --- | --- | --- | --- |
-| `message: <role>` | `text` (single line, typed verbatim) **or** `instruction` (multi-line, materialized + pointer) | live interactive role (`current`, `pick`, or a `launch` role already launched) | Injection is gated: `blocked` → not typed, run → `needsAttention`; `working` → the line is accepted by the agent runtime's own input queue (Prowl keeps none), shown in the panel. |
-| `launch: <role>` | `prompt` (kickoff, templated), optional `skill` (an id from the embedded skill registry — same pattern as a workflow id, e.g. `prowl.adversarial-reviewer`; it must resolve to a bundled skill, unknown ids are validation errors; custom skills are V2) | `launch` role, at most once per run (V1) | Profile plan with `AgentStartIntent.prompt`. The single-/multi-line decision is made on the *rendered* prompt: one line → passed verbatim (after the §10 rendered-text check); otherwise materialized, and the kickoff becomes the pointer line. |
+| `message: <role>` | `text` (single line, typed verbatim) **or** `instruction` (multi-line, materialized + pointer) | live interactive role (`current`, `pick`, or a `launch` role already launched) | Injection is gated: `blocked` → not typed, run → `needsAttention`; `working` → not typed either — the step waits in `waitingForRole` until the role is idle/done (064.012 corroboration rules), then injects and opens its activation, so an activation is only ever created against an idle agent (§5). The panel shows what it is waiting for. |
+| `launch: <role>` | `prompt` (kickoff, templated), optional `skill` (an id from the embedded skill registry — same pattern as a workflow id, e.g. `prowl.adversarial-reviewer`; it must resolve to a bundled skill, unknown ids are validation errors; custom skills are V2) | `launch` role, at most once per run (V1) | Profile plan with `AgentStartIntent.prompt`. The rendered prompt is passed whole through the launch boundary's prompt carrier (A2's `PROWL_LAUNCH_PROMPT`; no PTY line limit): multi-line prompts are allowed, NUL is rejected, and a rendered prompt above 32 KiB is `PROMPT_TOO_LARGE`. Materialization applies to `message` only. When the step has an `expect`, the runner appends the workflow completion protocol block (below) in place of S2's plain dispatch protocol. |
 | `action: <id>` | `with` (templated map) | — | V1 registry: `handoff.transition` (inputs `briefing?`, `from`, `to`; performs archive-first `.prowl/handoff/` transition; outputs `kickoff_prompt`, `artifact_path`, `has_briefing`), `handoff.checkpoint`, `git.context`. Every registered action declares a typed schema for its `with` inputs (required/optional) and its output keys; `prowl workflow schema` prints them. |
 | `notify: <text>` | — | — | Bell pipeline; click focuses the `current` role's pane, or — when the workflow has no `current` role — the source worktree (status panel). |
 | `close: <role>` | — | `launch` roles | Never implicit; cancel never closes panes. |
@@ -165,6 +167,16 @@ and every re-delivery after Relaunch, so no path ever shows a token-less or
 verdict-less command. Authors never spell the command (the validator warns when
 `text`/`instruction` contains `prowl workflow done`).
 
+**Where the token travels.** For a `message` step the token is part of the typed line
+(`PROWL_WORKFLOW_TOKEN=<token> …`, the same environment-prefix technique as today's
+`PROWL_HANDOFF_REQUEST_ID`). For a `launch` step it is placed in the launched surface's
+environment exactly like `PROWL_DISPATCH_ID`, and the **workflow protocol block** the runner
+appends to the kickoff prompt spells the command without a prefix: it names the run, the
+role, the expected sections, and one complete `prowl workflow done [--verdict <v>] -` command
+per allowed verdict. A `prowl agents dispatch-complete` issued from a pane whose pending
+record is a workflow activation is rejected with `WORKFLOW_DELIVERY_REQUIRED`, whose message
+carries the exact replacement command — it never completes the step with a missing output.
+
 **V1 native action schemas** (normative summary; `prowl workflow schema` prints the full
 JSON Schema):
 
@@ -186,6 +198,18 @@ expect:
   on_timeout: attention     # only with `timeout`: attention (default) | skip | cancel
 ```
 
+- **Activation = dispatch (decision 2026-08-29).** Every activation is a record in the shared
+  dispatch store (`AgentDispatchStore`, 064-S2): a `launch` step creates it through the
+  prompted-launch path, a `message` step through #733's re-dispatch into an existing surface.
+  One pending record per surface; it is created only while the role is idle (§4), so exactly
+  one runtime turn belongs to it and a `turn-ended` without a delivery is the `incomplete`
+  evidence the watchdog consumes (§10). `prowl workflow done` resolves the caller pane to that
+  pane's current pending record (kernel peer PID + process ancestry, as `dispatch-complete`
+  does) and additionally requires the activation token to match — correlation, not trust —
+  then validates the body, persists the output, and completes the record. Skip / Cancel /
+  Relaunch abandon the record (the reason names run and step). The `run` response and
+  `workflow status` expose each activation's dispatch id, so `prowl agents wait --dispatch`
+  works on workflow activations too; there is no separate `WorkflowRequestRegistry`.
 - **Invocation and activation identity.** Every execution of a `message` or `launch` step
   — once for a plain step, once per iteration inside `repeat`, again after Relaunch —
   mints a run-global, monotonic **invocation ordinal** (1, 2, 3, … across all steps and
@@ -299,9 +323,11 @@ prowl workflow schema                                         # JSON Schema / re
 
 **Resolution of `done`.** Two independent facts must agree: the **caller pane** (socket
 peer PID → process ancestry → shell PID → pane) identifies the run and role, and the
-**delivery token** (`PROWL_WORKFLOW_TOKEN`, read from the environment of the `prowl`
-process exactly like `PROWL_HANDOFF_REQUEST_ID` today, or `--token`) identifies the awaited
-step. Prowl mints the token when the step starts waiting, embeds it in the typed hint, and
+**delivery token** (`PROWL_WORKFLOW_TOKEN` — set in the launch environment for a `launch`
+step's activation exactly like `PROWL_DISPATCH_ID`, carried as the typed line's environment
+prefix for a `message` step's activation exactly like `PROWL_HANDOFF_REQUEST_ID` today, or
+`--token`) identifies the awaited step. Prowl mints the token when the step starts waiting,
+embeds it in the typed hint, and
 revokes it on Skip / Cancel / Relaunch; a stale or duplicated `done` from a pane that has
 moved on to another step is therefore rejected instead of misattributed. A pane belongs
 to at most one run at a time, so no run/step ids are needed in the typed command. Explicit
@@ -310,7 +336,7 @@ to at most one run at a time, so no run/step ids are needed in the typed command
 attributed to that activation's delivery role; if the step is not currently waiting the
 result is `STEP_NOT_EXPECTING`. If caller pane and explicit ids disagree,
 `ROLE_MISMATCH` unless `--force`. Launched surfaces may additionally carry
-`PROWL_WORKFLOW_RUN` / `PROWL_WORKFLOW_ROLE` as a cross-check hint; the registry is the
+`PROWL_WORKFLOW_RUN` / `PROWL_WORKFLOW_ROLE` as a cross-check hint; the dispatch store is the
 authority.
 
 **`--role` grammar** (source-specific; duplicate overrides for one role and overrides for
@@ -344,13 +370,18 @@ Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BU
 `OUTPUT_INVALID` (sections/format/verdict), `OUTPUT_TOO_LARGE`, `VERDICT_REQUIRED`,
 `PROFILE_NOT_FOUND`, `PROFILE_NOT_UNIQUE`, `SKILL_NOT_FOUND`, `RENDERED_TEXT_INVALID`
 (a rendered `text`/pointer/`--input` value would not survive as one terminal line),
-`UNSAFE_PATH`. (`AGENT_GONE` and `WAIT_TIMEOUT` belong to the `agents wait` contract, not
-to `prowl workflow`.)
+`UNSAFE_PATH`, `PROMPT_TOO_LARGE` (a rendered `launch` prompt above 32 KiB),
+`WORKFLOW_DELIVERY_REQUIRED` (`agents dispatch-complete` from a pane whose pending record is a
+workflow activation; the message carries the exact `prowl workflow done` replacement).
+(`AGENT_GONE` and `WAIT_TIMEOUT` belong to the `agents wait` contract, not to
+`prowl workflow`.)
 
 Companion primitives for CLI-driven orchestration (same boundaries as the runner):
 `prowl create pane <pane> --direction <dir> [--profile <name|uuid> --prompt -]`,
 `prowl create tab <worktree> [--profile … --prompt -]`, `prowl profiles list`,
-`prowl agents wait <pane> --until idle|done|blocked|changed [--timeout]`, `prowl send`,
+`prowl agents wait <pane> --until idle|blocked|changed|exit [--timeout]`,
+`prowl agents wait --dispatch <id>`, `prowl agents dispatch <pane> --prompt -` (#733 — the
+re-dispatch that `message` + `expect` rides on), `prowl agents signal`, `prowl send`,
 `prowl agents read`. `agents wait` (and `agents signal`) are specified in
 [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md); they consume
 the typed per-surface observer (`ObservedAgentState`: `snapshot` first, then `changed` /
@@ -365,11 +396,11 @@ changed` / `exit` was requested.
 | --- | --- |
 | Start | Resolve bindings, freeze plans, create run dir, write `run.json`, then execute step 1. `current` role must not already be in a run (`PANE_BUSY`). |
 | Advance | A step completes when its `expect` is satisfied (or it has none and its effect succeeded). `repeat` evaluates `until` before entry and after each iteration; `max` reached with `until` still false ends the run as `max_rounds_reached`. |
-| Message delivery | Injection is synchronous (`insertCommittedText` + submit, treated as one operation); Prowl keeps no queue — a `working` agent holds the line in its own input queue, and the panel says so. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). If the insert succeeded but the submit failed, the attention text says that the line may still sit unsubmitted in the pane's input (Focus pane lets the user press Enter there). **Retry** re-executes the step as a new invocation: it mints a new ordinal (and, when the step has an `expect`, revokes the previous activation's token and mints a new one) and injects the freshly rendered line. At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
+| Message delivery | A `message` step first waits for its role to be idle/done (`waitingForRole`; a `working` role is never injected into — §4, §5 activation rule; a later `turn-start` signal may relax this, §12), then injects synchronously (`insertCommittedText` + submit, treated as one operation) and opens the activation. A `message` step advances only after a successful injection; a `blocked` role, a missing surface, or a failed injection leaves the step active in `needsAttention` (Retry / Skip / Cancel). If the insert succeeded but the submit failed, the attention text says that the line may still sit unsubmitted in the pane's input (Focus pane lets the user press Enter there). **Retry** re-executes the step as a new invocation: it mints a new ordinal (and, when the step has an `expect`, revokes the previous activation's token and mints a new one) and injects the freshly rendered line. At most one pending injection per role; Cancel / Skip / Relaunch drop it. |
 | Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
 | Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
-| Watchdog | Driven by the periodic detection events (`agentEntryChanged` / `agentEntryRemoved`, forwarded to the runner by `AppFeature`'s single terminal-event subscription — `WorktreeTerminalManager.eventStream()` is single-consumer) plus an injected clock. When a step starts waiting the watchdog reads the role's current state first and schedules cancellable grace deadlines; it never depends on a later event alone. Every trigger has a grace period because detection is heuristic and a wrong guess must be harmless. Awaited role `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention` (Focus pane / Cancel). Awaited role `idle`/`done` ≥ `idle_grace` (default 3 min) without `done` → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`, harmless if the agent is still working because the runtime merely queues the line), then `needsAttention` after another `idle_grace` (Nudge again / Keep waiting / Skip / Cancel). Awaited role's agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). `working` never triggers anything. Grace values are global settings. |
+| Watchdog | Exact signals first, heuristics as fallback (decision 2026-08-29; 064-S5's watchdog part). The runner subscribes to the role's surface through `TerminalClient.observeAgentState` (064-S1 multicast: `snapshot` first, then `changed` / `removed` / `surfaceClosed` / `.signal`) and to the activation through `observeAgentDispatch`, plus an injected clock. When a step starts waiting the watchdog reads the current state first and schedules cancellable deadlines; it never depends on a later event alone. With a `verified_live` channel: `needs-input` → `needsAttention` immediately (Focus pane / Cancel); `turn-ended` without a delivery → `turn_grace` (default 15 s, floor 5 s; at expiry the state is re-read, and a role that is `working` again or has since reported `session-start` / `progress` re-arms instead of nudging) → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`) → `idle_grace` (default 3 min) → `needsAttention` (Nudge again / Keep waiting / Skip / Cancel); `session-end` or agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). Without a channel (manually launched or tier-B runtimes) the heuristic rules apply, using 064.012's corroboration for arm-time state: `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention`; `idle`/`done` ≥ `idle_grace` without a delivery → nudge, then `needsAttention` after another `idle_grace`. `working` never triggers anything. Grace values are global settings. |
 | `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |
 | Explicit `timeout` | Only when an author sets `expect.timeout`: `attention` (default) enters `needsAttention`; `skip` / `cancel` act automatically. |
 | Cancel | Stops advancing and injecting; keeps all panes and outputs; logs. |
@@ -412,4 +443,7 @@ headless` roles backed by a specified `HeadlessAgentExecutor` (cwd/env, stdout/s
 bounds, exit/cancel/timeout semantics, per-runtime trusted result extraction), `worktree:`
 on roles (cross-repo review), run resume, output retention policy, nested `repeat`,
 `outputs.<name>.json` field access, custom (non-bundled) `skill:` sources with their own
-rooted discovery and containment rules, `expect … from: <role>` on native actions.
+rooted discovery and containment rules, `expect … from: <role>` on native actions, a
+`turn-start` runtime signal (Claude `UserPromptSubmit`, Pi/OMP `agent_start`) that would let a
+`message` step inject into a `working` role early while still binding the activation to the
+right turn (V1 waits for idle instead).

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -102,16 +102,16 @@ User-visible result: onevcat's daily CLI-driven orchestration is first-class
 | Order | Slice | Entry | Depends | Outcome |
 | --- | --- | --- | --- | --- |
 | 1 | **B1** definitions (Yams, model, validator, JSON Schema, three-source discovery, `workflow list/validate/schema`) | 063 | — | DSL authorable and validatable; dormant until B3 |
-| 1 | **#733** `prowl agents dispatch <pane> --prompt -`: a new pending dispatch bound to an existing surface, one pending per surface, `dispatch-complete` resolved from the caller's ancestry to the pane's current record, refused while the agent is working or blocked | 064 | S2, 064.012 | a reviewer launched once takes N assignments, each with its own receipt — the shape `prowl.adversarial-review` (D2) needs, and usable from the CLI recipe as soon as it merges |
+| 1 | **#733** `prowl agents dispatch <pane> --prompt -`: a new pending dispatch bound to an existing surface, one pending per surface, `dispatch-complete` resolved from the caller's ancestry to the pane's current record, refused while the agent is working or blocked | 064 | S2, 064.012 | a reviewer launched once takes N assignments, each with its own receipt — the transport B3's `message` + `expect` rides on (decision 2026-08-29), and usable from the CLI recipe as soon as it merges |
 | 1 | **#726 T0** version attestation: per-runtime attested version record beside the research matrix + `make agent-versions` | 064 | S3 wave 1 | an installed runtime newer than its attested contract warns before a release |
-| 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) | 063 | B1 | — |
-| 3 | **B3** runner wiring + `workflow run/status/done/cancel` | 063 | A2, S1, B2 | engine powered on |
+| 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) | 063 | B1 | watchdog on exact signals (064-S5 watchdog part, moved from D2) |
+| 3 | **B3** runner wiring + `workflow run/status/done/cancel` | 063 | A2, S1, B2, #733 | engine powered on |
 | 4 | **C1** status center + run panel + notifications | 063 | B3 | runs visible |
 
 User-visible result: a workflow file runs from the CLI (`prowl workflow run`), its steps and
 attention states show in the status center, and a coordinating agent can re-dispatch into a
 reviewer it already launched. Parallelism: B1 ∥ #733 ∥ #726 T0 (the two 064 slices do not
-touch B1's files). Docs: `workflows.md` (CLI part), `cli.md`, `prowl-cli` skill.
+touch B1's files); #733 must merge before B3 starts. Docs: `workflows.md` (CLI part), `cli.md`, `prowl-cli` skill.
 
 ### R2b — Workflow GUI, docs, and the first built-in
 
@@ -120,7 +120,7 @@ touch B1's files). Docs: `workflows.md` (CLI part), `cli.md`, `prowl-cli` skill.
 | 1 | **C2** start sheet + entry points (capsule popover, palette, Active Agents) | 063 | B3 | GUI-initiated runs |
 | 2 | **D1** `prowl-workflows` authoring skill (skills embedding from 065), `docs/components/workflows.md`, Settings › Workflows page, CLI reachability status (deferred from C0) | 063 | B1, C2, 065-K1 | custom workflows, agent-assisted authoring |
 | 3 | **#726 T1** headless contract tests against the real tier-A binaries through the production renderers/decoder (`make test-agent-contracts`, passing runs update T0) | 064 | #726 T0, S3 wave 1 | hook contracts fail loudly on binary drift before D2's E2E leans on them |
-| 4 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E; watchdog consumes exact signals (064-S5 part) | 063 + 064 | A2, C2, D1, S3 wave 1, #733, #726 T1 | first built-in workflow |
+| 4 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | first built-in workflow |
 
 The shipped handoff (HUD + `prowl handoff`) stays untouched through R2a and R2b. The split
 replaces the earlier "one R2" default (decision 2026-08-29): R2's seven slices outweigh R1's
@@ -182,7 +182,7 @@ R1:  C0            A1 ──► A1b                         (shipped v2026.8.29)
                                ├──► S2 ──► S3w1 ──► #732 ──► #736
                           S1 ──┘
      065-S0/K1 ──► 065-K2 ──► 065-K3
-R2a: B1 ──► B2 ──► B3 (◄ A2, S1) ──► C1
+R2a: B1 ──► B2 ──► B3 (◄ A2, S1, #733) ──► C1
      #733 (◄ S2)        #726-T0 (◄ S3w1)
 R2b: C2 (◄ B3) ──► D1 (◄ B1, 065-K1) ──► D2 (◄ S3w1, #733, #726-T1)
      #726-T1 (◄ #726-T0)
@@ -192,6 +192,10 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-08-29 — B1 kickoff: the DSL spec was aligned with the shipped dispatch model (grilled
+  decisions in [063.006](006-b1-definitions.md)). #733 becomes a hard prerequisite of B3
+  (activations ride on re-dispatch), and 064-S5's watchdog part moves from D2 into B2 so the
+  runner never ships a heuristic-only watchdog. Order inside R2a is unchanged.
 - 2026-08-29 — R1 shipped in v2026.8.29 (tag `5ba8aacd`), including three unplanned tail PRs
   found by end-to-end passes over the `prowl-cli` skill: #732 (064.012 evidence semantics),
   #735 (Settings page renamed CLI & Skills), #736 (064.013 idle evidence fallback). R2 is

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -182,7 +182,7 @@ hooks.
 | **S2** | 063-A2, S1 | One atomic paired-dispatch path: every CLI `create tab|pane --profile --prompt` appends the completion protocol and returns `dispatch_id`; cooperative `dispatch-complete --outcome succeeded|failed --summary`; 256-entry non-destructive in-memory receipts; ID-only strict `prowl agents wait --dispatch`; generic `wait --until` with automatic overflow resnapshot and honest heuristic fallback; `agents` current evidence field; `--include-screen`; skill rubric. Route B becomes usable without polling or stale completion. |
 | **S3 wave 1** | S2, research matrix | Launch-scoped hook injection (adapter `signalHooks`, self-check) for tier A of the research matrix (flag/env per launch, live-verified): Claude Code `--settings`, Codex `-c notify=[…]` (native `agent-turn-complete` maps to `turn-ended`; hook trust bypass is never passed), Copilot `--plugin-dir`, Droid `--settings`, Qoder `--settings`, Pi `-e`, OMP `--hook`, OpenCode `OPENCODE_CONFIG_CONTENT`. `agents wait` becomes deterministic for Prowl-launched agents on these runtimes. This is the complete S3 hook scope, delivered as S3a–S3c in [006-s3-wave1-plan.md](006-s3-wave1-plan.md). |
 | **S4** | S1 | Transcript file-watch and OSC producers — layer 2 without hooks. |
-| **S5** | 063 C1 (part), S3/S4 + 063 V2 (rest) | 063's watchdog consumes exact signals (nudge on `turn-ended` without `done`, immediate attention on `needs-input`) — ships with 063-D2; later: 063 V2 observe mode (`expect.status` + `agents read` / hook `last_assistant_message`) and `on_attention: ask <role>`. Recorded in 063 amendments. |
+| **S5** | 063 C1 (part), S3/S4 + 063 V2 (rest) | 063's watchdog consumes exact signals (nudge on `turn-ended` without `done`, immediate attention on `needs-input`) — ships with 063-B2 (moved from D2 on 2026-08-29); later: 063 V2 observe mode (`expect.status` + `agents read` / hook `last_assistant_message`) and `on_attention: ask <role>`. Recorded in 063 amendments. |
 
 ### Verification
 
@@ -246,6 +246,11 @@ opencode; partial for qodercli/qwen/amp; docs/bundle for the rest). Key conclusi
 
 ## Amendments
 
+- Updated 2026-08-29 (063 B1 kickoff): 063's `expect` activations are records in this entry's
+  dispatch store (`launch` via the S2 prompted-launch path, `message` via #733's re-dispatch),
+  and S5's watchdog part ships with 063-B2 instead of D2. #733 therefore lands before 063-B3.
+  See [063 dsl-spec §5/§10](../063-agent-workflows/dsl-spec.md) and
+  [063.006](../063-agent-workflows/006-b1-definitions.md).
 - Updated 2026-08-29: shipped in v2026.8.29 with 063's R1. Two follow-ups are scheduled as
   slices in the shared [release plan](../063-agent-workflows/release-plan.md): #733
   (`prowl agents dispatch <pane> --prompt -`, one pending dispatch per surface, completion


### PR DESCRIPTION
## Summary

Re-reading `dsl-spec.md` against `main` before B1 showed that the spec (written 2026-08-21) predates S2 dispatch receipts, S3 hooks, and #733. Six decisions were grilled with the owner on 2026-08-29 and are recorded in the new slice record `docs-ai/063-agent-workflows/006-b1-definitions.md`:

1. **Activation = dispatch.** `expect` activations are `AgentDispatchStore` records — `launch` through the S2 prompted-launch path, `message` through #733's re-dispatch — and `prowl workflow done` is the body-validating completion of that record. The per-activation token stays for correlation only; no separate `WorkflowRequestRegistry`.
2. **Definitions live in `ProwlCLIShared`**; `workflow validate` / `schema` run without the app, `list` over the socket.
3. **Watchdog is exact-signal-first and ships in B2** (064-S5's watchdog part moves from D2): `needs-input` → attention immediately; `turn-ended` without delivery → 15 s grace (floor 5 s, re-check at expiry) → one nudge → 3 min → attention; heuristics only without a channel.
4. **`launch.prompt` may be multi-line** (A2's prompt carrier, 32 KiB cap); the appended protocol block is the workflow one, and `dispatch-complete` against an activation is `WORKFLOW_DELIVERY_REQUIRED` with the exact replacement command.
5. **`message` injects only into an idle role** (`waitingForRole`): the shipped signal set has no `turn-start`, so a mid-turn injection makes the next `turn-ended` ambiguous and trips S2's `incomplete` rule. A `turn-start` signal is recorded as the V2 path.
6. **B1 includes `prowl workflow list`** with a hidden enabled set (`@Shared`, opt-out), so the slice has an app-side surface for the end-to-end pass.

Spec sections amended: §4 (message/launch rows, token/protocol paragraph), §5 (activation bullet), §9 (`done` resolution, error codes, companion primitives now match the shipped `agents wait` conditions), §10 (message delivery, watchdog), §12. Release plan and the 063/064 plans follow: #733 is a hard prerequisite of B3, B2 carries the exact-signal watchdog, D2 keeps the E2E proof.

## Validation

- Docs-only change. All relative links and anchors in the five touched files resolve (scripted check).

https://claude.ai/code/session_01YSXSCVNoycSbCmwPMvcCnw
