### PR TITLE
Add workflow definitions with prowl workflow list, validate, and schema

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f754db8301c9da1c2526e397dc4b099bee8a678f1e853a4f2b121df3ef3fd4b3",
+  "originHash" : "56bd7c7f929ecda63c502cd413de28f4d0afbf515ee64fd6418beb35a916bc22",
   "pins" : [
     {
       "identity" : "rainbow",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
         "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,14 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     .package(url: "https://github.com/ajevans99/swift-json-schema", from: "0.13.1"),
     .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.0"),
+    .package(url: "https://github.com/jpsim/Yams.git", exact: "6.2.2"),
   ],
   targets: [
     .target(
       name: "ProwlCLIShared",
+      dependencies: [
+        .product(name: "Yams", package: "Yams"),
+      ],
       path: "supacode/CLIService/Shared"
     ),
     .executableTarget(
@@ -48,6 +52,7 @@ let package = Package(
         "ProwlCLIShared",
         "prowl",
         .product(name: "JSONSchema", package: "swift-json-schema"),
+        .product(name: "Yams", package: "Yams"),
       ],
       path: "ProwlCLITests"
     ),

--- a/ProwlCLI/Commands/ProwlCommand.swift
+++ b/ProwlCLI/Commands/ProwlCommand.swift
@@ -22,6 +22,7 @@ struct ProwlCommand: ParsableCommand {
       AgentsCommand.self,
       ProfilesCommand.self,
       SkillsCommand.self,
+      WorkflowCommand.self,
       FocusCommand.self,
       SendCommand.self,
       KeyCommand.self,

--- a/ProwlCLI/Commands/WorkflowCommand.swift
+++ b/ProwlCLI/Commands/WorkflowCommand.swift
@@ -1,0 +1,139 @@
+// ProwlCLI/Commands/WorkflowCommand.swift
+// `prowl workflow`: definitions discovery and authoring support (docs-ai 063 B1).
+// `list` asks the running app; `validate` and `schema` run locally and never open the socket.
+
+import ArgumentParser
+import Foundation
+import ProwlCLIShared
+
+struct WorkflowCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "workflow",
+    abstract: "Discover, validate, and describe Agent Workflow definitions.",
+    discussion: """
+      Definitions are YAML files (`prowl.workflow/v1`) found in the app bundle, ~/.prowl/workflows, \
+      and <repo>/.prowl/workflows. `validate` and `schema` work with Prowl closed; `list` needs the app.
+      """,
+    subcommands: [
+      WorkflowListCommand.self,
+      WorkflowValidateCommand.self,
+      WorkflowSchemaCommand.self,
+    ]
+  )
+}
+
+struct WorkflowListCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list",
+    abstract: "List the workflow definitions visible to a worktree, with validation status."
+  )
+
+  @OptionGroup var selector: SelectorOptions
+  @OptionGroup var options: GlobalOptions
+
+  @Argument(help: "Worktree id/name/path or a pane/tab handle (auto-resolved). Defaults to the caller's pane.")
+  var target: String?
+
+  mutating func run() throws {
+    try CLIExecution.run(
+      command: WorkflowCommandPayload.commandName, output: options.outputMode, colorEnabled: options.colorEnabled
+    ) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .workflow(WorkflowInput(action: .list, target: try selector.resolve(positionalTarget: target)))
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+}
+
+struct WorkflowValidateCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "validate",
+    abstract: "Parse and validate a workflow file locally; exits non-zero when it has errors."
+  )
+
+  enum Scope: String, ExpressibleByArgument, CaseIterable {
+    case bundle
+    case user
+    case repo
+
+    var value: WorkflowScope {
+      switch self {
+      case .bundle: .bundle
+      case .user: .user
+      case .repo: .repo
+      }
+    }
+  }
+
+  @Argument(help: "Path to a workflow YAML file.")
+  var file: String
+
+  @Option(
+    name: .long,
+    help: "Source the file belongs to (bundle, user, repo); inferred from its directory when omitted."
+  )
+  var scope: Scope?
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(
+      command: WorkflowCommandPayload.commandName, output: options.outputMode, colorEnabled: options.colorEnabled
+    ) {
+      let payload = try WorkflowCommandExecutor.current().validate(path: file, scope: scope?.value)
+      if payload.valid {
+        try WorkflowCommandRunner.render(.validate(payload), options: options)
+        return
+      }
+      // An invalid file is an error outcome whose details carry the full validate payload.
+      let response = CommandResponse(
+        ok: false,
+        command: WorkflowCommandPayload.commandName,
+        schemaVersion: WorkflowCommandPayload.schemaVersion,
+        error: CommandError(
+          code: CLIErrorCode.workflowInvalid,
+          message: "\(payload.path) has \(payload.diagnostics.filter { $0.severity == .error }.count) error(s).",
+          details: try RawJSON(encoding: payload)
+        )
+      )
+      switch options.outputMode {
+      case .json:
+        OutputRenderer.render(response, mode: .json)
+      case .text:
+        print(OutputRenderer.workflowValidateText(payload))
+      }
+      throw ExitCode.failure
+    }
+  }
+}
+
+struct WorkflowSchemaCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "schema",
+    abstract: "Print the JSON Schema of a workflow file (for authoring agents and editors)."
+  )
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(
+      command: WorkflowCommandPayload.commandName, output: options.outputMode, colorEnabled: options.colorEnabled
+    ) {
+      try WorkflowCommandRunner.render(.schema(try WorkflowCommandExecutor.current().schema()), options: options)
+    }
+  }
+}
+
+enum WorkflowCommandRunner {
+  static func render(_ payload: WorkflowCommandPayload, options: GlobalOptions) throws {
+    let response = CommandResponse(
+      ok: true,
+      command: WorkflowCommandPayload.commandName,
+      schemaVersion: WorkflowCommandPayload.schemaVersion,
+      data: try RawJSON(encoding: payload)
+    )
+    OutputRenderer.render(response, mode: options.outputMode)
+  }
+}

--- a/ProwlCLI/Output/OutputRenderer+Workflow.swift
+++ b/ProwlCLI/Output/OutputRenderer+Workflow.swift
@@ -1,0 +1,75 @@
+// ProwlCLI/Output/OutputRenderer+Workflow.swift
+// Text rendering for `prowl workflow`.
+
+import Foundation
+import ProwlCLIShared
+@preconcurrency import Rainbow
+
+extension OutputRenderer {
+  static func renderWorkflow(_ payload: WorkflowCommandPayload) {
+    switch payload {
+    case .list(let list):
+      print(workflowListText(list))
+    case .validate(let validate):
+      print(workflowValidateText(validate))
+    case .schema(let schema):
+      renderWorkflowSchema(schema)
+    }
+  }
+
+  static func workflowListText(_ payload: WorkflowListPayload) -> String {
+    var lines: [String] = []
+    if let worktree = payload.worktree {
+      lines.append("Worktree: \(worktree.name.bold)  \(worktree.path.dim)")
+    }
+    lines.append("Sources: bundle \(payload.sources.bundle ?? "—")  user \(payload.sources.user)  repo \(payload.sources.repo ?? "—")".dim)
+    guard !payload.workflows.isEmpty else {
+      lines.append("No workflow definitions found.")
+      return lines.joined(separator: "\n")
+    }
+    lines.append("")
+    for entry in payload.workflows {
+      let id = entry.id ?? "(unparsed)"
+      let name = entry.name.map { "  \($0)" } ?? ""
+      var flags: [String] = []
+      flags.append(entry.valid ? "valid".green : "invalid".red)
+      if entry.warnings > 0 { flags.append("\(entry.warnings) warning(s)".yellow) }
+      if entry.errors > 0 { flags.append("\(entry.errors) error(s)".red) }
+      if !entry.enabled { flags.append("disabled".dim) }
+      if entry.shadowed { flags.append("shadowed".dim) }
+      lines.append("\(id.bold)\(name)  [\(entry.scope.rawValue)]  \(flags.joined(separator: "  "))")
+      lines.append("  \(entry.path.dim)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  static func workflowValidateText(_ payload: WorkflowValidatePayload) -> String {
+    var lines = payload.diagnostics.map { diagnostic in
+      let position = diagnostic.line.map { line in
+        ":\(line)" + (diagnostic.column.map { ":\($0)" } ?? "")
+      } ?? ""
+      let severity = diagnostic.severity == .error ? "error".red : "warning".yellow
+      return "\(payload.path)\(position): \(severity)[\(diagnostic.code)]: \(diagnostic.message)"
+    }
+    let errors = payload.diagnostics.filter { $0.severity == .error }.count
+    let warnings = payload.diagnostics.count - errors
+    let identity = payload.workflow.map { "\($0.id) (\($0.name))" } ?? payload.path
+    if payload.valid {
+      lines.append("\("OK".green)  \(identity)\(warnings > 0 ? "  \(warnings) warning(s)".yellow : "")")
+    } else {
+      lines.append("\("INVALID".red)  \(identity)  \(errors) error(s), \(warnings) warning(s)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private static func renderWorkflowSchema(_ payload: WorkflowSchemaPayload) {
+    if let object = try? JSONSerialization.jsonObject(with: payload.schema.bytes),
+      let pretty = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    {
+      FileHandle.standardOutput.write(pretty)
+      FileHandle.standardOutput.write(Data([UInt8(ascii: "\n")]))
+      return
+    }
+    FileHandle.standardOutput.write(payload.schema.bytes)
+  }
+}

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -127,6 +127,14 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "workflow",
+         let data = response.data,
+         let payload = try? data.decode(as: WorkflowCommandPayload.self)
+      {
+        renderWorkflow(payload)
+        return
+      }
+
       if response.command == "focus",
          let data = response.data,
          let payload = try? data.decode(as: FocusCommandPayload.self)

--- a/ProwlCLI/Workflow/WorkflowCommandExecutor.swift
+++ b/ProwlCLI/Workflow/WorkflowCommandExecutor.swift
@@ -1,0 +1,62 @@
+// ProwlCLI/Workflow/WorkflowCommandExecutor.swift
+// Local execution of `prowl workflow validate` and `prowl workflow schema`: no socket, no app.
+
+import Foundation
+import ProwlCLIShared
+
+struct WorkflowCommandExecutor {
+  /// nil when the CLI is not inside an app bundle (and `PROWL_SKILLS_DIR` is unset): `skill:`
+  /// references are then reported as unchecked warnings instead of failing the file.
+  let bundledSkillIDs: Set<String>?
+  let homeDirectory: URL
+  let currentDirectory: URL
+
+  static func current(environment: [String: String] = ProcessInfo.processInfo.environment) -> Self {
+    let executableURL = Bundle.main.executableURL ?? URL(filePath: CommandLine.arguments[0])
+    let skills = try? ProwlSkills.bundledForCLI(executableURL: executableURL, environment: environment)
+    let home: URL
+    if let override = environment["HOME"], !override.isEmpty {
+      home = URL(filePath: override, directoryHint: .isDirectory)
+    } else {
+      home = FileManager.default.homeDirectoryForCurrentUser
+    }
+    return Self(
+      bundledSkillIDs: skills.map { Set($0.map(\.id)) },
+      homeDirectory: home.standardizedFileURL,
+      currentDirectory: URL(filePath: FileManager.default.currentDirectoryPath, directoryHint: .isDirectory)
+    )
+  }
+
+  func validate(path: String, scope explicitScope: WorkflowScope?) throws -> WorkflowValidatePayload {
+    let url = URL(filePath: path, directoryHint: .notDirectory, relativeTo: currentDirectory).standardizedFileURL
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory) else {
+      throw ExitError(code: CLIErrorCode.pathNotFound, message: "No file at \(url.path(percentEncoded: false)).")
+    }
+    guard !isDirectory.boolValue else {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument, message: "\(url.path(percentEncoded: false)) is a directory, not a workflow file.")
+    }
+    let scope = explicitScope ?? inferredScope(of: url)
+    let context = WorkflowValidationContext(scope: scope, bundledSkillIDs: bundledSkillIDs)
+    return WorkflowValidatePayload(file: WorkflowDiscovery.load(url: url, scope: scope, context: context))
+  }
+
+  func schema() throws -> WorkflowSchemaPayload {
+    WorkflowSchemaPayload(schema: RawJSON(Data(WorkflowJSONSchema.definitionSchemaJSON.utf8)))
+  }
+
+  /// `~/.prowl/workflows/*` is user scope; any other `.prowl/workflows/*` is repo scope (the
+  /// reserved-id rule applies to both); everything else is treated as a user file.
+  func inferredScope(of url: URL) -> WorkflowScope {
+    let directory = url.deletingLastPathComponent()
+    if directory == WorkflowSources.userDirectory(home: homeDirectory).standardizedFileURL {
+      return .user
+    }
+    let components = directory.pathComponents
+    if components.count >= 2, components.suffix(2) == [".prowl", "workflows"] {
+      return .repo
+    }
+    return .user
+  }
+}

--- a/ProwlCLIContracts/ContractBundle.swift
+++ b/ProwlCLIContracts/ContractBundle.swift
@@ -1,14 +1,20 @@
 import Foundation
 
 public enum ProwlCLIContractBundle {
-  public static let schemaData: Data = {
-    guard let url = Bundle.module.url(forResource: "cli-output-schema", withExtension: "json") else {
-      preconditionFailure("Missing Prowl CLI JSON Schema bundle resource.")
+  public static let schemaData: Data = load(resource: "cli-output-schema")
+
+  /// Draft 2020-12 schema of a `prowl.workflow/v1` file; must equal
+  /// `WorkflowJSONSchema.definitionSchemaJSON` (pinned by a test).
+  public static let workflowDefinitionSchemaData: Data = load(resource: "workflow-definition-schema")
+
+  private static func load(resource: String) -> Data {
+    guard let url = Bundle.module.url(forResource: resource, withExtension: "json") else {
+      preconditionFailure("Missing Prowl CLI JSON Schema resource \(resource).json.")
     }
     do {
       return try Data(contentsOf: url)
     } catch {
-      preconditionFailure("Failed to load Prowl CLI JSON Schema bundle: \(error)")
+      preconditionFailure("Failed to load Prowl CLI JSON Schema resource \(resource).json: \(error)")
     }
-  }()
+  }
 }

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -60,6 +60,9 @@
     },
     {
       "$ref": "#/$defs/handoffResponse"
+    },
+    {
+      "$ref": "#/$defs/workflowResponse"
     }
   ],
   "$defs": {
@@ -3649,6 +3652,288 @@
           }
         }
       ]
+    },
+    "workflowResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "data"
+          ],
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "command": {
+              "const": "workflow"
+            },
+            "schema_version": {
+              "const": "prowl.cli.workflow.v1"
+            },
+            "data": {
+              "$ref": "#/$defs/workflowData"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "error"
+          ],
+          "properties": {
+            "ok": {
+              "const": false
+            },
+            "command": {
+              "const": "workflow"
+            },
+            "schema_version": {
+              "const": "prowl.cli.workflow.v1"
+            },
+            "error": {
+              "$ref": "#/$defs/error"
+            }
+          }
+        }
+      ]
+    },
+    "workflowData": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/workflowListData"
+        },
+        {
+          "$ref": "#/$defs/workflowValidateData"
+        },
+        {
+          "$ref": "#/$defs/workflowSchemaData"
+        }
+      ]
+    },
+    "workflowScope": {
+      "enum": [
+        "bundle",
+        "user",
+        "repo"
+      ]
+    },
+    "workflowListData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "sources",
+        "workflows"
+      ],
+      "properties": {
+        "action": {
+          "const": "list"
+        },
+        "worktree": {
+          "$ref": "#/$defs/workflowListWorktree"
+        },
+        "sources": {
+          "$ref": "#/$defs/workflowListSources"
+        },
+        "workflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workflowListEntry"
+          }
+        }
+      }
+    },
+    "workflowListWorktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "path",
+        "root_path"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "root_path": {
+          "type": "string"
+        }
+      }
+    },
+    "workflowListSources": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "user"
+      ],
+      "properties": {
+        "bundle": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        }
+      }
+    },
+    "workflowListEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "path",
+        "enabled",
+        "valid",
+        "errors",
+        "warnings",
+        "shadowed"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/$defs/workflowScope"
+        },
+        "path": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "errors": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warnings": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "shadowed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "workflowValidateData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "path",
+        "valid",
+        "diagnostics"
+      ],
+      "properties": {
+        "action": {
+          "const": "validate"
+        },
+        "path": {
+          "type": "string"
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "workflow": {
+          "$ref": "#/$defs/workflowIdentity"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workflowDiagnostic"
+          }
+        }
+      }
+    },
+    "workflowIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "workflowDiagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "severity",
+        "code",
+        "message"
+      ],
+      "properties": {
+        "severity": {
+          "enum": [
+            "error",
+            "warning"
+          ]
+        },
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "workflowSchemaData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "schema"
+      ],
+      "properties": {
+        "action": {
+          "const": "schema"
+        },
+        "schema": {
+          "type": "object"
+        }
+      }
     }
   }
 }

--- a/ProwlCLIContracts/Resources/workflow-definition-schema.json
+++ b/ProwlCLIContracts/Resources/workflow-definition-schema.json
@@ -1,0 +1,536 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://prowl.onev.cat/contracts/workflow/v1/workflow-definition.json",
+  "title": "Prowl Agent Workflow (prowl.workflow/v1)",
+  "description": "Declarative multi-agent workflow run by Prowl (docs-ai 063 dsl-spec.md).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "id",
+    "name",
+    "steps"
+  ],
+  "properties": {
+    "schema": {
+      "const": "prowl.workflow/v1"
+    },
+    "id": {
+      "$ref": "#/$defs/workflowId"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "icon": {
+      "type": "string",
+      "description": "SF Symbol name"
+    },
+    "inputs": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/slug"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/input"
+      }
+    },
+    "roles": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/slug"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/role"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+    },
+    "workflowId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_.-]{0,63}$"
+    },
+    "template": {
+      "type": "string"
+    },
+    "input": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/integerInput"
+        },
+        {
+          "$ref": "#/$defs/stringInput"
+        },
+        {
+          "$ref": "#/$defs/enumInput"
+        }
+      ]
+    },
+    "integerInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "integer"
+        },
+        "default": {
+          "type": "integer"
+        },
+        "min": {
+          "type": "integer"
+        },
+        "max": {
+          "type": "integer"
+        },
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "stringInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "string"
+        },
+        "default": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "enumInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "values"
+      ],
+      "properties": {
+        "type": {
+          "const": "enum"
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "role": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/currentRole"
+        },
+        {
+          "$ref": "#/$defs/pickRole"
+        },
+        {
+          "$ref": "#/$defs/launchRole"
+        }
+      ]
+    },
+    "currentRole": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "const": "current"
+        }
+      }
+    },
+    "pickRole": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "const": "pick"
+        }
+      }
+    },
+    "launchRole": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "const": "launch"
+        },
+        "kind": {
+          "const": "interactive"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "suggest": {
+          "$ref": "#/$defs/suggest"
+        },
+        "bind": {
+          "enum": [
+            "ask",
+            "auto"
+          ]
+        },
+        "placement": {
+          "enum": [
+            "split",
+            "tab"
+          ]
+        },
+        "direction": {
+          "enum": [
+            "right",
+            "left",
+            "up",
+            "down"
+          ]
+        },
+        "background": {
+          "type": "boolean"
+        }
+      }
+    },
+    "suggest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "type": "string"
+        },
+        "execution_mode": {
+          "type": "string"
+        }
+      }
+    },
+    "step": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/messageStep"
+        },
+        {
+          "$ref": "#/$defs/launchStep"
+        },
+        {
+          "$ref": "#/$defs/actionStep"
+        },
+        {
+          "$ref": "#/$defs/notifyStep"
+        },
+        {
+          "$ref": "#/$defs/closeStep"
+        },
+        {
+          "$ref": "#/$defs/repeatStep"
+        }
+      ]
+    },
+    "loopStep": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/messageStep"
+        },
+        {
+          "$ref": "#/$defs/actionStep"
+        },
+        {
+          "$ref": "#/$defs/notifyStep"
+        },
+        {
+          "$ref": "#/$defs/closeStep"
+        }
+      ]
+    },
+    "messageStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "message": {
+          "$ref": "#/$defs/slug"
+        },
+        "text": {
+          "$ref": "#/$defs/template"
+        },
+        "instruction": {
+          "$ref": "#/$defs/template"
+        },
+        "expect": {
+          "$ref": "#/$defs/expect"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "required": [
+            "instruction"
+          ]
+        }
+      ]
+    },
+    "launchStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "launch",
+        "prompt"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "launch": {
+          "$ref": "#/$defs/slug"
+        },
+        "prompt": {
+          "$ref": "#/$defs/template"
+        },
+        "skill": {
+          "$ref": "#/$defs/workflowId"
+        },
+        "expect": {
+          "$ref": "#/$defs/expect"
+        }
+      }
+    },
+    "actionStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "action"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "action": {
+          "enum": [
+            "handoff.transition",
+            "handoff.checkpoint",
+            "git.context"
+          ]
+        },
+        "with": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/slug"
+          },
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        }
+      }
+    },
+    "notifyStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "notify"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "notify": {
+          "$ref": "#/$defs/template"
+        }
+      }
+    },
+    "closeStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "close"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "close": {
+          "$ref": "#/$defs/slug"
+        }
+      }
+    },
+    "repeatStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repeat",
+        "steps"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "title": {
+          "$ref": "#/$defs/template"
+        },
+        "repeat": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "max"
+          ],
+          "properties": {
+            "max": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 20
+                },
+                {
+                  "type": "string",
+                  "pattern": "^\\s*\\{\\{\\s*inputs\\.[a-z0-9_-]+\\s*\\}\\}\\s*$"
+                }
+              ]
+            },
+            "until": {
+              "type": "string",
+              "pattern": "^outputs\\.[a-z0-9_-]+\\.verdict\\s*(==\\s*[a-z0-9_-]+|in\\s*\\[[^\\]]*\\])$"
+            }
+          }
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/loopStep"
+          }
+        }
+      }
+    },
+    "expect": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "output": {
+          "$ref": "#/$defs/slug"
+        },
+        "format": {
+          "enum": [
+            "markdown",
+            "text",
+            "json"
+          ]
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "verdict": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/slug"
+          }
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^\\d+\\s*[smh]$"
+        },
+        "on_timeout": {
+          "enum": [
+            "attention",
+            "skip",
+            "cancel"
+          ]
+        }
+      },
+      "dependentRequired": {
+        "on_timeout": [
+          "timeout"
+        ]
+      }
+    }
+  }
+}

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1076,6 +1076,114 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(result.stdout.contains("Availability check has not completed"), result.stdout)
   }
 
+  // MARK: - workflow
+
+  private func withWorkflowFile(_ yaml: String, _ body: (URL, String) throws -> Void) throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workflow-cli-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let file = directory.appending(path: "flow.yaml")
+    try Data(yaml.utf8).write(to: file)
+    try body(file, directory.appending(path: "missing.sock").path(percentEncoded: false))
+  }
+
+  func testWorkflowValidateIsLocalOnlyAndReportsAValidFile() throws {
+    try withWorkflowFile(WorkflowFixtures.minimal(id: "demo")) { file, socketPath in
+      let environment = [ProwlSocket.environmentKey: socketPath]
+      let result = try runProwl(
+        args: ["workflow", "validate", file.path(percentEncoded: false), "--json"], environment: environment)
+      XCTAssertEqual(result.exitCode, 0, result.stderr)
+      try assertResponseMatchesSchema(Data(result.stdout.utf8))
+      let output = try jsonObject(from: result.stdout)
+      XCTAssertEqual(output["command"] as? String, "workflow")
+      XCTAssertEqual(output["schema_version"] as? String, "prowl.cli.workflow.v1")
+      let data = try XCTUnwrap(output["data"] as? [String: Any])
+      XCTAssertEqual(data["action"] as? String, "validate")
+      XCTAssertEqual(data["valid"] as? Bool, true)
+      XCTAssertEqual((data["workflow"] as? [String: Any])?["id"] as? String, "demo")
+      XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath), "The command never touches the socket")
+
+      let text = try runProwl(
+        args: ["workflow", "validate", file.path(percentEncoded: false), "--no-color"], environment: environment)
+      XCTAssertEqual(text.exitCode, 0, text.stderr)
+      XCTAssertTrue(text.stdout.contains("OK"), text.stdout)
+    }
+  }
+
+  func testWorkflowValidateFailsWithDiagnosticsForAnInvalidFile() throws {
+    let yaml = WorkflowFixtures.minimal(id: "demo", extraSteps: "  - id: b\n    close: ghost")
+    try withWorkflowFile(yaml) { file, socketPath in
+      let environment = [ProwlSocket.environmentKey: socketPath]
+      let result = try runProwl(
+        args: ["workflow", "validate", file.path(percentEncoded: false), "--json"], environment: environment)
+      XCTAssertEqual(result.exitCode, 1)
+      try assertResponseMatchesSchema(Data(result.stdout.utf8))
+      let output = try jsonObject(from: result.stdout)
+      XCTAssertEqual(output["ok"] as? Bool, false)
+      let error = try XCTUnwrap(output["error"] as? [String: Any])
+      XCTAssertEqual(error["code"] as? String, "WORKFLOW_INVALID")
+      let details = try XCTUnwrap(error["details"] as? [String: Any])
+      let diagnostics = try XCTUnwrap(details["diagnostics"] as? [[String: Any]])
+      XCTAssertEqual(diagnostics.map { $0["code"] as? String }, ["undefined_role"])
+      XCTAssertEqual(diagnostics.first?["line"] as? Int, 12)
+
+      let text = try runProwl(
+        args: ["workflow", "validate", file.path(percentEncoded: false), "--no-color"], environment: environment)
+      XCTAssertEqual(text.exitCode, 1)
+      XCTAssertTrue(text.stdout.contains("error[undefined_role]"), text.stdout)
+      XCTAssertTrue(text.stdout.contains("INVALID"), text.stdout)
+    }
+  }
+
+  func testWorkflowSchemaPrintsTheDefinitionSchema() throws {
+    let result = try runProwl(args: ["workflow", "schema", "--json"])
+    XCTAssertEqual(result.exitCode, 0, result.stderr)
+    try assertResponseMatchesSchema(Data(result.stdout.utf8))
+    let data = try XCTUnwrap(try jsonObject(from: result.stdout)["data"] as? [String: Any])
+    XCTAssertEqual(data["action"] as? String, "schema")
+    let schema = try XCTUnwrap(data["schema"] as? [String: Any])
+    XCTAssertEqual(schema["$id"] as? String, WorkflowJSONSchema.identifier)
+
+    let text = try runProwl(args: ["workflow", "schema"])
+    XCTAssertEqual(text.exitCode, 0, text.stderr)
+    let printed = try jsonObject(from: text.stdout)
+    XCTAssertEqual(printed["$id"] as? String, WorkflowJSONSchema.identifier)
+  }
+
+  func testWorkflowListRoundTripsThroughTheSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "workflow-list")
+    let payload = WorkflowCommandPayload.list(
+      WorkflowListPayload(
+        worktree: WorkflowListWorktree(id: "wt", name: "main", path: "/Projects/App", rootPath: "/Projects/App"),
+        sources: WorkflowListSources(bundle: nil, user: "/Users/me/.prowl/workflows", repo: "/Projects/App/.prowl/workflows"),
+        workflows: [
+          WorkflowListEntry(
+            id: "demo", name: "Demo", description: nil, scope: .repo, path: "/Projects/App/.prowl/workflows/demo.yaml",
+            enabled: true, valid: true, errors: 0, warnings: 1, shadowed: false)
+        ]))
+    let response = try CommandResponse(
+      ok: true, command: "workflow", schemaVersion: "prowl.cli.workflow.v1", data: RawJSON(encoding: payload))
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath, response: response, args: ["workflow", "list", "main", "--json"])
+    XCTAssertEqual(result.exitCode, 0, result.stderr)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    guard case .workflow(let input) = envelope.command else { return XCTFail("Expected a workflow envelope") }
+    XCTAssertEqual(input.action, .list)
+    XCTAssertEqual(input.target, .auto("main"))
+    let output = try jsonObject(from: result.stdout)
+    XCTAssertEqual(output["schema_version"] as? String, "prowl.cli.workflow.v1")
+
+    let text = try runWithMockServer(
+      socketPath: temporarySocketPath(suffix: "workflow-list-text"), response: response,
+      args: ["workflow", "list", "--no-color"]).1
+    XCTAssertEqual(text.exitCode, 0, text.stderr)
+    XCTAssertTrue(text.stdout.contains("demo"), text.stdout)
+    XCTAssertTrue(text.stdout.contains("[repo]"), text.stdout)
+    XCTAssertTrue(text.stdout.contains("1 warning(s)"), text.stdout)
+  }
+
   // MARK: - skills (local-only)
 
   func testSkillsListIsLocalOnlyAndValidatesAgainstSchema() throws {

--- a/ProwlCLITests/WorkflowCommandExecutorTests.swift
+++ b/ProwlCLITests/WorkflowCommandExecutorTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+@testable import prowl
+
+final class WorkflowCommandExecutorTests: XCTestCase {
+  private var root: URL!
+  private var home: URL!
+
+  override func setUpWithError() throws {
+    root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workflow-executor-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    home = root.appending(path: "home", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  private func executor(bundledSkillIDs: Set<String>? = ["prowl.adversarial-reviewer"]) -> WorkflowCommandExecutor {
+    WorkflowCommandExecutor(bundledSkillIDs: bundledSkillIDs, homeDirectory: home, currentDirectory: root)
+  }
+
+  @discardableResult
+  private func write(_ yaml: String, at relativePath: String) throws -> URL {
+    let url = root.appending(path: relativePath, directoryHint: .notDirectory)
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data(yaml.utf8).write(to: url)
+    return url
+  }
+
+  func testValidateReportsAValidFileWithItsIdentity() throws {
+    let url = try write(WorkflowFixtures.minimal(id: "demo"), at: "flows/demo.yaml")
+    let payload = try executor().validate(path: "flows/demo.yaml", scope: nil)
+    XCTAssertTrue(payload.valid)
+    XCTAssertEqual(payload.path, url.path(percentEncoded: false))
+    XCTAssertEqual(payload.workflow, WorkflowIdentity(id: "demo", name: "Demo"))
+    XCTAssertEqual(payload.diagnostics, [])
+  }
+
+  func testValidateReportsErrorsWithPositions() throws {
+    try write(WorkflowFixtures.minimal(id: "demo", extraSteps: "  - id: b\n    close: ghost"), at: "bad.yaml")
+    let payload = try executor().validate(path: "bad.yaml", scope: nil)
+    XCTAssertFalse(payload.valid)
+    XCTAssertEqual(payload.workflow?.id, "demo", "A file that parses keeps its identity")
+    XCTAssertEqual(payload.diagnostics.map(\.code), ["undefined_role"])
+    XCTAssertEqual(payload.diagnostics.first?.line, 12)
+  }
+
+  func testScopeIsInferredFromTheDirectoryUnlessOverridden() throws {
+    try write(WorkflowFixtures.adversarialReview, at: "home/.prowl/workflows/review.yaml")
+    try write(WorkflowFixtures.adversarialReview, at: "repo/.prowl/workflows/review.yaml")
+    try write(WorkflowFixtures.adversarialReview, at: "elsewhere/review.yaml")
+    let executor = executor()
+
+    XCTAssertEqual(executor.inferredScope(of: root.appending(path: "home/.prowl/workflows/review.yaml")), .user)
+    XCTAssertEqual(executor.inferredScope(of: root.appending(path: "repo/.prowl/workflows/review.yaml")), .repo)
+    XCTAssertEqual(executor.inferredScope(of: root.appending(path: "elsewhere/review.yaml")), .user)
+
+    let inferred = try executor.validate(path: "repo/.prowl/workflows/review.yaml", scope: nil)
+    XCTAssertEqual(inferred.diagnostics.map(\.code), ["reserved_id"])
+    let bundle = try executor.validate(path: "repo/.prowl/workflows/review.yaml", scope: .bundle)
+    XCTAssertTrue(bundle.valid)
+  }
+
+  func testSkillsAreUncheckedWithoutABundle() throws {
+    try write(WorkflowFixtures.adversarialReview, at: "review.yaml")
+    let payload = try executor(bundledSkillIDs: nil).validate(path: "review.yaml", scope: .bundle)
+    XCTAssertTrue(payload.valid)
+    XCTAssertEqual(payload.diagnostics.map(\.code), ["skill_unchecked"])
+  }
+
+  func testMissingAndDirectoryPathsFailWithTypedErrors() throws {
+    XCTAssertThrowsError(try executor().validate(path: "missing.yaml", scope: nil)) { error in
+      XCTAssertEqual((error as? ExitError)?.code, CLIErrorCode.pathNotFound)
+    }
+    XCTAssertThrowsError(try executor().validate(path: "home", scope: nil)) { error in
+      XCTAssertEqual((error as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
+  }
+
+  func testSchemaPayloadCarriesTheDefinitionSchema() throws {
+    let payload = try executor().schema()
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: payload.schema.bytes) as? [String: Any])
+    XCTAssertEqual(object["$id"] as? String, WorkflowJSONSchema.identifier)
+    XCTAssertEqual(object["$schema"] as? String, "https://json-schema.org/draft/2020-12/schema")
+  }
+}

--- a/ProwlCLITests/WorkflowCommandParsingTests.swift
+++ b/ProwlCLITests/WorkflowCommandParsingTests.swift
@@ -1,0 +1,48 @@
+import ProwlCLIShared
+import XCTest
+
+@testable import prowl
+
+final class WorkflowCommandParsingTests: XCTestCase {
+  func testRootRoutesWorkflowSubcommands() throws {
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["workflow", "list"]) is WorkflowListCommand)
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["workflow", "validate", "flow.yaml"]) is WorkflowValidateCommand)
+    XCTAssertTrue(try ProwlCommand.parseAsRoot(["workflow", "schema"]) is WorkflowSchemaCommand)
+  }
+
+  func testListAcceptsAPositionalTargetOrOneSelectorFlag() throws {
+    let bare = try WorkflowListCommand.parse(["--json"])
+    XCTAssertEqual(try bare.selector.resolve(positionalTarget: bare.target), .none)
+
+    let positional = try WorkflowListCommand.parse(["p3"])
+    XCTAssertEqual(try positional.selector.resolve(positionalTarget: positional.target), .auto("p3"))
+
+    let flag = try WorkflowListCommand.parse(["--worktree", "main"])
+    XCTAssertEqual(try flag.selector.resolve(positionalTarget: flag.target), .worktree("main"))
+
+    let both = try WorkflowListCommand.parse(["p3", "--worktree", "main"])
+    XCTAssertThrowsError(try both.selector.resolve(positionalTarget: both.target)) { error in
+      XCTAssertEqual((error as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
+  }
+
+  func testValidateRequiresAFileAndAcceptsAScope() throws {
+    let command = try WorkflowValidateCommand.parse(["flows/review.yaml", "--scope", "repo", "--json"])
+    XCTAssertEqual(command.file, "flows/review.yaml")
+    XCTAssertEqual(command.scope, .repo)
+    XCTAssertTrue(command.options.json)
+    XCTAssertNil(try WorkflowValidateCommand.parse(["x.yaml"]).scope)
+    XCTAssertThrowsError(try WorkflowValidateCommand.parse([]))
+    XCTAssertThrowsError(try WorkflowValidateCommand.parse(["x.yaml", "--scope", "global"]))
+  }
+
+  func testWorkflowInputEnvelopeEncodesTheTarget() throws {
+    let envelope = CommandEnvelope(output: .json, command: .workflow(WorkflowInput(action: .list, target: .auto("p3"))))
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    guard case .workflow(let input) = decoded.command else { return XCTFail("Expected a workflow envelope") }
+    XCTAssertEqual(input.action, .list)
+    XCTAssertEqual(input.target, .auto("p3"))
+    XCTAssertEqual(decoded.command.name, "workflow")
+  }
+}

--- a/ProwlCLITests/WorkflowDiscoveryTests.swift
+++ b/ProwlCLITests/WorkflowDiscoveryTests.swift
@@ -29,8 +29,18 @@ final class WorkflowDiscoveryTests: XCTestCase {
     WorkflowValidationContext(scope: scope, bundledSkillIDs: ["prowl.adversarial-reviewer"])
   }
 
-  func testMissingDirectoriesYieldNoFiles() {
-    let catalog = WorkflowDiscovery.catalog(
+  func testUnreadableDirectoriesThrowInsteadOfHidingTheirFiles() throws {
+    let user = try directory("user")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "demo.yaml")
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: user.path(percentEncoded: false))
+    defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: user.path(percentEncoded: false)) }
+    XCTAssertThrowsError(try WorkflowDiscovery.files(in: user, scope: .user, context: context(.user)))
+    XCTAssertThrowsError(
+      try WorkflowDiscovery.catalog(sources: WorkflowSources(bundle: nil, user: user, repo: nil), context: context))
+  }
+
+  func testMissingDirectoriesYieldNoFiles() throws {
+    let catalog = try WorkflowDiscovery.catalog(
       sources: WorkflowSources(bundle: nil, user: root.appending(path: "absent"), repo: nil), context: context)
     XCTAssertEqual(catalog, [])
   }
@@ -43,7 +53,7 @@ final class WorkflowDiscoveryTests: XCTestCase {
     try write("ignored", to: user, name: "notes.txt")
     try write(WorkflowFixtures.minimal(id: "hidden"), to: user, name: ".hidden.yaml")
 
-    let files = WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
+    let files = try WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
     XCTAssertEqual(files.map(\.url.lastPathComponent), ["alpha.yaml", "broken.yaml", "zeta.yml"])
     XCTAssertEqual(files.map(\.id), ["alpha", nil, "zeta"])
     XCTAssertEqual(files.map(\.isValid), [true, false, true])
@@ -54,7 +64,7 @@ final class WorkflowDiscoveryTests: XCTestCase {
   func testValidationDiagnosticsFollowParseDiagnostics() throws {
     let user = try directory("user")
     try write(WorkflowFixtures.minimal(id: "prowl.mine"), to: user, name: "mine.yaml")
-    let files = WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
+    let files = try WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
     XCTAssertEqual(files.map(\.isValid), [false])
     XCTAssertEqual(files[0].diagnostics.map(\.code), ["reserved_id"])
     XCTAssertNotNil(files[0].definition, "A file that parses keeps its definition even when validation fails")
@@ -72,7 +82,7 @@ final class WorkflowDiscoveryTests: XCTestCase {
     try write(WorkflowFixtures.adversarialReview, to: user, name: "override.yaml")
     try write(WorkflowFixtures.minimal(id: "demo"), to: repo, name: "demo.yaml")
 
-    let catalog = WorkflowDiscovery.catalog(
+    let catalog = try WorkflowDiscovery.catalog(
       sources: WorkflowSources(bundle: bundle, user: user, repo: repo), context: context)
     let rows = catalog.map { "\($0.file.id ?? "-") \($0.file.scope.rawValue) \($0.file.url.lastPathComponent) \($0.shadowed ? "shadowed" : ($0.file.isValid ? "wins" : "invalid"))" }
     XCTAssertEqual(
@@ -93,7 +103,7 @@ final class WorkflowDiscoveryTests: XCTestCase {
     let user = try directory("user")
     try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "b.yaml")
     try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "a.yaml")
-    let catalog = WorkflowDiscovery.catalog(
+    let catalog = try WorkflowDiscovery.catalog(
       sources: WorkflowSources(bundle: nil, user: user, repo: nil), context: context)
     XCTAssertEqual(catalog.map { "\($0.file.url.lastPathComponent) \($0.shadowed)" }, ["a.yaml false", "b.yaml true"])
   }
@@ -103,7 +113,7 @@ final class WorkflowDiscoveryTests: XCTestCase {
     let repo = try directory("repo")
     try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "demo.yaml")
     try write(WorkflowFixtures.minimal(id: "demo", extraSteps: "  - id: x\n    close: ghost"), to: repo, name: "demo.yaml")
-    let catalog = WorkflowDiscovery.catalog(
+    let catalog = try WorkflowDiscovery.catalog(
       sources: WorkflowSources(bundle: nil, user: user, repo: repo), context: context)
     XCTAssertEqual(
       catalog.map { "\($0.file.scope.rawValue) valid=\($0.file.isValid) shadowed=\($0.shadowed)" },

--- a/ProwlCLITests/WorkflowDiscoveryTests.swift
+++ b/ProwlCLITests/WorkflowDiscoveryTests.swift
@@ -131,6 +131,8 @@ final class WorkflowDiscoveryTests: XCTestCase {
     try FileManager.default.createSymbolicLink(
       at: user.appending(path: "dangling.yaml"), withDestinationURL: elsewhere.appending(path: "missing.yaml"))
 
+    XCTAssertEqual(mkfifo(user.appending(path: "pipe.yaml").path(percentEncoded: false), 0o644), 0)
+
     let files = try WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
     XCTAssertEqual(files.map(\.url.lastPathComponent), ["link.yaml", "real.yaml"])
     XCTAssertEqual(files.map(\.id), ["linked", "real"])

--- a/ProwlCLITests/WorkflowDiscoveryTests.swift
+++ b/ProwlCLITests/WorkflowDiscoveryTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class WorkflowDiscoveryTests: XCTestCase {
+  private var root: URL!
+
+  override func setUpWithError() throws {
+    root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workflow-discovery-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  private func directory(_ name: String) throws -> URL {
+    let url = root.appending(path: name, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func write(_ yaml: String, to directory: URL, name: String) throws {
+    try Data(yaml.utf8).write(to: directory.appending(path: name))
+  }
+
+  private func context(_ scope: WorkflowScope) -> WorkflowValidationContext {
+    WorkflowValidationContext(scope: scope, bundledSkillIDs: ["prowl.adversarial-reviewer"])
+  }
+
+  func testMissingDirectoriesYieldNoFiles() {
+    let catalog = WorkflowDiscovery.catalog(
+      sources: WorkflowSources(bundle: nil, user: root.appending(path: "absent"), repo: nil), context: context)
+    XCTAssertEqual(catalog, [])
+  }
+
+  func testFilesAreParsedValidatedAndOrderedByName() throws {
+    let user = try directory("user")
+    try write(WorkflowFixtures.minimal(id: "zeta"), to: user, name: "zeta.yml")
+    try write(WorkflowFixtures.minimal(id: "alpha"), to: user, name: "alpha.yaml")
+    try write("not: [valid", to: user, name: "broken.yaml")
+    try write("ignored", to: user, name: "notes.txt")
+    try write(WorkflowFixtures.minimal(id: "hidden"), to: user, name: ".hidden.yaml")
+
+    let files = WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
+    XCTAssertEqual(files.map(\.url.lastPathComponent), ["alpha.yaml", "broken.yaml", "zeta.yml"])
+    XCTAssertEqual(files.map(\.id), ["alpha", nil, "zeta"])
+    XCTAssertEqual(files.map(\.isValid), [true, false, true])
+    XCTAssertEqual(files[1].diagnostics.map(\.code), ["yaml_syntax"])
+    XCTAssertEqual(files.map(\.scope), [.user, .user, .user])
+  }
+
+  func testValidationDiagnosticsFollowParseDiagnostics() throws {
+    let user = try directory("user")
+    try write(WorkflowFixtures.minimal(id: "prowl.mine"), to: user, name: "mine.yaml")
+    let files = WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
+    XCTAssertEqual(files.map(\.isValid), [false])
+    XCTAssertEqual(files[0].diagnostics.map(\.code), ["reserved_id"])
+    XCTAssertNotNil(files[0].definition, "A file that parses keeps its definition even when validation fails")
+  }
+
+  func testPrecedenceAndShadowing() throws {
+    let bundle = try directory("bundle")
+    let user = try directory("user")
+    let repo = try directory("repo")
+    try write(WorkflowFixtures.adversarialReview, to: bundle, name: "adversarial-review.yaml")
+    try write(WorkflowFixtures.minimal(id: "shared"), to: bundle, name: "shared.yaml")
+    try write(WorkflowFixtures.minimal(id: "shared"), to: user, name: "shared.yaml")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "demo.yaml")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "demo-copy.yaml")
+    try write(WorkflowFixtures.adversarialReview, to: user, name: "override.yaml")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: repo, name: "demo.yaml")
+
+    let catalog = WorkflowDiscovery.catalog(
+      sources: WorkflowSources(bundle: bundle, user: user, repo: repo), context: context)
+    let rows = catalog.map { "\($0.file.id ?? "-") \($0.file.scope.rawValue) \($0.file.url.lastPathComponent) \($0.shadowed ? "shadowed" : ($0.file.isValid ? "wins" : "invalid"))" }
+    XCTAssertEqual(
+      rows,
+      [
+        "demo repo demo.yaml wins",
+        "demo user demo-copy.yaml shadowed",
+        "demo user demo.yaml shadowed",
+        "prowl.adversarial-review bundle adversarial-review.yaml wins",
+        "prowl.adversarial-review user override.yaml invalid",
+        "shared user shared.yaml wins",
+        "shared bundle shared.yaml shadowed",
+      ]
+    )
+  }
+
+  func testSameSourceDuplicatesKeepTheFirstFileByName() throws {
+    let user = try directory("user")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "b.yaml")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "a.yaml")
+    let catalog = WorkflowDiscovery.catalog(
+      sources: WorkflowSources(bundle: nil, user: user, repo: nil), context: context)
+    XCTAssertEqual(catalog.map { "\($0.file.url.lastPathComponent) \($0.shadowed)" }, ["a.yaml false", "b.yaml true"])
+  }
+
+  func testInvalidFilesNeverShadowValidOnes() throws {
+    let user = try directory("user")
+    let repo = try directory("repo")
+    try write(WorkflowFixtures.minimal(id: "demo"), to: user, name: "demo.yaml")
+    try write(WorkflowFixtures.minimal(id: "demo", extraSteps: "  - id: x\n    close: ghost"), to: repo, name: "demo.yaml")
+    let catalog = WorkflowDiscovery.catalog(
+      sources: WorkflowSources(bundle: nil, user: user, repo: repo), context: context)
+    XCTAssertEqual(
+      catalog.map { "\($0.file.scope.rawValue) valid=\($0.file.isValid) shadowed=\($0.shadowed)" },
+      ["user valid=true shadowed=false", "repo valid=false shadowed=false"])
+  }
+
+  func testSourceDirectoryHelpers() {
+    let home = URL(filePath: "/Users/me", directoryHint: .isDirectory)
+    XCTAssertEqual(WorkflowSources.userDirectory(home: home).path(percentEncoded: false), "/Users/me/.prowl/workflows/")
+    let repo = URL(filePath: "/Projects/App", directoryHint: .isDirectory)
+    XCTAssertEqual(WorkflowSources.repoDirectory(root: repo).path(percentEncoded: false), "/Projects/App/.prowl/workflows/")
+    let resources = URL(filePath: "/Applications/Prowl.app/Contents/Resources", directoryHint: .isDirectory)
+    XCTAssertEqual(
+      WorkflowSources.bundleDirectory(resourcesURL: resources).path(percentEncoded: false),
+      "/Applications/Prowl.app/Contents/Resources/workflows/")
+  }
+}

--- a/ProwlCLITests/WorkflowDiscoveryTests.swift
+++ b/ProwlCLITests/WorkflowDiscoveryTests.swift
@@ -120,6 +120,22 @@ final class WorkflowDiscoveryTests: XCTestCase {
       ["user valid=true shadowed=false", "repo valid=false shadowed=false"])
   }
 
+  func testOnlyRegularFilesAndLinksToThemAreRead() throws {
+    let user = try directory("user")
+    try write(WorkflowFixtures.minimal(id: "real"), to: user, name: "real.yaml")
+    try FileManager.default.createDirectory(at: user.appending(path: "folder.yaml"), withIntermediateDirectories: true)
+    let elsewhere = try directory("elsewhere")
+    try write(WorkflowFixtures.minimal(id: "linked"), to: elsewhere, name: "source.yaml")
+    try FileManager.default.createSymbolicLink(
+      at: user.appending(path: "link.yaml"), withDestinationURL: elsewhere.appending(path: "source.yaml"))
+    try FileManager.default.createSymbolicLink(
+      at: user.appending(path: "dangling.yaml"), withDestinationURL: elsewhere.appending(path: "missing.yaml"))
+
+    let files = try WorkflowDiscovery.files(in: user, scope: .user, context: context(.user))
+    XCTAssertEqual(files.map(\.url.lastPathComponent), ["link.yaml", "real.yaml"])
+    XCTAssertEqual(files.map(\.id), ["linked", "real"])
+  }
+
   func testSourceDirectoryHelpers() {
     let home = URL(filePath: "/Users/me", directoryHint: .isDirectory)
     XCTAssertEqual(WorkflowSources.userDirectory(home: home).path(percentEncoded: false), "/Users/me/.prowl/workflows/")

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class WorkflowDocumentParserTests: XCTestCase {
+  // MARK: - The spec example
+
+  func testParsesTheSpecExample() throws {
+    let result = WorkflowDocumentParser.parse(WorkflowFixtures.adversarialReview)
+    XCTAssertEqual(result.diagnostics, [])
+    let workflow = try XCTUnwrap(result.definition)
+
+    XCTAssertEqual(workflow.id, "prowl.adversarial-review")
+    XCTAssertEqual(workflow.name, "Adversarial Review")
+    XCTAssertEqual(workflow.description, "One reviewer, bounded rounds until clean.")
+    XCTAssertEqual(workflow.icon, "magnifyingglass.circle")
+
+    XCTAssertEqual(workflow.inputs.map(\.name), ["max_rounds", "focus", "mode"])
+    XCTAssertEqual(workflow.inputs[0].type, .integer)
+    XCTAssertEqual(workflow.inputs[0].defaultValue, .integer(5))
+    XCTAssertEqual(workflow.inputs[0].minimum, 1)
+    XCTAssertEqual(workflow.inputs[0].maximum, 10)
+    XCTAssertEqual(workflow.inputs[1].type, .string)
+    XCTAssertEqual(workflow.inputs[1].defaultValue, .string(""))
+    XCTAssertEqual(workflow.inputs[1].prompt, "What should the reviewer focus on?")
+    XCTAssertEqual(workflow.inputs[2].type, .enum)
+    XCTAssertEqual(workflow.inputs[2].values, ["strict", "lenient"])
+    XCTAssertEqual(workflow.inputs[2].defaultValue, .string("strict"))
+
+    XCTAssertEqual(workflow.roles.map(\.name), ["author", "reviewer"])
+    XCTAssertEqual(workflow.roles[0].source, .current)
+    XCTAssertNil(workflow.roles[0].launch)
+    let reviewer = try XCTUnwrap(workflow.roles[1].launch)
+    XCTAssertEqual(reviewer.kind, .interactive)
+    XCTAssertEqual(reviewer.agents, ["codex", "claude"])
+    XCTAssertEqual(reviewer.suggest, WorkflowProfileSuggestion(agent: "codex", reasoningEffort: "xhigh", executionMode: "standard"))
+    XCTAssertEqual(reviewer.bind, .ask)
+    XCTAssertEqual(reviewer.placement, .split)
+    XCTAssertEqual(reviewer.direction, .right)
+    XCTAssertFalse(reviewer.background)
+
+    XCTAssertEqual(workflow.steps.map(\.id), ["brief", "launch", "rounds", "context", "done", "cleanup"])
+    XCTAssertEqual(workflow.flattenedSteps.map(\.id), ["brief", "launch", "rounds", "fix", "rereview", "context", "done", "cleanup"])
+
+    guard case .message(let role, .instruction(let instruction), let briefExpect) = workflow.steps[0].action else {
+      return XCTFail("brief should be an instruction message")
+    }
+    XCTAssertEqual(role, "author")
+    XCTAssertTrue(instruction.hasPrefix("Write a short brief"))
+    XCTAssertEqual(briefExpect?.output, "brief")
+    XCTAssertEqual(briefExpect?.sections, ["## Scope", "## Claims"])
+    XCTAssertEqual(briefExpect?.timeoutSeconds, 600)
+    XCTAssertEqual(briefExpect?.format, .markdown)
+    XCTAssertNil(briefExpect?.verdict)
+    XCTAssertEqual(workflow.steps[0].outputName, "brief")
+
+    guard case .launch("reviewer", let prompt, "prowl.adversarial-reviewer", let launchExpect) = workflow.steps[1].action else {
+      return XCTFail("launch should target reviewer with a skill")
+    }
+    XCTAssertTrue(prompt.contains("{{ outputs.brief.path }}"))
+    XCTAssertEqual(launchExpect?.verdict, ["clean", "issues"])
+    XCTAssertEqual(launchExpect?.timeoutSeconds, 1800)
+
+    guard case .repeat(.template(let max), let until, let body) = workflow.steps[2].action else {
+      return XCTFail("rounds should be a repeat")
+    }
+    XCTAssertEqual(max, "{{ inputs.max_rounds }}")
+    XCTAssertEqual(until?.output, "findings")
+    XCTAssertEqual(until?.values, ["clean"])
+    XCTAssertEqual(body.map(\.id), ["fix", "rereview"])
+    XCTAssertEqual(body[0].title, "Round {{ loop.index }}: author addressing findings")
+
+    guard case .action("git.context", let inputs) = workflow.steps[3].action else {
+      return XCTFail("context should be a native action")
+    }
+    XCTAssertEqual(inputs, ["root": "{{ worktree.path }}"])
+    guard case .notify(let text) = workflow.steps[4].action else { return XCTFail("done should notify") }
+    XCTAssertTrue(text.hasPrefix("Adversarial review:"))
+    XCTAssertEqual(workflow.steps[5].action, .close(role: "reviewer"))
+  }
+
+  func testStepLocationsAreOneBased() throws {
+    let workflow = try WorkflowFixtures.parse(WorkflowFixtures.adversarialReview)
+    XCTAssertEqual(workflow.steps[0].location, WorkflowSourceLocation(line: 29, column: 5))
+    XCTAssertEqual(workflow.roles[1].location?.line, 16)
+  }
+
+  // MARK: - Structure
+
+  func testUnknownKeysAreReportedWithTheirPosition() {
+    let yaml = """
+      schema: prowl.workflow/v1
+      id: demo
+      name: Demo
+      bogus: 1
+      steps:
+        - id: a
+          notify: hi
+          expect: { output: x }
+      """
+    let diagnostics = WorkflowDocumentParser.parse(yaml).diagnostics
+    XCTAssertEqual(diagnostics.map(\.code), ["unknown_key", "expect_not_allowed"])
+    XCTAssertEqual(diagnostics[0].location, WorkflowSourceLocation(line: 4, column: 1))
+    XCTAssertEqual(diagnostics[1].location, WorkflowSourceLocation(line: 8, column: 13))
+  }
+
+  func testMissingRequiredKeysAndUnsupportedSchema() {
+    XCTAssertEqual(WorkflowFixtures.parseCodes("id: demo\nname: Demo\n"), ["missing_key", "missing_key"])
+    XCTAssertEqual(
+      WorkflowFixtures.parseCodes("schema: prowl.workflow/v2\nid: demo\nname: Demo\nsteps: []\n"),
+      ["unsupported_schema"])
+  }
+
+  func testDocumentMustBeAMappingAndYamlSyntaxErrorsCarryAPosition() throws {
+    XCTAssertEqual(WorkflowFixtures.parseCodes("- a\n- b\n"), ["document_not_mapping"])
+    let syntax = WorkflowDocumentParser.parse("schema: prowl.workflow/v1\nsteps: [\n")
+    XCTAssertEqual(syntax.diagnostics.map(\.code), ["yaml_syntax"])
+    XCTAssertNotNil(try XCTUnwrap(syntax.diagnostics.first).location)
+  }
+
+  func testQuotedScalarsAreStringsAndPlainScalarsAreTyped() {
+    let quoted = WorkflowFixtures.minimal()
+      + "inputs:\n  n: { type: integer, default: \"5\" }\n"
+    XCTAssertEqual(WorkflowFixtures.parseCodes(quoted), ["type_mismatch"])
+    let quotedBool = WorkflowFixtures.minimal(extraRoles: "  r:\n    source: launch\n    background: \"true\"")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(quotedBool), ["type_mismatch"])
+    let plain = WorkflowFixtures.minimal(extraRoles: "  r:\n    source: launch\n    background: true")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(plain), [])
+  }
+
+  func testInputKeysAreTypeSpecific() {
+    let stringWithMin = WorkflowFixtures.minimal() + "inputs:\n  s: { type: string, min: 1 }\n"
+    XCTAssertEqual(WorkflowFixtures.parseCodes(stringWithMin), ["key_requires_type"])
+    let enumWithoutValues = WorkflowFixtures.minimal() + "inputs:\n  e: { type: enum }\n"
+    XCTAssertEqual(WorkflowFixtures.parseCodes(enumWithoutValues), ["missing_key"])
+    let unknownType = WorkflowFixtures.minimal() + "inputs:\n  e: { type: float }\n"
+    XCTAssertEqual(WorkflowFixtures.parseCodes(unknownType), ["invalid_value"])
+  }
+
+  func testLaunchOnlyKeysAreRejectedOnOtherRoles() {
+    let yaml = WorkflowFixtures.minimal(extraRoles: "  partner:\n    source: pick\n    placement: tab")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(yaml), ["key_requires_launch"])
+  }
+
+  func testHeadlessKindIsReservedAndTabPlacementIgnoresDirection() {
+    let headless = WorkflowFixtures.minimal(extraRoles: "  r:\n    source: launch\n    kind: headless")
+    let diagnostics = WorkflowDocumentParser.parse(headless).diagnostics
+    XCTAssertEqual(diagnostics.map(\.code), ["reserved_kind"])
+    XCTAssertTrue(diagnostics[0].message.contains("reserved"))
+    let tab = WorkflowFixtures.minimal(extraRoles: "  r:\n    source: launch\n    placement: tab\n    direction: left")
+    let tabDiagnostics = WorkflowDocumentParser.parse(tab).diagnostics
+    XCTAssertEqual(tabDiagnostics.map(\.code), ["direction_ignored"])
+    XCTAssertEqual(tabDiagnostics[0].severity, .warning)
+  }
+
+  // MARK: - Steps
+
+  func testAStepNeedsExactlyOneVerb() {
+    let none = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    title: x")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(none), ["step_verb"])
+    let two = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: x\n    close: author")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(two), ["step_verb"])
+  }
+
+  func testMessageNeedsExactlyOneOfTextOrInstruction() {
+    let neither = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    message: author")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(neither), ["message_content"])
+    let both = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    message: author\n    text: a\n    instruction: b")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(both), ["message_content"])
+  }
+
+  func testExpectIsRejectedOnActionNotifyAndClose() {
+    for verb in ["action: git.context", "notify: hi", "close: author"] {
+      let yaml = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    \(verb)\n    expect: { output: o }")
+      XCTAssertEqual(WorkflowFixtures.parseCodes(yaml), ["expect_not_allowed"], verb)
+    }
+  }
+
+  func testRepeatRules() {
+    let nested = WorkflowFixtures.minimal(
+      extraSteps: """
+          - id: outer
+            repeat: { max: 2 }
+            steps:
+              - id: inner
+                repeat: { max: 2 }
+                steps:
+                  - id: leaf
+                    notify: hi
+        """)
+    XCTAssertEqual(WorkflowFixtures.parseCodes(nested), ["nested_repeat"])
+    let launchInside = WorkflowFixtures.minimal(
+      extraSteps: """
+          - id: loop
+            repeat: { max: 2 }
+            steps:
+              - id: l
+                launch: r
+                prompt: go
+        """,
+      extraRoles: "  r:\n    source: launch")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(launchInside), ["launch_inside_repeat"])
+    let noMax = WorkflowFixtures.minimal(extraSteps: "  - id: loop\n    repeat: {}\n    steps:\n      - id: x\n        notify: hi")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(noMax), ["missing_key"])
+    let badMax = WorkflowFixtures.minimal(extraSteps: "  - id: loop\n    repeat: { max: five }\n    steps:\n      - id: x\n        notify: hi")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(badMax), ["repeat_max"])
+  }
+
+  func testRepeatBoundsAndUntilForms() throws {
+    let yaml = WorkflowFixtures.minimal(
+      extraSteps: """
+          - id: a
+            repeat: { max: 3 }
+            steps:
+              - id: x
+                notify: hi
+          - id: b
+            repeat: { max: "{{ inputs.n }}", until: "outputs.f.verdict in [clean, done]" }
+            steps:
+              - id: y
+                notify: hi
+        """)
+    let workflow = try WorkflowFixtures.parse(yaml)
+    guard case .repeat(.literal(3), nil, _) = workflow.steps[1].action else { return XCTFail("literal max") }
+    guard case .repeat(.template("{{ inputs.n }}"), let until?, _) = workflow.steps[2].action else {
+      return XCTFail("template max with until")
+    }
+    XCTAssertEqual(until.output, "f")
+    XCTAssertEqual(until.values, ["clean", "done"])
+    let garbage = WorkflowFixtures.minimal(
+      extraSteps: "  - id: c\n    repeat: { max: 2, until: \"findings is clean\" }\n    steps:\n      - id: z\n        notify: hi")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(garbage), ["until_syntax"])
+  }
+
+  func testDurationsAndOnTimeout() {
+    XCTAssertEqual(WorkflowDocumentParser.parseDuration("90s"), 90)
+    XCTAssertEqual(WorkflowDocumentParser.parseDuration("10m"), 600)
+    XCTAssertEqual(WorkflowDocumentParser.parseDuration("2h"), 7200)
+    XCTAssertNil(WorkflowDocumentParser.parseDuration("10"))
+    XCTAssertNil(WorkflowDocumentParser.parseDuration("1d"))
+    let badTimeout = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 1d }")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(badTimeout), ["timeout_syntax"])
+    let orphanPolicy = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { on_timeout: skip }")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(orphanPolicy), ["on_timeout_requires_timeout"])
+  }
+
+  func testActionInputsKeepScalarSourceText() throws {
+    let yaml = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    action: handoff.transition\n    with: { from: author, to: author, note: 42 }")
+    let workflow = try WorkflowFixtures.parse(yaml)
+    guard case .action("handoff.transition", let inputs) = workflow.steps[1].action else { return XCTFail("action") }
+    XCTAssertEqual(inputs, ["from": "author", "to": "author", "note": "42"])
+    let nested = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    action: git.context\n    with: { root: [a] }")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(nested), ["type_mismatch"])
+  }
+}

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -285,5 +285,16 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertEqual(WorkflowFixtures.parseCodes(WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: \"true\"")), [])
     XCTAssertEqual(WorkflowFixtures.parseCodes(WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: Round 1")), [])
   }
+
+  func testUntilAndTimeoutFollowTheSchemaPatternsExactly() {
+    XCTAssertNil(WorkflowDocumentParser.parseDuration(" 10m"))
+    XCTAssertNil(WorkflowDocumentParser.parseDuration("10m "))
+    let paddedTimeout = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: \" 10m\" }")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(paddedTimeout), ["timeout_syntax"])
+    let paddedUntil = WorkflowFixtures.minimal(
+      extraSteps: "  - id: loop\n    repeat: { max: 2, until: \" outputs.f.verdict == clean\" }\n    steps:\n      - id: x\n        notify: hi")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(paddedUntil), ["until_syntax"])
+  }
 }
 

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -107,7 +107,7 @@ final class WorkflowDocumentParserTests: XCTestCase {
   func testMissingRequiredKeysAndUnsupportedSchema() {
     XCTAssertEqual(WorkflowFixtures.parseCodes("id: demo\nname: Demo\n"), ["missing_key", "missing_key"])
     XCTAssertEqual(
-      WorkflowFixtures.parseCodes("schema: prowl.workflow/v2\nid: demo\nname: Demo\nsteps: []\n"),
+      WorkflowFixtures.parseCodes("schema: prowl.workflow/v2\nid: demo\nname: Demo\nsteps:\n  - id: a\n    notify: hi\n"),
       ["unsupported_schema"])
   }
 
@@ -255,4 +255,35 @@ final class WorkflowDocumentParserTests: XCTestCase {
     let nested = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    action: git.context\n    with: { root: [a] }")
     XCTAssertEqual(WorkflowFixtures.parseCodes(nested), ["type_mismatch"])
   }
+
+  // MARK: - Round 1 review findings
+
+  func testHugeDurationsDoNotOverflow() {
+    XCTAssertNil(WorkflowDocumentParser.parseDuration("9223372036854775807h"))
+    XCTAssertNil(WorkflowDocumentParser.parseDuration("99999999999999999999s"))
+    XCTAssertEqual(WorkflowDocumentParser.parseDuration("2562047788015215h"), 2562047788015215 * 3600)
+    let overflow = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 9223372036854775807h }")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(overflow), ["timeout_syntax"])
+  }
+
+  func testStepsMustNotBeEmpty() {
+    XCTAssertEqual(
+      WorkflowFixtures.parseCodes("schema: prowl.workflow/v1\nid: demo\nname: Demo\nsteps: []\n"), ["steps_empty"])
+    let emptyBody = WorkflowFixtures.minimal(extraSteps: "  - id: loop\n    repeat: { max: 2 }\n    steps: []")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(emptyBody), ["steps_empty"])
+  }
+
+  func testStringFieldsRejectTypedPlainScalars() {
+    XCTAssertEqual(
+      WorkflowFixtures.parseCodes("schema: prowl.workflow/v1\nid: 1\nname: Demo\nsteps:\n  - id: a\n    notify: hi\n"),
+      ["type_mismatch"])
+    XCTAssertEqual(
+      WorkflowFixtures.parseCodes("schema: prowl.workflow/v1\nid: demo\nname: 1.5\nsteps:\n  - id: a\n    notify: hi\n"),
+      ["type_mismatch"])
+    XCTAssertEqual(WorkflowFixtures.parseCodes(WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: true")), ["type_mismatch"])
+    XCTAssertEqual(WorkflowFixtures.parseCodes(WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: \"true\"")), [])
+    XCTAssertEqual(WorkflowFixtures.parseCodes(WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: Round 1")), [])
+  }
 }
+

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -295,6 +295,11 @@ final class WorkflowDocumentParserTests: XCTestCase {
     let paddedUntil = WorkflowFixtures.minimal(
       extraSteps: "  - id: loop\n    repeat: { max: 2, until: \" outputs.f.verdict == clean\" }\n    steps:\n      - id: x\n        notify: hi")
     XCTAssertEqual(WorkflowFixtures.parseCodes(paddedUntil), ["until_syntax"])
+    for until in ["outputs.Brief.verdict == clean", "outputs.brief.verdict == Clean", "outputs.a.b.verdict == x"] {
+      let yaml = WorkflowFixtures.minimal(
+        extraSteps: "  - id: loop\n    repeat: { max: 2, until: \"\(until)\" }\n    steps:\n      - id: x\n        notify: hi")
+      XCTAssertEqual(WorkflowFixtures.parseCodes(yaml), ["until_syntax"], until)
+    }
   }
 }
 

--- a/ProwlCLITests/WorkflowFixtures.swift
+++ b/ProwlCLITests/WorkflowFixtures.swift
@@ -114,10 +114,12 @@ enum WorkflowFixtures {
     scope: WorkflowScope = .user,
     bundledSkillIDs: Set<String>? = ["prowl.adversarial-reviewer"],
     knownAgents: Set<String>? = nil,
-    installedAgents: Set<String>? = nil
+    installedAgents: Set<String>? = nil,
+    enabledProfiles: [WorkflowProfileSuggestion]? = nil
   ) -> [WorkflowDiagnostic] {
     let context = WorkflowValidationContext(
-      scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents)
+      scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents,
+      enabledProfiles: enabledProfiles)
     return WorkflowDiscovery.parse(yaml, url: URL(filePath: "/fixture.yaml"), scope: scope, context: context)
       .diagnostics
   }
@@ -127,10 +129,12 @@ enum WorkflowFixtures {
     scope: WorkflowScope = .user,
     bundledSkillIDs: Set<String>? = ["prowl.adversarial-reviewer"],
     knownAgents: Set<String>? = nil,
-    installedAgents: Set<String>? = nil
+    installedAgents: Set<String>? = nil,
+    enabledProfiles: [WorkflowProfileSuggestion]? = nil
   ) -> [String] {
     diagnostics(
-      yaml, scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents
+      yaml, scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents,
+      enabledProfiles: enabledProfiles
     ).map(\.code)
   }
 }

--- a/ProwlCLITests/WorkflowFixtures.swift
+++ b/ProwlCLITests/WorkflowFixtures.swift
@@ -1,0 +1,136 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+/// The dsl-spec.md §4 example and helpers shared by the workflow test suites.
+enum WorkflowFixtures {
+  static let adversarialReview = """
+    schema: prowl.workflow/v1
+    id: prowl.adversarial-review
+    name: Adversarial Review
+    description: One reviewer, bounded rounds until clean.
+    icon: magnifyingglass.circle
+
+    inputs:
+      max_rounds: { type: integer, default: 5, min: 1, max: 10 }
+      focus:      { type: string,  default: "", prompt: "What should the reviewer focus on?" }
+      mode:       { type: enum, values: [strict, lenient], default: strict }
+
+    roles:
+      author:
+        source: current
+      reviewer:
+        source: launch
+        kind: interactive
+        agents: [codex, claude]
+        suggest:
+          agent: codex
+          reasoning_effort: xhigh
+          execution_mode: standard
+        bind: ask
+        placement: split
+        direction: right
+        background: false
+
+    steps:
+      - id: brief
+        title: "Author writing the brief"
+        message: author
+        instruction: |
+          Write a short brief for an adversarial reviewer: ## Scope, ## Claims, ## How to verify.
+          Deliver it with the generated completion command.
+        expect: { output: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
+
+      - id: launch
+        title: "Reviewer starting round 1"
+        launch: reviewer
+        prompt: "Read {{ outputs.brief.path }} and the bundled reviewer skill, then review. Focus: {{ inputs.focus }}"
+        skill: prowl.adversarial-reviewer
+        expect: { output: findings, sections: ["## Findings", "## Verdict"], verdict: [clean, issues], timeout: 30m }
+
+      - id: rounds
+        repeat:
+          max: "{{ inputs.max_rounds }}"
+          until: outputs.findings.verdict == clean
+        steps:
+          - id: fix
+            title: "Round {{ loop.index }}: author addressing findings"
+            message: author
+            text: "Findings: {{ outputs.findings.path }}. Fix or rebut each item, then deliver your disposition."
+            expect: { output: disposition, timeout: 30m }
+          - id: rereview
+            title: "Round {{ loop.index }}: reviewer re-checking"
+            message: reviewer
+            text: "Disposition: {{ outputs.disposition.path }}. Re-review and deliver findings with a verdict."
+            expect: { output: findings, verdict: [clean, issues], timeout: 30m }
+
+      - id: context
+        action: git.context
+        with: { root: "{{ worktree.path }}" }
+
+      - id: done
+        notify: "Adversarial review: {{ outputs.findings.verdict }} after {{ loop.count }} round(s)"
+
+      - id: cleanup
+        close: reviewer
+    """
+
+  /// A minimal valid user-scope workflow: one current role, one message step.
+  static func minimal(id: String = "demo", extraSteps: String = "", extraRoles: String = "") -> String {
+    """
+    schema: prowl.workflow/v1
+    id: \(id)
+    name: Demo
+    roles:
+      author:
+        source: current
+    \(extraRoles)
+    steps:
+      - id: ask
+        message: author
+        text: "Say hello."
+    \(extraSteps)
+
+    """
+  }
+
+  static func parse(_ yaml: String, file: StaticString = #filePath, line: UInt = #line) throws -> WorkflowDefinition {
+    let result = WorkflowDocumentParser.parse(yaml)
+    return try XCTUnwrap(
+      result.definition,
+      "Expected the document to parse; diagnostics: \(result.diagnostics)",
+      file: file,
+      line: line
+    )
+  }
+
+  static func parseCodes(_ yaml: String) -> [String] {
+    WorkflowDocumentParser.parse(yaml).diagnostics.map(\.code)
+  }
+
+  /// Parse + validate; parse errors short-circuit validation exactly as discovery does.
+  static func diagnostics(
+    _ yaml: String,
+    scope: WorkflowScope = .user,
+    bundledSkillIDs: Set<String>? = ["prowl.adversarial-reviewer"],
+    knownAgents: Set<String>? = nil,
+    installedAgents: Set<String>? = nil
+  ) -> [WorkflowDiagnostic] {
+    let context = WorkflowValidationContext(
+      scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents)
+    return WorkflowDiscovery.parse(yaml, url: URL(filePath: "/fixture.yaml"), scope: scope, context: context)
+      .diagnostics
+  }
+
+  static func codes(
+    _ yaml: String,
+    scope: WorkflowScope = .user,
+    bundledSkillIDs: Set<String>? = ["prowl.adversarial-reviewer"],
+    knownAgents: Set<String>? = nil,
+    installedAgents: Set<String>? = nil
+  ) -> [String] {
+    diagnostics(
+      yaml, scope: scope, bundledSkillIDs: bundledSkillIDs, knownAgents: knownAgents, installedAgents: installedAgents
+    ).map(\.code)
+  }
+}

--- a/ProwlCLITests/WorkflowSchemaTests.swift
+++ b/ProwlCLITests/WorkflowSchemaTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import JSONSchema
+import ProwlCLIContracts
+import ProwlCLIShared
+import XCTest
+import Yams
+
+final class WorkflowSchemaTests: XCTestCase {
+  // MARK: - CLI output contract (prowl.cli.workflow.v1)
+
+  func testOutputSchemaAcceptsEveryAction() throws {
+    let entry =
+      #"{"id":"demo","name":"Demo","description":"d","scope":"user","path":"/Users/me/.prowl/workflows/demo.yaml","enabled":true,"valid":true,"errors":0,"warnings":1,"shadowed":false}"#
+    let unparsed =
+      #"{"scope":"repo","path":"/Projects/App/.prowl/workflows/broken.yaml","enabled":false,"valid":false,"errors":1,"warnings":0,"shadowed":false}"#
+    let list =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","worktree":{"id":"w","name":"main","path":"/Projects/App","root_path":"/Projects/App"},"sources":{"bundle":"/Applications/Prowl.app/Contents/Resources/workflows","user":"/Users/me/.prowl/workflows","repo":"/Projects/App/.prowl/workflows"},"workflows":[\#(entry),\#(unparsed)]}}"#
+    let listWithoutWorktree =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","sources":{"user":"/Users/me/.prowl/workflows"},"workflows":[]}}"#
+    let validate =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"validate","path":"/x.yaml","valid":true,"workflow":{"id":"demo","name":"Demo"},"diagnostics":[{"severity":"warning","code":"timeout_long","message":"long","line":4,"column":7},{"severity":"warning","code":"skill_unchecked","message":"unchecked"}]}}"#
+    let schema =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"schema","schema":{"$id":"x","type":"object"}}}"#
+    let error =
+      #"{"ok":false,"command":"workflow","schema_version":"prowl.cli.workflow.v1","error":{"code":"WORKFLOW_INVALID","message":"2 error(s).","details":{"action":"validate","path":"/x.yaml","valid":false,"diagnostics":[]}}}"#
+    for instance in [list, listWithoutWorktree, validate, schema, error] {
+      try assertValidity(instance, expected: true)
+    }
+  }
+
+  func testOutputSchemaRejectsUnknownFieldsBadScopesAndCrossActionFields() throws {
+    let unknownField =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","sources":{"user":"/u"},"workflows":[],"extra":1}}"#
+    let badScope =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","sources":{"user":"/u"},"workflows":[{"scope":"global","path":"/p","enabled":true,"valid":true,"errors":0,"warnings":0,"shadowed":false}]}}"#
+    let crossAction =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"schema","schema":{},"workflows":[]}}"#
+    let badSeverity =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"validate","path":"/x","valid":false,"diagnostics":[{"severity":"fatal","code":"c","message":"m"}]}}"#
+    let wrongVersion =
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v2","data":{"action":"schema","schema":{}}}"#
+    for instance in [unknownField, badScope, crossAction, badSeverity, wrongVersion] {
+      try assertValidity(instance, expected: false)
+    }
+  }
+
+  func testPayloadRoundTripsThroughCodableWithTheActionDiscriminator() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let validate = WorkflowCommandPayload.validate(
+      WorkflowValidatePayload(
+        path: "/x.yaml", valid: false, workflow: WorkflowIdentity(id: "demo", name: "Demo"),
+        diagnostics: [
+          WorkflowDiagnosticPayload(severity: .error, code: "undefined_role", message: "Role 'x'", line: 3, column: 5)
+        ]))
+    let data = try encoder.encode(validate)
+    XCTAssertTrue(String(decoding: data, as: UTF8.self).hasPrefix(#"{"action":"validate""#))
+    XCTAssertEqual(try JSONDecoder().decode(WorkflowCommandPayload.self, from: data), validate)
+
+    let list = WorkflowCommandPayload.list(
+      WorkflowListPayload(worktree: nil, sources: WorkflowListSources(bundle: nil, user: "/u", repo: nil), workflows: []))
+    XCTAssertEqual(
+      String(decoding: try encoder.encode(list), as: UTF8.self),
+      #"{"action":"list","sources":{"user":"/u"},"workflows":[]}"#)
+    let schema = WorkflowCommandPayload.schema(WorkflowSchemaPayload(schema: RawJSON(Data(#"{"type":"object"}"#.utf8))))
+    XCTAssertEqual(try JSONDecoder().decode(WorkflowCommandPayload.self, from: try encoder.encode(schema)), schema)
+  }
+
+  // MARK: - Workflow definition schema
+
+  func testDefinitionSchemaResourceMatchesTheSwiftConstant() throws {
+    let resource = try JSONSerialization.jsonObject(with: ProwlCLIContractBundle.workflowDefinitionSchemaData)
+    let constant = try WorkflowJSONSchema.definitionSchemaObject()
+    XCTAssertEqual(resource as? NSDictionary, constant as NSDictionary)
+    XCTAssertEqual(constant["$id"] as? String, WorkflowJSONSchema.identifier)
+  }
+
+  func testDefinitionSchemaAcceptsTheSpecExampleAndRejectsStructuralErrors() throws {
+    try assertDefinitionValidity(WorkflowFixtures.adversarialReview, expected: true)
+    try assertDefinitionValidity(WorkflowFixtures.minimal(), expected: true)
+
+    let unknownKey = WorkflowFixtures.minimal() + "bogus: 1\n"
+    let twoVerbs = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    notify: x\n    close: author")
+    let headless = WorkflowFixtures.minimal(extraRoles: "  r:\n    source: launch\n    kind: headless")
+    let badMax = WorkflowFixtures.minimal(
+      extraSteps: "  - id: loop\n    repeat: { max: 21 }\n    steps:\n      - id: x\n        notify: hi")
+    let launchInLoop = WorkflowFixtures.minimal(
+      extraSteps: "  - id: loop\n    repeat: { max: 2 }\n    steps:\n      - id: l\n        launch: r\n        prompt: go",
+      extraRoles: "  r:\n    source: launch")
+    let orphanPolicy = WorkflowFixtures.minimal(
+      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { on_timeout: skip }")
+    for (name, yaml) in [
+      ("unknownKey", unknownKey), ("twoVerbs", twoVerbs), ("headless", headless), ("badMax", badMax),
+      ("launchInLoop", launchInLoop), ("orphanPolicy", orphanPolicy),
+    ] {
+      try assertDefinitionValidity(yaml, expected: false, name)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func assertValidity(_ instance: String, expected: Bool) throws {
+    let schemaText = try XCTUnwrap(String(data: ProwlCLIContractBundle.schemaData, encoding: .utf8))
+    let result = try Schema(instance: schemaText).validate(instance: instance)
+    XCTAssertEqual(result.isValid, expected, "Schema errors for \(instance): \(result.errors ?? [])")
+  }
+
+  private func assertDefinitionValidity(_ yaml: String, expected: Bool, _ name: String = "") throws {
+    let object = try XCTUnwrap(Yams.load(yaml: yaml))
+    let json = try JSONSerialization.data(withJSONObject: object)
+    let result = try Schema(instance: WorkflowJSONSchema.definitionSchemaJSON)
+      .validate(instance: String(decoding: json, as: UTF8.self))
+    XCTAssertEqual(result.isValid, expected, "\(name): \(result.errors ?? [])")
+  }
+}

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -473,5 +473,41 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal() + "inputs:\n  m: { type: enum, values: [\"\", b] }\n"), ["enum_value_empty"])
   }
+
+  // MARK: - Round 3 review findings
+
+  func testSkipWarningsRespectProducerAndConsumerOrder() {
+    let consumedBefore = """
+        - id: first
+          message: author
+          text: First
+          expect: { output: brief }
+        - id: use
+          notify: "{{ outputs.brief.path }}"
+        - id: second
+          message: author
+          text: Second
+          expect: { output: brief, timeout: 5m, on_timeout: skip }
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: consumedBefore)), [], "nothing after the skip depends on it")
+    let loopCarried = """
+        - id: seed
+          message: author
+          text: Seed
+          expect: { output: draft, verdict: [go, stop] }
+        - id: loop
+          repeat: { max: 3, until: "outputs.draft.verdict == stop" }
+          steps:
+            - id: use
+              notify: "{{ outputs.draft.path }}"
+            - id: redo
+              message: author
+              text: Redo
+              expect: { output: draft, verdict: [go, stop], timeout: 5m, on_timeout: skip }
+      """
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: loopCarried)), ["skip_ends_run"],
+      "the next iteration and the until check read the skipped output")
+  }
 }
 

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -289,4 +289,113 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role), installedAgents: ["codex"]), [])
     XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role)), [], "unknown catalogs skip the warnings")
   }
+
+  // MARK: - Round 1 review findings
+
+  func testControlCharactersIncludingTabsAreRejectedInTypedText() {
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  s: { type: string, default: \"has\\ttab\" }\n"),
+      ["input_default_multiline"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: author\n    text: \"a\\tb\"")), ["text_multiline"])
+  }
+
+  func testRoleInputsOfNativeActionsMustNameDeclaredRoles() {
+    let missing = "  - id: t\n    action: handoff.transition\n    with: { from: missing, to: also-missing }"
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: missing)), ["unknown_role", "unknown_role"])
+    let templated = "  - id: t\n    action: handoff.transition\n    with: { from: \"{{ roles.author.name }}\", to: author }"
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: templated)), ["role_input_literal"])
+    let valid = "  - id: t\n    action: handoff.transition\n    with: { from: author, to: author }"
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: valid)), [])
+  }
+
+  func testVerdictReferencesFollowTheLatestProducer() {
+    let stale = """
+        - id: first
+          message: author
+          text: First
+          expect: { output: result, verdict: [clean, issues] }
+        - id: second
+          message: author
+          text: Second
+          expect: { output: result }
+        - id: report
+          notify: "{{ outputs.result.verdict }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: stale)), ["unknown_variable"])
+    let refreshed = """
+        - id: first
+          message: author
+          text: First
+          expect: { output: result }
+        - id: second
+          message: author
+          text: Second
+          expect: { output: result, verdict: [clean, issues] }
+        - id: report
+          notify: "{{ outputs.result.verdict }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: refreshed)), [])
+  }
+
+  func testOutputsProducedOnlyInsideASkippableLoopAreNotVisibleAfterIt() {
+    let skippable = """
+        - id: initial
+          message: author
+          text: Initial
+          expect: { output: verdict, verdict: [clean, issues] }
+        - id: retry
+          repeat: { max: 2, until: "outputs.verdict.verdict == clean" }
+          steps:
+            - id: produce
+              message: author
+              text: Retry
+              expect: { output: retry_result }
+        - id: report
+          notify: "{{ outputs.retry_result.path }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: skippable)), ["unknown_variable"])
+    let unconditional = """
+        - id: retry
+          repeat: { max: 2 }
+          steps:
+            - id: produce
+              message: author
+              text: Retry
+              expect: { output: retry_result }
+        - id: report
+          notify: "{{ outputs.retry_result.path }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: unconditional)), [])
+    let produced_before_and_inside = """
+        - id: initial
+          message: author
+          text: Initial
+          expect: { output: findings, verdict: [clean, issues] }
+        - id: loop
+          repeat: { max: 2, until: "outputs.findings.verdict == clean" }
+          steps:
+            - id: again
+              message: author
+              text: Again
+              expect: { output: findings }
+        - id: path
+          notify: "{{ outputs.findings.path }}"
+        - id: verdict
+          notify: "{{ outputs.findings.verdict }}"
+      """
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: produced_before_and_inside)), ["until_verdict_undeclared", "unknown_variable"],
+      "the in-loop producer declares no verdict: until cannot read it and neither can a later reference")
+  }
+
+  func testSuggestWarnsWhenNoEnabledProfileMatches() {
+    let role = "  r:\n    source: launch\n    suggest: { agent: codex, reasoning_effort: xhigh }"
+    let codexHigh = WorkflowProfileSuggestion(agent: "codex", model: "gpt-5", reasoningEffort: "xhigh", executionMode: "standard")
+    let claude = WorkflowProfileSuggestion(agent: "claude", model: nil, reasoningEffort: nil, executionMode: "standard")
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role), enabledProfiles: [claude]), ["suggest_unmatched"])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role), enabledProfiles: [claude, codexHigh]), [])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role)), [], "no profile catalog: no warning")
+  }
 }
+

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import ProwlCLIShared
+import XCTest
+
+final class WorkflowValidatorTests: XCTestCase {
+  private func minimal(id: String = "demo", steps: String = "", roles: String = "") -> String {
+    WorkflowFixtures.minimal(id: id, extraSteps: steps, extraRoles: roles)
+  }
+
+  private func errors(_ diagnostics: [WorkflowDiagnostic]) -> [String] {
+    diagnostics.filter { $0.severity == .error }.map(\.code)
+  }
+
+  private func warnings(_ diagnostics: [WorkflowDiagnostic]) -> [String] {
+    diagnostics.filter { $0.severity == .warning }.map(\.code)
+  }
+
+  // MARK: - The spec example
+
+  func testSpecExampleIsValidInBundleScope() {
+    let diagnostics = WorkflowFixtures.diagnostics(WorkflowFixtures.adversarialReview, scope: .bundle)
+    XCTAssertEqual(diagnostics, [])
+  }
+
+  func testReservedIDIsRejectedOutsideTheBundle() {
+    for scope in [WorkflowScope.user, .repo] {
+      let diagnostics = WorkflowFixtures.diagnostics(WorkflowFixtures.adversarialReview, scope: scope)
+      XCTAssertEqual(errors(diagnostics), ["reserved_id"], "\(scope)")
+    }
+  }
+
+  func testUnknownBundleReportsSkillsAsUncheckedAndAKnownBundleChecksThem() {
+    let unchecked = WorkflowFixtures.diagnostics(
+      WorkflowFixtures.adversarialReview, scope: .bundle, bundledSkillIDs: nil)
+    XCTAssertEqual(warnings(unchecked), ["skill_unchecked"])
+    XCTAssertEqual(errors(unchecked), [])
+    let missing = WorkflowFixtures.diagnostics(
+      WorkflowFixtures.adversarialReview, scope: .bundle, bundledSkillIDs: ["prowl-cli"])
+    XCTAssertEqual(errors(missing), ["skill_not_found"])
+  }
+
+  // MARK: - Ids and roles
+
+  func testSlugsAreEnforcedForIdsRolesStepsOutputsAndInputs() {
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(id: "Demo Flow")), ["workflow_id"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(roles: "  Reviewer:\n    source: pick")), ["role_name_slug"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: Fix It\n    notify: hi")), ["step_id_slug"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(
+        minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { output: Bad.Name }")),
+      ["output_name_slug"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  Max: { type: integer }\n"), ["input_name_slug"])
+  }
+
+  func testAtMostOneCurrentRole() {
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(roles: "  other:\n    source: current")), ["multiple_current_roles"])
+  }
+
+  func testUndefinedRolesAndRoleSources() {
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: ghost\n    text: hi")), ["undefined_role"])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    close: ghost")), ["undefined_role"])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    close: author")), ["close_role_source"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    launch: author\n    prompt: go")), ["launch_role_source"])
+  }
+
+  func testLaunchOrderingRules() {
+    let role = "  r:\n    source: launch"
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: r\n    text: hi", roles: role)),
+      ["message_before_launch"])
+    let twice = "  - id: l1\n    launch: r\n    prompt: go\n  - id: l2\n    launch: r\n    prompt: again"
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: twice, roles: role)), ["launch_twice"])
+    let ordered = "  - id: l1\n    launch: r\n    prompt: go\n  - id: m\n    message: r\n    text: \"pane {{ roles.r.pane }}\""
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: ordered, roles: role)), [])
+  }
+
+  func testDuplicateStepIdsAcrossNesting() {
+    let steps = """
+        - id: loop
+          repeat: { max: 2 }
+          steps:
+            - id: ask
+              notify: hi
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), ["duplicate_step_id"])
+  }
+
+  // MARK: - Inputs
+
+  func testInputConstraints() {
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  n: { type: integer, default: 11, min: 1, max: 10 }\n"),
+      ["input_range"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  n: { type: integer, min: 5, max: 1 }\n"), ["input_range"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  m: { type: enum, values: [a, b], default: c }\n"), ["enum_default"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  m: { type: enum, values: [a, a] }\n"), ["enum_values_duplicate"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  s: { type: string, default: \"two\\nlines\" }\n"),
+      ["input_default_multiline"])
+  }
+
+  // MARK: - Templates
+
+  func testTemplateReferencesAreWhitelistedAndOrdered() {
+    let role = "  r:\n    source: launch"
+    func codes(_ text: String, roles: String = "") -> [String] {
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    notify: \"\(text)\"", roles: roles))
+    }
+    XCTAssertEqual(codes("{{ run.id }} {{ run.dir }} {{ worktree.path }} {{ worktree.branch }}"), [])
+    XCTAssertEqual(codes("{{ roles.author.name }} {{ roles.author.agent }} {{ roles.author.pane }}"), [])
+    XCTAssertEqual(codes("{{ nope.x }}"), ["unknown_variable"])
+    XCTAssertEqual(codes("{{ worktree.owner }}"), ["unknown_variable"])
+    XCTAssertEqual(codes("{{ inputs.missing }}"), ["unknown_variable"])
+    XCTAssertEqual(codes("{{ outputs.brief.path }}"), ["unknown_variable"], "no producer yet")
+    XCTAssertEqual(codes("{{ roles.r.pane }}", roles: role), ["unknown_variable"], "launch role not launched")
+    XCTAssertEqual(codes("{{ loop.index }}"), ["unknown_variable"], "outside repeat")
+    XCTAssertEqual(codes("{{ loop.count }}"), ["unknown_variable"], "before any loop")
+    XCTAssertEqual(codes("{{ open"), ["template_syntax"])
+    XCTAssertEqual(codes("{{ }}"), ["template_syntax"])
+  }
+
+  func testOutputAndActionReferencesFollowProducers() {
+    let steps = """
+        - id: b
+          message: author
+          text: hi
+          expect: { output: brief }
+        - id: ctx
+          action: git.context
+        - id: n
+          notify: "{{ outputs.brief.path }} {{ actions.ctx.path }} {{ actions.ctx.branch }}"
+        - id: v
+          notify: "{{ outputs.brief.verdict }}"
+        - id: k
+          notify: "{{ actions.ctx.nope }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), ["unknown_variable", "unknown_variable"])
+  }
+
+  func testActionsInsideALoopAreNotVisibleAfterIt() {
+    let steps = """
+        - id: loop
+          repeat: { max: 2 }
+          steps:
+            - id: ctx
+              action: git.context
+            - id: inside
+              notify: "{{ actions.ctx.path }} round {{ loop.index }}"
+        - id: after
+          notify: "{{ loop.count }} {{ actions.ctx.path }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), ["unknown_variable"])
+  }
+
+  // MARK: - Actions
+
+  func testActionInputsFollowTheRegistry() {
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    action: fs.delete")), ["unknown_action"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    action: git.context\n    with: { depth: 3 }")),
+      ["unknown_action_input"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    action: handoff.transition\n    with: { from: author }")),
+      ["missing_action_input"])
+  }
+
+  // MARK: - Repeat and until
+
+  func testRepeatMaxBounds() {
+    func loop(_ max: String) -> String {
+      minimal(steps: "  - id: loop\n    repeat: { max: \(max) }\n    steps:\n      - id: x\n        notify: hi")
+    }
+    XCTAssertEqual(WorkflowFixtures.codes(loop("0")), ["repeat_max_range"])
+    XCTAssertEqual(WorkflowFixtures.codes(loop("21")), ["repeat_max_range"])
+    XCTAssertEqual(WorkflowFixtures.codes(loop("20")), [])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop("\"{{ inputs.n }}\"") + "inputs:\n  n: { type: integer }\n"), [])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop("\"{{ inputs.n }}\"") + "inputs:\n  n: { type: string }\n"), ["repeat_max_template"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop("\"{{ inputs.n }} rounds\"") + "inputs:\n  n: { type: integer }\n"),
+      ["repeat_max_template"])
+  }
+
+  func testUntilNeedsADeclaredVerdict() {
+    func loop(until: String, producer: String) -> String {
+      minimal(
+        steps: """
+          \(producer)
+            - id: loop
+              repeat: { max: 2, until: "\(until)" }
+              steps:
+                - id: x
+                  notify: hi
+          """)
+    }
+    let verdictProducer = "  - id: p\n    message: author\n    text: hi\n    expect: { output: f, verdict: [clean, issues] }"
+    let plainProducer = "  - id: p\n    message: author\n    text: hi\n    expect: { output: f }"
+    XCTAssertEqual(WorkflowFixtures.codes(loop(until: "outputs.f.verdict == clean", producer: verdictProducer)), [])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop(until: "outputs.f.verdict == done", producer: verdictProducer)),
+      ["until_verdict_literal"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop(until: "outputs.f.verdict == clean", producer: plainProducer)),
+      ["until_verdict_undeclared"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(loop(until: "outputs.g.verdict == clean", producer: verdictProducer)), ["until_output"])
+  }
+
+  func testUntilMayReferenceAnOutputProducedInsideTheLoop() {
+    let steps = """
+        - id: loop
+          repeat: { max: 2, until: "outputs.f.verdict == clean" }
+          steps:
+            - id: x
+              message: author
+              text: hi
+              expect: { output: f, verdict: [clean, issues] }
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), [])
+  }
+
+  // MARK: - Expect
+
+  func testVerdictRules() {
+    func expect(_ verdict: String) -> String {
+      minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { verdict: \(verdict) }")
+    }
+    XCTAssertEqual(WorkflowFixtures.codes(expect("[clean]")), ["verdict_count"])
+    XCTAssertEqual(WorkflowFixtures.codes(expect("[a, b, c, d, e]")), ["verdict_count"])
+    XCTAssertEqual(WorkflowFixtures.codes(expect("[clean, clean]")), ["verdict_duplicate"])
+    XCTAssertEqual(WorkflowFixtures.codes(expect("[clean, \"Needs Work\"]")), ["verdict_slug"])
+    XCTAssertEqual(WorkflowFixtures.codes(expect("[clean, issues]")), [])
+  }
+
+  func testTextMustBeOneLineButInstructionsMayNot() {
+    let text = minimal(steps: "  - id: b\n    message: author\n    text: \"two\\nlines\"")
+    XCTAssertEqual(WorkflowFixtures.codes(text), ["text_multiline"])
+    let instruction = minimal(steps: "  - id: b\n    message: author\n    instruction: |\n      two\n      lines")
+    XCTAssertEqual(WorkflowFixtures.codes(instruction), [])
+  }
+
+  // MARK: - Warnings
+
+  func testWarnings() {
+    let long = minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 3h }")
+    XCTAssertEqual(WorkflowFixtures.codes(long), ["timeout_long"])
+    let spelled = minimal(steps: "  - id: b\n    message: author\n    text: \"finish with prowl workflow done -\"")
+    XCTAssertEqual(WorkflowFixtures.codes(spelled), ["spells_completion_command"])
+    XCTAssertEqual(WorkflowFixtures.diagnostics(spelled).first?.severity, .warning)
+  }
+
+  func testSkipWarnsOnlyWhenALaterNonOptionalConsumerExists() {
+    let blocking = """
+        - id: b
+          message: author
+          text: hi
+          expect: { output: brief, timeout: 5m, on_timeout: skip }
+        - id: n
+          notify: "{{ outputs.brief.path }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: blocking)), ["skip_ends_run"])
+    let optional = """
+        - id: b
+          message: author
+          text: hi
+          expect: { output: brief, timeout: 5m, on_timeout: skip }
+        - id: t
+          action: handoff.checkpoint
+          with: { briefing: "{{ outputs.brief.path }}" }
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: optional)), [])
+  }
+
+  func testAgentTokenWarnings() {
+    let role = "  r:\n    source: launch\n    agents: [codex, robo]"
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(roles: role), knownAgents: ["codex", "claude"]), ["unknown_agent"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(roles: role), installedAgents: ["claude"]), ["agents_not_installed"])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role), installedAgents: ["codex"]), [])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role)), [], "unknown catalogs skip the warnings")
+  }
+}

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -397,5 +397,81 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role), enabledProfiles: [claude, codexHigh]), [])
     XCTAssertEqual(WorkflowFixtures.codes(minimal(roles: role)), [], "no profile catalog: no warning")
   }
+
+  // MARK: - Round 2 review findings
+
+  func testUntilReadsOnlyTheFinalProducerOfTheLoopBody() {
+    let steps = """
+        - id: initial
+          message: author
+          text: Initial
+          expect: { output: result, verdict: [retry, stop] }
+        - id: loop
+          repeat: { max: 3, until: "outputs.result.verdict == stop" }
+          steps:
+            - id: intermediate
+              message: author
+              text: Working
+              expect: { output: result, verdict: [working, failed] }
+            - id: final
+              message: author
+              text: Final
+              expect: { output: result, verdict: [retry, stop] }
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), [])
+  }
+
+  func testALaterSkippableLoopSeesTheFoldedStateOfAnEarlierOne() {
+    let steps = """
+        - id: initial
+          message: author
+          text: Initial
+          expect: { output: findings, verdict: [clean, issues] }
+        - id: first
+          repeat: { max: 2, until: "outputs.findings.verdict == clean" }
+          steps:
+            - id: again
+              message: author
+              text: Again
+              expect: { output: findings, verdict: [needs-work, clean] }
+        - id: second
+          repeat: { max: 2, until: "outputs.findings.verdict == needs-work" }
+          steps:
+            - id: poke
+              notify: "round {{ loop.index }}"
+      """
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(steps: steps)), ["until_verdict_literal"],
+      "if the first loop is skipped the latest findings verdict set is {clean, issues}; needs-work is not in it")
+  }
+
+  func testSkipWarningsSurviveFoldingASkippableLoop() {
+    let steps = """
+        - id: initial
+          message: author
+          text: Initial
+          expect: { output: gate, verdict: [go, stop] }
+        - id: loop
+          repeat: { max: 2, until: "outputs.gate.verdict == stop" }
+          steps:
+            - id: produce
+              message: author
+              text: Produce
+              expect: { output: draft, timeout: 5m, on_timeout: skip }
+            - id: consume
+              notify: "{{ outputs.draft.path }}"
+      """
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: steps)), ["skip_ends_run"])
+  }
+
+  func testBlankNamesAndTokensAreRejectedLikeTheSchemaDoes() {
+    XCTAssertEqual(
+      WorkflowFixtures.codes("schema: prowl.workflow/v1\nid: demo\nname: \"\"\nroles:\n  author:\n    source: current\nsteps:\n  - id: a\n    notify: hi\n"),
+      ["name_empty"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal(roles: "  r:\n    source: launch\n    agents: [\"\", codex]")), ["agent_token_empty"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  m: { type: enum, values: [\"\", b] }\n"), ["enum_value_empty"])
+  }
 }
 

--- a/docs-ai/013-prowl-cli/contracts/schema.md
+++ b/docs-ai/013-prowl-cli/contracts/schema.md
@@ -18,6 +18,7 @@ The bundle has one versioned success-or-error response schema for every wire com
 | `agents.signal` | `#/$defs/agentsSignalResponse` |
 | `profiles` | `#/$defs/profilesResponse` |
 | `skills` (local-only) | `#/$defs/skillsResponse` |
+| `workflow` (`list` over the socket; `validate`/`schema` local-only) | `#/$defs/workflowResponse` |
 | `focus` | `#/$defs/focusResponse` |
 | `send` | `#/$defs/sendResponse` |
 | `key` | `#/$defs/keyResponse` |
@@ -29,8 +30,10 @@ The bundle has one versioned success-or-error response schema for every wire com
 | `handoff` | `#/$defs/handoffResponse` |
 
 The bundle root is a `oneOf` across these responses and is valid for any complete
-socket response. `skills` never crosses the socket; its responses are produced locally by
-the CLI on the same envelope and are validated from real command runs.
+socket response. `skills` never crosses the socket, and neither do `workflow validate` / `workflow schema`;
+their responses are produced locally by the CLI on the same envelope and are validated from
+real command runs. The workflow *definition* schema (`workflow-definition-schema.json`, printed
+by `prowl workflow schema`) sits beside the bundle and is pinned to its Swift copy by a test.
 
 ## Executable verification
 

--- a/docs-ai/013-prowl-cli/contracts/workflow.md
+++ b/docs-ai/013-prowl-cli/contracts/workflow.md
@@ -1,0 +1,159 @@
+# `prowl workflow` Contract
+
+## Status
+
+Current version: `prowl.cli.workflow.v1` (docs-ai 063 B1).
+
+`workflow` is the definitions surface of Agent Workflows: it discovers, validates, and
+describes `prowl.workflow/v1` YAML files. `list` crosses the socket (the app resolves the
+worktree and reads the enabled set); `validate` and `schema` are **local-only** and work with
+Prowl closed. Every response uses `command: "workflow"` and one closed `data` object
+discriminated by `action`. Running workflows (`run`, `status`, `done`, `cancel`) is a later
+slice and is not part of this contract.
+
+## Input
+
+```bash
+prowl workflow list [target] [--target|--worktree|--tab|--pane <selector>] [--json]
+prowl workflow validate <file> [--scope bundle|user|repo] [--json]
+prowl workflow schema [--json]
+```
+
+### Sources and precedence
+
+| Scope | Directory | Notes |
+| --- | --- | --- |
+| `bundle` | `Prowl.app/Contents/Resources/workflows/` | ids `prowl.*` are reserved for this source; absent until the first built-in ships |
+| `user` | `~/.prowl/workflows/` | |
+| `repo` | `<worktree root>/.prowl/workflows/` | resolved per worktree |
+
+Files with extension `.yaml` or `.yml` directly inside a source directory are read in
+file-name order; hidden files and other extensions are ignored. A **valid** file (parses and
+validates without errors) shadows valid files with the same id in lower-precedence sources
+(`repo` > `user` > `bundle`) and later files in the same source. Invalid files never shadow
+and are never shadowed; a file that does not parse is listed without an `id`.
+
+### `list` worktree resolution
+
+- No selector: the caller's own pane (socket peer ancestry → pane → worktree), then the
+  focused worktree. When neither exists the response omits `worktree` and `sources.repo` and
+  searches the bundle and user sources only.
+- Any selector follows the 060 targeting rules (`TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE`);
+  a pane or tab selector resolves to its worktree.
+
+### `validate` scope
+
+`--scope` decides whether a `prowl.*` id is allowed. When omitted it is inferred from the
+file's directory: `~/.prowl/workflows` → `user`, any other `…/.prowl/workflows` → `repo`,
+anything else → `user`. The path must be an existing file (`PATH_NOT_FOUND`; a directory is
+`INVALID_ARGUMENT`).
+
+### Bundle resolution for skills
+
+`skill:` references are checked against the bundled skill registry resolved exactly as
+`prowl skills` does (`PROWL_SKILLS_DIR`, then the executable's app bundle). When no bundle can
+be resolved the reference is reported as a `skill_unchecked` **warning** and the file stays
+valid; the app-side `list` always has the bundle.
+
+## Success
+
+### `list`
+
+```json
+{
+  "ok": true,
+  "command": "workflow",
+  "schema_version": "prowl.cli.workflow.v1",
+  "data": {
+    "action": "list",
+    "worktree": { "id": "…", "name": "main", "path": "/Projects/App", "root_path": "/Projects/App" },
+    "sources": {
+      "bundle": "/Applications/Prowl.app/Contents/Resources/workflows",
+      "user": "/Users/me/.prowl/workflows",
+      "repo": "/Projects/App/.prowl/workflows"
+    },
+    "workflows": [
+      {
+        "id": "review",
+        "name": "Review",
+        "description": "…",
+        "scope": "repo",
+        "path": "/Projects/App/.prowl/workflows/review.yaml",
+        "enabled": true,
+        "valid": true,
+        "errors": 0,
+        "warnings": 1,
+        "shadowed": false
+      }
+    ]
+  }
+}
+```
+
+- `worktree`, `sources.bundle`, and `sources.repo` are omitted when they do not apply.
+- `workflows[]` is ordered by id (winners first, then shadowed files by scope precedence
+  and path); files without an id come last. `id`, `name`, and `description` are omitted when
+  the file did not parse or has no description.
+- `enabled` is the user's per-definition switch keyed by `<scope>/<id>` (all enabled by
+  default; the Settings toggle arrives with 063 D1). A file without an id is never enabled.
+
+### `validate`
+
+```json
+{
+  "ok": true,
+  "command": "workflow",
+  "schema_version": "prowl.cli.workflow.v1",
+  "data": {
+    "action": "validate",
+    "path": "/Projects/App/.prowl/workflows/review.yaml",
+    "valid": true,
+    "workflow": { "id": "review", "name": "Review" },
+    "diagnostics": [
+      { "severity": "warning", "code": "timeout_long", "message": "…", "line": 31, "column": 9 }
+    ]
+  }
+}
+```
+
+`diagnostics[]` lists parse diagnostics first, then validation diagnostics; `line` and
+`column` are 1-based and omitted when a diagnostic has no position. `workflow` is present
+whenever the file parsed. Codes are stable identifiers (`unknown_key`, `undefined_role`,
+`message_before_launch`, `until_verdict_literal`, `skill_unchecked`, …) and are the
+contract; messages are not.
+
+### `schema`
+
+```json
+{
+  "ok": true,
+  "command": "workflow",
+  "schema_version": "prowl.cli.workflow.v1",
+  "data": { "action": "schema", "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "…": "…" } }
+}
+```
+
+`data.schema` is the Draft 2020-12 workflow definition schema
+(`ProwlCLIContracts/Resources/workflow-definition-schema.json`, `$id`
+`https://prowl.onev.cat/contracts/workflow/v1/workflow-definition.json`). In text mode the
+schema is printed alone, pretty-printed.
+
+## Errors
+
+| Code | When |
+| --- | --- |
+| `WORKFLOW_INVALID` | `validate` found at least one error. `details` carries the full validate payload (`action`, `path`, `valid: false`, `workflow` when parsed, `diagnostics`). Exit status 1. |
+| `WORKFLOW_NOT_FOUND` | Reserved for id-addressed actions of later slices. |
+| `WORKFLOW_FAILED` | `list` could not read a source directory or encode the payload. |
+| `TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE` | `list` selector resolution. |
+| `PATH_NOT_FOUND` / `INVALID_ARGUMENT` | `validate` path is missing or a directory; conflicting selectors on `list`. |
+| `APP_NOT_RUNNING` | `list` without a reachable app. Never raised by `validate` or `schema`. |
+
+## Verification
+
+`ProwlCLITests/WorkflowDocumentParserTests`, `WorkflowValidatorTests`,
+`WorkflowDiscoveryTests`, `WorkflowSchemaTests` (output contract + definition schema pinned
+to `WorkflowJSONSchema.definitionSchemaJSON`), `WorkflowCommandParsingTests`,
+`WorkflowCommandExecutorTests`, and the `workflow` cases in `ProwlCLIIntegrationTests`
+(real `prowl` process for `validate`/`schema`, mock socket for `list`);
+`supacodeTests/WorkflowCommandHandlerTests` for worktree resolution and the enabled set.

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — R1 (C0/A1/A1b/A2 with 064-S1/S2/S3 wave 1 and 065) shipped in v2026.8.29; R2a (B1 → B2 → B3 → C1, with #733 and #726 T0) is next |
+| **Status** | In progress — R1 shipped in v2026.8.29; R2a under way: B1 implemented (definitions in `ProwlCLIShared`, `prowl workflow list/validate/schema`; [006](006-b1-definitions.md)), #733 and #726 T0 in flight; B2 next |
 | **Anchor date** | 2026-08-21 |
 | **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a/R2b/R3 (B1–D3) TBD |
 | **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), [release plan (living)](release-plan.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -183,6 +183,35 @@ the `Resources/workflows` staging in the Makefile (ships with the first bundled 
 - No app-side `installedAgents` when the availability probe has not run yet (nil skips the
   warning rather than reporting everything as not installed).
 
+## Review
+
+Adversarial review with a `Pi Reviewer` Profile in a split beside the implementing pane
+(`prowl create pane … --profile "Pi Reviewer" --prompt -` → `agents wait --dispatch`, briefs
+and findings under `/tmp/prowl-b1-review/`), read-only and SwiftPM-only so it could run beside
+the app builds.
+
+- **Round 1 — 7 findings, all real, fixed test-first in `51460efe`.** P0: a duration such as
+  `9223372036854775807h` overflowed `amount * 3600` and trapped the CLI (now
+  `multipliedReportingOverflow` → `timeout_syntax`). P1: `handoff.transition`'s `from`/`to`
+  were free strings (now `WorkflowActionInput.Kind.role`, literal declared roles only). P1:
+  output metadata accumulated monotonically — a later producer without a verdict still let
+  `{{ outputs.x.verdict }}` validate, and outputs first produced inside a loop with `until`
+  stayed visible after a loop that may run zero times (now per-producer tracking with
+  `latestVerdicts`, and `foldSkippableLoopOutputs` after a skippable loop). P2: `steps: []` and
+  `id: 1` passed the parser but not the published schema (`steps_empty`, `strictText`); a tab
+  passed `isSingleLine` (all C0/C1 controls rejected now); the "no enabled profile matches
+  `suggest`" warning had no data (`WorkflowValidationContext.enabledProfiles`, fed by the app);
+  an unreadable source directory listed as empty (discovery throws → `WORKFLOW_FAILED`).
+- **Round 2 — 1 P1 + 4 P2, all real, fixed test-first.** P1: `until` intersected every producer
+  in the loop body although only the body's final delivery is read after an iteration (now the
+  final in-body producer plus the folded pre-loop `latestVerdicts`, which also fixes a later
+  skippable loop reading a skipped loop's historical producer). P2: folding dropped
+  `on_timeout: skip` metadata (`skipOutputs` tracked apart from the output table); blank
+  `name`, agent tokens, and enum values were accepted against the schema's `minLength`
+  (`name_empty`, `agent_token_empty`, `enum_value_empty`); a directory or dangling link named
+  `*.yaml` was listed as `unreadable` (discovery keeps regular files and links to them only).
+- Round 3: pending at the time of writing; recorded below when closed.
+
 ## Open items
 
 - The `Resources/workflows` staging (Makefile + folder reference) ships with the first

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented on `feat/workflow-definitions-b1` (2026-08-29); PR: TBD. Owner decisions were settled
+Implemented on `feat/workflow-definitions-b1` (2026-08-29); PR [#740](https://github.com/onevcat/Prowl/pull/740). Owner decisions were settled
 in a grill session on 2026-08-29 (below) after a re-read of [dsl-spec.md](dsl-spec.md) against what
 R1 shipped; the spec's §4/§5/§9/§10/§12 were amended in #738. The "Delivered" section records
 what landed and where it deviates from the scope below.

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Planned (2026-08-29) — first R2a slice. Owner decisions were settled in a grill session on
-2026-08-29 (below) after a re-read of [dsl-spec.md](dsl-spec.md) against what R1 shipped; the
-spec's §4/§5/§9/§10/§12 were amended in the same change. Implementation PR: TBD.
+Implemented on `feat/workflow-definitions-b1` (2026-08-29); PR: TBD. Owner decisions were settled
+in a grill session on 2026-08-29 (below) after a re-read of [dsl-spec.md](dsl-spec.md) against what
+R1 shipped; the spec's §4/§5/§9/§10/§12 were amended in #738. The "Delivered" section records
+what landed and where it deviates from the scope below.
 
 ## Context
 
@@ -102,9 +103,63 @@ instance, drop the §4 example into a scratch user `~/.prowl/workflows/`, run `p
 list --json`, `validate` on the example and on a deliberately broken copy, and `schema`,
 driven from the bundled `prowl-cli` skill recipe.
 
+## Delivered
+
+- **Yams 6.2.2** pinned exactly in `Package.swift` (`ProwlCLIShared` and the test target) and as
+  an `XCRemoteSwiftPackageReference` on the app target. Every new Shared declaration is
+  `nonisolated` because the app target defaults to MainActor isolation — the first two app
+  builds failed on exactly that, and on an `Equatable` conformance of `WorkflowInput` that
+  pulled in `TargetSelector`'s main-actor conformance (dropped; the input needs no equality).
+- **Model + parser** (`WorkflowDefinition.swift`, `WorkflowDocumentParser.swift`): Yams
+  `compose` into a positioned `Node` tree read by `MappingReader` / `SequenceReader`, so every
+  diagnostic carries the YAML line/column (1-based) and unknown keys are errors. Plain scalars
+  are typed (`max: 5` is an integer, `max: "5"` a string); durations are `\d+[smh]`; `until` is
+  parsed into `(output, values)`; `repeat.max` keeps either the literal or the raw template.
+  Structural rules that the spec lists under validation but that need no cross-reference
+  (`kind: headless`, `expect` on `action`/`notify`/`close`, nested `repeat`, `launch` inside
+  `repeat`, missing `max`) are parser diagnostics, so a file with them yields no definition.
+- **Validator** (`WorkflowValidator.swift`): one `Walker` pass in document order with a
+  `repeat`-scoped action table; `outputs.*` references need an earlier producer anywhere
+  (loop bodies included), `actions.*` references need a producer in the same or an enclosing
+  sequence, `roles.<r>.pane` needs the role launched, `loop.index` needs a loop, `loop.count`
+  a loop before or around. `until` accepts a producer before the loop or inside its body (the
+  pre-entry check then simply reads "not satisfied"; B2 owns that rule). Warnings:
+  `skill_unchecked` (no bundle), `unknown_agent` / `agents_not_installed` (only when the
+  catalogs are supplied), `timeout_long`, `spells_completion_command`, `skip_ends_run`,
+  `direction_ignored`. Diagnostic codes are the contract; messages are not.
+- **Action registry** (`WorkflowActionRegistry.swift`): `handoff.transition`,
+  `handoff.checkpoint`, `git.context` with typed inputs/outputs for the validator and schema.
+- **JSON Schema** (`WorkflowJSONSchema.swift` + `ProwlCLIContracts/Resources/
+  workflow-definition-schema.json`): hand-written Draft 2020-12, `oneOf` per step shape and
+  per role source, loop steps exclude `launch`/`repeat`; a test pins the resource to the Swift
+  constant and validates the spec example (via Yams → JSON) plus six structural negatives.
+- **Discovery** (`WorkflowDiscovery.swift`): `WorkflowSources` (bundle/user/repo URLs),
+  per-directory `files`, and `catalog` with precedence and shadowing; the bundle directory
+  (`SupacodePaths.bundledWorkflowsURL`) is absent until D2 and tolerated.
+- **CLI** (`WorkflowCommand.swift`, `WorkflowCommandExecutor.swift`,
+  `OutputRenderer+Workflow.swift`): `validate <file> [--scope]` and `schema` local;
+  `list [target]` over the socket with `WorkflowInput { action: list, target }` and the new
+  `Command.workflow` case. An invalid file returns `ok: false` / `WORKFLOW_INVALID` with the
+  validate payload in `error.details` and exit status 1; text mode prints
+  `path:line:column: severity[code]: message` lines and an `OK` / `INVALID` summary.
+- **App** (`WorkflowCommandHandler.swift`, router + `supacodeApp` wiring): caller pane →
+  focused worktree → explicit selector resolution, then discovery with the bundle's skill ids,
+  the `DetectedAgent` catalog, and the availability probe as `installedAgents`. The enabled
+  set is `UserGlobalSettings.disabledWorkflowIDs` (`<scope>/<id>`, sorted, deduplicated;
+  opt-out so new files are enabled).
+- **Contracts and docs**: `cli-output-schema.json` gained `workflowResponse` (+ nine defs),
+  `docs-ai/013-prowl-cli/contracts/workflow.md`, the coverage row in `schema.md`, and a
+  `prowl workflow` section plus error rows in `docs/components/cli.md`. The `prowl-cli` skill
+  is unchanged until B3.
+
+### Deviations from the scope above
+
+- `list --json` reports `errors` / `warnings` counts only; diagnostics stay with `validate`
+  (the second open item, resolved as the default).
+- No app-side `installedAgents` when the availability probe has not run yet (nil skips the
+  warning rather than reporting everything as not installed).
+
 ## Open items
 
-- Yams version pin and the xcodeproj package reference (first shared third-party dependency).
-- Whether `list --json` should include per-file validation diagnostics inline or only a
-  status plus a pointer to `validate` (default: status + counts; diagnostics stay with
-  `validate`).
+- The `Resources/workflows` staging (Makefile + folder reference) ships with the first
+  bundled definition (D2); discovery already tolerates the missing folder.

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -210,7 +210,16 @@ the app builds.
   `name`, agent tokens, and enum values were accepted against the schema's `minLength`
   (`name_empty`, `agent_token_empty`, `enum_value_empty`); a directory or dangling link named
   `*.yaml` was listed as `unreadable` (discovery keeps regular files and links to them only).
-- Round 3: pending at the time of writing; recorded below when closed.
+- **Round 3 — 3 P2, all real, fixed test-first in `90bd561b`.** `skip_ends_run` ignored
+  reader order (now `OutputUse{ordinal, loopID}`: a reader after the skip, or anywhere in the
+  same loop body including the loop's `until`, blocks; an earlier reader does not); a FIFO
+  named `*.yaml` passed the regular-file check (`FileAttributeType.typeRegular` after
+  resolving links); `until`/`timeout` trimmed surrounding whitespace the schema rejects.
+- **Round 4 — 1 P2 (grammar only), fixed test-first.** `parseUntil` accepted non-slug output
+  names and `==` values that the schema's `until` pattern rejects; the validator caught them
+  semantically (`until_output` / `until_verdict_literal`), so behavior was safe but the
+  parser and schema grammars differed. The parser now uses the schema's slug tokens. Nothing
+  at P0–P1 remained after round 2; the loop is closed here.
 
 ## Open items
 

--- a/docs-ai/063-agent-workflows/006-b1-definitions.md
+++ b/docs-ai/063-agent-workflows/006-b1-definitions.md
@@ -94,14 +94,38 @@ the `Resources/workflows` staging in the Makefile (ships with the first bundled 
 - CLI: `validate` / `schema` executor tests (JSON and text), `list` socket round trip with a
   stubbed handler, contract schema conformance for every payload shape.
 
-## Verification
+## Verification (2026-08-29, all run)
 
-`make check`, `make build-cli`, `make test-cli-unit`, `make test-cli-smoke`,
-`make test-cli-integration`, `make build-app`, the new Swift Testing suites; then the
-end-to-end pass required by the release plan's cadence rules: against an isolated Debug
-instance, drop the §4 example into a scratch user `~/.prowl/workflows/`, run `prowl workflow
-list --json`, `validate` on the example and on a deliberately broken copy, and `schema`,
-driven from the bundled `prowl-cli` skill recipe.
+- Red first: the parser and validator suites were written against the spec and failed on
+  the first run for real reasons (`MappingReader` double-reported a non-mapping document,
+  `notify`/`close` rejected `expect` as an unknown key instead of `expect_not_allowed`, the
+  minimal fixture lacked a trailing newline, catalog ordering put an invalid repo file
+  before the valid user winner, `JSONEncoder` escaped `/`); each fix is pinned by the test
+  that caught it.
+- Gates: `make check` (swift-format, SwiftLint strict, 44 script tests), `make build-cli`,
+  `make test-cli-unit` (194), `make test-cli-smoke`, `make test-cli-integration` (106, four
+  new `workflow` cases: real `prowl` process for `validate`/`schema`, mock socket for `list`),
+  `make build-app`, and the full `make test` (2671 passed, 0 failed) including
+  `WorkflowCommandHandlerTests` (6) and the router test.
+- Live, against an isolated Debug instance of this build (`CFFIXED_USER_HOME` scratch home,
+  own `PROWL_CLI_SOCKET`, a scratch Git repo opened with `prowl open`, the bundled CLI from the
+  copied app; script kept in the session scratchpad as `e2e/b1-live.sh`):
+  `workflow list --json` from outside any pane resolved the focused worktree and listed the
+  repo `demo` as the winner, the user `demo` as shadowed, the user `prowl.mine` and the repo
+  `prowl.adversarial-review` as invalid (reserved id; `skill_not_found` against the real
+  bundle, which ships only `prowl-cli`), and an unparsable `broken.yaml` as `(unparsed)`;
+  `list main` and `list <pane UUID>` resolved the same worktree; `list nope` returned
+  `TARGET_NOT_FOUND`; the bundled CLI's `validate --scope bundle` on the §4 example failed
+  only on the unbundled skill (a `swift build` CLI reports `skill_unchecked` instead, as
+  documented); `validate` on the broken file returned `WORKFLOW_INVALID` with a positioned
+  `yaml_syntax` diagnostic; `schema` printed the definition schema; and `prowl send` of
+  `workflow list --json` into the pane resolved the **caller's own pane** to the worktree
+  without any selector. The instance was ended with SIGKILL — quitting through AppleScript
+  hit a two-minute AppleEvent timeout, which is unrelated to this slice.
+- A crash report that arrived during this verification (`ProwlApp-2026-08-29-112626.ips`)
+  belongs to a different isolated instance: its binary UUID matches the #733 worktree build
+  (`apps/new`), launched before this slice's E2E started. It was handed to that branch for
+  investigation.
 
 ## Delivered
 

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -34,7 +34,7 @@ say when each is cut:
 | Release | State | Next action |
 | --- | --- | --- |
 | R1 | **Shipped** — v2026.8.29 (2026-08-29) | — |
-| R2a | Next | B1 ∥ #733 ∥ #726 T0 on three branches from `main`; B1 starts with a grilled slice record |
+| R2a | In progress | B1 implemented on `feat/workflow-definitions-b1` (PR TBD); #726 T0 = #739 (review pending); #733 in progress on `feat/agent-redispatch` |
 | R2b | Planned | after R2a ships |
 | R3 | Planned | after R2b ships |
 

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -34,7 +34,7 @@ say when each is cut:
 | Release | State | Next action |
 | --- | --- | --- |
 | R1 | **Shipped** — v2026.8.29 (2026-08-29) | — |
-| R2a | In progress | B1 implemented on `feat/workflow-definitions-b1` (PR TBD); #726 T0 = #739 (review pending); #733 in progress on `feat/agent-redispatch` |
+| R2a | In progress | B1 = #740 (review); #726 T0 = #739 (review); #733 in progress on `feat/agent-redispatch`; B2 next |
 | R2b | Planned | after R2a ships |
 | R3 | Planned | after R2b ships |
 
@@ -101,7 +101,7 @@ User-visible result: onevcat's daily CLI-driven orchestration is first-class
 
 | Order | Slice | Entry | Depends | Outcome |
 | --- | --- | --- | --- | --- |
-| 1 | **B1** definitions (Yams, model, validator, JSON Schema, three-source discovery, `workflow list/validate/schema`) | 063 | — | DSL authorable and validatable; dormant until B3 |
+| 1 | **B1** definitions (Yams, model, validator, JSON Schema, three-source discovery, `workflow list/validate/schema`) — #740, record [063.006](006-b1-definitions.md) | 063 | — | DSL authorable and validatable; dormant until B3 |
 | 1 | **#733** `prowl agents dispatch <pane> --prompt -`: a new pending dispatch bound to an existing surface, one pending per surface, `dispatch-complete` resolved from the caller's ancestry to the pane's current record, refused while the agent is working or blocked | 064 | S2, 064.012 | a reviewer launched once takes N assignments, each with its own receipt — the transport B3's `message` + `expect` rides on (decision 2026-08-29), and usable from the CLI recipe as soon as it merges |
 | 1 | **#726 T0** version attestation: per-runtime attested version record beside the research matrix + `make agent-versions` | 064 | S3 wave 1 | an installed runtime newer than its attested contract warns before a release |
 | 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) | 063 | B1 | watchdog on exact signals (064-S5 watchdog part, moved from D2) |

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -431,6 +431,52 @@ Settings › Agents › CLI & Skills › **Agent Skills** offers the same user-s
 from the GUI (Install / Remove / Repair / Replace per skill × detected target) and shows
 the same status as `prowl skills list` — see [settings](settings.md#agent-skills).
 
+### `prowl workflow`
+Discover, validate, and describe Agent Workflow definitions — YAML files
+(`schema: prowl.workflow/v1`) that declare a multi-agent flow Prowl runs. Definitions come
+from three sources, later ones winning for the same id: the app bundle
+(`Prowl.app/Contents/Resources/workflows/`, ids `prowl.*` are reserved for it) <
+`~/.prowl/workflows/*.yaml` < `<repo>/.prowl/workflows/*.yaml`. `validate` and `schema` run
+**locally** and work with Prowl closed; `list` needs the app.
+
+```bash
+prowl workflow list [target] [--json]                   # every definition visible to a worktree, with status
+prowl workflow validate <file> [--scope bundle|user|repo] [--json]   # parse + validate one file; exit 1 on errors
+prowl workflow schema [--json]                          # JSON Schema (Draft 2020-12) of a workflow file
+```
+
+- `list` searches the repo source of one worktree: the caller's own pane's worktree, else the
+  focused worktree, or any target (`pN`/`tN`/UUID/worktree id/name/path, or `--worktree`,
+  `--tab`, `--pane`, `--target`). Without a resolvable worktree only the bundle and user
+  sources are searched. Each `.data.workflows[]` item carries `id`, `name`, `description`,
+  `scope` (`bundle` | `user` | `repo`), `path`, `enabled`, `valid`, `errors`, `warnings`, and
+  `shadowed` (a higher-precedence source defines the same id, so this file is not the one
+  that runs). A file that does not parse is listed with `valid: false` and no `id`. Invalid
+  files never shadow valid ones.
+- `validate` prints every diagnostic as `path:line:column: error[code]: message` (warnings
+  likewise) and ends with `OK <id> (<name>)` or `INVALID …`. Errors make the command fail
+  with `WORKFLOW_INVALID`; in JSON the full validate payload (`path`, `valid`, `workflow`,
+  `diagnostics[]` with `severity`, `code`, `message`, optional `line`/`column`) is under
+  `.error.details`, and a valid file returns it under `.data`. The scope decides whether a
+  `prowl.*` id is allowed; it is inferred from the file's directory (`~/.prowl/workflows` →
+  user, any other `.prowl/workflows` → repo, elsewhere → user) unless `--scope` says
+  otherwise. When the `prowl` binary is not inside an app bundle (a development build with
+  `PROWL_SKILLS_DIR` unset), `skill:` references cannot be checked and are reported as
+  `skill_unchecked` warnings instead of errors.
+- `schema` prints the machine-readable definition schema for editors and authoring agents
+  (`--json` wraps it as `.data.schema`). Structural rules live in the schema; cross-reference
+  rules (undefined roles, premature `{{ outputs.* }}`, `until` verdicts, …) are enforced by
+  `validate` only.
+
+```bash
+prowl workflow validate .prowl/workflows/review.yaml
+prowl workflow list --json | jq '.data.workflows[] | select(.valid) | .id'
+prowl workflow schema > /tmp/workflow.schema.json
+```
+
+JSON is `prowl.cli.workflow.v1` with `data.action` = `list` | `validate` | `schema`.
+Running a workflow (`prowl workflow run`, `status`, `done`, `cancel`) is not available yet.
+
 ### `prowl read [target]`
 Read a pane's content.
 
@@ -731,6 +777,8 @@ artifacts and terminal excerpts do not appear in `git status`.
 | `INSTALL_CONFLICT` | A real file or directory occupies a skill link slot, or a project-scope target folder is a symlink leading outside the repository; nothing was changed. Remove or fix it manually, or choose other targets. |
 | `BUNDLE_NOT_FOUND` | The `prowl` binary is not inside a Prowl app bundle and `PROWL_SKILLS_DIR` is unset or invalid — run the installed `prowl` or set the override. |
 | `INVALID_SKILL_FRONTMATTER` | A bundled (or `PROWL_SKILLS_DIR`) skill's `SKILL.md` frontmatter is malformed — fix the override skill, or reinstall Prowl if the bundle itself is damaged. |
+| `WORKFLOW_INVALID` | `workflow validate` found errors; the full diagnostics are in `.error.details` (JSON) or on stdout (text). Fix the file and re-run. |
+| `WORKFLOW_NOT_FOUND` | No workflow definition with that id is visible to the worktree — re-run `workflow list`. |
 | `NO_ACTIVE_PANE` | No pane for focused-target; pass an explicit `--pane`. |
 | `EMPTY_INPUT` | `send` got neither argv nor stdin (or both). |
 | `INVALID_ARGUMENT` | Bad flag/combo (e.g. `--capture --no-wait`) or out-of-range value. |
@@ -740,7 +788,7 @@ artifacts and terminal excerpts do not appear in `git status`.
 | `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`create tab` path, or the `skills --scope project` start point (`--path` and the current directory must lie inside a Git repository). |
 | `LAUNCH_FAILED` | App launch or socket wait failed; the message includes the last socket diagnostic when available. |
 | `TRANSPORT_FAILED` | Socket transport failed for a reason other than app availability or permission, such as `ENOTSOCK` or an invalid `PROWL_CLI_SOCKET` path. |
-| `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `PROFILES_FAILED`, `SKILLS_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `CREATE_FAILED`, `CLOSE_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`, `HANDOFF_FAILED`) | The action itself failed. |
+| `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `PROFILES_FAILED`, `SKILLS_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `CREATE_FAILED`, `CLOSE_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`, `HANDOFF_FAILED`, `WORKFLOW_FAILED`) | The action itself failed. |
 
 ## Safety & self-targeting
 

--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		C8B33B9AFE69E738ABFA08BE /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 497B582F42253CBC8FBF101F /* ComposableArchitecture */; };
 		D1BB05892F5ACB5900553512 /* YiTong in Frameworks */ = {isa = PBXBuildFile; productRef = D1BB05882F5ACB5900553512 /* YiTong */; };
 		66055880DA0BAF0D05D67D02 /* GlyphonKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0C10F7612452A2EF85A71541 /* GlyphonKit */; };
+		7A1D5E2C9B3F4A6D8E0C1B2C /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */; };
 		D63D00F72F2A5EEE00018D05 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */; };
 		D64162B02F23CAF100260CA3 /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = D64162AD2F23CAF100260CA3 /* ghostty */; };
 		D64162B12F23CAF100260CA3 /* terminfo in Resources */ = {isa = PBXBuildFile; fileRef = D64162AE2F23CAF100260CA3 /* terminfo */; };
@@ -87,6 +88,7 @@
 			files = (
 				D1BB05892F5ACB5900553512 /* YiTong in Frameworks */,
 				66055880DA0BAF0D05D67D02 /* GlyphonKit in Frameworks */,
+				7A1D5E2C9B3F4A6D8E0C1B2C /* Yams in Frameworks */,
 				C8B33B9AFE69E738ABFA08BE /* ComposableArchitecture in Frameworks */,
 				886A649F771240E8A5AC792D /* Dependencies in Frameworks */,
 				D6A1CB312F1F4ABF004FDABD /* GhosttyKit.xcframework in Frameworks */,
@@ -174,6 +176,7 @@
 				D6D054272F2E3EBF00D70ED5 /* PostHog */,
 				D1BB05882F5ACB5900553512 /* YiTong */,
 				0C10F7612452A2EF85A71541 /* GlyphonKit */,
+				7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */,
 			);
 			productName = supacode;
 			productReference = D69CE04A2F1F378200584C57 /* Prowl.app */;
@@ -240,6 +243,7 @@
 				D6D054262F2E3EB300D70ED5 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				D1BB05872F5ACB5900553512 /* XCRemoteSwiftPackageReference "YiTong" */,
 				AA918EA35EA8913669138FE5 /* XCRemoteSwiftPackageReference "GlyphonKit" */,
+				7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = D69CE04B2F1F378200584C57 /* Products */;
@@ -726,6 +730,14 @@
 				minimumVersion = 0.1.0;
 			};
 		};
+		7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jpsim/Yams.git";
+			requirement = {
+				kind = exactVersion;
+				version = 6.2.2;
+			};
+		};
 		D6D054262F2E3EB300D70ED5 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
@@ -766,6 +778,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA918EA35EA8913669138FE5 /* XCRemoteSwiftPackageReference "GlyphonKit" */;
 			productName = GlyphonKit;
+		};
+		7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
 		};
 		D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e72afa9e5f10f1505a3d4fb929733c3183a228458b9840524d15027f7afd88ff",
+  "originHash" : "7643fa12a28d827327bdbe83f87db88bb3a3e9b400463e3aa384776ca321786f",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -161,6 +161,15 @@
       "state" : {
         "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
         "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     },
     {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -1156,6 +1156,28 @@ struct SupacodeApp: App {
       }
 
     )
+    let workflowHandler = WorkflowCommandHandler {
+      @Shared(.userGlobalSettings) var settings
+      @Shared(.agentRuntimeAvailabilityProbeResults) var probeResults
+      let bundledSkills = Bundle.main.resourceURL.flatMap { try? ProwlSkills.bundled(resourcesURL: $0) }
+      let installedAgents =
+        probeResults.isEmpty
+        ? nil
+        : Set(probeResults.filter { $0.value.isAvailable }.keys.map { $0.agent.rawValue })
+      return WorkflowRuntimeSnapshot(
+        resolution: TargetResolutionSnapshotBuilder.makeSnapshot(
+          repositoriesState: appStore.state.repositories,
+          terminalManager: terminalManager
+        ),
+        paneByShellPID: terminalManager.paneByShellPID(),
+        bundleWorkflowsURL: SupacodePaths.bundledWorkflowsURL,
+        userWorkflowsURL: WorkflowSources.userDirectory(home: FileManager.default.homeDirectoryForCurrentUser),
+        disabledWorkflowIDs: Set(settings.disabledWorkflowIDs),
+        bundledSkillIDs: bundledSkills.map { Set($0.map(\.id)) },
+        knownAgents: Set(DetectedAgent.allCases.map(\.rawValue)),
+        installedAgents: installedAgents
+      )
+    }
     return CLICommandRouter(
       openHandler: openHandler,
       listHandler: listHandler,
@@ -1175,7 +1197,8 @@ struct SupacodeApp: App {
       closeHandler: lifecycleHandler,
       tabHandler: tabHandler,
       paneHandler: paneHandler,
-      handoffHandler: handoffHandler
+      handoffHandler: handoffHandler,
+      workflowHandler: workflowHandler
     )
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -1175,7 +1175,15 @@ struct SupacodeApp: App {
         disabledWorkflowIDs: Set(settings.disabledWorkflowIDs),
         bundledSkillIDs: bundledSkills.map { Set($0.map(\.id)) },
         knownAgents: Set(DetectedAgent.allCases.map(\.rawValue)),
-        installedAgents: installedAgents
+        installedAgents: installedAgents,
+        enabledProfiles: settings.agentProfiles.filter(\.isEnabled).map { profile in
+          WorkflowProfileSuggestion(
+            agent: profile.runtime.agent.rawValue,
+            model: profile.model,
+            reasoningEffort: profile.reasoningEffort,
+            executionMode: profile.executionMode.rawValue
+          )
+        }
       )
     }
     return CLICommandRouter(

--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -24,6 +24,7 @@ final class CLICommandRouter {
   private let tabHandler: any CommandHandler
   private let paneHandler: any CommandHandler
   private let handoffHandler: any CommandHandler
+  private let workflowHandler: any CommandHandler
 
   init(
     openHandler: any CommandHandler = StubCommandHandler(command: "open"),
@@ -44,7 +45,8 @@ final class CLICommandRouter {
     closeHandler: any CommandHandler = StubCommandHandler(command: "close"),
     tabHandler: any CommandHandler = StubCommandHandler(command: "tab"),
     paneHandler: any CommandHandler = StubCommandHandler(command: "pane"),
-    handoffHandler: any CommandHandler = StubCommandHandler(command: "handoff")
+    handoffHandler: any CommandHandler = StubCommandHandler(command: "handoff"),
+    workflowHandler: any CommandHandler = StubCommandHandler(command: "workflow")
   ) {
     self.openHandler = openHandler
     self.listHandler = listHandler
@@ -65,6 +67,7 @@ final class CLICommandRouter {
     self.tabHandler = tabHandler
     self.paneHandler = paneHandler
     self.handoffHandler = handoffHandler
+    self.workflowHandler = workflowHandler
   }
 
   // Intentional exhaustive routing table for the public CLI command union.
@@ -94,6 +97,7 @@ final class CLICommandRouter {
     case .tab: handler = tabHandler
     case .pane: handler = paneHandler
     case .handoff: handler = handoffHandler
+    case .workflow: handler = workflowHandler
     }
     return await handler.handle(envelope: envelope, context: context)
   }

--- a/supacode/CLIService/Shared/CommandEnvelope.swift
+++ b/supacode/CLIService/Shared/CommandEnvelope.swift
@@ -33,6 +33,7 @@ public enum Command: Codable, Sendable {
   case tab(TabInput)
   case pane(PaneInput)
   case handoff(HandoffInput)
+  case workflow(WorkflowInput)
 
   public var name: String {
     switch self {
@@ -55,6 +56,7 @@ public enum Command: Codable, Sendable {
     case .tab: "tab"
     case .pane: "pane"
     case .handoff: "handoff"
+    case .workflow: "workflow"
     }
   }
 }

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -93,6 +93,12 @@ public enum CLIErrorCode {
   /// A HUD-injected request was already superseded by its fallback.
   public static let handoffRequestSuperseded = "HANDOFF_REQUEST_SUPERSEDED"
 
+  // Workflow
+  public static let workflowFailed = "WORKFLOW_FAILED"
+  public static let workflowNotFound = "WORKFLOW_NOT_FOUND"
+  /// The file parsed or validated with errors; `details` carries the validate payload.
+  public static let workflowInvalid = "WORKFLOW_INVALID"
+
   // Transport
   public static let transportFailed = "TRANSPORT_FAILED"
   public static let socketPermissionDenied = "SOCKET_PERMISSION_DENIED"

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -643,3 +643,22 @@ public struct PaneInput: Codable, Sendable {
     self.force = try container.decodeIfPresent(Bool.self, forKey: .force) ?? false
   }
 }
+
+// MARK: - Workflow
+
+nonisolated public enum WorkflowInputAction: String, Codable, Sendable {
+  /// Discover definitions for a worktree; the only workflow action that crosses the socket today.
+  case list
+}
+
+nonisolated public struct WorkflowInput: Codable, Sendable {
+  public let action: WorkflowInputAction
+  /// Worktree whose repo source is searched: any 060 target; `.none` = the caller's pane, then
+  /// the focused worktree.
+  public let target: TargetSelector
+
+  public init(action: WorkflowInputAction = .list, target: TargetSelector = .none) {
+    self.action = action
+    self.target = target
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowActionRegistry.swift
+++ b/supacode/CLIService/Shared/WorkflowActionRegistry.swift
@@ -5,13 +5,24 @@
 import Foundation
 
 nonisolated public struct WorkflowActionInput: Equatable, Sendable {
+  public enum Kind: String, Equatable, Sendable {
+    /// Templated text.
+    case string
+    /// Templated path.
+    case path
+    /// A role name declared by the workflow; never templated.
+    case role
+  }
+
   public let name: String
   public let required: Bool
+  public let kind: Kind
   public let description: String
 
-  public init(name: String, required: Bool, description: String) {
+  public init(name: String, required: Bool, kind: Kind = .string, description: String) {
     self.name = name
     self.required = required
+    self.kind = kind
     self.description = description
   }
 }
@@ -56,9 +67,10 @@ nonisolated public enum WorkflowActionRegistry {
         "Archive-first `.prowl/handoff/` transition from one role to another; without a briefing "
         + "it becomes a context-only transition.",
       inputs: [
-        WorkflowActionInput(name: "briefing", required: false, description: "Path to the validated briefing"),
-        WorkflowActionInput(name: "from", required: true, description: "Outgoing role"),
-        WorkflowActionInput(name: "to", required: true, description: "Receiving role"),
+        WorkflowActionInput(
+          name: "briefing", required: false, kind: .path, description: "Path to the validated briefing"),
+        WorkflowActionInput(name: "from", required: true, kind: .role, description: "Outgoing role"),
+        WorkflowActionInput(name: "to", required: true, kind: .role, description: "Receiving role"),
         WorkflowActionInput(name: "note", required: false, description: "Log note"),
       ],
       outputs: [
@@ -71,7 +83,8 @@ nonisolated public enum WorkflowActionRegistry {
       id: "handoff.checkpoint",
       description: "Save progress for a later successor; regenerates `context.md`.",
       inputs: [
-        WorkflowActionInput(name: "briefing", required: false, description: "Path to the validated briefing"),
+        WorkflowActionInput(
+          name: "briefing", required: false, kind: .path, description: "Path to the validated briefing"),
         WorkflowActionInput(name: "note", required: false, description: "Log note"),
       ],
       outputs: [
@@ -83,7 +96,8 @@ nonisolated public enum WorkflowActionRegistry {
       id: "git.context",
       description: "Generate a markdown summary of the worktree's repository state.",
       inputs: [
-        WorkflowActionInput(name: "root", required: false, description: "Repository root; defaults to the worktree")
+        WorkflowActionInput(
+          name: "root", required: false, kind: .path, description: "Repository root; defaults to the worktree")
       ],
       outputs: [
         WorkflowActionOutput(name: "path", description: "Path to the generated markdown summary"),

--- a/supacode/CLIService/Shared/WorkflowActionRegistry.swift
+++ b/supacode/CLIService/Shared/WorkflowActionRegistry.swift
@@ -1,0 +1,98 @@
+// ProwlShared/WorkflowActionRegistry.swift
+// Typed schemas of the V1 native actions (dsl-spec.md §4). The validator and `prowl workflow
+// schema` read them; execution arrives with the runner.
+
+import Foundation
+
+nonisolated public struct WorkflowActionInput: Equatable, Sendable {
+  public let name: String
+  public let required: Bool
+  public let description: String
+
+  public init(name: String, required: Bool, description: String) {
+    self.name = name
+    self.required = required
+    self.description = description
+  }
+}
+
+nonisolated public struct WorkflowActionOutput: Equatable, Sendable {
+  public let name: String
+  public let description: String
+
+  public init(name: String, description: String) {
+    self.name = name
+    self.description = description
+  }
+}
+
+nonisolated public struct WorkflowActionSchema: Equatable, Sendable {
+  public let id: String
+  public let description: String
+  public let inputs: [WorkflowActionInput]
+  public let outputs: [WorkflowActionOutput]
+
+  public init(id: String, description: String, inputs: [WorkflowActionInput], outputs: [WorkflowActionOutput]) {
+    self.id = id
+    self.description = description
+    self.inputs = inputs
+    self.outputs = outputs
+  }
+
+  public func input(named name: String) -> WorkflowActionInput? {
+    inputs.first { $0.name == name }
+  }
+
+  public func hasOutput(named name: String) -> Bool {
+    outputs.contains { $0.name == name }
+  }
+}
+
+nonisolated public enum WorkflowActionRegistry {
+  public static let all: [WorkflowActionSchema] = [
+    WorkflowActionSchema(
+      id: "handoff.transition",
+      description:
+        "Archive-first `.prowl/handoff/` transition from one role to another; without a briefing "
+        + "it becomes a context-only transition.",
+      inputs: [
+        WorkflowActionInput(name: "briefing", required: false, description: "Path to the validated briefing"),
+        WorkflowActionInput(name: "from", required: true, description: "Outgoing role"),
+        WorkflowActionInput(name: "to", required: true, description: "Receiving role"),
+        WorkflowActionInput(name: "note", required: false, description: "Log note"),
+      ],
+      outputs: [
+        WorkflowActionOutput(name: "kickoff_prompt", description: "Kickoff prompt for the receiver"),
+        WorkflowActionOutput(name: "artifact_path", description: "Path of the handoff artifact"),
+        WorkflowActionOutput(name: "has_briefing", description: "Whether a briefing was delivered"),
+      ]
+    ),
+    WorkflowActionSchema(
+      id: "handoff.checkpoint",
+      description: "Save progress for a later successor; regenerates `context.md`.",
+      inputs: [
+        WorkflowActionInput(name: "briefing", required: false, description: "Path to the validated briefing"),
+        WorkflowActionInput(name: "note", required: false, description: "Log note"),
+      ],
+      outputs: [
+        WorkflowActionOutput(name: "artifact_path", description: "Path of the handoff artifact"),
+        WorkflowActionOutput(name: "has_briefing", description: "Whether a briefing was delivered"),
+      ]
+    ),
+    WorkflowActionSchema(
+      id: "git.context",
+      description: "Generate a markdown summary of the worktree's repository state.",
+      inputs: [
+        WorkflowActionInput(name: "root", required: false, description: "Repository root; defaults to the worktree")
+      ],
+      outputs: [
+        WorkflowActionOutput(name: "path", description: "Path to the generated markdown summary"),
+        WorkflowActionOutput(name: "branch", description: "Checked-out branch"),
+      ]
+    ),
+  ]
+
+  public static func schema(for id: String, in actions: [WorkflowActionSchema] = all) -> WorkflowActionSchema? {
+    actions.first { $0.id == id }
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowCommandPayload.swift
+++ b/supacode/CLIService/Shared/WorkflowCommandPayload.swift
@@ -1,0 +1,232 @@
+// ProwlShared/WorkflowCommandPayload.swift
+// `prowl workflow` response data (`prowl.cli.workflow.v1`), discriminated by `action`.
+// `list` crosses the socket; `validate` and `schema` are produced locally by the CLI.
+
+import Foundation
+
+nonisolated public enum WorkflowCommandPayload: Codable, Equatable, Sendable {
+  public static let schemaVersion = "prowl.cli.workflow.v1"
+  public static let commandName = "workflow"
+
+  case list(WorkflowListPayload)
+  case validate(WorkflowValidatePayload)
+  case schema(WorkflowSchemaPayload)
+
+  public var action: WorkflowCommandAction {
+    switch self {
+    case .list: .list
+    case .validate: .validate
+    case .schema: .schema
+    }
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case action
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    switch try container.decode(WorkflowCommandAction.self, forKey: .action) {
+    case .list: self = .list(try WorkflowListPayload(from: decoder))
+    case .validate: self = .validate(try WorkflowValidatePayload(from: decoder))
+    case .schema: self = .schema(try WorkflowSchemaPayload(from: decoder))
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(action, forKey: .action)
+    switch self {
+    case .list(let payload): try payload.encode(to: encoder)
+    case .validate(let payload): try payload.encode(to: encoder)
+    case .schema(let payload): try payload.encode(to: encoder)
+    }
+  }
+}
+
+nonisolated public enum WorkflowCommandAction: String, Codable, Equatable, Sendable {
+  case list
+  case validate
+  case schema
+}
+
+// MARK: - list
+
+nonisolated public struct WorkflowListPayload: Codable, Equatable, Sendable {
+  /// The worktree whose repo source was searched; absent when no worktree could be resolved.
+  public let worktree: WorkflowListWorktree?
+  public let sources: WorkflowListSources
+  public let workflows: [WorkflowListEntry]
+
+  public init(worktree: WorkflowListWorktree?, sources: WorkflowListSources, workflows: [WorkflowListEntry]) {
+    self.worktree = worktree
+    self.sources = sources
+    self.workflows = workflows
+  }
+}
+
+nonisolated public struct WorkflowListWorktree: Codable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let path: String
+  public let rootPath: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case path
+    case rootPath = "root_path"
+  }
+
+  public init(id: String, name: String, path: String, rootPath: String) {
+    self.id = id
+    self.name = name
+    self.path = path
+    self.rootPath = rootPath
+  }
+}
+
+/// Directories searched; a nil entry means the source does not apply (no app bundle, no worktree).
+nonisolated public struct WorkflowListSources: Codable, Equatable, Sendable {
+  public let bundle: String?
+  public let user: String
+  public let repo: String?
+
+  public init(bundle: String?, user: String, repo: String?) {
+    self.bundle = bundle
+    self.user = user
+    self.repo = repo
+  }
+}
+
+nonisolated public struct WorkflowListEntry: Codable, Equatable, Sendable {
+  /// Absent when the file did not parse.
+  public let id: String?
+  public let name: String?
+  public let description: String?
+  public let scope: WorkflowScope
+  public let path: String
+  public let enabled: Bool
+  public let valid: Bool
+  public let errors: Int
+  public let warnings: Int
+  public let shadowed: Bool
+
+  public init(
+    id: String?,
+    name: String?,
+    description: String?,
+    scope: WorkflowScope,
+    path: String,
+    enabled: Bool,
+    valid: Bool,
+    errors: Int,
+    warnings: Int,
+    shadowed: Bool
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.scope = scope
+    self.path = path
+    self.enabled = enabled
+    self.valid = valid
+    self.errors = errors
+    self.warnings = warnings
+    self.shadowed = shadowed
+  }
+
+  public init(entry: WorkflowCatalogEntry, enabled: Bool) {
+    self.init(
+      id: entry.file.id,
+      name: entry.file.definition?.name,
+      description: entry.file.definition?.description,
+      scope: entry.file.scope,
+      path: entry.file.url.path(percentEncoded: false),
+      enabled: enabled,
+      valid: entry.file.isValid,
+      errors: entry.file.diagnostics.errorCount,
+      warnings: entry.file.diagnostics.warningCount,
+      shadowed: entry.shadowed
+    )
+  }
+}
+
+// MARK: - validate
+
+nonisolated public struct WorkflowValidatePayload: Codable, Equatable, Sendable {
+  public let path: String
+  public let valid: Bool
+  /// Present when the file parsed, even if validation then failed.
+  public let workflow: WorkflowIdentity?
+  public let diagnostics: [WorkflowDiagnosticPayload]
+
+  public init(path: String, valid: Bool, workflow: WorkflowIdentity?, diagnostics: [WorkflowDiagnosticPayload]) {
+    self.path = path
+    self.valid = valid
+    self.workflow = workflow
+    self.diagnostics = diagnostics
+  }
+
+  public init(file: WorkflowSourceFile) {
+    self.init(
+      path: file.url.path(percentEncoded: false),
+      valid: file.isValid,
+      workflow: file.definition.map { WorkflowIdentity(id: $0.id, name: $0.name) },
+      diagnostics: file.diagnostics.map(WorkflowDiagnosticPayload.init)
+    )
+  }
+}
+
+nonisolated public struct WorkflowIdentity: Codable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+
+  public init(id: String, name: String) {
+    self.id = id
+    self.name = name
+  }
+}
+
+nonisolated public struct WorkflowDiagnosticPayload: Codable, Equatable, Sendable {
+  public let severity: WorkflowDiagnosticSeverity
+  public let code: String
+  public let message: String
+  public let line: Int?
+  public let column: Int?
+
+  public init(severity: WorkflowDiagnosticSeverity, code: String, message: String, line: Int?, column: Int?) {
+    self.severity = severity
+    self.code = code
+    self.message = message
+    self.line = line
+    self.column = column
+  }
+
+  public init(_ diagnostic: WorkflowDiagnostic) {
+    self.init(
+      severity: diagnostic.severity,
+      code: diagnostic.code,
+      message: diagnostic.message,
+      line: diagnostic.location?.line,
+      column: diagnostic.location?.column
+    )
+  }
+}
+
+// MARK: - schema
+
+nonisolated public struct WorkflowSchemaPayload: Codable, Equatable, Sendable {
+  /// The Draft 2020-12 JSON Schema of a workflow file, inline.
+  public let schema: RawJSON
+
+  public init(schema: RawJSON) {
+    self.schema = schema
+  }
+}
+
+nonisolated extension RawJSON: Equatable {
+  public static func == (lhs: RawJSON, rhs: RawJSON) -> Bool {
+    lhs.bytes == rhs.bytes
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowDefinition.swift
+++ b/supacode/CLIService/Shared/WorkflowDefinition.swift
@@ -1,0 +1,407 @@
+// ProwlShared/WorkflowDefinition.swift
+// The `prowl.workflow/v1` definition model (docs-ai 063, dsl-spec.md).
+// Pure data: parsing lives in WorkflowDocumentParser, semantic rules in WorkflowValidator.
+
+import Foundation
+
+nonisolated public enum WorkflowSchema {
+  public static let identifier = "prowl.workflow/v1"
+  /// `prowl.*` ids are reserved for definitions shipped inside the app bundle.
+  public static let reservedIDPrefix = "prowl."
+  public static let repeatMaximum = 20
+  public static let verdictRange = 2...4
+  /// Workflow and skill ids may contain dots; a leading alphanumeric rules out `.` and `..`.
+  public static var workflowIDPattern: Regex<Substring> { /^[a-z0-9][a-z0-9_.-]{0,63}$/ }
+  /// Step ids, role names, output names, input names, and verdict values become path
+  /// components and CLI arguments.
+  public static var slugPattern: Regex<Substring> { /^[a-z0-9][a-z0-9_-]{0,63}$/ }
+
+  public static func isWorkflowID(_ value: String) -> Bool {
+    value.wholeMatch(of: workflowIDPattern) != nil
+  }
+
+  public static func isSlug(_ value: String) -> Bool {
+    value.wholeMatch(of: slugPattern) != nil
+  }
+}
+
+/// 1-based position inside the YAML source.
+nonisolated public struct WorkflowSourceLocation: Equatable, Sendable, Codable {
+  public let line: Int
+  public let column: Int
+
+  public init(line: Int, column: Int) {
+    self.line = line
+    self.column = column
+  }
+}
+
+nonisolated public enum WorkflowDiagnosticSeverity: String, Equatable, Sendable, Codable {
+  case error
+  case warning
+}
+
+nonisolated public struct WorkflowDiagnostic: Equatable, Sendable, Codable {
+  public let severity: WorkflowDiagnosticSeverity
+  /// Stable machine-readable code (`unknown_key`, `undefined_role`, …).
+  public let code: String
+  public let message: String
+  public let location: WorkflowSourceLocation?
+
+  public init(
+    severity: WorkflowDiagnosticSeverity,
+    code: String,
+    message: String,
+    location: WorkflowSourceLocation? = nil
+  ) {
+    self.severity = severity
+    self.code = code
+    self.message = message
+    self.location = location
+  }
+
+  public static func error(_ code: String, _ message: String, at location: WorkflowSourceLocation? = nil) -> Self {
+    Self(severity: .error, code: code, message: message, location: location)
+  }
+
+  public static func warning(_ code: String, _ message: String, at location: WorkflowSourceLocation? = nil) -> Self {
+    Self(severity: .warning, code: code, message: message, location: location)
+  }
+}
+
+nonisolated extension [WorkflowDiagnostic] {
+  public var hasErrors: Bool { contains { $0.severity == .error } }
+  public var errorCount: Int { filter { $0.severity == .error }.count }
+  public var warningCount: Int { filter { $0.severity == .warning }.count }
+}
+
+// MARK: - Definition
+
+nonisolated public struct WorkflowDefinition: Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let description: String?
+  public let icon: String?
+  public let inputs: [WorkflowInputDefinition]
+  public let roles: [WorkflowRoleDefinition]
+  public let steps: [WorkflowStepDefinition]
+
+  public init(
+    id: String,
+    name: String,
+    description: String? = nil,
+    icon: String? = nil,
+    inputs: [WorkflowInputDefinition] = [],
+    roles: [WorkflowRoleDefinition] = [],
+    steps: [WorkflowStepDefinition] = []
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.icon = icon
+    self.inputs = inputs
+    self.roles = roles
+    self.steps = steps
+  }
+
+  public func role(named name: String) -> WorkflowRoleDefinition? {
+    roles.first { $0.name == name }
+  }
+
+  public func input(named name: String) -> WorkflowInputDefinition? {
+    inputs.first { $0.name == name }
+  }
+
+  /// Every step in document order, `repeat` bodies inlined after their `repeat` step.
+  public var flattenedSteps: [WorkflowStepDefinition] {
+    steps.flatMap { step -> [WorkflowStepDefinition] in
+      if case .repeat(_, _, let body) = step.action {
+        return [step] + body
+      }
+      return [step]
+    }
+  }
+}
+
+// MARK: - Inputs
+
+nonisolated public enum WorkflowInputType: String, Equatable, Sendable, Codable {
+  case integer
+  case string
+  case `enum`
+}
+
+nonisolated public enum WorkflowScalar: Equatable, Sendable {
+  case integer(Int)
+  case string(String)
+
+  public var stringValue: String {
+    switch self {
+    case .integer(let value): String(value)
+    case .string(let value): value
+    }
+  }
+}
+
+nonisolated public struct WorkflowInputDefinition: Equatable, Sendable {
+  public let name: String
+  public let type: WorkflowInputType
+  public let defaultValue: WorkflowScalar?
+  public let prompt: String?
+  public let minimum: Int?
+  public let maximum: Int?
+  /// Allowed values of an `enum` input; empty otherwise.
+  public let values: [String]
+  public let location: WorkflowSourceLocation?
+
+  public init(
+    name: String,
+    type: WorkflowInputType,
+    defaultValue: WorkflowScalar? = nil,
+    prompt: String? = nil,
+    minimum: Int? = nil,
+    maximum: Int? = nil,
+    values: [String] = [],
+    location: WorkflowSourceLocation? = nil
+  ) {
+    self.name = name
+    self.type = type
+    self.defaultValue = defaultValue
+    self.prompt = prompt
+    self.minimum = minimum
+    self.maximum = maximum
+    self.values = values
+    self.location = location
+  }
+}
+
+// MARK: - Roles
+
+nonisolated public enum WorkflowRoleSource: String, Equatable, Sendable, Codable {
+  case current
+  case launch
+  case pick
+}
+
+nonisolated public enum WorkflowRoleKind: String, Equatable, Sendable, Codable {
+  case interactive
+}
+
+nonisolated public enum WorkflowBindMode: String, Equatable, Sendable, Codable {
+  case ask
+  case auto
+}
+
+nonisolated public enum WorkflowPlacement: String, Equatable, Sendable, Codable {
+  case split
+  case tab
+}
+
+nonisolated public enum WorkflowSplitDirection: String, Equatable, Sendable, Codable {
+  case right
+  case left
+  case top = "up"
+  case down
+}
+
+/// Subset of profile preset fields a `launch` role may suggest; never a profile name or UUID.
+nonisolated public struct WorkflowProfileSuggestion: Equatable, Sendable {
+  public let agent: String?
+  public let model: String?
+  public let reasoningEffort: String?
+  public let executionMode: String?
+
+  public init(
+    agent: String? = nil,
+    model: String? = nil,
+    reasoningEffort: String? = nil,
+    executionMode: String? = nil
+  ) {
+    self.agent = agent
+    self.model = model
+    self.reasoningEffort = reasoningEffort
+    self.executionMode = executionMode
+  }
+}
+
+nonisolated public struct WorkflowLaunchRequirements: Equatable, Sendable {
+  public let kind: WorkflowRoleKind
+  /// Allow-list of agent tokens; nil = any launchable agent.
+  public let agents: [String]?
+  public let suggest: WorkflowProfileSuggestion?
+  public let bind: WorkflowBindMode
+  public let placement: WorkflowPlacement
+  public let direction: WorkflowSplitDirection
+  public let background: Bool
+
+  public init(
+    kind: WorkflowRoleKind = .interactive,
+    agents: [String]? = nil,
+    suggest: WorkflowProfileSuggestion? = nil,
+    bind: WorkflowBindMode = .ask,
+    placement: WorkflowPlacement = .split,
+    direction: WorkflowSplitDirection = .right,
+    background: Bool = false
+  ) {
+    self.kind = kind
+    self.agents = agents
+    self.suggest = suggest
+    self.bind = bind
+    self.placement = placement
+    self.direction = direction
+    self.background = background
+  }
+}
+
+nonisolated public struct WorkflowRoleDefinition: Equatable, Sendable {
+  public let name: String
+  public let source: WorkflowRoleSource
+  /// Present exactly when `source == .launch`.
+  public let launch: WorkflowLaunchRequirements?
+  public let location: WorkflowSourceLocation?
+
+  public init(
+    name: String,
+    source: WorkflowRoleSource,
+    launch: WorkflowLaunchRequirements? = nil,
+    location: WorkflowSourceLocation? = nil
+  ) {
+    self.name = name
+    self.source = source
+    self.launch = launch
+    self.location = location
+  }
+}
+
+// MARK: - Steps
+
+nonisolated public enum WorkflowOutputFormat: String, Equatable, Sendable, Codable {
+  case markdown
+  case text
+  case json
+}
+
+nonisolated public enum WorkflowTimeoutPolicy: String, Equatable, Sendable, Codable {
+  case attention
+  case skip
+  case cancel
+}
+
+nonisolated public struct WorkflowExpectation: Equatable, Sendable {
+  /// Output name; nil means the step id (see `WorkflowStepDefinition.outputName`).
+  public let output: String?
+  public let format: WorkflowOutputFormat
+  public let sections: [String]
+  /// Declared verdict values; nil when the step has no verdict.
+  public let verdict: [String]?
+  /// Hard cap in seconds; nil = wait as long as the agent works.
+  public let timeoutSeconds: Int?
+  public let onTimeout: WorkflowTimeoutPolicy?
+  public let location: WorkflowSourceLocation?
+
+  public init(
+    output: String? = nil,
+    format: WorkflowOutputFormat = .markdown,
+    sections: [String] = [],
+    verdict: [String]? = nil,
+    timeoutSeconds: Int? = nil,
+    onTimeout: WorkflowTimeoutPolicy? = nil,
+    location: WorkflowSourceLocation? = nil
+  ) {
+    self.output = output
+    self.format = format
+    self.sections = sections
+    self.verdict = verdict
+    self.timeoutSeconds = timeoutSeconds
+    self.onTimeout = onTimeout
+    self.location = location
+  }
+}
+
+nonisolated public enum WorkflowMessageContent: Equatable, Sendable {
+  /// One line, typed verbatim.
+  case text(String)
+  /// Multi-line, materialized to a run file; one pointer line is typed.
+  case instruction(String)
+
+  public var body: String {
+    switch self {
+    case .text(let value), .instruction(let value): value
+    }
+  }
+}
+
+nonisolated public enum WorkflowRepeatBound: Equatable, Sendable {
+  case literal(Int)
+  /// The raw template, e.g. `{{ inputs.max_rounds }}`; must reference exactly one integer input.
+  case template(String)
+}
+
+nonisolated public struct WorkflowUntilCondition: Equatable, Sendable {
+  public let output: String
+  /// Allowed verdict literals; one value for `==`, several for `in [...]`.
+  public let values: [String]
+  public let location: WorkflowSourceLocation?
+
+  public init(output: String, values: [String], location: WorkflowSourceLocation? = nil) {
+    self.output = output
+    self.values = values
+    self.location = location
+  }
+}
+
+nonisolated public enum WorkflowStepAction: Equatable, Sendable {
+  case message(role: String, content: WorkflowMessageContent, expect: WorkflowExpectation?)
+  case launch(role: String, prompt: String, skill: String?, expect: WorkflowExpectation?)
+  /// `with` values are templated strings; YAML scalars are kept as their source text.
+  case action(id: String, inputs: [String: String])
+  case notify(String)
+  case close(role: String)
+  case `repeat`(max: WorkflowRepeatBound, until: WorkflowUntilCondition?, steps: [WorkflowStepDefinition])
+
+  public var verb: String {
+    switch self {
+    case .message: "message"
+    case .launch: "launch"
+    case .action: "action"
+    case .notify: "notify"
+    case .close: "close"
+    case .repeat: "repeat"
+    }
+  }
+
+  public var expect: WorkflowExpectation? {
+    switch self {
+    case .message(_, _, let expect), .launch(_, _, _, let expect): expect
+    case .action, .notify, .close, .repeat: nil
+    }
+  }
+
+  /// The role a `message`, `launch`, or `close` step addresses.
+  public var targetRole: String? {
+    switch self {
+    case .message(let role, _, _), .launch(let role, _, _, _), .close(let role): role
+    case .action, .notify, .repeat: nil
+    }
+  }
+}
+
+nonisolated public struct WorkflowStepDefinition: Equatable, Sendable {
+  public let id: String
+  public let title: String?
+  public let action: WorkflowStepAction
+  public let location: WorkflowSourceLocation?
+
+  public init(id: String, title: String? = nil, action: WorkflowStepAction, location: WorkflowSourceLocation? = nil) {
+    self.id = id
+    self.title = title
+    self.action = action
+    self.location = location
+  }
+
+  /// The output this step delivers, when it has an `expect`.
+  public var outputName: String? {
+    guard let expect = action.expect else { return nil }
+    return expect.output ?? id
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowDiscovery.swift
+++ b/supacode/CLIService/Shared/WorkflowDiscovery.swift
@@ -1,0 +1,169 @@
+// ProwlShared/WorkflowDiscovery.swift
+// Three-source workflow discovery (dsl-spec.md §2): bundle < user < repo, `prowl.*` reserved
+// for the bundle. Directories that do not exist yield no files.
+
+import Foundation
+
+/// One YAML file found in a workflow source directory, parsed and validated.
+nonisolated public struct WorkflowSourceFile: Equatable, Sendable {
+  public let scope: WorkflowScope
+  public let url: URL
+  /// nil when the file did not parse.
+  public let definition: WorkflowDefinition?
+  /// Parse diagnostics followed by validation diagnostics.
+  public let diagnostics: [WorkflowDiagnostic]
+
+  public init(scope: WorkflowScope, url: URL, definition: WorkflowDefinition?, diagnostics: [WorkflowDiagnostic]) {
+    self.scope = scope
+    self.url = url
+    self.definition = definition
+    self.diagnostics = diagnostics
+  }
+
+  public var id: String? { definition?.id }
+  public var isValid: Bool { definition != nil && !diagnostics.hasErrors }
+}
+
+/// The directories that hold definitions; nil = the source does not apply (no bundle, no repo).
+nonisolated public struct WorkflowSources: Equatable, Sendable {
+  public let bundle: URL?
+  public let user: URL
+  public let repo: URL?
+
+  public init(bundle: URL?, user: URL, repo: URL?) {
+    self.bundle = bundle
+    self.user = user
+    self.repo = repo
+  }
+
+  public static let userDirectoryName = "workflows"
+  public static let bundleDirectoryName = "workflows"
+  public static let repoRelativePath = ".prowl/workflows"
+
+  public static func userDirectory(home: URL) -> URL {
+    home.appending(path: ".prowl", directoryHint: .isDirectory)
+      .appending(path: userDirectoryName, directoryHint: .isDirectory)
+  }
+
+  public static func repoDirectory(root: URL) -> URL {
+    root.appending(path: repoRelativePath, directoryHint: .isDirectory)
+  }
+
+  public static func bundleDirectory(resourcesURL: URL) -> URL {
+    resourcesURL.appending(path: bundleDirectoryName, directoryHint: .isDirectory)
+  }
+}
+
+nonisolated public struct WorkflowCatalogEntry: Equatable, Sendable {
+  public let file: WorkflowSourceFile
+  /// A file with the same id in a source of higher precedence wins; this one is not runnable.
+  public let shadowed: Bool
+
+  public init(file: WorkflowSourceFile, shadowed: Bool) {
+    self.file = file
+    self.shadowed = shadowed
+  }
+}
+
+nonisolated public enum WorkflowDiscovery {
+  public static let fileExtensions: Set<String> = ["yaml", "yml"]
+
+  /// Parses and validates every workflow file directly inside `directory`, in file-name order.
+  public static func files(
+    in directory: URL?,
+    scope: WorkflowScope,
+    context: WorkflowValidationContext,
+    fileManager: FileManager = .default
+  ) -> [WorkflowSourceFile] {
+    guard let directory else { return [] }
+    let contents =
+      (try? fileManager.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])) ?? []
+    return
+      contents
+      .filter { fileExtensions.contains($0.pathExtension.lowercased()) }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+      .map { url in load(url: url, scope: scope, context: context) }
+  }
+
+  /// Parses and validates one file. A file that cannot be read is an `unreadable` error.
+  public static func load(url: URL, scope: WorkflowScope, context: WorkflowValidationContext) -> WorkflowSourceFile {
+    let yaml: String
+    do {
+      yaml = try String(contentsOf: url, encoding: .utf8)
+    } catch {
+      return WorkflowSourceFile(
+        scope: scope, url: url, definition: nil,
+        diagnostics: [.error("unreadable", "Cannot read the file: \(error.localizedDescription)")])
+    }
+    return parse(yaml, url: url, scope: scope, context: context)
+  }
+
+  public static func parse(
+    _ yaml: String, url: URL, scope: WorkflowScope, context: WorkflowValidationContext
+  ) -> WorkflowSourceFile {
+    let parsed = WorkflowDocumentParser.parse(yaml)
+    guard let definition = parsed.definition else {
+      return WorkflowSourceFile(scope: scope, url: url, definition: nil, diagnostics: parsed.diagnostics)
+    }
+    let validation = WorkflowValidator.validate(definition, context: context)
+    return WorkflowSourceFile(
+      scope: scope, url: url, definition: definition, diagnostics: parsed.diagnostics + validation)
+  }
+
+  /// Every file from every source with precedence applied: a valid file shadows valid files with
+  /// the same id in lower-precedence sources (repo > user > bundle) and later files in the same
+  /// source. Invalid files never shadow and are never shadowed. Order: by id, winners first,
+  /// files without an id last.
+  public static func catalog(
+    sources: WorkflowSources,
+    context: (WorkflowScope) -> WorkflowValidationContext,
+    fileManager: FileManager = .default
+  ) -> [WorkflowCatalogEntry] {
+    let files =
+      files(in: sources.bundle, scope: .bundle, context: context(.bundle), fileManager: fileManager)
+      + files(in: sources.user, scope: .user, context: context(.user), fileManager: fileManager)
+      + files(in: sources.repo, scope: .repo, context: context(.repo), fileManager: fileManager)
+    var winners: [String: URL] = [:]
+    for file in files where file.isValid {
+      guard let id = file.id else { continue }
+      // Later sources have higher precedence; within a source the first file wins.
+      if let existing = winners[id], existingScope(of: existing, in: files) == file.scope {
+        continue
+      }
+      winners[id] = file.url
+    }
+    return files.map { file in
+      let shadowed = file.isValid && file.id.map { winners[$0] != file.url } == true
+      return WorkflowCatalogEntry(file: file, shadowed: shadowed)
+    }
+    .sorted(by: precedes)
+  }
+
+  private static func existingScope(of url: URL, in files: [WorkflowSourceFile]) -> WorkflowScope? {
+    files.first { $0.url == url }?.scope
+  }
+
+  private static func precedes(_ lhs: WorkflowCatalogEntry, _ rhs: WorkflowCatalogEntry) -> Bool {
+    switch (lhs.file.id, rhs.file.id) {
+    case (nil, nil): return lhs.file.url.path() < rhs.file.url.path()
+    case (nil, _): return false
+    case (_, nil): return true
+    case (let left?, let right?):
+      if left != right { return left < right }
+      let leftWins = lhs.file.isValid && !lhs.shadowed
+      let rightWins = rhs.file.isValid && !rhs.shadowed
+      if leftWins != rightWins { return leftWins }
+      if lhs.file.scope != rhs.file.scope { return rank(lhs.file.scope) > rank(rhs.file.scope) }
+      return lhs.file.url.path() < rhs.file.url.path()
+    }
+  }
+
+  private static func rank(_ scope: WorkflowScope) -> Int {
+    switch scope {
+    case .bundle: 0
+    case .user: 1
+    case .repo: 2
+    }
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowDiscovery.swift
+++ b/supacode/CLIService/Shared/WorkflowDiscovery.swift
@@ -69,16 +69,16 @@ nonisolated public enum WorkflowDiscovery {
   public static let fileExtensions: Set<String> = ["yaml", "yml"]
 
   /// Parses and validates every workflow file directly inside `directory`, in file-name order.
+  /// A missing directory is an empty source; one that exists but cannot be read throws.
   public static func files(
     in directory: URL?,
     scope: WorkflowScope,
     context: WorkflowValidationContext,
     fileManager: FileManager = .default
-  ) -> [WorkflowSourceFile] {
-    guard let directory else { return [] }
-    let contents =
-      (try? fileManager.contentsOfDirectory(
-        at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])) ?? []
+  ) throws -> [WorkflowSourceFile] {
+    guard let directory, fileManager.fileExists(atPath: directory.path(percentEncoded: false)) else { return [] }
+    let contents = try fileManager.contentsOfDirectory(
+      at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])
     return
       contents
       .filter { fileExtensions.contains($0.pathExtension.lowercased()) }
@@ -119,9 +119,9 @@ nonisolated public enum WorkflowDiscovery {
     sources: WorkflowSources,
     context: (WorkflowScope) -> WorkflowValidationContext,
     fileManager: FileManager = .default
-  ) -> [WorkflowCatalogEntry] {
+  ) throws -> [WorkflowCatalogEntry] {
     let files =
-      files(in: sources.bundle, scope: .bundle, context: context(.bundle), fileManager: fileManager)
+      try files(in: sources.bundle, scope: .bundle, context: context(.bundle), fileManager: fileManager)
       + files(in: sources.user, scope: .user, context: context(.user), fileManager: fileManager)
       + files(in: sources.repo, scope: .repo, context: context(.repo), fileManager: fileManager)
     var winners: [String: URL] = [:]

--- a/supacode/CLIService/Shared/WorkflowDiscovery.swift
+++ b/supacode/CLIService/Shared/WorkflowDiscovery.swift
@@ -89,9 +89,9 @@ nonisolated public enum WorkflowDiscovery {
   /// Regular files and symlinks that resolve to one; directories and dangling links are not
   /// definitions even when named `*.yaml`.
   private static func isRegularFile(_ url: URL, _ fileManager: FileManager) -> Bool {
-    var isDirectory: ObjCBool = false
     let path = url.resolvingSymlinksInPath().path(percentEncoded: false)
-    return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && !isDirectory.boolValue
+    let type = (try? fileManager.attributesOfItem(atPath: path))?[.type] as? FileAttributeType
+    return type == .typeRegular
   }
 
   /// Parses and validates one file. A file that cannot be read is an `unreadable` error.

--- a/supacode/CLIService/Shared/WorkflowDiscovery.swift
+++ b/supacode/CLIService/Shared/WorkflowDiscovery.swift
@@ -78,12 +78,20 @@ nonisolated public enum WorkflowDiscovery {
   ) throws -> [WorkflowSourceFile] {
     guard let directory, fileManager.fileExists(atPath: directory.path(percentEncoded: false)) else { return [] }
     let contents = try fileManager.contentsOfDirectory(
-      at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])
+      at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
     return
       contents
-      .filter { fileExtensions.contains($0.pathExtension.lowercased()) }
+      .filter { fileExtensions.contains($0.pathExtension.lowercased()) && isRegularFile($0, fileManager) }
       .sorted { $0.lastPathComponent < $1.lastPathComponent }
       .map { url in load(url: url, scope: scope, context: context) }
+  }
+
+  /// Regular files and symlinks that resolve to one; directories and dangling links are not
+  /// definitions even when named `*.yaml`.
+  private static func isRegularFile(_ url: URL, _ fileManager: FileManager) -> Bool {
+    var isDirectory: ObjCBool = false
+    let path = url.resolvingSymlinksInPath().path(percentEncoded: false)
+    return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && !isDirectory.boolValue
   }
 
   /// Parses and validates one file. A file that cannot be read is an `unreadable` error.

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -310,7 +310,9 @@ nonisolated public enum WorkflowDocumentParser {
   private static func parseUntil(
     _ text: String, at location: WorkflowSourceLocation?, _ collector: DiagnosticCollector
   ) -> WorkflowUntilCondition? {
-    let pattern = /^outputs\.([A-Za-z0-9_.-]+)\.verdict\s*(?:==\s*([^\s\[\]]+)|in\s*\[([^\]]*)\])$/
+    // The same grammar as the published schema's `until` pattern: slug tokens only.
+    let pattern =
+      /^outputs\.([a-z0-9][a-z0-9_-]{0,63})\.verdict\s*(?:==\s*([a-z0-9][a-z0-9_-]{0,63})|in\s*\[([^\]]*)\])$/
     guard let match = text.wholeMatch(of: pattern) else {
       collector.error(
         "until_syntax",

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -51,7 +51,8 @@ nonisolated public enum WorkflowDocumentParser {
     let name = document.requiredString("name")
     let inputs = document.mapping("inputs").map(parseInputs) ?? []
     let roles = document.mapping("roles").map(parseRoles) ?? []
-    let steps = document.requiredSequence("steps").map { parseSteps($0, insideRepeat: false) } ?? []
+    let steps =
+      document.requiredSequence("steps").map { parseSteps($0, insideRepeat: false, at: document.location) } ?? []
     guard let id, let name else { return nil }
     return WorkflowDefinition(
       id: id,
@@ -170,8 +171,13 @@ nonisolated public enum WorkflowDocumentParser {
 
   private static let verbKeys = ["message", "launch", "action", "notify", "close", "repeat"]
 
-  private static func parseSteps(_ steps: SequenceReader, insideRepeat: Bool) -> [WorkflowStepDefinition] {
-    steps.mappings().compactMap { parseStep($0, insideRepeat: insideRepeat) }
+  private static func parseSteps(
+    _ steps: SequenceReader, insideRepeat: Bool, at location: WorkflowSourceLocation?
+  ) -> [WorkflowStepDefinition] {
+    if steps.isEmpty {
+      steps.collector.error("steps_empty", "'\(steps.path)' needs at least one step.", at: location)
+    }
+    return steps.mappings().compactMap { parseStep($0, insideRepeat: insideRepeat) }
   }
 
   private static func parseStep(_ step: MappingReader, insideRepeat: Bool) -> WorkflowStepDefinition? {
@@ -277,7 +283,7 @@ nonisolated public enum WorkflowDocumentParser {
     body.checkKeys(["max", "until"])
     let max = parseRepeatBound(body)
     let until = body.string("until").flatMap { parseUntil($0, at: body.location(of: "until"), body.collector) }
-    let steps = step.requiredSequence("steps").map { parseSteps($0, insideRepeat: true) }
+    let steps = step.requiredSequence("steps").map { parseSteps($0, insideRepeat: true, at: step.location) }
     guard let max, let steps else { return nil }
     return .repeat(max: max, until: until, steps: steps)
   }
@@ -360,11 +366,14 @@ nonisolated public enum WorkflowDocumentParser {
     guard let match = text.trimmingCharacters(in: .whitespaces).wholeMatch(of: /^(\d+)\s*([smh])$/),
       let amount = Int(match.1)
     else { return nil }
-    switch match.2 {
-    case "s": return amount
-    case "m": return amount * 60
-    default: return amount * 3600
-    }
+    let factor =
+      switch match.2 {
+      case "s": 1
+      case "m": 60
+      default: 3600
+      }
+    let (seconds, overflow) = amount.multipliedReportingOverflow(by: factor)
+    return overflow ? nil : seconds
   }
 }
 
@@ -462,8 +471,20 @@ nonisolated struct MappingReader {
     }
   }
 
+  /// A string-valued field. Unquoted scalars that YAML resolves to a number, boolean, or null are
+  /// type errors so that `id: 1` cannot masquerade as the string "1" (quote it to keep text).
   func string(_ key: String) -> String? {
     guard let node = mapping[key] else { return nil }
+    return strictText(node, key: key)
+  }
+
+  func strictText(_ node: Node, key: String) -> String? {
+    if node.isPlainScalar, node.int != nil || node.bool != nil || node.float != nil {
+      collector.error(
+        "type_mismatch", "'\(key)' in \(path) must be a string; quote the value to keep it as text.",
+        at: node.sourceLocation)
+      return nil
+    }
     return scalarText(node, key: key)
   }
 
@@ -527,7 +548,7 @@ nonisolated struct MappingReader {
       collector.error("type_mismatch", "'\(key)' in \(path) must be a list.", at: node.sourceLocation)
       return nil
     }
-    return sequence.compactMap { scalarText($0, key: key) }
+    return sequence.compactMap { strictText($0, key: key) }
   }
 
   func mapping(_ key: String) -> MappingReader? {
@@ -557,6 +578,8 @@ nonisolated struct SequenceReader {
     self.collector = collector
     self.path = path
   }
+
+  var isEmpty: Bool { sequence.isEmpty }
 
   func mappings() -> [MappingReader] {
     sequence.enumerated().compactMap { index, node in

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -1,0 +1,566 @@
+// ProwlShared/WorkflowDocumentParser.swift
+// YAML → WorkflowDefinition with positioned diagnostics. Structural rules only (keys, types,
+// shapes); cross-reference rules live in WorkflowValidator.
+
+import Foundation
+import Yams
+
+nonisolated public struct WorkflowParseResult: Equatable, Sendable {
+  /// Present only when no error diagnostic was produced.
+  public let definition: WorkflowDefinition?
+  public let diagnostics: [WorkflowDiagnostic]
+}
+
+nonisolated public enum WorkflowDocumentParser {
+  public static func parse(_ yaml: String) -> WorkflowParseResult {
+    let collector = DiagnosticCollector()
+    let root: Node?
+    do {
+      root = try Yams.compose(yaml: yaml)
+    } catch let error as YamlError {
+      collector.error("yaml_syntax", error.problemDescription, at: error.problemLocation)
+      return WorkflowParseResult(definition: nil, diagnostics: collector.diagnostics)
+    } catch {
+      collector.error("yaml_syntax", error.localizedDescription)
+      return WorkflowParseResult(definition: nil, diagnostics: collector.diagnostics)
+    }
+    guard let root, case .mapping = root,
+      let mapping = MappingReader(node: root, collector: collector, path: "document")
+    else {
+      collector.error("document_not_mapping", "The workflow file must be a YAML mapping.", at: root?.sourceLocation)
+      return WorkflowParseResult(definition: nil, diagnostics: collector.diagnostics)
+    }
+    let definition = parseDocument(mapping)
+    let diagnostics = collector.diagnostics
+    return WorkflowParseResult(definition: diagnostics.hasErrors ? nil : definition, diagnostics: diagnostics)
+  }
+
+  // MARK: - Document
+
+  private static func parseDocument(_ document: MappingReader) -> WorkflowDefinition? {
+    document.checkKeys(["schema", "id", "name", "description", "icon", "inputs", "roles", "steps"])
+    let schema = document.requiredString("schema")
+    if let schema, schema != WorkflowSchema.identifier {
+      document.collector.error(
+        "unsupported_schema",
+        "Unsupported schema '\(schema)'; expected '\(WorkflowSchema.identifier)'.",
+        at: document.location(of: "schema")
+      )
+    }
+    let id = document.requiredString("id")
+    let name = document.requiredString("name")
+    let inputs = document.mapping("inputs").map(parseInputs) ?? []
+    let roles = document.mapping("roles").map(parseRoles) ?? []
+    let steps = document.requiredSequence("steps").map { parseSteps($0, insideRepeat: false) } ?? []
+    guard let id, let name else { return nil }
+    return WorkflowDefinition(
+      id: id,
+      name: name,
+      description: document.string("description"),
+      icon: document.string("icon"),
+      inputs: inputs,
+      roles: roles,
+      steps: steps
+    )
+  }
+
+  // MARK: - Inputs
+
+  private static func parseInputs(_ inputs: MappingReader) -> [WorkflowInputDefinition] {
+    inputs.entries().compactMap { name, node in
+      guard let input = MappingReader(node: node, collector: inputs.collector, path: "inputs.\(name)") else {
+        return nil
+      }
+      return parseInput(name: name, input)
+    }
+  }
+
+  private static func parseInput(name: String, _ input: MappingReader) -> WorkflowInputDefinition? {
+    input.checkKeys(["type", "default", "min", "max", "prompt", "values"])
+    guard let type = input.requiredEnum("type", WorkflowInputType.self) else { return nil }
+    let defaultValue: WorkflowScalar? =
+      switch type {
+      case .integer: input.int("default").map(WorkflowScalar.integer)
+      case .string, .enum: input.string("default").map(WorkflowScalar.string)
+      }
+    for key in ["min", "max"] where type != .integer && input.has(key) {
+      input.collector.error(
+        "key_requires_type", "'\(key)' applies to integer inputs only.", at: input.location(of: key))
+    }
+    if type != .enum, input.has("values") {
+      input.collector.error(
+        "key_requires_type", "'values' applies to enum inputs only.", at: input.location(of: "values"))
+    }
+    if type == .enum, !input.has("values") {
+      input.collector.error("missing_key", "Enum input '\(name)' needs 'values'.", at: input.location)
+    }
+    return WorkflowInputDefinition(
+      name: name,
+      type: type,
+      defaultValue: defaultValue,
+      prompt: input.string("prompt"),
+      minimum: input.int("min"),
+      maximum: input.int("max"),
+      values: input.stringList("values") ?? [],
+      location: input.location
+    )
+  }
+
+  // MARK: - Roles
+
+  private static func parseRoles(_ roles: MappingReader) -> [WorkflowRoleDefinition] {
+    roles.entries().compactMap { name, node in
+      guard let role = MappingReader(node: node, collector: roles.collector, path: "roles.\(name)") else {
+        return nil
+      }
+      return parseRole(name: name, role)
+    }
+  }
+
+  private static let launchOnlyKeys = ["kind", "agents", "suggest", "bind", "placement", "direction", "background"]
+
+  private static func parseRole(name: String, _ role: MappingReader) -> WorkflowRoleDefinition? {
+    role.checkKeys(["source"] + launchOnlyKeys)
+    guard let source = role.requiredEnum("source", WorkflowRoleSource.self) else { return nil }
+    guard source == .launch else {
+      for key in launchOnlyKeys where role.has(key) {
+        role.collector.error(
+          "key_requires_launch", "'\(key)' applies to launch roles only.", at: role.location(of: key))
+      }
+      return WorkflowRoleDefinition(name: name, source: source, location: role.location)
+    }
+    if let kind = role.string("kind"), WorkflowRoleKind(rawValue: kind) == nil {
+      let message =
+        kind == "headless"
+        ? "'kind: headless' is reserved for a later version; only 'interactive' is accepted."
+        : "Unknown kind '\(kind)'; only 'interactive' is accepted."
+      role.collector.error("reserved_kind", message, at: role.location(of: "kind"))
+    }
+    var suggest: WorkflowProfileSuggestion?
+    if let suggestion = role.mapping("suggest") {
+      suggestion.checkKeys(["agent", "model", "reasoning_effort", "execution_mode"])
+      suggest = WorkflowProfileSuggestion(
+        agent: suggestion.string("agent"),
+        model: suggestion.string("model"),
+        reasoningEffort: suggestion.string("reasoning_effort"),
+        executionMode: suggestion.string("execution_mode")
+      )
+    }
+    let placement = role.enumValue("placement", WorkflowPlacement.self) ?? .split
+    if placement == .tab, role.has("direction") {
+      role.collector.warning(
+        "direction_ignored", "'direction' applies to split placement only.", at: role.location(of: "direction"))
+    }
+    return WorkflowRoleDefinition(
+      name: name,
+      source: source,
+      launch: WorkflowLaunchRequirements(
+        agents: role.stringList("agents"),
+        suggest: suggest,
+        bind: role.enumValue("bind", WorkflowBindMode.self) ?? .ask,
+        placement: placement,
+        direction: role.enumValue("direction", WorkflowSplitDirection.self) ?? .right,
+        background: role.bool("background") ?? false
+      ),
+      location: role.location
+    )
+  }
+
+  // MARK: - Steps
+
+  private static let verbKeys = ["message", "launch", "action", "notify", "close", "repeat"]
+
+  private static func parseSteps(_ steps: SequenceReader, insideRepeat: Bool) -> [WorkflowStepDefinition] {
+    steps.mappings().compactMap { parseStep($0, insideRepeat: insideRepeat) }
+  }
+
+  private static func parseStep(_ step: MappingReader, insideRepeat: Bool) -> WorkflowStepDefinition? {
+    let verbs = verbKeys.filter(step.has)
+    guard verbs.count == 1, let verb = verbs.first else {
+      step.collector.error(
+        "step_verb",
+        verbs.isEmpty
+          ? "A step needs exactly one verb (\(verbKeys.joined(separator: ", ")))."
+          : "A step has exactly one verb; found \(verbs.joined(separator: ", ")).",
+        at: step.location
+      )
+      return nil
+    }
+    let idNode = step.requiredString("id")
+    let action = parseAction(verb: verb, step, insideRepeat: insideRepeat)
+    guard let id = idNode, let action else { return nil }
+    return WorkflowStepDefinition(id: id, title: step.string("title"), action: action, location: step.location)
+  }
+
+  private static func parseAction(verb: String, _ step: MappingReader, insideRepeat: Bool) -> WorkflowStepAction? {
+    switch verb {
+    case "message": return parseMessage(step)
+    case "launch": return parseLaunch(step, insideRepeat: insideRepeat)
+    case "action": return parseNativeAction(step)
+    case "notify":
+      step.checkKeys(["id", "title", "notify", "expect"])
+      rejectExpect(step)
+      return step.requiredString("notify").map(WorkflowStepAction.notify)
+    case "close":
+      step.checkKeys(["id", "title", "close", "expect"])
+      rejectExpect(step)
+      return step.requiredString("close").map { WorkflowStepAction.close(role: $0) }
+    case "repeat": return parseRepeat(step, insideRepeat: insideRepeat)
+    default: return nil
+    }
+  }
+
+  private static func rejectExpect(_ step: MappingReader) {
+    guard step.has("expect") else { return }
+    step.collector.error(
+      "expect_not_allowed",
+      "'expect' is valid on message and launch steps only; native actions return typed outputs synchronously.",
+      at: step.location(of: "expect")
+    )
+  }
+
+  private static func parseMessage(_ step: MappingReader) -> WorkflowStepAction? {
+    step.checkKeys(["id", "title", "message", "text", "instruction", "expect"])
+    let role = step.requiredString("message")
+    let text = step.string("text")
+    let instruction = step.string("instruction")
+    let content: WorkflowMessageContent?
+    switch (text, instruction) {
+    case (let text?, nil): content = .text(text)
+    case (nil, let instruction?): content = .instruction(instruction)
+    default:
+      step.collector.error(
+        "message_content", "A message step needs exactly one of 'text' or 'instruction'.", at: step.location)
+      content = nil
+    }
+    let expect = parseExpect(step)
+    guard let role, let content else { return nil }
+    return .message(role: role, content: content, expect: expect)
+  }
+
+  private static func parseLaunch(_ step: MappingReader, insideRepeat: Bool) -> WorkflowStepAction? {
+    step.checkKeys(["id", "title", "launch", "prompt", "skill", "expect"])
+    if insideRepeat {
+      step.collector.error("launch_inside_repeat", "'launch' is not allowed inside 'repeat'.", at: step.location)
+    }
+    let role = step.requiredString("launch")
+    let prompt = step.requiredString("prompt")
+    let expect = parseExpect(step)
+    guard let role, let prompt else { return nil }
+    return .launch(role: role, prompt: prompt, skill: step.string("skill"), expect: expect)
+  }
+
+  private static func parseNativeAction(_ step: MappingReader) -> WorkflowStepAction? {
+    step.checkKeys(["id", "title", "action", "with", "expect"])
+    rejectExpect(step)
+    guard let id = step.requiredString("action") else { return nil }
+    var inputs: [String: String] = [:]
+    if let with = step.mapping("with") {
+      for (key, node) in with.entries() {
+        if let value = with.scalarText(node, key: key) {
+          inputs[key] = value
+        }
+      }
+    }
+    return .action(id: id, inputs: inputs)
+  }
+
+  private static func parseRepeat(_ step: MappingReader, insideRepeat: Bool) -> WorkflowStepAction? {
+    step.checkKeys(["id", "title", "repeat", "steps"])
+    rejectExpect(step)
+    if insideRepeat {
+      step.collector.error("nested_repeat", "'repeat' cannot be nested.", at: step.location)
+    }
+    guard let body = MappingReader(node: step.node(for: "repeat"), collector: step.collector, path: "repeat") else {
+      return nil
+    }
+    body.checkKeys(["max", "until"])
+    let max = parseRepeatBound(body)
+    let until = body.string("until").flatMap { parseUntil($0, at: body.location(of: "until"), body.collector) }
+    let steps = step.requiredSequence("steps").map { parseSteps($0, insideRepeat: true) }
+    guard let max, let steps else { return nil }
+    return .repeat(max: max, until: until, steps: steps)
+  }
+
+  private static func parseRepeatBound(_ body: MappingReader) -> WorkflowRepeatBound? {
+    guard let node = body.node(for: "max") else {
+      body.collector.error("missing_key", "'repeat' needs 'max'.", at: body.location)
+      return nil
+    }
+    if node.isPlainScalar, let value = node.int {
+      return .literal(value)
+    }
+    if let text = node.string, WorkflowTemplate.containsReference(text) {
+      return .template(text)
+    }
+    body.collector.error(
+      "repeat_max",
+      "'max' must be a positive integer literal or a template of one integer input.",
+      at: body.location(of: "max")
+    )
+    return nil
+  }
+
+  private static func parseUntil(
+    _ text: String, at location: WorkflowSourceLocation?, _ collector: DiagnosticCollector
+  ) -> WorkflowUntilCondition? {
+    let pattern = /^outputs\.([A-Za-z0-9_.-]+)\.verdict\s*(?:==\s*([^\s\[\]]+)|in\s*\[([^\]]*)\])$/
+    guard let match = text.trimmingCharacters(in: .whitespaces).wholeMatch(of: pattern) else {
+      collector.error(
+        "until_syntax",
+        "'until' must be 'outputs.<name>.verdict == <value>' or 'outputs.<name>.verdict in [<values>]'.",
+        at: location
+      )
+      return nil
+    }
+    let output = String(match.1)
+    let values: [String]
+    if let single = match.2 {
+      values = [String(single)]
+    } else {
+      values = (match.3 ?? "").split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+    }
+    return WorkflowUntilCondition(output: output, values: values, location: location)
+  }
+
+  // MARK: - Expect
+
+  private static func parseExpect(_ step: MappingReader) -> WorkflowExpectation? {
+    guard let expect = MappingReader(node: step.node(for: "expect"), collector: step.collector, path: "expect") else {
+      return nil
+    }
+    expect.checkKeys(["output", "format", "sections", "verdict", "timeout", "on_timeout"])
+    let timeout = expect.string("timeout").flatMap { text -> Int? in
+      guard let seconds = parseDuration(text) else {
+        expect.collector.error(
+          "timeout_syntax", "'timeout' must be a duration like 90s, 10m, or 2h.", at: expect.location(of: "timeout"))
+        return nil
+      }
+      return seconds
+    }
+    let onTimeout = expect.enumValue("on_timeout", WorkflowTimeoutPolicy.self)
+    if onTimeout != nil, !expect.has("timeout") {
+      expect.collector.error(
+        "on_timeout_requires_timeout", "'on_timeout' applies only together with 'timeout'.",
+        at: expect.location(of: "on_timeout"))
+    }
+    return WorkflowExpectation(
+      output: expect.string("output"),
+      format: expect.enumValue("format", WorkflowOutputFormat.self) ?? .markdown,
+      sections: expect.stringList("sections") ?? [],
+      verdict: expect.stringList("verdict"),
+      timeoutSeconds: timeout,
+      onTimeout: onTimeout,
+      location: expect.location
+    )
+  }
+
+  public static func parseDuration(_ text: String) -> Int? {
+    guard let match = text.trimmingCharacters(in: .whitespaces).wholeMatch(of: /^(\d+)\s*([smh])$/),
+      let amount = Int(match.1)
+    else { return nil }
+    switch match.2 {
+    case "s": return amount
+    case "m": return amount * 60
+    default: return amount * 3600
+    }
+  }
+}
+
+// MARK: - Readers
+
+nonisolated final class DiagnosticCollector {
+  private(set) var diagnostics: [WorkflowDiagnostic] = []
+
+  func error(_ code: String, _ message: String, at location: WorkflowSourceLocation? = nil) {
+    diagnostics.append(.error(code, message, at: location))
+  }
+
+  func warning(_ code: String, _ message: String, at location: WorkflowSourceLocation? = nil) {
+    diagnostics.append(.warning(code, message, at: location))
+  }
+}
+
+nonisolated extension Node {
+  var sourceLocation: WorkflowSourceLocation? {
+    mark.map { WorkflowSourceLocation(line: $0.line, column: $0.column) }
+  }
+
+  /// Unquoted scalars resolve to YAML's core types; quoted ones are always strings.
+  var isPlainScalar: Bool {
+    guard case .scalar(let scalar) = self else { return false }
+    return scalar.style == .plain
+  }
+}
+
+nonisolated extension YamlError {
+  var problemDescription: String {
+    switch self {
+    case .scanner(_, let problem, _, _), .parser(_, let problem, _, _), .composer(_, let problem, _, _):
+      return problem
+    case .reader(let problem, _, _, _), .writer(let problem):
+      return problem
+    default:
+      return localizedDescription
+    }
+  }
+
+  var problemLocation: WorkflowSourceLocation? {
+    switch self {
+    case .scanner(_, _, let mark, _), .parser(_, _, let mark, _), .composer(_, _, let mark, _):
+      return WorkflowSourceLocation(line: mark.line, column: mark.column)
+    default:
+      return nil
+    }
+  }
+}
+
+/// Reads one YAML mapping, reporting unknown keys and type mismatches with positions.
+nonisolated struct MappingReader {
+  let mapping: Node.Mapping
+  let collector: DiagnosticCollector
+  let path: String
+  let location: WorkflowSourceLocation?
+
+  init?(node: Node?, collector: DiagnosticCollector, path: String) {
+    guard let node else { return nil }
+    guard case .mapping(let mapping) = node else {
+      collector.error("type_mismatch", "'\(path)' must be a mapping.", at: node.sourceLocation)
+      return nil
+    }
+    self.mapping = mapping
+    self.collector = collector
+    self.path = path
+    location = node.sourceLocation
+  }
+
+  func has(_ key: String) -> Bool { mapping[key] != nil }
+
+  func node(for key: String) -> Node? { mapping[key] }
+
+  func location(of key: String) -> WorkflowSourceLocation? {
+    mapping[key]?.sourceLocation ?? location
+  }
+
+  /// Key/value pairs in document order; non-string keys are errors.
+  func entries() -> [(String, Node)] {
+    mapping.compactMap { key, value in
+      guard let name = key.string else {
+        collector.error("type_mismatch", "Keys in '\(path)' must be strings.", at: key.sourceLocation)
+        return nil
+      }
+      return (name, value)
+    }
+  }
+
+  func checkKeys(_ allowed: [String]) {
+    for (key, node) in mapping where key.string.map({ !allowed.contains($0) }) ?? false {
+      collector.error(
+        "unknown_key", "Unknown key '\(key.string ?? "?")' in \(path).",
+        at: key.sourceLocation ?? node.sourceLocation)
+    }
+  }
+
+  func string(_ key: String) -> String? {
+    guard let node = mapping[key] else { return nil }
+    return scalarText(node, key: key)
+  }
+
+  func requiredString(_ key: String) -> String? {
+    guard let value = string(key) else {
+      if !has(key) {
+        collector.error("missing_key", "'\(path)' needs '\(key)'.", at: location)
+      }
+      return nil
+    }
+    return value
+  }
+
+  /// A scalar's source text; sequences, mappings, and nulls are type errors.
+  func scalarText(_ node: Node, key: String) -> String? {
+    guard case .scalar(let scalar) = node, !(node.isPlainScalar && node.null != nil) else {
+      collector.error("type_mismatch", "'\(key)' in \(path) must be a string.", at: node.sourceLocation)
+      return nil
+    }
+    return scalar.string
+  }
+
+  func int(_ key: String) -> Int? {
+    guard let node = mapping[key] else { return nil }
+    guard node.isPlainScalar, let value = node.int else {
+      collector.error("type_mismatch", "'\(key)' in \(path) must be an integer.", at: node.sourceLocation)
+      return nil
+    }
+    return value
+  }
+
+  func bool(_ key: String) -> Bool? {
+    guard let node = mapping[key] else { return nil }
+    guard node.isPlainScalar, let value = node.bool else {
+      collector.error("type_mismatch", "'\(key)' in \(path) must be true or false.", at: node.sourceLocation)
+      return nil
+    }
+    return value
+  }
+
+  func enumValue<T: RawRepresentable>(_ key: String, _ type: T.Type) -> T? where T.RawValue == String {
+    guard let text = string(key) else { return nil }
+    guard let value = T(rawValue: text) else {
+      collector.error("invalid_value", "'\(key)' in \(path) has unsupported value '\(text)'.", at: location(of: key))
+      return nil
+    }
+    return value
+  }
+
+  func requiredEnum<T: RawRepresentable>(_ key: String, _ type: T.Type) -> T? where T.RawValue == String {
+    guard has(key) else {
+      collector.error("missing_key", "'\(path)' needs '\(key)'.", at: location)
+      return nil
+    }
+    return enumValue(key, type)
+  }
+
+  func stringList(_ key: String) -> [String]? {
+    guard let node = mapping[key] else { return nil }
+    guard case .sequence(let sequence) = node else {
+      collector.error("type_mismatch", "'\(key)' in \(path) must be a list.", at: node.sourceLocation)
+      return nil
+    }
+    return sequence.compactMap { scalarText($0, key: key) }
+  }
+
+  func mapping(_ key: String) -> MappingReader? {
+    MappingReader(node: mapping[key], collector: collector, path: "\(path).\(key)")
+  }
+
+  func requiredSequence(_ key: String) -> SequenceReader? {
+    guard let node = mapping[key] else {
+      collector.error("missing_key", "'\(path)' needs '\(key)'.", at: location)
+      return nil
+    }
+    return SequenceReader(node: node, collector: collector, path: "\(path).\(key)")
+  }
+}
+
+nonisolated struct SequenceReader {
+  let sequence: Node.Sequence
+  let collector: DiagnosticCollector
+  let path: String
+
+  init?(node: Node, collector: DiagnosticCollector, path: String) {
+    guard case .sequence(let sequence) = node else {
+      collector.error("type_mismatch", "'\(path)' must be a list.", at: node.sourceLocation)
+      return nil
+    }
+    self.sequence = sequence
+    self.collector = collector
+    self.path = path
+  }
+
+  func mappings() -> [MappingReader] {
+    sequence.enumerated().compactMap { index, node in
+      MappingReader(node: node, collector: collector, path: "\(path)[\(index)]")
+    }
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -311,7 +311,7 @@ nonisolated public enum WorkflowDocumentParser {
     _ text: String, at location: WorkflowSourceLocation?, _ collector: DiagnosticCollector
   ) -> WorkflowUntilCondition? {
     let pattern = /^outputs\.([A-Za-z0-9_.-]+)\.verdict\s*(?:==\s*([^\s\[\]]+)|in\s*\[([^\]]*)\])$/
-    guard let match = text.trimmingCharacters(in: .whitespaces).wholeMatch(of: pattern) else {
+    guard let match = text.wholeMatch(of: pattern) else {
       collector.error(
         "until_syntax",
         "'until' must be 'outputs.<name>.verdict == <value>' or 'outputs.<name>.verdict in [<values>]'.",
@@ -363,7 +363,7 @@ nonisolated public enum WorkflowDocumentParser {
   }
 
   public static func parseDuration(_ text: String) -> Int? {
-    guard let match = text.trimmingCharacters(in: .whitespaces).wholeMatch(of: /^(\d+)\s*([smh])$/),
+    guard let match = text.wholeMatch(of: /^(\d+)\s*([smh])$/),
       let amount = Int(match.1)
     else { return nil }
     let factor =

--- a/supacode/CLIService/Shared/WorkflowJSONSchema.swift
+++ b/supacode/CLIService/Shared/WorkflowJSONSchema.swift
@@ -1,0 +1,265 @@
+// ProwlShared/WorkflowJSONSchema.swift
+// Draft 2020-12 JSON Schema of a `prowl.workflow/v1` file, printed by `prowl workflow schema`.
+// The same document is checked in as ProwlCLIContracts/Resources/workflow-definition-schema.json;
+// a test pins the two together. Structural shape only — cross-reference rules are the validator's.
+
+import Foundation
+
+nonisolated public enum WorkflowJSONSchema {
+  public static let identifier = "https://prowl.onev.cat/contracts/workflow/v1/workflow-definition.json"
+
+  public static func definitionSchemaObject() throws -> [String: Any] {
+    let object = try JSONSerialization.jsonObject(with: Data(definitionSchemaJSON.utf8))
+    guard let dictionary = object as? [String: Any] else {
+      throw CocoaError(.coderInvalidValue)
+    }
+    return dictionary
+  }
+
+  public static let definitionSchemaJSON = #"""
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://prowl.onev.cat/contracts/workflow/v1/workflow-definition.json",
+      "title": "Prowl Agent Workflow (prowl.workflow/v1)",
+      "description": "Declarative multi-agent workflow run by Prowl (docs-ai 063 dsl-spec.md).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "id", "name", "steps"],
+      "properties": {
+        "schema": { "const": "prowl.workflow/v1" },
+        "id": { "$ref": "#/$defs/workflowId" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "icon": { "type": "string", "description": "SF Symbol name" },
+        "inputs": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/slug" },
+          "additionalProperties": { "$ref": "#/$defs/input" }
+        },
+        "roles": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/slug" },
+          "additionalProperties": { "$ref": "#/$defs/role" }
+        },
+        "steps": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/step" } }
+      },
+      "$defs": {
+        "slug": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$" },
+        "workflowId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_.-]{0,63}$" },
+        "template": { "type": "string" },
+        "input": {
+          "oneOf": [
+            { "$ref": "#/$defs/integerInput" },
+            { "$ref": "#/$defs/stringInput" },
+            { "$ref": "#/$defs/enumInput" }
+          ]
+        },
+        "integerInput": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "integer" },
+            "default": { "type": "integer" },
+            "min": { "type": "integer" },
+            "max": { "type": "integer" },
+            "prompt": { "type": "string" }
+          }
+        },
+        "stringInput": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "string" },
+            "default": { "type": "string" },
+            "prompt": { "type": "string" }
+          }
+        },
+        "enumInput": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "values"],
+          "properties": {
+            "type": { "const": "enum" },
+            "values": {
+              "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 }
+            },
+            "default": { "type": "string" },
+            "prompt": { "type": "string" }
+          }
+        },
+        "role": {
+          "oneOf": [
+            { "$ref": "#/$defs/currentRole" },
+            { "$ref": "#/$defs/pickRole" },
+            { "$ref": "#/$defs/launchRole" }
+          ]
+        },
+        "currentRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source"],
+          "properties": { "source": { "const": "current" } }
+        },
+        "pickRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source"],
+          "properties": { "source": { "const": "pick" } }
+        },
+        "launchRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source"],
+          "properties": {
+            "source": { "const": "launch" },
+            "kind": { "const": "interactive" },
+            "agents": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "suggest": { "$ref": "#/$defs/suggest" },
+            "bind": { "enum": ["ask", "auto"] },
+            "placement": { "enum": ["split", "tab"] },
+            "direction": { "enum": ["right", "left", "up", "down"] },
+            "background": { "type": "boolean" }
+          }
+        },
+        "suggest": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "agent": { "type": "string" },
+            "model": { "type": "string" },
+            "reasoning_effort": { "type": "string" },
+            "execution_mode": { "type": "string" }
+          }
+        },
+        "step": {
+          "oneOf": [
+            { "$ref": "#/$defs/messageStep" },
+            { "$ref": "#/$defs/launchStep" },
+            { "$ref": "#/$defs/actionStep" },
+            { "$ref": "#/$defs/notifyStep" },
+            { "$ref": "#/$defs/closeStep" },
+            { "$ref": "#/$defs/repeatStep" }
+          ]
+        },
+        "loopStep": {
+          "oneOf": [
+            { "$ref": "#/$defs/messageStep" },
+            { "$ref": "#/$defs/actionStep" },
+            { "$ref": "#/$defs/notifyStep" },
+            { "$ref": "#/$defs/closeStep" }
+          ]
+        },
+        "messageStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "message"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "message": { "$ref": "#/$defs/slug" },
+            "text": { "$ref": "#/$defs/template" },
+            "instruction": { "$ref": "#/$defs/template" },
+            "expect": { "$ref": "#/$defs/expect" }
+          },
+          "oneOf": [{ "required": ["text"] }, { "required": ["instruction"] }]
+        },
+        "launchStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "launch", "prompt"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "launch": { "$ref": "#/$defs/slug" },
+            "prompt": { "$ref": "#/$defs/template" },
+            "skill": { "$ref": "#/$defs/workflowId" },
+            "expect": { "$ref": "#/$defs/expect" }
+          }
+        },
+        "actionStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "action"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "action": { "enum": ["handoff.transition", "handoff.checkpoint", "git.context"] },
+            "with": {
+              "type": "object",
+              "propertyNames": { "$ref": "#/$defs/slug" },
+              "additionalProperties": { "type": ["string", "number", "boolean"] }
+            }
+          }
+        },
+        "notifyStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "notify"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "notify": { "$ref": "#/$defs/template" }
+          }
+        },
+        "closeStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "close"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "close": { "$ref": "#/$defs/slug" }
+          }
+        },
+        "repeatStep": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "repeat", "steps"],
+          "properties": {
+            "id": { "$ref": "#/$defs/slug" },
+            "title": { "$ref": "#/$defs/template" },
+            "repeat": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["max"],
+              "properties": {
+                "max": {
+                  "oneOf": [
+                    { "type": "integer", "minimum": 1, "maximum": 20 },
+                    {
+                      "type": "string",
+                      "pattern": "^\\s*\\{\\{\\s*inputs\\.[a-z0-9_-]+\\s*\\}\\}\\s*$"
+                    }
+                  ]
+                },
+                "until": {
+                  "type": "string",
+                  "pattern":
+                    "^outputs\\.[a-z0-9_-]+\\.verdict\\s*(==\\s*[a-z0-9_-]+|in\\s*\\[[^\\]]*\\])$"
+                }
+              }
+            },
+            "steps": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/loopStep" } }
+          }
+        },
+        "expect": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "output": { "$ref": "#/$defs/slug" },
+            "format": { "enum": ["markdown", "text", "json"] },
+            "sections": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "verdict": {
+              "type": "array", "minItems": 2, "maxItems": 4, "uniqueItems": true, "items": { "$ref": "#/$defs/slug" }
+            },
+            "timeout": { "type": "string", "pattern": "^\\d+\\s*[smh]$" },
+            "on_timeout": { "enum": ["attention", "skip", "cancel"] }
+          },
+          "dependentRequired": { "on_timeout": ["timeout"] }
+        }
+      }
+    }
+    """#
+}

--- a/supacode/CLIService/Shared/WorkflowTemplate.swift
+++ b/supacode/CLIService/Shared/WorkflowTemplate.swift
@@ -1,0 +1,54 @@
+// ProwlShared/WorkflowTemplate.swift
+// `{{ path }}` reference scanning for workflow templates (dsl-spec.md §6). Substitution-only:
+// no expressions, defaults, or filters. Rendering belongs to the runner.
+
+import Foundation
+
+nonisolated public enum WorkflowTemplate {
+  public struct Reference: Equatable, Sendable {
+    /// The dotted path as written, e.g. `outputs.findings.path`.
+    public let path: String
+    public let components: [String]
+
+    public init(path: String) {
+      self.path = path
+      components = path.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+    }
+  }
+
+  public enum ScanError: Error, Equatable, Sendable {
+    case unbalanced
+    case emptyReference
+    case invalidPath(String)
+  }
+
+  private static var referencePattern: Regex<(Substring, Substring)> { /\{\{([^{}]*)\}\}/ }
+  private static var pathPattern: Regex<Substring> { /^[a-z0-9_.-]+$/ }
+
+  public static func containsReference(_ text: String) -> Bool {
+    text.contains("{{")
+  }
+
+  /// Every reference in document order. Throws on an unbalanced or malformed placeholder.
+  public static func references(in text: String) throws(ScanError) -> [Reference] {
+    var references: [Reference] = []
+    var remainder = Substring(text)
+    while let match = remainder.firstMatch(of: referencePattern) {
+      let path = match.1.trimmingCharacters(in: .whitespaces)
+      guard !path.isEmpty else { throw .emptyReference }
+      guard path.wholeMatch(of: pathPattern) != nil else { throw .invalidPath(path) }
+      references.append(Reference(path: path))
+      remainder = remainder[match.range.upperBound...]
+    }
+    if remainder.contains("{{") || remainder.contains("}}") {
+      throw .unbalanced
+    }
+    return references
+  }
+
+  /// True when the whole string is exactly one reference (surrounding whitespace allowed).
+  public static func isSingleReference(_ text: String) -> Bool {
+    guard let match = text.wholeMatch(of: /\s*\{\{([^{}]*)\}\}\s*/) else { return false }
+    return !match.1.trimmingCharacters(in: .whitespaces).isEmpty
+  }
+}

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -67,6 +67,19 @@ nonisolated private enum OutputConsumer {
   case optionalActionInput
 }
 
+/// Where an output is read or skipped: the step's walk ordinal and the loop body it sits in.
+nonisolated private struct OutputUse {
+  let consumer: OutputConsumer
+  let ordinal: Int
+  let loopID: String?
+}
+
+nonisolated private struct SkipRecord {
+  let name: String
+  let use: OutputUse
+  let location: WorkflowSourceLocation?
+}
+
 nonisolated private struct OutputProducer {
   let verdicts: Set<String>?
   /// The `repeat` step whose body holds the producer; nil at the top level.
@@ -88,7 +101,9 @@ nonisolated private final class Walker {
   private var stepIDs: Set<String> = []
   private var launchedRoles: Set<String> = []
   private var outputs: [String: OutputInfo] = [:]
-  private var consumers: [String: [OutputConsumer]] = [:]
+  private var consumers: [String: [OutputUse]] = [:]
+  /// Walk position of the step being checked; 0 before the first step.
+  private var ordinal = 0
   /// Action steps visible to the step being validated: outer sequences first, current last.
   private var actionScopes: [[String: WorkflowActionSchema]] = [[:]]
   private var insideRepeat = false
@@ -96,7 +111,7 @@ nonisolated private final class Walker {
   private var loopSeen = false
   /// `on_timeout: skip` expectations, kept apart from `outputs` so folding a skippable loop
   /// cannot lose them before the consumers are reported.
-  private var skipOutputs: [(name: String, location: WorkflowSourceLocation?)] = []
+  private var skipOutputs: [SkipRecord] = []
 
   init(definition: WorkflowDefinition, context: WorkflowValidationContext) {
     self.definition = definition
@@ -224,6 +239,7 @@ nonisolated private final class Walker {
   // MARK: Steps
 
   private func checkStep(_ step: WorkflowStepDefinition) {
+    ordinal += 1
     if !WorkflowSchema.isSlug(step.id) {
       collector.error("step_id_slug", "Step id '\(step.id)' is not a valid slug.", at: step.location)
     }
@@ -425,7 +441,9 @@ nonisolated private final class Walker {
       collector.error(
         "until_verdict_literal", "'\(value)' is not a declared verdict of output '\(until.output)'.", at: location)
     }
-    consumers[until.output, default: []].append(.until)
+    // `until` reads the output before entry and after every iteration: a skip anywhere in
+    // the loop body feeds it, so it counts as a reader inside that loop.
+    consumers[until.output, default: []].append(OutputUse(consumer: .until, ordinal: ordinal, loopID: loopID))
   }
 
   // MARK: Expect
@@ -450,7 +468,9 @@ nonisolated private final class Walker {
     info.producers.append(OutputProducer(verdicts: verdicts, loopID: currentLoopID))
     info.latestVerdicts = verdicts
     if expect.onTimeout == .skip {
-      skipOutputs.append((name, location))
+      skipOutputs.append(
+        SkipRecord(
+          name: name, use: OutputUse(consumer: .template, ordinal: ordinal, loopID: currentLoopID), location: location))
     }
     outputs[name] = info
   }
@@ -467,9 +487,15 @@ nonisolated private final class Walker {
     }
   }
 
+  /// A skipped delivery ends the run only when a non-optional reader comes after it — later in
+  /// document order, or anywhere in the same loop body, which the next iteration reads again.
   private func reportSkipConsumers() {
-    for (name, location) in skipOutputs {
-      let blocking = (consumers[name] ?? []).contains { $0 != .optionalActionInput }
+    for record in skipOutputs {
+      let (name, skip, location) = (record.name, record.use, record.location)
+      let blocking = (consumers[name] ?? []).contains { use in
+        use.consumer != .optionalActionInput
+          && (use.ordinal > skip.ordinal || (use.loopID != nil && use.loopID == skip.loopID))
+      }
       guard blocking else { continue }
       collector.warning(
         "skip_ends_run",
@@ -531,7 +557,7 @@ nonisolated private final class Walker {
     if parts[2] == "verdict", info.latestVerdicts == nil {
       return false
     }
-    consumers[parts[1], default: []].append(consumer)
+    consumers[parts[1], default: []].append(OutputUse(consumer: consumer, ordinal: ordinal, loopID: currentLoopID))
     return true
   }
 

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -78,7 +78,6 @@ nonisolated private struct OutputInfo {
   /// Verdict set of the producer whose delivery is the latest at this point of the walk; nil
   /// when it declares none, or when a skippable loop leaves the latest producer ambiguous.
   var latestVerdicts: Set<String>?
-  var skipLocations: [WorkflowSourceLocation?] = []
 }
 
 nonisolated private final class Walker {
@@ -95,6 +94,9 @@ nonisolated private final class Walker {
   private var insideRepeat = false
   private var currentLoopID: String?
   private var loopSeen = false
+  /// `on_timeout: skip` expectations, kept apart from `outputs` so folding a skippable loop
+  /// cannot lose them before the consumers are reported.
+  private var skipOutputs: [(name: String, location: WorkflowSourceLocation?)] = []
 
   init(definition: WorkflowDefinition, context: WorkflowValidationContext) {
     self.definition = definition
@@ -112,6 +114,9 @@ nonisolated private final class Walker {
   // MARK: Header, inputs, roles
 
   private func checkHeader() {
+    if definition.name.trimmingCharacters(in: .whitespaces).isEmpty {
+      collector.error("name_empty", "'name' must not be blank.")
+    }
     if !WorkflowSchema.isWorkflowID(definition.id) {
       collector.error("workflow_id", "Workflow id '\(definition.id)' is not a valid id (lowercase slug, max 64).")
     }
@@ -146,6 +151,9 @@ nonisolated private final class Walker {
       if input.values.isEmpty {
         collector.error("enum_values_empty", "Enum input '\(input.name)' needs at least one value.", at: input.location)
       }
+      if input.values.contains(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+        collector.error("enum_value_empty", "Enum input '\(input.name)' lists an empty value.", at: input.location)
+      }
       if Set(input.values).count != input.values.count {
         collector.error("enum_values_duplicate", "Enum input '\(input.name)' repeats a value.", at: input.location)
       }
@@ -167,6 +175,9 @@ nonisolated private final class Walker {
         collector.error("role_name_slug", "Role name '\(role.name)' is not a valid slug.", at: role.location)
       }
       guard let launch = role.launch else { continue }
+      if (launch.agents ?? []).contains(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+        collector.error("agent_token_empty", "Role '\(role.name)' lists an empty agent token.", at: role.location)
+      }
       checkAgentTokens(launch.agents ?? [], role: role)
       if let suggested = launch.suggest?.agent {
         checkAgentTokens([suggested], role: role)
@@ -392,12 +403,17 @@ nonisolated private final class Walker {
         at: location)
       return
     }
-    var relevant = info.producers.filter { $0.loopID == loopID }
-    if let last = before[until.output]?.producers.last {
-      relevant.append(last)
+    // Only the body's final producer is read after an iteration; before entry the latest
+    // pre-loop state applies, already folded when it came out of a skippable loop.
+    var candidates: [Set<String>?] = []
+    if let final = info.producers.last(where: { $0.loopID == loopID }) {
+      candidates.append(final.verdicts)
     }
-    let sets = relevant.compactMap(\.verdicts)
-    guard sets.count == relevant.count, let first = sets.first else {
+    if let earlier = before[until.output] {
+      candidates.append(earlier.latestVerdicts)
+    }
+    let sets = candidates.compactMap { $0 }
+    guard sets.count == candidates.count, let first = sets.first else {
       collector.error("until_verdict_undeclared", "Output '\(until.output)' declares no verdict.", at: location)
       return
     }
@@ -434,7 +450,7 @@ nonisolated private final class Walker {
     info.producers.append(OutputProducer(verdicts: verdicts, loopID: currentLoopID))
     info.latestVerdicts = verdicts
     if expect.onTimeout == .skip {
-      info.skipLocations.append(location)
+      skipOutputs.append((name, location))
     }
     outputs[name] = info
   }
@@ -452,15 +468,13 @@ nonisolated private final class Walker {
   }
 
   private func reportSkipConsumers() {
-    for (name, info) in outputs.sorted(by: { $0.key < $1.key }) {
+    for (name, location) in skipOutputs {
       let blocking = (consumers[name] ?? []).contains { $0 != .optionalActionInput }
       guard blocking else { continue }
-      for location in info.skipLocations {
-        collector.warning(
-          "skip_ends_run",
-          "'on_timeout: skip' on output '\(name)' would end the run: a later step depends on it.",
-          at: location)
-      }
+      collector.warning(
+        "skip_ends_run",
+        "'on_timeout: skip' on output '\(name)' would end the run: a later step depends on it.",
+        at: location)
     }
   }
 

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -18,6 +18,8 @@ nonisolated public struct WorkflowValidationContext: Sendable {
   public let knownAgents: Set<String>?
   /// Agents installed locally; nil = the "nothing installed" warning is skipped.
   public let installedAgents: Set<String>?
+  /// Preset fields of the enabled Agent Profiles; nil = the `suggest` match warning is skipped.
+  public let enabledProfiles: [WorkflowProfileSuggestion]?
   public let actions: [WorkflowActionSchema]
 
   public init(
@@ -25,12 +27,14 @@ nonisolated public struct WorkflowValidationContext: Sendable {
     bundledSkillIDs: Set<String>? = nil,
     knownAgents: Set<String>? = nil,
     installedAgents: Set<String>? = nil,
+    enabledProfiles: [WorkflowProfileSuggestion]? = nil,
     actions: [WorkflowActionSchema] = WorkflowActionRegistry.all
   ) {
     self.scope = scope
     self.bundledSkillIDs = bundledSkillIDs
     self.knownAgents = knownAgents
     self.installedAgents = installedAgents
+    self.enabledProfiles = enabledProfiles
     self.actions = actions
   }
 }
@@ -49,8 +53,7 @@ nonisolated public enum WorkflowValidator {
 
   static func isSingleLine(_ text: String) -> Bool {
     !text.unicodeScalars.contains { scalar in
-      scalar == "\n" || scalar == "\r" || scalar == "\u{2028}" || scalar == "\u{2029}"
-        || (scalar.value < 0x20 && scalar != "\t") || (0x7F...0x9F).contains(scalar.value)
+      scalar == "\u{2028}" || scalar == "\u{2029}" || scalar.value < 0x20 || (0x7F...0x9F).contains(scalar.value)
     }
   }
 }
@@ -64,8 +67,17 @@ nonisolated private enum OutputConsumer {
   case optionalActionInput
 }
 
+nonisolated private struct OutputProducer {
+  let verdicts: Set<String>?
+  /// The `repeat` step whose body holds the producer; nil at the top level.
+  let loopID: String?
+}
+
 nonisolated private struct OutputInfo {
-  var verdicts: Set<String>?
+  var producers: [OutputProducer] = []
+  /// Verdict set of the producer whose delivery is the latest at this point of the walk; nil
+  /// when it declares none, or when a skippable loop leaves the latest producer ambiguous.
+  var latestVerdicts: Set<String>?
   var skipLocations: [WorkflowSourceLocation?] = []
 }
 
@@ -81,6 +93,7 @@ nonisolated private final class Walker {
   /// Action steps visible to the step being validated: outer sequences first, current last.
   private var actionScopes: [[String: WorkflowActionSchema]] = [[:]]
   private var insideRepeat = false
+  private var currentLoopID: String?
   private var loopSeen = false
 
   init(definition: WorkflowDefinition, context: WorkflowValidationContext) {
@@ -166,7 +179,27 @@ nonisolated private final class Walker {
           "No installed agent satisfies role '\(role.name)' (\(agents.joined(separator: ", "))).",
           at: role.location)
       }
+      if let suggest = launch.suggest, let profiles = context.enabledProfiles,
+        !profiles.contains(where: { Self.profile($0, matches: suggest) })
+      {
+        collector.warning(
+          "suggest_unmatched", "No enabled Agent Profile matches the suggestion for role '\(role.name)'.",
+          at: role.location)
+      }
     }
+  }
+
+  /// Every field the suggestion names must equal the profile's; absent fields do not constrain.
+  private static func profile(
+    _ profile: WorkflowProfileSuggestion, matches suggest: WorkflowProfileSuggestion
+  ) -> Bool {
+    for (wanted, actual) in [
+      (suggest.agent, profile.agent), (suggest.model, profile.model),
+      (suggest.reasoningEffort, profile.reasoningEffort), (suggest.executionMode, profile.executionMode),
+    ] where wanted != nil && wanted != actual {
+      return false
+    }
+    return true
   }
 
   private func checkAgentTokens(_ tokens: [String], role: WorkflowRoleDefinition) {
@@ -270,7 +303,19 @@ nonisolated private final class Walker {
         collector.error("unknown_action_input", "Action '\(id)' has no input '\(key)'.", at: step.location)
         continue
       }
-      checkTemplate(value, at: step.location, consumer: input.required ? .requiredActionInput : .optionalActionInput)
+      switch input.kind {
+      case .role:
+        if WorkflowTemplate.containsReference(value) {
+          collector.error(
+            "role_input_literal", "Action '\(id)' input '\(key)' must name a role literally, not a template.",
+            at: step.location)
+        } else if definition.role(named: value) == nil {
+          collector.error(
+            "unknown_role", "Action '\(id)' input '\(key)' names undefined role '\(value)'.", at: step.location)
+        }
+      case .string, .path:
+        checkTemplate(value, at: step.location, consumer: input.required ? .requiredActionInput : .optionalActionInput)
+      }
     }
     for input in schema.inputs where input.required && inputs[input.name] == nil {
       collector.error("missing_action_input", "Action '\(id)' requires input '\(input.name)'.", at: step.location)
@@ -283,15 +328,36 @@ nonisolated private final class Walker {
     body: [WorkflowStepDefinition]
   ) {
     checkRepeatBound(max, at: step.location)
-    let producedBefore = Set(outputs.keys)
+    let before = outputs
     insideRepeat = true
+    currentLoopID = step.id
     actionScopes.append([:])
     body.forEach(checkStep)
     actionScopes.removeLast()
     insideRepeat = false
+    currentLoopID = nil
     loopSeen = true
-    if let until {
-      checkUntil(until, producedBefore: producedBefore, at: until.location ?? step.location)
+    guard let until else { return }
+    checkUntil(until, loopID: step.id, before: before, at: until.location ?? step.location)
+    foldSkippableLoopOutputs(before: before)
+  }
+
+  /// A loop with `until` may run zero times: outputs first produced inside it are not visible
+  /// afterwards, and an output also produced before keeps only the verdicts both producers
+  /// declare.
+  private func foldSkippableLoopOutputs(before: [String: OutputInfo]) {
+    for (name, info) in outputs {
+      guard let earlier = before[name] else {
+        outputs[name] = nil
+        continue
+      }
+      var folded = info
+      if let outer = earlier.latestVerdicts, let inner = info.latestVerdicts {
+        folded.latestVerdicts = outer.intersection(inner)
+      } else {
+        folded.latestVerdicts = nil
+      }
+      outputs[name] = folded
     }
   }
 
@@ -314,8 +380,11 @@ nonisolated private final class Walker {
     }
   }
 
+  /// `until` reads the latest delivery of its output: before entry that is the last producer
+  /// before the loop, after each iteration any producer in the body — every one of them must
+  /// declare a verdict set that holds the literals.
   private func checkUntil(
-    _ until: WorkflowUntilCondition, producedBefore: Set<String>, at location: WorkflowSourceLocation?
+    _ until: WorkflowUntilCondition, loopID: String, before: [String: OutputInfo], at location: WorkflowSourceLocation?
   ) {
     guard let info = outputs[until.output] else {
       collector.error(
@@ -323,11 +392,16 @@ nonisolated private final class Walker {
         at: location)
       return
     }
-    _ = producedBefore
-    guard let verdicts = info.verdicts else {
+    var relevant = info.producers.filter { $0.loopID == loopID }
+    if let last = before[until.output]?.producers.last {
+      relevant.append(last)
+    }
+    let sets = relevant.compactMap(\.verdicts)
+    guard sets.count == relevant.count, let first = sets.first else {
       collector.error("until_verdict_undeclared", "Output '\(until.output)' declares no verdict.", at: location)
       return
     }
+    let verdicts = sets.dropFirst().reduce(first) { $0.intersection($1) }
     if until.values.isEmpty {
       collector.error("until_syntax", "'until' needs at least one verdict value.", at: location)
     }
@@ -356,9 +430,9 @@ nonisolated private final class Walker {
       collector.warning("timeout_long", "'timeout' above 2h; the watchdog already supervises waiting.", at: location)
     }
     var info = outputs[name] ?? OutputInfo()
-    if let verdict = expect.verdict {
-      info.verdicts = (info.verdicts ?? []).union(verdict)
-    }
+    let verdicts = expect.verdict.map(Set.init)
+    info.producers.append(OutputProducer(verdicts: verdicts, loopID: currentLoopID))
+    info.latestVerdicts = verdicts
     if expect.onTimeout == .skip {
       info.skipLocations.append(location)
     }
@@ -440,7 +514,7 @@ nonisolated private final class Walker {
     _ parts: [String], at location: WorkflowSourceLocation?, consumer: OutputConsumer
   ) -> Bool {
     guard let info = outputs[parts[1]], ["path", "verdict"].contains(parts[2]) else { return false }
-    if parts[2] == "verdict", info.verdicts == nil {
+    if parts[2] == "verdict", info.latestVerdicts == nil {
       return false
     }
     consumers[parts[1], default: []].append(consumer)

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -1,0 +1,477 @@
+// ProwlShared/WorkflowValidator.swift
+// Semantic rules of dsl-spec.md §7 over a parsed WorkflowDefinition: references, control flow,
+// slugs, verdicts, templates. Structural rules (keys, types) are the parser's.
+
+import Foundation
+
+nonisolated public enum WorkflowScope: String, Codable, Equatable, Sendable, CaseIterable {
+  case bundle
+  case user
+  case repo
+}
+
+nonisolated public struct WorkflowValidationContext: Sendable {
+  public let scope: WorkflowScope
+  /// nil = the bundle is unavailable; `skill:` references are reported as unchecked warnings.
+  public let bundledSkillIDs: Set<String>?
+  /// The agent token catalog; nil = unknown tokens are not reported.
+  public let knownAgents: Set<String>?
+  /// Agents installed locally; nil = the "nothing installed" warning is skipped.
+  public let installedAgents: Set<String>?
+  public let actions: [WorkflowActionSchema]
+
+  public init(
+    scope: WorkflowScope,
+    bundledSkillIDs: Set<String>? = nil,
+    knownAgents: Set<String>? = nil,
+    installedAgents: Set<String>? = nil,
+    actions: [WorkflowActionSchema] = WorkflowActionRegistry.all
+  ) {
+    self.scope = scope
+    self.bundledSkillIDs = bundledSkillIDs
+    self.knownAgents = knownAgents
+    self.installedAgents = installedAgents
+    self.actions = actions
+  }
+}
+
+nonisolated public enum WorkflowValidator {
+  public static let completionCommand = "prowl workflow done"
+  public static let longTimeoutSeconds = 2 * 3600
+
+  public static func validate(
+    _ definition: WorkflowDefinition, context: WorkflowValidationContext
+  ) -> [WorkflowDiagnostic] {
+    let walker = Walker(definition: definition, context: context)
+    walker.run()
+    return walker.collector.diagnostics
+  }
+
+  static func isSingleLine(_ text: String) -> Bool {
+    !text.unicodeScalars.contains { scalar in
+      scalar == "\n" || scalar == "\r" || scalar == "\u{2028}" || scalar == "\u{2029}"
+        || (scalar.value < 0x20 && scalar != "\t") || (0x7F...0x9F).contains(scalar.value)
+    }
+  }
+}
+
+// MARK: - Walker
+
+nonisolated private enum OutputConsumer {
+  case template
+  case until
+  case requiredActionInput
+  case optionalActionInput
+}
+
+nonisolated private struct OutputInfo {
+  var verdicts: Set<String>?
+  var skipLocations: [WorkflowSourceLocation?] = []
+}
+
+nonisolated private final class Walker {
+  let definition: WorkflowDefinition
+  let context: WorkflowValidationContext
+  let collector = DiagnosticCollector()
+
+  private var stepIDs: Set<String> = []
+  private var launchedRoles: Set<String> = []
+  private var outputs: [String: OutputInfo] = [:]
+  private var consumers: [String: [OutputConsumer]] = [:]
+  /// Action steps visible to the step being validated: outer sequences first, current last.
+  private var actionScopes: [[String: WorkflowActionSchema]] = [[:]]
+  private var insideRepeat = false
+  private var loopSeen = false
+
+  init(definition: WorkflowDefinition, context: WorkflowValidationContext) {
+    self.definition = definition
+    self.context = context
+  }
+
+  func run() {
+    checkHeader()
+    definition.inputs.forEach(checkInput)
+    checkRoles()
+    definition.steps.forEach(checkStep)
+    reportSkipConsumers()
+  }
+
+  // MARK: Header, inputs, roles
+
+  private func checkHeader() {
+    if !WorkflowSchema.isWorkflowID(definition.id) {
+      collector.error("workflow_id", "Workflow id '\(definition.id)' is not a valid id (lowercase slug, max 64).")
+    }
+    if context.scope != .bundle, definition.id.hasPrefix(WorkflowSchema.reservedIDPrefix) {
+      collector.error(
+        "reserved_id", "Ids starting with '\(WorkflowSchema.reservedIDPrefix)' are reserved for bundled workflows.")
+    }
+  }
+
+  private func checkInput(_ input: WorkflowInputDefinition) {
+    if !WorkflowSchema.isSlug(input.name) {
+      collector.error("input_name_slug", "Input name '\(input.name)' is not a valid slug.", at: input.location)
+    }
+    switch input.type {
+    case .integer:
+      if let minimum = input.minimum, let maximum = input.maximum, minimum > maximum {
+        collector.error("input_range", "Input '\(input.name)' has min above max.", at: input.location)
+      }
+      if case .integer(let value)? = input.defaultValue,
+        (input.minimum.map { value < $0 } ?? false) || (input.maximum.map { value > $0 } ?? false)
+      {
+        collector.error("input_range", "Input '\(input.name)' default lies outside min…max.", at: input.location)
+      }
+    case .string:
+      if case .string(let value)? = input.defaultValue, !WorkflowValidator.isSingleLine(value) {
+        collector.error(
+          "input_default_multiline",
+          "String input '\(input.name)' default must be one line without control characters.",
+          at: input.location)
+      }
+    case .enum:
+      if input.values.isEmpty {
+        collector.error("enum_values_empty", "Enum input '\(input.name)' needs at least one value.", at: input.location)
+      }
+      if Set(input.values).count != input.values.count {
+        collector.error("enum_values_duplicate", "Enum input '\(input.name)' repeats a value.", at: input.location)
+      }
+      if case .string(let value)? = input.defaultValue, !input.values.contains(value) {
+        collector.error(
+          "enum_default", "Enum input '\(input.name)' default '\(value)' is not one of its values.", at: input.location)
+      }
+    }
+  }
+
+  private func checkRoles() {
+    let currentRoles = definition.roles.filter { $0.source == .current }
+    if currentRoles.count > 1 {
+      collector.error(
+        "multiple_current_roles", "At most one role may use 'source: current'.", at: currentRoles[1].location)
+    }
+    for role in definition.roles {
+      if !WorkflowSchema.isSlug(role.name) {
+        collector.error("role_name_slug", "Role name '\(role.name)' is not a valid slug.", at: role.location)
+      }
+      guard let launch = role.launch else { continue }
+      checkAgentTokens(launch.agents ?? [], role: role)
+      if let suggested = launch.suggest?.agent {
+        checkAgentTokens([suggested], role: role)
+      }
+      if let agents = launch.agents, let installed = context.installedAgents, !agents.isEmpty,
+        Set(agents).isDisjoint(with: installed)
+      {
+        collector.warning(
+          "agents_not_installed",
+          "No installed agent satisfies role '\(role.name)' (\(agents.joined(separator: ", "))).",
+          at: role.location)
+      }
+    }
+  }
+
+  private func checkAgentTokens(_ tokens: [String], role: WorkflowRoleDefinition) {
+    guard let known = context.knownAgents else { return }
+    for token in tokens where !known.contains(token) {
+      collector.warning(
+        "unknown_agent", "Role '\(role.name)' names an unknown agent token '\(token)'.", at: role.location)
+    }
+  }
+
+  // MARK: Steps
+
+  private func checkStep(_ step: WorkflowStepDefinition) {
+    if !WorkflowSchema.isSlug(step.id) {
+      collector.error("step_id_slug", "Step id '\(step.id)' is not a valid slug.", at: step.location)
+    }
+    if !stepIDs.insert(step.id).inserted {
+      collector.error("duplicate_step_id", "Step id '\(step.id)' is used more than once.", at: step.location)
+    }
+    if let title = step.title {
+      checkTemplate(title, at: step.location, consumer: .template)
+    }
+    switch step.action {
+    case .message(let role, let content, let expect):
+      checkMessage(step, role: role, content: content, expect: expect)
+    case .launch(let role, let prompt, let skill, let expect):
+      checkLaunch(step, role: role, prompt: prompt, skill: skill, expect: expect)
+    case .action(let id, let inputs):
+      checkAction(step, id: id, inputs: inputs)
+    case .notify(let text):
+      checkTemplate(text, at: step.location, consumer: .template)
+    case .close(let role):
+      if let definitionRole = requireRole(role, at: step.location), definitionRole.source != .launch {
+        collector.error("close_role_source", "'close' applies to launch roles only.", at: step.location)
+      }
+    case .repeat(let max, let until, let body):
+      checkRepeat(step, max: max, until: until, body: body)
+    }
+  }
+
+  private func checkMessage(
+    _ step: WorkflowStepDefinition, role: String, content: WorkflowMessageContent, expect: WorkflowExpectation?
+  ) {
+    if let definitionRole = requireRole(role, at: step.location), definitionRole.source == .launch,
+      !launchedRoles.contains(role)
+    {
+      collector.error(
+        "message_before_launch", "Step '\(step.id)' messages launch role '\(role)' before its launch step.",
+        at: step.location)
+    }
+    if case .text(let text) = content, !WorkflowValidator.isSingleLine(text) {
+      collector.error(
+        "text_multiline", "'text' must be one line; use 'instruction' for multi-line content.", at: step.location)
+    }
+    checkTemplate(content.body, at: step.location, consumer: .template)
+    warnIfSpellingCompletion(content.body, at: step.location)
+    checkExpect(expect, step: step)
+  }
+
+  private func checkLaunch(
+    _ step: WorkflowStepDefinition, role: String, prompt: String, skill: String?, expect: WorkflowExpectation?
+  ) {
+    if let definitionRole = requireRole(role, at: step.location) {
+      if definitionRole.source != .launch {
+        collector.error("launch_role_source", "'launch' applies to launch roles only.", at: step.location)
+      } else if launchedRoles.contains(role) {
+        collector.error("launch_twice", "Launch role '\(role)' is launched more than once.", at: step.location)
+      }
+    }
+    checkTemplate(prompt, at: step.location, consumer: .template)
+    warnIfSpellingCompletion(prompt, at: step.location)
+    if let skill {
+      checkSkill(skill, at: step.location)
+    }
+    checkExpect(expect, step: step)
+    launchedRoles.insert(role)
+  }
+
+  private func checkSkill(_ skill: String, at location: WorkflowSourceLocation?) {
+    guard WorkflowSchema.isWorkflowID(skill) else {
+      collector.error("skill_id", "Skill id '\(skill)' is not a valid id.", at: location)
+      return
+    }
+    guard let bundled = context.bundledSkillIDs else {
+      collector.warning(
+        "skill_unchecked", "Skill '\(skill)' was not checked: the app bundle is unavailable.", at: location)
+      return
+    }
+    if !bundled.contains(skill) {
+      collector.error("skill_not_found", "Skill '\(skill)' is not a bundled skill.", at: location)
+    }
+  }
+
+  private func checkAction(_ step: WorkflowStepDefinition, id: String, inputs: [String: String]) {
+    guard let schema = WorkflowActionRegistry.schema(for: id, in: context.actions) else {
+      collector.error("unknown_action", "Unknown action '\(id)'.", at: step.location)
+      return
+    }
+    for (key, value) in inputs.sorted(by: { $0.key < $1.key }) {
+      guard let input = schema.input(named: key) else {
+        collector.error("unknown_action_input", "Action '\(id)' has no input '\(key)'.", at: step.location)
+        continue
+      }
+      checkTemplate(value, at: step.location, consumer: input.required ? .requiredActionInput : .optionalActionInput)
+    }
+    for input in schema.inputs where input.required && inputs[input.name] == nil {
+      collector.error("missing_action_input", "Action '\(id)' requires input '\(input.name)'.", at: step.location)
+    }
+    actionScopes[actionScopes.count - 1][step.id] = schema
+  }
+
+  private func checkRepeat(
+    _ step: WorkflowStepDefinition, max: WorkflowRepeatBound, until: WorkflowUntilCondition?,
+    body: [WorkflowStepDefinition]
+  ) {
+    checkRepeatBound(max, at: step.location)
+    let producedBefore = Set(outputs.keys)
+    insideRepeat = true
+    actionScopes.append([:])
+    body.forEach(checkStep)
+    actionScopes.removeLast()
+    insideRepeat = false
+    loopSeen = true
+    if let until {
+      checkUntil(until, producedBefore: producedBefore, at: until.location ?? step.location)
+    }
+  }
+
+  private func checkRepeatBound(_ max: WorkflowRepeatBound, at location: WorkflowSourceLocation?) {
+    switch max {
+    case .literal(let value):
+      if !(1...WorkflowSchema.repeatMaximum).contains(value) {
+        collector.error("repeat_max_range", "'max' must lie in 1…\(WorkflowSchema.repeatMaximum).", at: location)
+      }
+    case .template(let text):
+      let references = (try? WorkflowTemplate.references(in: text)) ?? []
+      guard WorkflowTemplate.isSingleReference(text), references.count == 1,
+        let reference = references.first, reference.components.count == 2, reference.components[0] == "inputs",
+        let input = definition.input(named: reference.components[1]), input.type == .integer
+      else {
+        collector.error(
+          "repeat_max_template", "'max' may only be a template of exactly one integer input.", at: location)
+        return
+      }
+    }
+  }
+
+  private func checkUntil(
+    _ until: WorkflowUntilCondition, producedBefore: Set<String>, at location: WorkflowSourceLocation?
+  ) {
+    guard let info = outputs[until.output] else {
+      collector.error(
+        "until_output", "'until' references output '\(until.output)', which no earlier or enclosed step produces.",
+        at: location)
+      return
+    }
+    _ = producedBefore
+    guard let verdicts = info.verdicts else {
+      collector.error("until_verdict_undeclared", "Output '\(until.output)' declares no verdict.", at: location)
+      return
+    }
+    if until.values.isEmpty {
+      collector.error("until_syntax", "'until' needs at least one verdict value.", at: location)
+    }
+    for value in until.values where !verdicts.contains(value) {
+      collector.error(
+        "until_verdict_literal", "'\(value)' is not a declared verdict of output '\(until.output)'.", at: location)
+    }
+    consumers[until.output, default: []].append(.until)
+  }
+
+  // MARK: Expect
+
+  private func checkExpect(_ expect: WorkflowExpectation?, step: WorkflowStepDefinition) {
+    guard let expect, let name = step.outputName else { return }
+    let location = expect.location ?? step.location
+    if !WorkflowSchema.isSlug(name) {
+      collector.error("output_name_slug", "Output name '\(name)' is not a valid slug.", at: location)
+    }
+    if expect.sections.contains(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+      collector.error("section_empty", "'sections' entries must not be empty.", at: location)
+    }
+    if let verdict = expect.verdict {
+      checkVerdict(verdict, at: location)
+    }
+    if let timeout = expect.timeoutSeconds, timeout > WorkflowValidator.longTimeoutSeconds {
+      collector.warning("timeout_long", "'timeout' above 2h; the watchdog already supervises waiting.", at: location)
+    }
+    var info = outputs[name] ?? OutputInfo()
+    if let verdict = expect.verdict {
+      info.verdicts = (info.verdicts ?? []).union(verdict)
+    }
+    if expect.onTimeout == .skip {
+      info.skipLocations.append(location)
+    }
+    outputs[name] = info
+  }
+
+  private func checkVerdict(_ verdict: [String], at location: WorkflowSourceLocation?) {
+    if !WorkflowSchema.verdictRange.contains(verdict.count) {
+      collector.error("verdict_count", "'verdict' declares 2–4 values.", at: location)
+    }
+    if Set(verdict).count != verdict.count {
+      collector.error("verdict_duplicate", "'verdict' repeats a value.", at: location)
+    }
+    for value in verdict where !WorkflowSchema.isSlug(value) {
+      collector.error("verdict_slug", "Verdict '\(value)' is not a valid slug.", at: location)
+    }
+  }
+
+  private func reportSkipConsumers() {
+    for (name, info) in outputs.sorted(by: { $0.key < $1.key }) {
+      let blocking = (consumers[name] ?? []).contains { $0 != .optionalActionInput }
+      guard blocking else { continue }
+      for location in info.skipLocations {
+        collector.warning(
+          "skip_ends_run",
+          "'on_timeout: skip' on output '\(name)' would end the run: a later step depends on it.",
+          at: location)
+      }
+    }
+  }
+
+  // MARK: Templates
+
+  private func checkTemplate(_ text: String, at location: WorkflowSourceLocation?, consumer: OutputConsumer) {
+    let references: [WorkflowTemplate.Reference]
+    do {
+      references = try WorkflowTemplate.references(in: text)
+    } catch {
+      collector.error("template_syntax", "Malformed template placeholder: \(error).", at: location)
+      return
+    }
+    for reference in references {
+      checkReference(reference, at: location, consumer: consumer)
+    }
+  }
+
+  private func checkReference(
+    _ reference: WorkflowTemplate.Reference, at location: WorkflowSourceLocation?, consumer: OutputConsumer
+  ) {
+    let parts = reference.components
+    let valid: Bool
+    switch (parts.first, parts.count) {
+    case ("run", 2): valid = ["id", "dir"].contains(parts[1])
+    case ("worktree", 2): valid = ["path", "name", "branch"].contains(parts[1])
+    case ("inputs", 2): valid = definition.input(named: parts[1]) != nil
+    case ("loop", 2): valid = parts[1] == "index" ? insideRepeat : (parts[1] == "count" && (insideRepeat || loopSeen))
+    case ("roles", 3): valid = checkRoleReference(parts, at: location)
+    case ("outputs", 3): valid = checkOutputReference(parts, at: location, consumer: consumer)
+    case ("actions", 3): valid = checkActionReference(parts)
+    default: valid = false
+    }
+    if !valid {
+      collector.error(
+        "unknown_variable", "Unknown or premature template variable '{{ \(reference.path) }}'.", at: location)
+    }
+  }
+
+  private func checkRoleReference(_ parts: [String], at location: WorkflowSourceLocation?) -> Bool {
+    guard let role = definition.role(named: parts[1]), ["name", "agent", "pane"].contains(parts[2]) else {
+      return false
+    }
+    if parts[2] == "pane", role.source == .launch, !launchedRoles.contains(role.name) {
+      return false
+    }
+    return true
+  }
+
+  private func checkOutputReference(
+    _ parts: [String], at location: WorkflowSourceLocation?, consumer: OutputConsumer
+  ) -> Bool {
+    guard let info = outputs[parts[1]], ["path", "verdict"].contains(parts[2]) else { return false }
+    if parts[2] == "verdict", info.verdicts == nil {
+      return false
+    }
+    consumers[parts[1], default: []].append(consumer)
+    return true
+  }
+
+  private func checkActionReference(_ parts: [String]) -> Bool {
+    for scope in actionScopes.reversed() {
+      if let schema = scope[parts[1]] {
+        return schema.hasOutput(named: parts[2])
+      }
+    }
+    return false
+  }
+
+  // MARK: Helpers
+
+  private func requireRole(_ name: String, at location: WorkflowSourceLocation?) -> WorkflowRoleDefinition? {
+    guard let role = definition.role(named: name) else {
+      collector.error("undefined_role", "Role '\(name)' is not defined.", at: location)
+      return nil
+    }
+    return role
+  }
+
+  private func warnIfSpellingCompletion(_ text: String, at location: WorkflowSourceLocation?) {
+    if text.contains(WorkflowValidator.completionCommand) {
+      collector.warning(
+        "spells_completion_command",
+        "Do not spell '\(WorkflowValidator.completionCommand)'; the runner appends the generated completion command.",
+        at: location)
+    }
+  }
+}

--- a/supacode/CLIService/WorkflowCommandHandler.swift
+++ b/supacode/CLIService/WorkflowCommandHandler.swift
@@ -1,0 +1,143 @@
+// supacode/CLIService/WorkflowCommandHandler.swift
+// Handles `prowl workflow list`: resolves the worktree whose repo source is searched, runs
+// three-source discovery, and applies the (hidden until D1) enabled set.
+
+import Foundation
+
+struct WorkflowRuntimeSnapshot {
+  let resolution: TargetResolutionSnapshot
+  let paneByShellPID: [pid_t: CallerPane]
+  let bundleWorkflowsURL: URL?
+  let userWorkflowsURL: URL
+  /// `<scope>/<id>` keys of definitions the user switched off.
+  let disabledWorkflowIDs: Set<String>
+  let bundledSkillIDs: Set<String>?
+  let knownAgents: Set<String>
+  let installedAgents: Set<String>?
+}
+
+@MainActor
+final class WorkflowCommandHandler: CommandHandler {
+  typealias SnapshotProvider = @MainActor () -> WorkflowRuntimeSnapshot
+
+  private let snapshotProvider: SnapshotProvider
+
+  init(snapshotProvider: @escaping SnapshotProvider) {
+    self.snapshotProvider = snapshotProvider
+  }
+
+  static func disabledKey(scope: WorkflowScope, id: String) -> String {
+    "\(scope.rawValue)/\(id)"
+  }
+
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    await handle(envelope: envelope, context: CLICommandContext())
+  }
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope: CommandEnvelope, context: CLICommandContext) async -> CommandResponse {
+    guard case .workflow(let input) = envelope.command else {
+      return failure(code: CLIErrorCode.invalidArgument, message: "Expected a workflow command.")
+    }
+    let snapshot = snapshotProvider()
+    switch resolveWorktree(input.target, snapshot: snapshot, context: context) {
+    case .failure(.notFound(let message)):
+      return failure(code: CLIErrorCode.targetNotFound, message: message)
+    case .failure(.notUnique(let message)):
+      return failure(code: CLIErrorCode.targetNotUnique, message: message)
+    case .success(let worktree):
+      do {
+        let payload = try listPayload(worktree: worktree, snapshot: snapshot)
+        return try CommandResponse(
+          ok: true,
+          command: WorkflowCommandPayload.commandName,
+          schemaVersion: WorkflowCommandPayload.schemaVersion,
+          data: RawJSON(encoding: WorkflowCommandPayload.list(payload))
+        )
+      } catch {
+        return failure(code: CLIErrorCode.workflowFailed, message: "Failed to list workflows: \(error)")
+      }
+    }
+  }
+
+  // MARK: - Worktree resolution
+
+  /// `.none` prefers the caller's own pane, then the focused worktree; nil means no worktree
+  /// could be resolved and only the bundle and user sources are searched.
+  private func resolveWorktree(
+    _ selector: TargetSelector,
+    snapshot: WorkflowRuntimeSnapshot,
+    context: CLICommandContext
+  ) -> Result<TargetResolutionSnapshot.Worktree?, TargetResolverError> {
+    let resolver = TargetResolver { snapshot.resolution }
+    if case .none = selector {
+      if let callerPane = callerPane(context: context, paneByShellPID: snapshot.paneByShellPID),
+        let worktree = snapshot.resolution.worktrees.first(where: { $0.id == callerPane.worktreeID })
+      {
+        return .success(worktree)
+      }
+      guard case .success(let focused) = resolver.resolve(.none) else {
+        return .success(nil)
+      }
+      return .success(snapshot.resolution.worktrees.first { $0.id == focused.worktreeID })
+    }
+    return resolver.resolve(selector).map { resolved in
+      snapshot.resolution.worktrees.first { $0.id == resolved.worktreeID }
+    }
+  }
+
+  private func callerPane(context: CLICommandContext, paneByShellPID: [pid_t: CallerPane]) -> CallerPane? {
+    if !context.callerProcessAncestry.isEmpty {
+      return CallerPaneResolver.pane(
+        forCallerProcessAncestry: context.callerProcessAncestry, paneByShellPID: paneByShellPID)
+    }
+    guard let callerProcessID = context.callerProcessID else { return nil }
+    return CallerPaneResolver.pane(forCallerProcess: callerProcessID, paneByShellPID: paneByShellPID)
+  }
+
+  // MARK: - Listing
+
+  private func listPayload(
+    worktree: TargetResolutionSnapshot.Worktree?, snapshot: WorkflowRuntimeSnapshot
+  ) throws -> WorkflowListPayload {
+    let repoURL = worktree.map {
+      WorkflowSources.repoDirectory(root: URL(filePath: $0.rootPath, directoryHint: .isDirectory))
+    }
+    let sources = WorkflowSources(bundle: snapshot.bundleWorkflowsURL, user: snapshot.userWorkflowsURL, repo: repoURL)
+    let catalog = WorkflowDiscovery.catalog(sources: sources) { scope in
+      WorkflowValidationContext(
+        scope: scope,
+        bundledSkillIDs: snapshot.bundledSkillIDs,
+        knownAgents: snapshot.knownAgents,
+        installedAgents: snapshot.installedAgents
+      )
+    }
+    let workflows = catalog.map { entry in
+      let enabled =
+        entry.file.id.map {
+          !snapshot.disabledWorkflowIDs.contains(Self.disabledKey(scope: entry.file.scope, id: $0))
+        } ?? false
+      return WorkflowListEntry(entry: entry, enabled: enabled)
+    }
+    return WorkflowListPayload(
+      worktree: worktree.map {
+        WorkflowListWorktree(id: $0.id, name: $0.name, path: $0.path, rootPath: $0.rootPath)
+      },
+      sources: WorkflowListSources(
+        bundle: sources.bundle?.path(percentEncoded: false),
+        user: sources.user.path(percentEncoded: false),
+        repo: sources.repo?.path(percentEncoded: false)
+      ),
+      workflows: workflows
+    )
+  }
+
+  private func failure(code: String, message: String) -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: WorkflowCommandPayload.commandName,
+      schemaVersion: WorkflowCommandPayload.schemaVersion,
+      error: CommandError(code: code, message: message)
+    )
+  }
+}

--- a/supacode/CLIService/WorkflowCommandHandler.swift
+++ b/supacode/CLIService/WorkflowCommandHandler.swift
@@ -14,6 +14,8 @@ struct WorkflowRuntimeSnapshot {
   let bundledSkillIDs: Set<String>?
   let knownAgents: Set<String>
   let installedAgents: Set<String>?
+  /// Preset fields of the enabled Agent Profiles, for the `suggest` match warning.
+  let enabledProfiles: [WorkflowProfileSuggestion]
 }
 
 @MainActor
@@ -104,12 +106,13 @@ final class WorkflowCommandHandler: CommandHandler {
       WorkflowSources.repoDirectory(root: URL(filePath: $0.rootPath, directoryHint: .isDirectory))
     }
     let sources = WorkflowSources(bundle: snapshot.bundleWorkflowsURL, user: snapshot.userWorkflowsURL, repo: repoURL)
-    let catalog = WorkflowDiscovery.catalog(sources: sources) { scope in
+    let catalog = try WorkflowDiscovery.catalog(sources: sources) { scope in
       WorkflowValidationContext(
         scope: scope,
         bundledSkillIDs: snapshot.bundledSkillIDs,
         knownAgents: snapshot.knownAgents,
-        installedAgents: snapshot.installedAgents
+        installedAgents: snapshot.installedAgents,
+        enabledProfiles: snapshot.enabledProfiles
       )
     }
     let workflows = catalog.map { entry in

--- a/supacode/Features/Settings/Models/UserGlobalSettings.swift
+++ b/supacode/Features/Settings/Models/UserGlobalSettings.swift
@@ -6,6 +6,8 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
   /// One-shot seeding marker for agent profiles (docs-ai 053): seeded profiles
   /// the user deletes must never respawn.
   var didSeedAgentProfiles: Bool
+  /// `<scope>/<id>` keys of workflow definitions switched off (docs-ai 063 B1; Settings UI in D1).
+  var disabledWorkflowIDs: [String]
 
   static let `default` = UserGlobalSettings(customCommands: [])
 
@@ -13,16 +15,19 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
     case customCommands
     case agentProfiles
     case didSeedAgentProfiles
+    case disabledWorkflowIDs
   }
 
   init(
     customCommands: [UserCustomCommand],
     agentProfiles: [AgentProfile] = [],
-    didSeedAgentProfiles: Bool = false
+    didSeedAgentProfiles: Bool = false,
+    disabledWorkflowIDs: [String] = []
   ) {
     self.customCommands = UserCustomCommand.normalizedCommands(customCommands)
     self.agentProfiles = AgentProfile.normalizedProfiles(agentProfiles)
     self.didSeedAgentProfiles = didSeedAgentProfiles
+    self.disabledWorkflowIDs = Self.normalizedWorkflowIDs(disabledWorkflowIDs)
   }
 
   init(from decoder: Decoder) throws {
@@ -32,13 +37,21 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
     let profiles = try container.decodeIfPresent([AgentProfile].self, forKey: .agentProfiles) ?? []
     agentProfiles = AgentProfile.normalizedProfiles(profiles)
     didSeedAgentProfiles = try container.decodeIfPresent(Bool.self, forKey: .didSeedAgentProfiles) ?? false
+    let disabled = try container.decodeIfPresent([String].self, forKey: .disabledWorkflowIDs) ?? []
+    disabledWorkflowIDs = Self.normalizedWorkflowIDs(disabled)
   }
 
   func normalized() -> UserGlobalSettings {
     UserGlobalSettings(
       customCommands: customCommands,
       agentProfiles: agentProfiles,
-      didSeedAgentProfiles: didSeedAgentProfiles
+      didSeedAgentProfiles: didSeedAgentProfiles,
+      disabledWorkflowIDs: disabledWorkflowIDs
     )
+  }
+
+  /// Stable order, no duplicates: the set semantics of a persisted list.
+  static func normalizedWorkflowIDs(_ ids: [String]) -> [String] {
+    Array(Set(ids)).sorted()
   }
 }

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -39,6 +39,12 @@ nonisolated enum SupacodePaths {
     Bundle.main.resourceURL?.appending(path: "docs", directoryHint: .isDirectory)
   }
 
+  /// Bundled workflow definitions (`Prowl.app/Contents/Resources/workflows`); absent until the
+  /// first built-in ships, which discovery tolerates.
+  static var bundledWorkflowsURL: URL? {
+    Bundle.main.resourceURL.map(WorkflowSources.bundleDirectory(resourcesURL:))
+  }
+
   static var bundledCLIURL: URL? {
     Bundle.main.resourceURL?.appending(
       path: "prowl-cli/prowl",

--- a/supacodeTests/WorkflowCommandHandlerTests.swift
+++ b/supacodeTests/WorkflowCommandHandlerTests.swift
@@ -74,7 +74,8 @@ struct WorkflowCommandHandlerTests {
         disabledWorkflowIDs: disabled,
         bundledSkillIDs: [],
         knownAgents: ["codex", "claude"],
-        installedAgents: nil
+        installedAgents: nil,
+        enabledProfiles: []
       )
     }
   }
@@ -143,6 +144,18 @@ struct WorkflowCommandHandlerTests {
     let (missing, _) = try await list(handler, target: .worktree("nope"))
     #expect(missing.ok == false)
     #expect(missing.error?.code == CLIErrorCode.targetNotFound)
+  }
+
+  @Test func unreadableSourceDirectoriesFailWithWorkflowFailed() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let path = fixture.userWorkflows.path(percentEncoded: false)
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: path)
+    defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path) }
+    let handler = WorkflowCommandHandler { fixture.snapshot(focused: true) }
+    let (response, _) = try await list(handler)
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.workflowFailed)
   }
 
   @Test func disabledKeysCombineScopeAndID() {

--- a/supacodeTests/WorkflowCommandHandlerTests.swift
+++ b/supacodeTests/WorkflowCommandHandlerTests.swift
@@ -1,0 +1,158 @@
+// supacodeTests/WorkflowCommandHandlerTests.swift
+// `prowl workflow list` over the socket: worktree resolution, three-source discovery, enabled set.
+
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorkflowCommandHandlerTests {
+  private static let minimal = """
+    schema: prowl.workflow/v1
+    id: %ID%
+    name: Demo
+    roles:
+      author:
+        source: current
+    steps:
+      - id: ask
+        message: author
+        text: "Say hello."
+    """
+
+  private struct Fixture {
+    let root: URL
+    let userWorkflows: URL
+    let repoRoot: URL
+    let paneID = UUID()
+    let shellPID: pid_t = 4242
+
+    init() throws {
+      root =
+        FileManager.default.temporaryDirectory
+        .appending(path: "prowl-workflow-handler-\(UUID().uuidString)", directoryHint: .isDirectory)
+        .standardizedFileURL
+      userWorkflows = root.appending(path: "home/.prowl/workflows", directoryHint: .isDirectory)
+      repoRoot = root.appending(path: "repo", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: userWorkflows, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(
+        at: WorkflowSources.repoDirectory(root: repoRoot), withIntermediateDirectories: true)
+      try write("demo", to: userWorkflows.appending(path: "demo.yaml"))
+      try write("repo-only", to: WorkflowSources.repoDirectory(root: repoRoot).appending(path: "repo.yaml"))
+    }
+
+    func write(_ id: String, to url: URL) throws {
+      try Data(WorkflowCommandHandlerTests.minimal.replacingOccurrences(of: "%ID%", with: id).utf8).write(to: url)
+    }
+
+    func cleanUp() {
+      try? FileManager.default.removeItem(at: root)
+    }
+
+    func snapshot(focused: Bool = true, disabled: Set<String> = []) -> WorkflowRuntimeSnapshot {
+      let surfaceView = GhosttySurfaceView(
+        runtime: GhosttyRuntime(),
+        workingDirectory: nil,
+        context: GHOSTTY_SURFACE_CONTEXT_TAB,
+        skipsSurfaceCreationForTesting: true
+      )
+      let pane = TargetResolutionSnapshot.Pane(
+        id: paneID, handle: 1, title: "shell", cwd: repoRoot.path(percentEncoded: false), isFocusedInTab: true,
+        surfaceView: surfaceView)
+      let tab = TargetResolutionSnapshot.Tab(
+        id: UUID(), handle: 1, title: "Tab", selected: true, panes: [pane], focusedPaneID: paneID)
+      let worktree = TargetResolutionSnapshot.Worktree(
+        id: "wt-1", name: "main", path: repoRoot.path(percentEncoded: false),
+        rootPath: repoRoot.path(percentEncoded: false), kind: .git, tabs: [tab])
+      return WorkflowRuntimeSnapshot(
+        resolution: TargetResolutionSnapshot(worktrees: [worktree], focusedWorktreeID: focused ? "wt-1" : nil),
+        paneByShellPID: [shellPID: CallerPane(worktreeID: "wt-1", surfaceID: paneID)],
+        bundleWorkflowsURL: nil,
+        userWorkflowsURL: userWorkflows,
+        disabledWorkflowIDs: disabled,
+        bundledSkillIDs: [],
+        knownAgents: ["codex", "claude"],
+        installedAgents: nil
+      )
+    }
+  }
+
+  private func list(
+    _ handler: WorkflowCommandHandler, target: TargetSelector = .none, context: CLICommandContext = CLICommandContext()
+  ) async throws -> (CommandResponse, WorkflowListPayload?) {
+    let envelope = CommandEnvelope(output: .json, command: .workflow(WorkflowInput(action: .list, target: target)))
+    let response = await handler.handle(envelope: envelope, context: context)
+    guard let data = response.data else { return (response, nil) }
+    guard case .list(let payload) = try JSONDecoder().decode(WorkflowCommandPayload.self, from: data.bytes) else {
+      return (response, nil)
+    }
+    return (response, payload)
+  }
+
+  @Test func callerPaneSelectsItsWorktreeAndTheRepoSource() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let handler = WorkflowCommandHandler { fixture.snapshot(focused: false, disabled: ["user/demo"]) }
+    let context = CLICommandContext(
+      callerProcessID: 9999,
+      callerProcessAncestry: [CallerProcessIdentity(processID: fixture.shellPID, startedAt: nil)])
+
+    let (response, payload) = try await list(handler, context: context)
+    #expect(response.ok)
+    #expect(response.schemaVersion == "prowl.cli.workflow.v1")
+    let listed = try #require(payload)
+    #expect(listed.worktree?.id == "wt-1")
+    #expect(listed.sources.repo == WorkflowSources.repoDirectory(root: fixture.repoRoot).path(percentEncoded: false))
+    #expect(listed.sources.bundle == nil)
+    #expect(listed.workflows.map(\.id) == ["demo", "repo-only"])
+    #expect(listed.workflows.map(\.scope) == [.user, .repo])
+    #expect(listed.workflows.map(\.enabled) == [false, true])
+    #expect(listed.workflows.map(\.valid) == [true, true])
+  }
+
+  @Test func withoutACallerTheFocusedWorktreeIsUsed() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let handler = WorkflowCommandHandler { fixture.snapshot(focused: true) }
+    let (_, payload) = try await list(handler)
+    #expect(payload?.worktree?.id == "wt-1")
+    #expect(payload?.workflows.map(\.id) == ["demo", "repo-only"])
+  }
+
+  @Test func withoutAnyWorktreeOnlyBundleAndUserSourcesAreSearched() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let handler = WorkflowCommandHandler { fixture.snapshot(focused: false) }
+    let (response, payload) = try await list(handler)
+    #expect(response.ok)
+    #expect(payload?.worktree == nil)
+    #expect(payload?.sources.repo == nil)
+    #expect(payload?.workflows.map(\.id) == ["demo"])
+  }
+
+  @Test func explicitSelectorsResolveThroughTheTargetResolver() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let handler = WorkflowCommandHandler { fixture.snapshot(focused: false) }
+    let (_, byName) = try await list(handler, target: .worktree("main"))
+    #expect(byName?.worktree?.id == "wt-1")
+    let (_, byPane) = try await list(handler, target: .auto("p1"))
+    #expect(byPane?.worktree?.id == "wt-1")
+    let (missing, _) = try await list(handler, target: .worktree("nope"))
+    #expect(missing.ok == false)
+    #expect(missing.error?.code == CLIErrorCode.targetNotFound)
+  }
+
+  @Test func disabledKeysCombineScopeAndID() {
+    #expect(WorkflowCommandHandler.disabledKey(scope: .repo, id: "review") == "repo/review")
+  }
+
+  @Test func routerStubsWorkflowUntilWired() async {
+    let response = await CLICommandRouter().route(
+      CommandEnvelope(output: .json, command: .workflow(WorkflowInput())))
+    #expect(response.command == "workflow")
+    #expect(response.error?.code == "NOT_IMPLEMENTED")
+  }
+}


### PR DESCRIPTION
## Summary

First R2a slice of Agent Workflows (docs-ai 063, B1). The `prowl.workflow/v1` DSL becomes concrete without anything running yet:

- **Yams-backed parser with positioned diagnostics** (`WorkflowDocumentParser`): unknown keys are errors, plain scalars are typed (`max: 5` vs `max: "5"`), every diagnostic carries a 1-based line/column and a stable code.
- **Validator** for the spec's §7 cross-reference rules (`WorkflowValidator`): roles, launch ordering, duplicate ids, template whitelist with producer-before-consumer for `outputs.*` / `actions.*` / `roles.<r>.pane` / `loop.*`, action input schemas, `repeat.max` bounds, `until` verdict sets, slugs, and the warnings (`skill_unchecked`, `spells_completion_command`, `skip_ends_run`, `timeout_long`, agent-catalog warnings).
- **V1 native action schemas** (`handoff.transition`, `handoff.checkpoint`, `git.context`) and a hand-written **Draft 2020-12 JSON Schema** of a workflow file, checked in as a contract resource and pinned to its Swift copy by a test.
- **Three-source discovery** (bundle < user < repo, `prowl.*` reserved for the bundle) with precedence and shadowing; invalid files never shadow.
- **CLI**: `prowl workflow validate <file> [--scope]` and `prowl workflow schema` run locally with Prowl closed; `prowl workflow list [target]` goes through the socket, resolves the caller's pane → focused worktree → explicit target, and reads a hidden per-definition enabled set (`UserGlobalSettings.disabledWorkflowIDs`, opt-out; the Settings toggle arrives with D1). An invalid file is `WORKFLOW_INVALID` with the full validate payload in `error.details` and exit status 1.
- Contract `prowl.cli.workflow.v1` (`docs-ai/013-prowl-cli/contracts/workflow.md`, `cli-output-schema.json`), `docs/components/cli.md` section and error rows. The `prowl-cli` skill is deliberately untouched until B3 ships the run commands.

Everything lives in `ProwlCLIShared` per the grilled decision (063.006 G2); all new Shared declarations are `nonisolated` because the app target defaults to MainActor isolation. Yams 6.2.2 is pinned exactly in `Package.swift` and the xcodeproj.

## Validation

- `make check`, `make build-cli`, `make test-cli-unit` (194), `make test-cli-smoke`, `make test-cli-integration` (106; four new `workflow` cases: real process for `validate`/`schema`, mock socket for `list`), `make build-app`, full `make test` (2671 passed, 0 failed) incl. `WorkflowCommandHandlerTests` and the router test.
- Live against an isolated Debug instance (scratch home + socket, scratch Git repo, bundled CLI): focused-worktree, by-name, by-pane-UUID and unknown-target resolution; repo/user shadowing; reserved-id and `skill_not_found` against the real bundle; `WORKFLOW_INVALID` with a positioned `yaml_syntax` diagnostic; `schema`; and `prowl send` of `workflow list` into a pane resolving the caller's own pane. Details in `docs-ai/063-agent-workflows/006-b1-definitions.md`.

## Not changed

- No `run`/`status`/`done`/`cancel`, no runner (B2/B3), no Settings page (D1), no bundled definitions or `Resources/workflows` staging (ships with the first built-in).

https://claude.ai/code/session_01YSXSCVNoycSbCmwPMvcCnw
