### PR TITLE
CLI: dispatch a new task into an existing agent pane

### DIFF
--- a/ProwlCLI/Commands/AgentsCommand.swift
+++ b/ProwlCLI/Commands/AgentsCommand.swift
@@ -11,6 +11,7 @@ struct AgentsCommand: ParsableCommand {
       AgentsReadCommand.self,
       AgentsSignalCommand.self,
       AgentsHookCommand.self,
+      AgentsDispatchCommand.self,
       AgentsDispatchCompleteCommand.self,
       AgentsDispatchAbandonCommand.self,
       AgentsWaitCommand.self,

--- a/ProwlCLI/Commands/AgentsDispatchCommand.swift
+++ b/ProwlCLI/Commands/AgentsDispatchCommand.swift
@@ -9,7 +9,7 @@ extension AgentWaitMinimumConfidence: ExpressibleByArgument {}
 struct AgentsDispatchCompleteCommand: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "dispatch-complete",
-    abstract: "Record the terminal outcome for this launched dispatch."
+    abstract: "Record the terminal outcome for this pane's current dispatch."
   )
 
   @Option(name: .long, help: "Terminal outcome: succeeded or failed.")
@@ -35,22 +35,22 @@ struct AgentsDispatchCompleteCommand: ParsableCommand {
   }
 
   func validate() throws {
-    let input = DispatchCompleteInput(dispatchID: "validation", outcome: outcome, summary: summary)
+    let input = DispatchCompleteInput(dispatchID: nil, outcome: outcome, summary: summary)
     if let message = input.validationErrorMessage {
       throw ValidationError(message)
     }
   }
 
+  /// The app resolves the receipt from the caller's process ancestry; a launch-scoped
+  /// `PROWL_DISPATCH_ID` rides along as diagnostics only, so its absence is not an error.
   func makeInput(
     environment: [String: String] = ProcessInfo.processInfo.environment
   ) throws -> DispatchCompleteInput {
-    guard let dispatchID = environment[DispatchCompleteInput.environmentKey] else {
-      throw ExitError(
-        code: CLIErrorCode.dispatchContextRequired,
-        message: "This command requires launch-scoped PROWL_DISPATCH_ID context."
-      )
-    }
-    let input = DispatchCompleteInput(dispatchID: dispatchID, outcome: outcome, summary: summary)
+    let input = DispatchCompleteInput(
+      dispatchID: environment[DispatchCompleteInput.environmentKey],
+      outcome: outcome,
+      summary: summary
+    )
     if let message = input.validationErrorMessage {
       throw ExitError(code: CLIErrorCode.invalidArgument, message: message)
     }

--- a/ProwlCLI/Commands/AgentsDispatchPromptCommand.swift
+++ b/ProwlCLI/Commands/AgentsDispatchPromptCommand.swift
@@ -1,0 +1,84 @@
+import ArgumentParser
+import Foundation
+import ProwlCLIShared
+
+/// `prowl agents dispatch <pane> --prompt -`: assign a new task to an agent that already
+/// runs in a pane and receive a pending dispatch receipt for it.
+struct AgentsDispatchCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "dispatch",
+    abstract: "Dispatch a new prompt into an existing idle agent pane and return its pending receipt."
+  )
+
+  @Argument(help: "Target agent pane handle (pN) or pane UUID from prowl agents.")
+  var pane: String
+
+  @Option(name: .long, help: "Prompt source; the only supported value is '-' for piped stdin.")
+  var prompt: String
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(command: "agents.dispatch", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .agentsDispatch(try makeInput())
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+
+  func validate() throws {
+    guard Self.isExplicitPaneTarget(pane) else {
+      throw ValidationError("agents dispatch requires a pane handle (pN) or pane UUID.")
+    }
+    guard prompt == "-" else {
+      throw ValidationError("--prompt accepts only '-' to read the prompt from stdin.")
+    }
+  }
+
+  func makeInput(
+    stdinIsTerminal: Bool = isatty(fileno(stdin)) != 0,
+    readStdin: () throws -> Data? = { try FileHandle.standardInput.readToEnd() }
+  ) throws -> DispatchInput {
+    guard !stdinIsTerminal else {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "--prompt - requires piped stdin; it cannot read from an interactive terminal."
+      )
+    }
+    guard let data = try? readStdin() else {
+      throw ExitError(code: CLIErrorCode.emptyInput, message: "Failed to read the dispatch prompt from stdin.")
+    }
+    guard data.count <= DispatchInput.maximumPromptUTF8ByteCount else {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "The dispatch prompt exceeds the 256 KiB UTF-8 limit."
+      )
+    }
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw ExitError(code: CLIErrorCode.emptyInput, message: "Failed to read the dispatch prompt as UTF-8.")
+    }
+    // Heredocs end with a newline and Windows-authored files carry CRLF; neither is content.
+    var prompt = text.replacing("\r\n", with: "\n")
+    while prompt.hasSuffix("\n") { prompt.removeLast() }
+    guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw ExitError(code: CLIErrorCode.emptyInput, message: "The dispatch prompt is empty.")
+    }
+    let input = DispatchInput(pane: pane, prompt: prompt)
+    if let message = input.validationErrorMessage {
+      throw ExitError(code: CLIErrorCode.invalidArgument, message: message)
+    }
+    return input
+  }
+
+  private static func isExplicitPaneTarget(_ value: String) -> Bool {
+    if UUID(uuidString: value) != nil { return true }
+    let normalized = value.lowercased()
+    guard normalized.hasPrefix("p") else { return false }
+    let digits = normalized.dropFirst()
+    return !digits.isEmpty
+      && digits.allSatisfy { $0.isASCII && $0.isNumber }
+      && Int(digits).map({ $0 > 0 }) == true
+  }
+}

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -87,6 +87,14 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "agents.dispatch",
+         let data = response.data,
+         let payload = try? data.decode(as: AgentDispatchCommandPayload.self)
+      {
+        print(dispatchText(payload))
+        return
+      }
+
       if response.command == "agents.dispatch-complete",
          let data = response.data,
          let payload = try? data.decode(as: DispatchCompleteCommandPayload.self)
@@ -333,6 +341,14 @@ enum OutputRenderer {
     return "Signaled \(event) for pane \(payload.pane.id)."
   }
 
+  static func dispatchText(_ payload: AgentDispatchCommandPayload) -> String {
+    [
+      "Dispatched \(payload.dispatch.id) (\(payload.dispatch.state.rawValue))",
+      "  pane: \(payload.target.pane.id)",
+      "  created: \(payload.dispatch.createdAt)",
+    ].joined(separator: "\n")
+  }
+
   static func dispatchCompleteText(_ payload: DispatchCompleteCommandPayload) -> String {
     let replayed = payload.replayed ? " (replayed)" : ""
     return [
@@ -370,6 +386,20 @@ enum OutputRenderer {
 
   static func errorText(_ error: CommandError, command: String) -> String {
     var lines = ["error [\(error.code)]: \(error.message)"]
+    if command == "agents.dispatch",
+      let details = try? error.details?.decode(as: AgentDispatchErrorDetails.self)
+    {
+      lines.append("  pane: \(details.target.pane.id)")
+      if let record = details.record {
+        lines.append("  dispatch: \(record.id) (\(record.state.rawValue))")
+      }
+      if let observation = details.observation {
+        lines.append(
+          "  observation: \(observation.status.rawValue) [\(observation.confidence)] via \(observation.source)"
+        )
+      }
+      return lines.joined(separator: "\n")
+    }
     guard command == "agents.wait",
       let details = try? error.details?.decode(as: AgentWaitErrorDetails.self)
     else {

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -20,6 +20,9 @@
       "$ref": "#/$defs/agentsSignalResponse"
     },
     {
+      "$ref": "#/$defs/agentsDispatchResponse"
+    },
+    {
       "$ref": "#/$defs/agentsDispatchCompleteResponse"
     },
     {
@@ -1306,6 +1309,64 @@
         }
       }
     },
+    "agentsDispatchData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "dispatch"
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/target"
+        },
+        "dispatch": {
+          "$ref": "#/$defs/dispatchPendingRecord"
+        }
+      }
+    },
+    "agentsDispatchErrorDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target"
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/target"
+        },
+        "record": {
+          "$ref": "#/$defs/dispatchRecord"
+        },
+        "observation": {
+          "$ref": "#/$defs/agentWaitObservation"
+        },
+        "signals": {
+          "$ref": "#/$defs/agentSignals"
+        }
+      }
+    },
+    "agentsDispatchError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "$ref": "#/$defs/agentsDispatchErrorDetails"
+        }
+      }
+    },
     "agentsDispatchCompleteData": {
       "type": "object",
       "additionalProperties": false,
@@ -2565,6 +2626,58 @@
             },
             "error": {
               "$ref": "#/$defs/error"
+            }
+          }
+        }
+      ]
+    },
+    "agentsDispatchResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "data"
+          ],
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "command": {
+              "const": "agents.dispatch"
+            },
+            "schema_version": {
+              "const": "prowl.cli.agents.dispatch.v1"
+            },
+            "data": {
+              "$ref": "#/$defs/agentsDispatchData"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ok",
+            "command",
+            "schema_version",
+            "error"
+          ],
+          "properties": {
+            "ok": {
+              "const": false
+            },
+            "command": {
+              "const": "agents.dispatch"
+            },
+            "schema_version": {
+              "const": "prowl.cli.agents.dispatch.v1"
+            },
+            "error": {
+              "$ref": "#/$defs/agentsDispatchError"
             }
           }
         }

--- a/ProwlCLITests/AgentsCommandParsingTests.swift
+++ b/ProwlCLITests/AgentsCommandParsingTests.swift
@@ -174,13 +174,18 @@ final class AgentsCommandParsingTests: XCTestCase {
     XCTAssertTrue(command.options.json)
   }
 
-  func testDispatchCompleteRejectsMissingContextInvalidOutcomeAndBoundedSummary() throws {
-    let missingContext = try AgentsDispatchCompleteCommand.parse([
+  func testDispatchCompleteWithoutLaunchContextSendsNoDispatchID() throws {
+    let command = try AgentsDispatchCompleteCommand.parse([
       "--outcome", "failed", "--summary", "SDK unavailable",
     ])
-    XCTAssertThrowsError(try missingContext.makeInput(environment: [:])) {
-      XCTAssertEqual(($0 as? ExitError)?.code, CLIErrorCode.dispatchContextRequired)
-    }
+    let input = try command.makeInput(environment: [:])
+
+    XCTAssertNil(input.dispatchID)
+    XCTAssertEqual(input.outcome, .failed)
+    XCTAssertEqual(input.summary, "SDK unavailable")
+  }
+
+  func testDispatchCompleteRejectsInvalidOutcomeAndBoundedSummary() throws {
     XCTAssertThrowsError(
       try AgentsDispatchCompleteCommand.parse(["--outcome", "cancelled", "--summary", "Nope"])
     )
@@ -194,6 +199,48 @@ final class AgentsCommandParsingTests: XCTestCase {
         "--outcome", "failed", "--summary", String(repeating: "界", count: 10_923),
       ])
     )
+  }
+
+  func testDispatchParsesPaneAndReadsMultilinePromptFromPipedStdin() throws {
+    let command = try AgentsDispatchCommand.parse(["p7", "--prompt", "-", "--json"])
+    let input = try command.makeInput(
+      stdinIsTerminal: false,
+      readStdin: { Data("Round two.\r\nRe-review the diff.\n\n".utf8) }
+    )
+
+    XCTAssertEqual(input.pane, "p7")
+    XCTAssertEqual(input.prompt, "Round two.\nRe-review the diff.")
+    XCTAssertTrue(command.options.json)
+    XCTAssertNil(input.validationErrorMessage)
+    XCTAssertEqual(
+      try AgentsDispatchCommand.parse(["6E1A2A10-D99F-4E3F-920C-D93AA3C05764", "--prompt", "-"]).pane,
+      "6E1A2A10-D99F-4E3F-920C-D93AA3C05764"
+    )
+  }
+
+  func testDispatchRequiresExplicitPaneStdinPromptAndBoundedControlFreeText() throws {
+    XCTAssertThrowsError(try AgentsDispatchCommand.parse(["main", "--prompt", "-"]))
+    XCTAssertThrowsError(try AgentsDispatchCommand.parse(["p7"]))
+    XCTAssertThrowsError(try AgentsDispatchCommand.parse(["p7", "--prompt", "Inline text"]))
+
+    let command = try AgentsDispatchCommand.parse(["p7", "--prompt", "-"])
+    XCTAssertThrowsError(try command.makeInput(stdinIsTerminal: true, readStdin: { Data() })) {
+      XCTAssertEqual(($0 as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
+    XCTAssertThrowsError(try command.makeInput(stdinIsTerminal: false, readStdin: { Data("\n\n".utf8) })) {
+      XCTAssertEqual(($0 as? ExitError)?.code, CLIErrorCode.emptyInput)
+    }
+    XCTAssertThrowsError(try command.makeInput(stdinIsTerminal: false, readStdin: { Data("bell\u{07}".utf8) })) {
+      XCTAssertEqual(($0 as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
+    XCTAssertThrowsError(
+      try command.makeInput(
+        stdinIsTerminal: false,
+        readStdin: { Data(repeating: UInt8(ascii: "x"), count: DispatchInput.maximumPromptUTF8ByteCount + 1) }
+      )
+    ) {
+      XCTAssertEqual(($0 as? ExitError)?.code, CLIErrorCode.invalidArgument)
+    }
   }
 
   func testDispatchAbandonParsesIDAndReasonAndRejectsBoundViolations() throws {

--- a/ProwlCLITests/DispatchOutputRendererTests.swift
+++ b/ProwlCLITests/DispatchOutputRendererTests.swift
@@ -38,6 +38,53 @@ final class DispatchOutputRendererTests: XCTestCase {
     )
   }
 
+  func testDispatchReceiptAndRefusalsRenderDeterministically() throws {
+    let payload = AgentDispatchCommandPayload(
+      target: Self.target,
+      dispatch: DispatchPendingRecord(id: "d2", createdAt: "2026-08-29T02:00:00.000Z")
+    )
+    XCTAssertEqual(
+      OutputRenderer.dispatchText(payload),
+      "Dispatched d2 (pending)\n  pane: pane\n  created: 2026-08-29T02:00:00.000Z"
+    )
+
+    let pending = CommandError(
+      code: "DISPATCH_PENDING",
+      message: "Pending.",
+      details: try RawJSON(
+        encoding: AgentDispatchErrorDetails(
+          target: Self.target,
+          record: .pending(DispatchPendingRecord(id: "d1", createdAt: "2026-08-29T02:00:00.000Z"))
+        ))
+    )
+    XCTAssertEqual(
+      OutputRenderer.errorText(pending, command: "agents.dispatch"),
+      "error [DISPATCH_PENDING]: Pending.\n  pane: pane\n  dispatch: d1 (pending)"
+    )
+
+    let busy = CommandError(
+      code: "DISPATCH_TARGET_BUSY",
+      message: "Busy.",
+      details: try RawJSON(
+        encoding: AgentDispatchErrorDetails(
+          target: Self.target,
+          observation: AgentWaitObservation(
+            status: .working,
+            rawState: "working",
+            source: "detection",
+            confidence: "heuristic",
+            timestamp: "2026-08-29T02:00:00.000Z",
+            revision: 3
+          ),
+          signals: AgentSignalsPayload(channels: [], last: nil, lastBinding: nil)
+        ))
+    )
+    XCTAssertEqual(
+      OutputRenderer.errorText(busy, command: "agents.dispatch"),
+      "error [DISPATCH_TARGET_BUSY]: Busy.\n  pane: pane\n  observation: working [heuristic] via detection"
+    )
+  }
+
   func testWaitSuccessRendersModeProvenanceAndSummary() {
     let payload = AgentWaitCommandPayload.dispatch(
       AgentDispatchWaitPayload(

--- a/ProwlCLITests/DispatchSchemaTests.swift
+++ b/ProwlCLITests/DispatchSchemaTests.swift
@@ -17,6 +17,8 @@ final class DispatchSchemaTests: XCTestCase {
       "dispatchRecord",
       "agentSignals",
       "agentWaitScreen",
+      "agentsDispatchResponse",
+      "agentsDispatchErrorDetails",
       "agentsDispatchCompleteResponse",
       "agentsDispatchAbandonResponse",
       "agentsWaitResponse",
@@ -36,6 +38,32 @@ final class DispatchSchemaTests: XCTestCase {
 
     try assertValid(completion)
     try assertValid(timeout)
+  }
+
+  func testSchemaAcceptsDispatchSuccessAndStructuredRefusalsButNotUnknownDetails() throws {
+    let target =
+      #"{"worktree":{"id":"wt","name":"main","path":"/Projects/Prowl","root_path":"/Projects/Prowl","kind":"git"},"tab":{"id":"tab","title":"Tab","selected":true},"pane":{"id":"pane","title":"Pane","cwd":"/Projects/Prowl","focused":true}}"#
+    let success =
+      #"{"ok":true,"command":"agents.dispatch","schema_version":"prowl.cli.agents.dispatch.v1","data":{"target":"# + target
+      + #","dispatch":{"id":"d2","state":"pending","created_at":"2026-08-29T02:00:00.000Z"}}}"#
+    let pending =
+      #"{"ok":false,"command":"agents.dispatch","schema_version":"prowl.cli.agents.dispatch.v1","error":{"code":"DISPATCH_PENDING","message":"Pending.","details":{"target":"# + target
+      + #","record":{"id":"d1","state":"pending","created_at":"2026-08-29T02:00:00.000Z"}}}}"#
+    let busy =
+      #"{"ok":false,"command":"agents.dispatch","schema_version":"prowl.cli.agents.dispatch.v1","error":{"code":"DISPATCH_TARGET_BUSY","message":"Busy.","details":{"target":"# + target
+      + #","observation":{"status":"working","raw_state":"working","source":"detection","confidence":"heuristic","at":"2026-08-29T02:00:00.000Z","revision":3},"signals":{"channels":[]}}}}"#
+    let unknown =
+      #"{"ok":false,"command":"agents.dispatch","schema_version":"prowl.cli.agents.dispatch.v1","error":{"code":"DISPATCH_PENDING","message":"Pending.","details":{"target":"# + target
+      + #","waited_ms":1}}}"#
+    let extraData =
+      #"{"ok":true,"command":"agents.dispatch","schema_version":"prowl.cli.agents.dispatch.v1","data":{"target":"# + target
+      + #","dispatch":{"id":"d2","state":"pending","created_at":"2026-08-29T02:00:00.000Z"},"delivered":true}}"#
+
+    try assertValid(success)
+    try assertValid(pending)
+    try assertValid(busy)
+    try assertInvalid(unknown)
+    try assertInvalid(extraData)
   }
 
   func testSchemaRejectsCrossVariantFieldsAndUnknownWaitDetails() throws {

--- a/ProwlCLITests/DispatchWireModelTests.swift
+++ b/ProwlCLITests/DispatchWireModelTests.swift
@@ -5,6 +5,7 @@ import XCTest
 final class DispatchWireModelTests: XCTestCase {
   func testDispatchCommandsRoundTripWithStableNames() throws {
     let commands: [Command] = [
+      .agentsDispatch(DispatchInput(pane: "p7", prompt: "Round two.\nRe-review the diff.")),
       .agentsDispatchComplete(
         DispatchCompleteInput(dispatchID: "dispatch-1", outcome: .succeeded, summary: "Done")
       ),
@@ -18,13 +19,36 @@ final class DispatchWireModelTests: XCTestCase {
 
     XCTAssertEqual(
       commands.map(\.name),
-      ["agents.dispatch-complete", "agents.dispatch-abandon", "agents.wait"]
+      ["agents.dispatch", "agents.dispatch-complete", "agents.dispatch-abandon", "agents.wait"]
     )
     for command in commands {
       let data = try JSONEncoder().encode(CommandEnvelope(output: .json, command: command))
       let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
       XCTAssertEqual(decoded.command.name, command.name)
     }
+  }
+
+  func testDispatchCompleteInputCarriesTheLaunchIDOnlyAsOptionalDiagnostics() throws {
+    let withoutID = try JSONEncoder().encode(
+      CommandEnvelope(
+        output: .json,
+        command: .agentsDispatchComplete(DispatchCompleteInput(dispatchID: nil, outcome: .succeeded, summary: "Done"))
+      ))
+    guard case .agentsDispatchComplete(let decoded) = try JSONDecoder().decode(CommandEnvelope.self, from: withoutID).command
+    else {
+      return XCTFail("Expected agents.dispatch-complete")
+    }
+    XCTAssertNil(decoded.dispatchID)
+    XCTAssertNil(decoded.validationErrorMessage)
+
+    let legacy = Data(
+      #"{"output":"json","command":{"agentsDispatchComplete":{"_0":{"dispatch_id":"d1","outcome":"failed","summary":"No"}}}}"#
+        .utf8)
+    guard case .agentsDispatchComplete(let legacyInput) = try JSONDecoder().decode(CommandEnvelope.self, from: legacy).command
+    else {
+      return XCTFail("Expected agents.dispatch-complete")
+    }
+    XCTAssertEqual(legacyInput.dispatchID, "d1")
   }
 
   func testCommandErrorDetailsRoundTripWithoutChangingLegacyErrors() throws {

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -391,6 +391,106 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(rendered["schema_version"] as? String, "prowl.cli.agents.signal.v1")
   }
 
+  func testDispatchRoundTripsOverSocketWithStdinPrompt() throws {
+    let socketPath = temporarySocketPath(suffix: "dispatch")
+    let response = try CommandResponse(
+      ok: true,
+      command: "agents.dispatch",
+      schemaVersion: "prowl.cli.agents.dispatch.v1",
+      data: RawJSON(
+        encoding: AgentDispatchCommandPayload(
+          target: makeTabTarget(),
+          dispatch: DispatchPendingRecord(id: "dispatch-2", createdAt: "2026-08-29T04:00:00.000Z")
+        )
+      )
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents", "dispatch", "p7", "--prompt", "-", "--json"],
+      stdinData: Data("Round two.\nRe-review the diff against main.\n".utf8)
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    guard case .agentsDispatch(let input) = envelope.command else {
+      return XCTFail("Expected agents.dispatch command envelope")
+    }
+    XCTAssertEqual(input.pane, "p7")
+    XCTAssertEqual(input.prompt, "Round two.\nRe-review the diff against main.")
+    let rendered = try jsonObject(from: result.stdout)
+    let data = try XCTUnwrap(rendered["data"] as? [String: Any])
+    let dispatch = try XCTUnwrap(data["dispatch"] as? [String: Any])
+    XCTAssertEqual(dispatch["id"] as? String, "dispatch-2")
+    XCTAssertEqual(dispatch["state"] as? String, "pending")
+  }
+
+  func testDispatchRefusalRendersGovernedDetails() throws {
+    let socketPath = temporarySocketPath(suffix: "dispatch-pending")
+    let response = CommandResponse(
+      ok: false,
+      command: "agents.dispatch",
+      schemaVersion: "prowl.cli.agents.dispatch.v1",
+      error: CommandError(
+        code: CLIErrorCode.dispatchPending,
+        message: "Pending.",
+        details: try RawJSON(
+          encoding: AgentDispatchErrorDetails(
+            target: makeTabTarget(),
+            record: .pending(DispatchPendingRecord(id: "dispatch-1", createdAt: "2026-08-29T04:00:00.000Z"))
+          ))
+      )
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents", "dispatch", "p7", "--prompt", "-"],
+      stdinData: Data("Round two.\n".utf8)
+    )
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    XCTAssertTrue(result.stderr.contains("error [DISPATCH_PENDING]: Pending."))
+    XCTAssertTrue(result.stderr.contains("dispatch: dispatch-1 (pending)"))
+  }
+
+  func testDispatchCompleteRoundTripsOverSocketWithoutLaunchContext() throws {
+    let socketPath = temporarySocketPath(suffix: "dispatch-complete-no-env")
+    let response = try CommandResponse(
+      ok: true,
+      command: "agents.dispatch-complete",
+      schemaVersion: "prowl.cli.agents.dispatch-complete.v1",
+      data: RawJSON(
+        encoding: DispatchCompleteCommandPayload(
+          target: makeTabTarget(),
+          receipt: DispatchCompletedRecord(
+            id: "dispatch-complete-2",
+            outcome: .failed,
+            summary: "Blocked",
+            createdAt: "2026-08-29T04:00:00.000Z",
+            completedAt: "2026-08-29T04:01:00.000Z"
+          ),
+          replayed: false
+        )
+      )
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents", "dispatch-complete", "--outcome", "failed", "--summary", "Blocked", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    guard case .agentsDispatchComplete(let input) = envelope.command else {
+      return XCTFail("Expected agents.dispatch-complete command envelope")
+    }
+    XCTAssertNil(input.dispatchID)
+    XCTAssertEqual(input.outcome, .failed)
+  }
+
   func testDispatchCompleteRoundTripsOverSocket() throws {
     let socketPath = temporarySocketPath(suffix: "dispatch-complete")
     let response = try CommandResponse(

--- a/docs-ai/013-prowl-cli/contracts/agents-wait.md
+++ b/docs-ai/013-prowl-cli/contracts/agents-wait.md
@@ -4,27 +4,76 @@
 
 Current versions:
 
+- `prowl.cli.agents.dispatch.v1`
 - `prowl.cli.agents.dispatch-complete.v1`
 - `prowl.cli.agents.dispatch-abandon.v1`
 - `prowl.cli.agents.wait.v1`
 
 ## Exact dispatch completion
 
-Every prompted `create tab|pane --profile … --prompt -` returns a pending dispatch. The
-launched child receives its id through `PROWL_DISPATCH_ID`; callers cannot supply an id to
-completion manually.
+Every prompted `create tab|pane --profile … --prompt -` returns a pending dispatch, and
+`agents dispatch` (below) returns one for an agent already running in a pane. Callers cannot
+supply an id to completion manually.
 
 ```bash
 prowl agents dispatch-complete --outcome succeeded|failed --summary <text> [--json]
 ```
 
 `--summary` is required, control-free, and limited to 32768 UTF-8 bytes. The app resolves the
-socket peer ancestry and requires the caller to belong to the dispatch-bound surface.
-Completion is first-write-wins: an identical retry replays the receipt, while a conflicting
-outcome or summary fails. `turn-ended` is observation only and never becomes success.
+socket peer ancestry to the caller's pane and completes that pane's current pending record;
+with no pending record it addresses the pane's most recently issued record so an identical
+retry replays its receipt and a conflicting one fails. A caller outside any pane fails with
+`DISPATCH_CONTEXT_REQUIRED`; a pane that never held a dispatch fails with
+`DISPATCH_NOT_FOUND`. The launch child still receives `PROWL_DISPATCH_ID`, and the CLI
+forwards it when present, but it is compatibility diagnostics only: a process launched with an
+older id completes the pane's current record. Completion is first-write-wins. `turn-ended` is
+observation only and never becomes success.
 
 Success returns `target`, completed `receipt`, and `replayed`. The immutable receipt contains
 `id`, `state=completed`, `outcome`, `summary`, `created_at`, and `completed_at`.
+
+## Re-dispatch into an existing pane
+
+```bash
+prowl agents dispatch <pN|pane-uuid> --prompt - [--json]
+```
+
+The pane is resolved once to the immutable target snapshot. `--prompt` accepts only `-` and
+reads piped UTF-8 stdin up to 256 KiB; an interactive terminal is rejected. CRLF is
+normalized and trailing newlines are dropped by the CLI; the app rejects an empty prompt or
+any control character other than newline and tab with `INVALID_ARGUMENT`, because the text is
+delivered through the pane's input path (one bracketed paste — `ghostty_surface_text` goes
+through Ghostty's paste encoder, so newlines survive as one message in Claude Code and Codex —
+followed by Enter) where other control bytes are stripped or reinterpreted.
+
+Checks run in this order, before any text is typed:
+
+1. `DISPATCH_PENDING` when the pane already holds a pending record; `error.details.record`
+   carries it. The existing record is never overwritten — complete, abandon, or lose it first.
+2. `AGENT_NOT_FOUND` when the pane hosts no detected agent (no appearance grace: the command
+   targets an agent that already exists); `AGENT_GONE` when the surface is closed.
+3. `DISPATCH_TARGET_BUSY` unless the agent is idle by the arm-time rules of
+   `agents wait --until idle` under `auto`: an exact `turn-ended` level counts only with detector
+   corroboration (idle/done); a detector-only idle view counts after two seconds unchanged, and
+   only where the wait would fall back to the detector (no covering `verified_live` channel, or
+   one holding no terminal level). Idle by one source alone — a `turn-ended` the detector has
+   not corroborated yet (its working hold after a turn), or a detector view still stabilizing —
+   is not a refusal: the precondition polls every 200 ms for up to five seconds, as the wait
+   would, and refuses only when the budget expires. A working or blocked detector state without
+   such evidence, or a runtime `needs-input` level, refuses immediately.
+   `error.details.observation` and `signals` carry the evidence.
+
+Then one main-actor step issues the record and binds it to the pane's *current* evidence
+epoch — never a new one, so the generation that will report the receipt is the one already
+proven for the pane — and the rendered text (`[Prowl] ` + prompt + the versioned completion
+protocol) is inserted and submitted. A delivery failure cancels the issuance. Success returns
+`target` and the pending `dispatch` record with the `create` shape; the id never appears in the
+typed text.
+
+Every later rule is unchanged: `agents wait --dispatch`, `dispatch-abandon`,
+`DISPATCH_NEEDS_INPUT`, `DISPATCH_INCOMPLETE`, `AGENT_GONE`, capacity, and eviction apply to the
+new record exactly as to a launch record. One pending record per surface is enforced by the
+store on binding (`surfacePending`), so a launch and a re-dispatch can never race for one pane.
 
 ## Explicit abandonment
 

--- a/docs-ai/013-prowl-cli/contracts/agents.md
+++ b/docs-ai/013-prowl-cli/contracts/agents.md
@@ -19,7 +19,8 @@ create roster rows. Text output additionally shows a current-process `pN` handle
 Use `prowl agents read <pN|pane-uuid>` for a semantic agent snapshot. A process inside
 a Prowl pane can report cooperative runtime events with `prowl agents signal`; these
 commands have separate [read](agents-read.md) and [signal](agents-signal.md) contracts.
-Condition and exact-receipt waiting is specified by [agents-wait](agents-wait.md).
+Condition and exact-receipt waiting, and re-dispatching a new task into an existing agent
+pane with `prowl agents dispatch`, are specified by [agents-wait](agents-wait.md).
 The complete roster response schema is
 `#/$defs/agentsResponse` in
 [`schema-bundle.json`](../../../ProwlCLIContracts/Resources/cli-output-schema.json).

--- a/docs-ai/013-prowl-cli/contracts/input.md
+++ b/docs-ai/013-prowl-cli/contracts/input.md
@@ -9,7 +9,7 @@ and the executable [schema bundle](schema.md).
 ```text
 prowl [path]
 prowl open [path]
-prowl list | agents [read|signal] | profiles | skills | focus | read | send | key | handoff | create | close
+prowl list | agents [read|signal|dispatch|dispatch-complete|dispatch-abandon|wait] | profiles | skills | focus | read | send | key | handoff | create | close
 ```
 
 Bare path forms (`/`, `./`, `../`, `~/`, `file://`, `.`, `..`) enter `open`.
@@ -85,10 +85,27 @@ Session/origin are at most 256 UTF-8 bytes and detail is at most 32768. All are 
 and control-free when present. Parser and handler enforce the same shared validation.
 See [agents-signal.md](agents-signal.md).
 
+## Agent dispatch grammar
+
+```bash
+prowl agents dispatch <pN|pane-uuid> --prompt -
+prowl agents dispatch-complete --outcome <succeeded|failed> --summary <text>
+prowl agents dispatch-abandon --dispatch <id> --reason <text>
+prowl agents wait --dispatch <id> [--timeout <1...600>] [--include-screen <1...200>]
+prowl agents wait <pN|pane-uuid> --until <idle|blocked|changed|exit> [--timeout <1...600>]
+                  [--min-confidence <auto|exact|high|heuristic>] [--include-screen <1...200>]
+```
+
+`agents dispatch` requires a pane-only target and `--prompt -`: the prompt is piped UTF-8
+stdin up to 256 KiB, CRLF-normalized, trailing newlines dropped, non-empty, and free of
+control characters other than newline and tab. `dispatch-complete` takes no id; it forwards
+a launch-scoped `PROWL_DISPATCH_ID` only when present. See [agents-wait.md](agents-wait.md).
+
 ## Command-specific exceptions
 
 - `agents read <pN|pane-uuid>` is a pane-only semantic snapshot, no selectors or
   focus fallback.
+- `agents dispatch <pN|pane-uuid>` is pane-only as well; it never falls back to focus.
 - `agents signal` accepts no selector. Its source is the caller pane resolved from the
   socket peer process ancestry, never UI focus or `PROWL_PANE_ID`.
 - `handoff` defaults to the calling pane, not UI focus.

--- a/docs-ai/013-prowl-cli/contracts/schema.md
+++ b/docs-ai/013-prowl-cli/contracts/schema.md
@@ -16,6 +16,10 @@ The bundle has one versioned success-or-error response schema for every wire com
 | `agents` | `#/$defs/agentsResponse` |
 | `agents.read` | `#/$defs/agentsReadResponse` |
 | `agents.signal` | `#/$defs/agentsSignalResponse` |
+| `agents.dispatch` | `#/$defs/agentsDispatchResponse` (errors may carry `#/$defs/agentsDispatchErrorDetails`) |
+| `agents.dispatch-complete` | `#/$defs/agentsDispatchCompleteResponse` |
+| `agents.dispatch-abandon` | `#/$defs/agentsDispatchAbandonResponse` |
+| `agents.wait` | `#/$defs/agentsWaitResponse` (errors may carry `#/$defs/agentsWaitErrorDetails`) |
 | `profiles` | `#/$defs/profilesResponse` |
 | `skills` (local-only) | `#/$defs/skillsResponse` |
 | `focus` | `#/$defs/focusResponse` |

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -246,6 +246,11 @@ opencode; partial for qodercli/qwen/amp; docs/bundle for the rest). Key conclusi
 
 ## Amendments
 
+- Updated 2026-08-29 (#733 re-dispatch): `prowl agents dispatch <pane> --prompt -` creates a
+  new pending record for an agent already running in a pane (one pending record per surface,
+  idle precondition shared with `agents wait --until idle`, delivery measured as one bracketed
+  paste), and `dispatch-complete` resolves the record from the caller pane instead of
+  `PROWL_DISPATCH_ID` — see [014-re-dispatch.md](014-re-dispatch.md).
 - Updated 2026-08-29 (063 B1 kickoff): 063's `expect` activations are records in this entry's
   dispatch store (`launch` via the S2 prompted-launch path, `message` via #733's re-dispatch),
   and S5's watchdog part ships with 063-B2 instead of D2. #733 therefore lands before 063-B3.

--- a/docs-ai/064-agent-completion-signals/014-re-dispatch.md
+++ b/docs-ai/064-agent-completion-signals/014-re-dispatch.md
@@ -1,0 +1,112 @@
+# 064.014 — Re-dispatch Into an Existing Pane: Plan and Action
+
+## Status
+
+Implemented from `feat/agent-redispatch` for [#733](https://github.com/onevcat/Prowl/issues/733)
+(R2a in the shared [release plan](../063-agent-workflows/release-plan.md)). Amends S2
+([003](003-s2-dispatch-wait-design.md)) and the evidence rules of [012](012-cli-evidence-semantics.md) /
+[013](013-idle-evidence-fallback.md); the 063 workflow runner consumes the store primitive
+introduced here for `message` steps ([dsl-spec §5](../063-agent-workflows/dsl-spec.md)).
+
+## Trigger
+
+A coordinator running several review rounds against one reviewer had to choose between a
+plain `send` (context kept, no receipt — "asked a question" looks like "finished") and a fresh
+Profile launch per round (exact receipt, context lost, every round re-reads the diff and is
+exposed to startup failures again). The #732 loop launched three Profiles for that reason;
+063's `prowl.adversarial-review` wants one interactive reviewer that is re-dispatched until
+its verdict is clean.
+
+Before this change a dispatch record existed only for a prompted Profile launch: the id rode
+the child-only `PROWL_DISPATCH_ID`, `dispatch-complete` read it back from the environment, and
+a pane therefore had at most one dispatch for its whole lifetime.
+
+## Decisions
+
+| # | Decision | Alternatives rejected |
+| --- | --- | --- |
+| D1 | `prowl agents dispatch <pane> --prompt -` creates a new pending record bound to the existing surface and delivers `[Prowl] ` + prompt + the same versioned completion protocol a launch appends, through the pane's input path (`insertCommittedText` + `submitLine`, the `send` path). The response has the `create` shape (`target`, `dispatch.{id,state,created_at}`). | A `--dispatch` flag on `send` (would make an ordinary send grow receipt semantics); a compact single-line protocol suffix (unnecessary once delivery was measured, and would diverge from the launch prompt agents already recognize). |
+| D2 | Multi-line prompts are accepted. Measured: `ghostty_surface_text` routes through `Surface.completeClipboardPaste` → `input.paste.encode`, which wraps the text in bracketed paste (`\x1b[200~ … \x1b[201~`) whenever the TUI has mode 2004 on and otherwise rewrites `\n` as `\r`; a three-line `prowl send` reached both Claude Code 2.1.251 and Codex 0.149.1 as one message (each replied `RECEIVED 3 lines`). The CLI normalizes CRLF and drops trailing newlines; the app rejects any control character other than newline and tab (ESC and the C0 bytes the paste encoder strips to spaces) with `INVALID_ARGUMENT`. Cap 256 KiB, as for `create --prompt`. | Requiring a single line (the fallback the issue anticipated if delivery had split the text). |
+| D3 | `dispatch-complete` resolves the record from the caller's process ancestry → pane → that pane's current pending record; with no pending record it addresses the pane's most recently issued record so an identical retry still replays and a conflicting one still fails. `PROWL_DISPATCH_ID` stays launch-scoped, the CLI forwards it when present, the app only logs it when it differs. `DispatchCompleteInput.dispatch_id` became optional (an old CLI still sends it; a new CLI without the variable no longer fails client-side with `DISPATCH_CONTEXT_REQUIRED`). | Requiring the id to match the current record (would break a launched worker after its first re-dispatch, contradicting the issue); a public `--dispatch` on completion (breaks the "no public id" trust model). |
+| D4 | One pending record per surface, enforced in the store: `bind` throws `surfacePending` when the surface already holds a pending record (self-rebinding stays idempotent), `pendingSnapshot(surfaceID:)` answers the handler, and the manager checks before issuing so no slot is consumed. A second `dispatch` fails with `DISPATCH_PENDING` carrying the pending record; nothing is typed. | Checking only in the handler (the launch and re-dispatch paths would still be able to race for one pane); superseding the previous record (would silently abandon a running assignment). |
+| D5 | The idle precondition reuses the wait handler's evidence rules instead of a new heuristic. The pure evaluation (`exactMatch`, `detectorReports`, `allowsHeuristic`, `heuristicMatches`, the two-second `HeuristicStabilizer`, `normalizedState`) moved from `AgentWaitCommandHandler` into `AgentConditionEvidence`, and `agents dispatch` evaluates the arm-time `--until idle` decision under `auto`: a `turn-ended` level counts only with detector corroboration (every level is pre-arm at dispatch time), a detector-only idle view must stay unchanged for two seconds and only where the wait would fall back to the detector. Idle by one source alone is not yet a refusal — the wait would keep polling — so the precondition polls for up to five seconds (`idleGraceMilliseconds`, covering the detector's three-second working hold after a turn and the two-second stabilization) and only then refuses; working or blocked without such evidence, or a runtime `needs-input` the screen does not show, is `DISPATCH_TARGET_BUSY` immediately, with the observation and signals in `error.details`. `AGENT_NOT_FOUND` has no appearance grace: the command targets an agent that already exists. | Blocking until idle with a `--timeout` (the issue asks for a refusal, and a coordinator that wants to wait has `agents wait --until idle`); accepting the detector's idle view without stabilization (a transient screen would let text merge into a running turn); refusing an uncorroborated `turn-ended` immediately (the first live run did: `--until idle` resolved on the fresh hook signal while the detector still held `working`, and the dispatch issued in the same second was refused — the recipe's two commands must work back to back). |
+| D6 | The record binds to the pane's *current* evidence epoch (after reconciling the detector's process generation), never to a new one: the generation that will report the receipt is the one already proven for the pane, so its managed-hook and cooperative signals keep counting. A pane without an epoch record cannot be dispatched to (`DISPATCH_FAILED`). | Calling `beginDispatchEpoch` as the launch path does (its ten-second first-generation window would reject the long-running agent and silence its `verified_live` channel). |
+| D7 | Wire additions: `Command.agentsDispatch(DispatchInput{pane,prompt})` → `agents.dispatch`, response `prowl.cli.agents.dispatch.v1` (`AgentDispatchCommandPayload`), governed `AgentDispatchErrorDetails{target,record?,observation?,signals?}` behind `agentsDispatchError`, and the new codes `DISPATCH_PENDING` / `DISPATCH_TARGET_BUSY`. Text mode renders the pending id and refusal evidence. | Reusing the condition-mode wait error details (their `mode`/`condition` fields would lie). |
+
+## Delivered behavior
+
+- `AgentDispatchStore`: `pendingSnapshot(surfaceID:)`, `complete(surfaceID:outcome:summary:)`
+  (pending → latest → `notFound`), and the `surfacePending` guard on `bind`.
+- `WorktreeTerminalManager`: `issueAgentDispatch(boundTo:)` (issue + bind to the current epoch
+  in one main-actor step, rolling back the issuance on a bind failure),
+  `pendingAgentDispatchSnapshot(surfaceID:)`, `completeAgentDispatch(surfaceID:…)`; the four
+  copies of the evidence-epoch refresh collapsed into `refreshEvidenceEpoch(surfaceID:)`.
+- `AgentConditionEvidence` (new) holds the shared condition rules; `AgentWaitCommandHandler`
+  keeps its behavior and tests through `typealias ConditionSnapshot = AgentConditionSnapshot`.
+- `AgentDispatchCommandHandler` (new): validate → resolve pane → `DISPATCH_PENDING` →
+  `AGENT_GONE` / `AGENT_NOT_FOUND` → idle verdict (`DISPATCH_TARGET_BUSY`) → issue+bind
+  (`DISPATCH_CAPACITY_EXCEEDED`, `DISPATCH_PENDING` on a race, `DISPATCH_FAILED`) → deliver
+  (`DISPATCH_FAILED` cancels the issuance) → `target` + pending `dispatch`.
+  `AgentDispatchCompleteCommandHandler` now completes by caller surface.
+- `AgentDispatchPrompt.renderInjected(userPrompt:)` = `[Prowl] ` + the launch rendering.
+- CLI: `prowl agents dispatch <pN|uuid> --prompt -` (`AgentsDispatchPromptCommand.swift`),
+  `dispatch-complete` without a required environment id, text renderers, the executable
+  schema (`agentsDispatchResponse`, `agentsDispatchErrorDetails`), and the mock-socket
+  integration fixtures.
+- Docs: `docs/components/cli.md`, the contract pages (`agents-wait.md`, `input.md`,
+  `schema.md`, `agents.md`), and the `prowl-cli` skill's "reuse one reviewer across rounds"
+  recipe with the `--until idle` step between rounds.
+
+## Verification
+
+- Store, handler, evidence, lifecycle, signal, and hook-carrier suites via `xcodebuild test`;
+  CLI parsing, wire-model, schema, renderer, and socket round-trip tests via SwiftPM; `make
+  check`, `make build-cli`, `make test-cli-unit`, `make test-cli-smoke`,
+  `make test-cli-integration`, `make build-app` (results in the PR).
+- Delivery measurement (D2) against the baseline Debug build in an isolated instance
+  (`CFFIXED_USER_HOME` scratch home, `PROWL_CLI_SOCKET=/tmp/redispatch.sock`): unprompted
+  "Claude Code" and "Codex" Profiles, `printf '%s\n' <three lines> | prowl send --pane … --no-wait`;
+  both TUIs echoed the three lines as one composer entry and answered `RECEIVED 3 lines`.
+- Live end-to-end against the branch's Debug build in the same isolated instance, with the
+  "Claude Code" (2.1.251) and "Codex" (0.149.1) Profiles and the branch's CLI on the
+  agents' `PATH` (full transcript in the PR):
+  - `create tab --profile … --prompt -` → `wait --dispatch` succeeded (Claude Code 5 s;
+    Codex first returned `DISPATCH_INCOMPLETE` — see below — and the re-armed wait returned
+    the receipt).
+  - `wait --until idle` (exact `hook_claude` / `hook_codex`) → `agents dispatch <pane> --prompt -`
+    → pending record → a second `dispatch` in the same second refused `DISPATCH_PENDING` with
+    the record in `error.details` → `wait --dispatch` succeeded in 2.7 s / 4.0 s with
+    summaries that reference round 1 ("previous round was ROUND 1"), i.e. the same session
+    completed the new record although its process was launched with the round-1
+    `PROWL_DISPATCH_ID`. The pane shows the `[Prowl] ` prefixed prompt and protocol as one
+    composer entry.
+  - A plain `send` that keeps the agent busy (`sleep 20`) → `dispatch` refused
+    `DISPATCH_TARGET_BUSY` (`observation.status: working`) for both runtimes → `wait --until
+    idle` resolved on the fresh hook `turn-ended` while the detector still held `working` →
+    the dispatch issued in the same second settled within the grace (record created 3 s after
+    the wait resolved) → round 3 asked for `--outcome failed` → `wait --dispatch` returned
+    `DISPATCH_FAILED` with the failed receipt, for both runtimes.
+  - `dispatch-complete` from the coordinator's own shell (outside any pane) →
+    `DISPATCH_CONTEXT_REQUIRED`; from a plain shell pane that never held a dispatch →
+    `DISPATCH_NOT_FOUND`.
+
+## Observed but not changed
+
+- Codex emitted a `turn-ended` before running the completion command on its first prompted
+  turn (the "usage limit reset available" notice preceded the tool call), so the first
+  `wait --dispatch` returned `DISPATCH_INCOMPLETE` and a re-armed wait returned the receipt
+  twelve seconds after issuance — the S2 incomplete → re-arm flow, unchanged.
+- A re-dispatch into a manually launched agent (no `verified_live` channel) takes the
+  two-second detector stabilization every time; documented, and the exact path resolves at once
+  once the agent has reported `turn-ended` cooperatively.
+- `agents dispatch` types into the pane but never focuses it, so a background reviewer stays
+  in the background; a person typing into that pane at the same moment would interleave, as
+  with `send`.
+- Build hygiene: the first incremental Debug build of this branch on top of a `main` build
+  crashed (`EXC_BAD_ACCESS` in `swift_release` while a completed `send --capture` route task
+  released its `CommandEnvelope`). `CLISocketServer.o` had not been recompiled after `Command`
+  gained the `agentsDispatch` case, so its stale outlined destroy of `Command` released the
+  new `.send` payload with the old `.key` layout. A clean build (`xcodebuild clean` +
+  `make build-app`) does not reproduce it and the test bundle, compiled fresh, never did.
+  Reviewers building this branch incrementally on top of an older DerivedData should clean
+  first.

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -4,7 +4,7 @@
 > an agent) can list panes, read their screens, run commands and capture output,
 > send keystrokes, focus, and open/close tabs and panes programmatically.
 
-**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl agents read, prowl agents signal, prowl profiles list, prowl skills, skills install, agent skills, prowl read, prowl send, prowl key, prowl focus, prowl create, prowl close, prowl open, prowl handoff, pane id, agent, profile, automation, json, capture, socket
+**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl agents read, prowl agents signal, prowl agents dispatch, prowl agents wait, prowl profiles list, prowl skills, skills install, agent skills, prowl read, prowl send, prowl key, prowl focus, prowl create, prowl close, prowl open, prowl handoff, pane id, agent, profile, automation, json, capture, socket
 
 **Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
 
@@ -288,11 +288,46 @@ prowl agents dispatch-complete --outcome failed --summary "Blocked by an invalid
 ```
 
 The required summary must be one non-empty line with no control characters and at most 32 KiB
-of UTF-8. The command accepts no public dispatch id; outside a prompted launch it fails with
-`DISPATCH_CONTEXT_REQUIRED`. Prowl reads the launch-scoped environment value and independently
-verifies the socket caller's process ancestry against the immutable launch pane. Repeating
-identical completion is safe; a conflicting retry is rejected. Unprompted Profile launches
-remain interactive and do not create a dispatch.
+of UTF-8. The command accepts no public dispatch id: Prowl resolves the socket caller's
+process ancestry to its pane and completes *that pane's current pending dispatch*, so a
+worker completes whatever it was most recently assigned even when it was launched with an
+older `PROWL_DISPATCH_ID` (the variable is kept for the launch case as diagnostics only).
+Outside any Prowl pane the command fails with `DISPATCH_CONTEXT_REQUIRED`; in a pane that
+never held a dispatch it fails with `DISPATCH_NOT_FOUND`. Repeating an identical completion
+replays the receipt; a conflicting retry is rejected. Unprompted Profile launches remain
+interactive and do not create a dispatch.
+
+A pane keeps its agent between assignments. To hand a *new* task to an agent that is already
+running — a reviewer that should keep its context across rounds — dispatch into the pane
+instead of launching another Profile:
+
+```bash
+prowl agents dispatch p7 --prompt - --json <<'EOF'
+Round 2: re-review the diff against main. Report only findings not already fixed.
+EOF
+```
+
+`--prompt -` reads the prompt from piped stdin (up to 256 KiB of UTF-8; newlines and tabs are
+allowed, other control characters are rejected with `INVALID_ARGUMENT`). Prowl creates a new
+pending `data.dispatch` bound to the pane and its current agent generation, then types the
+prompt plus the same completion protocol a launch appends — as one bracketed paste followed by
+Enter, prefixed with `[Prowl] ` so the origin is visible — through the pane's input path.
+The response carries `data.target` and `data.dispatch.{id,state,created_at}` exactly like a
+prompted `create`, and every wait, receipt, abandon, needs-input, incomplete, and gone rule
+below applies to the new record unchanged.
+
+Preconditions are checked before anything is typed: the pane must host a detected agent
+(`AGENT_NOT_FOUND` otherwise) that is idle by the same evidence rules as
+`agents wait --until idle` — a `turn-ended` the detector corroborates resolves at once; a
+`turn-ended` the screen has not caught up with yet (the detector holds `working` for a few
+seconds after a turn) or a detector-only idle view that still needs its two seconds of
+stability is given up to five seconds to settle; a working or blocked agent without such
+evidence (including a runtime `needs-input` the screen does not show) is refused with
+`DISPATCH_TARGET_BUSY` rather than having text merged into its running turn. One pending
+dispatch per pane: while a record is pending, a second `dispatch` fails with
+`DISPATCH_PENDING` and never overwrites it; complete, abandon, or lose the previous record
+first. Because a receipt can precede Codex's own `turn-ended` by a second or two, wait for
+`--until idle` between rounds before dispatching again.
 
 The coordinator waits by exact id:
 
@@ -717,9 +752,11 @@ artifacts and terminal excerpts do not appear in `git status`.
 | `TARGET_NOT_UNIQUE` | Selector matched several — be more specific (use `--pane`). |
 | `PROFILE_NOT_FOUND` | No enabled Profile matches the UUID or exact name — re-run `profiles list`; disabled Profiles cannot launch. |
 | `PROFILE_NOT_UNIQUE` | Several enabled Profiles have the exact name — use the Profile UUID from `profiles list`. |
-| `AGENT_NOT_FOUND` / `AGENT_UNSUPPORTED` | `agents read` target no longer hosts an agent, or it is not Codex/Claude Code; `agents wait <pane> --until …` saw no detected agent within its ten-second appearance grace. Re-run `agents`. |
-| `DISPATCH_NOT_FOUND` | No dispatch record matches `--dispatch`; records are memory-only and reset on app restart. |
-| `DISPATCH_CONTEXT_REQUIRED` | `dispatch-complete` ran outside a prompted Profile launch (no launch-scoped `PROWL_DISPATCH_ID`). |
+| `AGENT_NOT_FOUND` / `AGENT_UNSUPPORTED` | `agents read` target no longer hosts an agent, or it is not Codex/Claude Code; `agents wait <pane> --until …` saw no detected agent within its ten-second appearance grace; `agents dispatch` targeted a pane with no detected agent. Re-run `agents`. |
+| `DISPATCH_NOT_FOUND` | No dispatch record matches `--dispatch`, or `dispatch-complete` ran in a pane that never held one; records are memory-only and reset on app restart. |
+| `DISPATCH_CONTEXT_REQUIRED` | `dispatch-complete` ran from a process outside any Prowl pane (tmux/detached wrapper, another terminal), so no pane could own the receipt. |
+| `DISPATCH_PENDING` | `agents dispatch` refused: the pane already holds a pending dispatch (`.error.details.record`). Wait for it, or `dispatch-abandon` it, before dispatching again. |
+| `DISPATCH_TARGET_BUSY` | `agents dispatch` refused: the pane's agent is working or blocked (`.error.details.observation`, `.signals`). Wait for `--until idle`, then retry. |
 | `DISPATCH_ALREADY_TERMINAL` | `dispatch-abandon` targeted a record that already completed, was abandoned, or is gone. |
 | `DISPATCH_FAILED` / `DISPATCH_ABANDONED` / `DISPATCH_NEEDS_INPUT` / `DISPATCH_INCOMPLETE` | `agents wait --dispatch` structured outcomes; `.error.details` retains the record, target, and evidence (see **Dispatch completion and waiting**). |
 | `SOURCE_REQUIRED` | A caller-owned command such as `agents signal` or selector-free `handoff` could not map the socket peer ancestry to a Prowl pane. Run it inside the source pane without tmux/detached wrappers, or use an explicit selector where that command permits one. |
@@ -781,6 +818,8 @@ fi
   latency, and text typed into a runtime that is still starting can merge with the next message.
 - `--until idle|blocked` report the current state (a pre-existing signal needs the detector to
   agree); use `--until changed` to wait for the next turn edge.
+- To give a running agent another task with a receipt, use `agents dispatch <pane> --prompt -`
+  once it is idle — not `send` (no receipt) and not a fresh Profile launch (loses its context).
 - `agents read` returns `pending` while the agent works or is blocked, even if a previous turn
   completed.
 - `--capture` needs shell integration; otherwise `read --wait-stable` or file

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -116,6 +116,40 @@ own `turn-ended`, so `prowl agents` / `agents read` right after a receipt can st
 `working` / `pending`; if the next action sends another prompt to the same pane, wait for an
 idle condition or read a stable screen first.
 
+Reuse one reviewer across rounds instead of launching a fresh Profile per round: launch once,
+then hand each later round to the same pane with `agents dispatch`, which keeps the reviewer's
+context and still returns an exact receipt per round.
+
+```bash
+launch="$(prowl create pane "$PROWL_PANE_ID" --direction right --profile Reviewer --prompt - --json <<'EOF'
+Round 1: review the current branch against main. Write findings to /tmp/review-1.md.
+EOF
+)"
+pane="$(printf '%s\n' "$launch" | jq -r '.data.target.pane.id')"
+dispatch="$(printf '%s\n' "$launch" | jq -r '.data.dispatch.id')"
+prowl agents wait --dispatch "$dispatch" --json | jq -r '.data.receipt.summary'
+# … fix the findings, then:
+prowl agents wait "$pane" --until idle --timeout 30 --json >/dev/null
+round="$(prowl agents dispatch "$pane" --prompt - --json <<'EOF'
+Round 2: re-review the diff against main. Report only findings not already fixed; write them to /tmp/review-2.md.
+EOF
+)"
+dispatch="$(printf '%s\n' "$round" | jq -r '.data.dispatch.id')"
+prowl agents wait --dispatch "$dispatch" --json | jq -r '.data.receipt.summary'
+```
+
+`agents dispatch` needs a pane whose detected agent is idle: it applies the same evidence
+rules as `--until idle` (a corroborated `turn-ended` resolves at once; a detector-only idle
+view must hold for two seconds) and refuses a working or blocked agent with
+`DISPATCH_TARGET_BUSY` instead of merging text into the running turn — hence the `--until idle`
+between rounds, which also covers Codex's late `turn-ended`. When that wait resolved on a fresh
+runtime `turn-ended` a moment before the screen caught up, the dispatch waits up to five
+seconds for the screen to agree before refusing, so the two commands work back to back. A pane
+holds at most one pending dispatch: a second `dispatch` fails with `DISPATCH_PENDING` (the
+record is in `.error.details.record`) until you wait for or `dispatch-abandon` the previous
+one. The prompt is piped stdin (multi-line is fine; it arrives as one message), and the
+reviewer completes with the usual `agents dispatch-complete` — from its own pane, no id needed.
+
 Create a fresh tab in a listed worktree:
 
 ```bash
@@ -163,6 +197,7 @@ Key fields by command:
 - `agents` → `.data.agents[]` with `.status`, `.raw_state`, `.detection_reason`, `.type`, `.name`, `.pane.{id,focused,cwd}`, `.tab`, `.worktree`, `.project.{name,branch,path}`.
 - `agents read` → `.data.agent`, `.data.blocker.text`, `.data.result.{state,text}` — `pending`, `unavailable`, `missing`, `incomplete`, `too_large` carry no partial text; `pending` is returned whenever the agent is working or blocked, even if an earlier turn completed.
 - `agents signal` → `.data.pane.{id,worktree_id}`, `.data.signal.{event,source,confidence,binding,at,session_id,detail,claimed_origin}`, optional `.data.warnings[]` (`code=signal_unbound`); optional fields are omitted.
+- `agents dispatch` → `.data.target` and the new pending `.data.dispatch.{id,state,created_at}`; refusals carry `.error.details.{target,record,observation,signals}`.
 - `agents wait --dispatch` → `.data.receipt`, immutable `.data.target`, `.data.signals`, optional `.data.screen`; nonzero results retain the record and evidence under `.error.details`.
 - `agents wait <pane> --until …` → `.data.observation.{status,raw_state,source,confidence,at,revision}`, `.data.signals`, and optional `.data.screen`. `source`/`confidence` are the evidence that satisfied the condition; `status`/`raw_state` are what the screen detector saw at that moment, so `idle` satisfied by a `turn-ended` signal may still show `status: working`.
 - `read` → `.data.text`, `.data.line_count`, `.data.truncated`, `.data.mode`, `.data.source`; `.data.stabilized` / `.data.waited_ms` with `--wait-stable`.
@@ -233,7 +268,8 @@ printf '%s\n' "$result" | jq '.data.observation, .data.screen'
 - `EMPTY_INPUT`, `INVALID_ARGUMENT`, `UNSUPPORTED_KEY`, `INVALID_REPEAT`: fix the arguments (`prowl <cmd> --help`).
 - `CAPTURE_UNSUPPORTED`: drop `--capture` and use `read --wait-stable` or file redirection.
 - `WAIT_TIMEOUT`: inspect `.error.details`, then re-arm the wait if the task remains active.
-- `AGENT_NOT_FOUND` (`agents wait`): no detected agent appeared in the pane within ten seconds — confirm the pane with `prowl agents --json` before re-arming. `DISPATCH_NOT_FOUND`: no such dispatch record (records reset on app restart). `DISPATCH_CONTEXT_REQUIRED`: `dispatch-complete` ran outside a prompted Profile launch. `DISPATCH_ALREADY_TERMINAL`: `dispatch-abandon` hit a record that already completed, was abandoned, or is gone.
+- `AGENT_NOT_FOUND` (`agents wait`, `agents dispatch`): no detected agent in the pane (a wait tolerates ten seconds; a dispatch does not) — confirm the pane with `prowl agents --json`. `DISPATCH_NOT_FOUND`: no such dispatch record, or `dispatch-complete` ran in a pane that never held one (records reset on app restart). `DISPATCH_CONTEXT_REQUIRED`: `dispatch-complete` ran from a process outside any Prowl pane. `DISPATCH_ALREADY_TERMINAL`: `dispatch-abandon` hit a record that already completed, was abandoned, or is gone.
+- `DISPATCH_PENDING` / `DISPATCH_TARGET_BUSY` (`agents dispatch`): the pane still holds a pending record (wait for it or abandon it), or its agent is working/blocked (wait `--until idle`, then retry). Nothing was typed into the pane.
 - `DISPATCH_FAILED` / `DISPATCH_ABANDONED`: the exact dispatch is terminal; inspect its retained record and immutable target in `.error.details`.
 - `AGENT_GONE`: inspect `.error.details.mode`. `dispatch` means the exact worker is terminal and retains a record; `condition` means the target pane closed. Without details on `agents signal`, the caller pane disappeared before recording.
 - `DISPATCH_NEEDS_INPUT` / `DISPATCH_INCOMPLETE`: the dispatch remains pending; use the intervention sequencing in **Reading Agent Output** before waiting again.
@@ -259,4 +295,4 @@ Required sections are `## Objective`, `## Current State`, and `## Next Steps`; o
 
 ## Command Set
 
-`list`, `agents`, `agents read`, `agents signal`, `agents dispatch-complete`, `agents dispatch-abandon`, `agents wait`, `profiles list`, `skills list|install|uninstall|path` (local-only), `read`, `send`, `key`, `focus`, `create tab`, `create pane`, `close`, `handoff to`, `handoff save`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with an explicit `close`. `tab create`, `tab close`, and `pane close` remain deprecated aliases for one release.
+`list`, `agents`, `agents read`, `agents signal`, `agents dispatch`, `agents dispatch-complete`, `agents dispatch-abandon`, `agents wait`, `profiles list`, `skills list|install|uninstall|path` (local-only), `read`, `send`, `key`, `focus`, `create tab`, `create pane`, `close`, `handoff to`, `handoff save`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with an explicit `close`. `tab create`, `tab close`, and `pane close` remain deprecated aliases for one release.

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -755,14 +755,13 @@ struct SupacodeApp: App {
     )
     let dispatchCompleteHandler = AgentDispatchCompleteCommandHandler(
       resolveCaller: resolveAgentSignalCaller,
-      complete: { dispatchID, outcome, summary, surfaceID in
+      complete: { surfaceID, outcome, summary in
         do {
           return .success(
             try terminalManager.completeAgentDispatch(
-              dispatchID: dispatchID,
+              surfaceID: surfaceID,
               outcome: outcome,
-              summary: summary,
-              callerSurfaceID: surfaceID
+              summary: summary
             ))
         } catch let error as AgentDispatchStoreError {
           return .failure(error)
@@ -914,6 +913,24 @@ struct SupacodeApp: App {
       }
       return resolver.resolveLifecycleTarget(selector)
     }
+    let agentConditionSnapshot: @MainActor (TabResolvedTarget) -> AgentConditionSnapshot = { target in
+      guard let surfaceID = UUID(uuidString: target.paneID) else {
+        return .init(agent: nil, signal: nil, revision: 0, isLive: false, signals: .empty)
+      }
+      let observed = terminalManager.agentObservationSnapshot(surfaceID: surfaceID)
+      let agent = appStore.state.repositories.activeAgents.entries.first {
+        $0.surfaceID == surfaceID
+      }
+      let signalEvidence = terminalManager.currentAgentSignalEvidence(surfaceID: surfaceID)
+      return .init(
+        agent: agent,
+        signal: signalEvidence.activeTerminal,
+        changedSignal: signalEvidence.latest,
+        revision: observed?.revision ?? 0,
+        isLive: terminalManager.isSurfaceLive(surfaceID),
+        signals: terminalManager.agentSignalsPayload(surfaceID: surfaceID)
+      )
+    }
     let agentWaitHandler = AgentWaitCommandHandler(
       observeDispatch: { dispatchID in
         do {
@@ -930,24 +947,7 @@ struct SupacodeApp: App {
       resolveConditionTarget: { pane in
         resolveTabTarget(.pane(pane))
       },
-      conditionSnapshot: { target in
-        guard let surfaceID = UUID(uuidString: target.paneID) else {
-          return .init(agent: nil, signal: nil, revision: 0, isLive: false, signals: .empty)
-        }
-        let observed = terminalManager.agentObservationSnapshot(surfaceID: surfaceID)
-        let agent = appStore.state.repositories.activeAgents.entries.first {
-          $0.surfaceID == surfaceID
-        }
-        let signalEvidence = terminalManager.currentAgentSignalEvidence(surfaceID: surfaceID)
-        return .init(
-          agent: agent,
-          signal: signalEvidence.activeTerminal,
-          changedSignal: signalEvidence.latest,
-          revision: observed?.revision ?? 0,
-          isLive: terminalManager.isSurfaceLive(surfaceID),
-          signals: terminalManager.agentSignalsPayload(surfaceID: surfaceID)
-        )
-      },
+      conditionSnapshot: agentConditionSnapshot,
       signalsProvider: { target in
         guard let surfaceID = UUID(uuidString: target.pane.id) else { return .empty }
         return terminalManager.agentSignalsPayload(surfaceID: surfaceID)
@@ -960,6 +960,37 @@ struct SupacodeApp: App {
           return nil
         }
         return surface.readActiveContentsForCLI()
+      }
+    )
+    let dispatchHandler = AgentDispatchCommandHandler(
+      resolveTarget: { pane in
+        resolveTabTarget(.pane(pane))
+      },
+      pendingDispatch: { target in
+        UUID(uuidString: target.paneID).flatMap { terminalManager.pendingAgentDispatchSnapshot(surfaceID: $0) }
+      },
+      conditionSnapshot: agentConditionSnapshot,
+      issueDispatch: { target in
+        do {
+          return .success(try terminalManager.issueAgentDispatch(boundTo: target))
+        } catch let error as AgentDispatchStoreError {
+          return .failure(error)
+        } catch {
+          return .failure(.bindingMissing)
+        }
+      },
+      deliverPrompt: { target, text in
+        // The same input path as `prowl send`: one committed-text paste, then Enter.
+        guard let surfaceID = UUID(uuidString: target.paneID),
+          let state = terminalManager.stateIfExists(for: target.worktreeID),
+          state.insertCommittedText(text, in: surfaceID)
+        else {
+          return false
+        }
+        return state.submitLine(in: surfaceID)
+      },
+      cancelDispatch: { dispatchID in
+        terminalManager.cancelAgentDispatchIssuance(dispatchID: dispatchID)
       }
     )
     let createTab: TabCommandHandler.CreateTabProvider = { target, path in
@@ -1163,6 +1194,7 @@ struct SupacodeApp: App {
       agentsReadHandler: agentReadHandler,
       agentsSignalHandler: agentSignalHandler,
       agentsHookHandler: agentHookHandler,
+      agentsDispatchHandler: dispatchHandler,
       agentsDispatchCompleteHandler: dispatchCompleteHandler,
       agentsDispatchAbandonHandler: dispatchAbandonHandler,
       agentsWaitHandler: agentWaitHandler,

--- a/supacode/CLIService/AgentConditionEvidence.swift
+++ b/supacode/CLIService/AgentConditionEvidence.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// The per-poll view of one pane that condition evidence is evaluated against.
+struct AgentConditionSnapshot: Sendable {
+  let agent: ActiveAgentEntry?
+  /// Active terminal evidence for idle, blocked, and exit conditions.
+  let signal: AgentSignal?
+  /// Latest current-epoch signal used only to detect a post-baseline change.
+  let changedSignal: AgentSignal?
+  let revision: UInt64
+  let isLive: Bool
+  let signals: AgentSignalsPayload
+
+  init(
+    agent: ActiveAgentEntry?,
+    signal: AgentSignal?,
+    changedSignal: AgentSignal? = nil,
+    revision: UInt64,
+    isLive: Bool,
+    signals: AgentSignalsPayload
+  ) {
+    self.agent = agent
+    self.signal = signal
+    self.changedSignal = changedSignal ?? signal
+    self.revision = revision
+    self.isLive = isLive
+    self.signals = signals
+  }
+}
+
+/// The evidence rules shared by `agents wait <pane> --until …` and the idle precondition of
+/// `agents dispatch` (064.012/013). Keeping them in one place means a re-dispatch accepts
+/// exactly the pane states an `--until idle` wait would resolve, and refuses the rest.
+@MainActor
+enum AgentConditionEvidence {
+  /// What a wait saw when it was armed; a re-dispatch evaluates against the current snapshot
+  /// itself, so every signal it sees is a pre-arm level.
+  struct Baseline: Sendable {
+    let revision: UInt64
+    let changedSignal: AgentSignal?
+    /// Terminal evidence that already existed when the wait was armed; it satisfies `idle` or
+    /// `blocked` only with detector corroboration, so a stale level cannot end a fresh wait.
+    let terminalSignal: AgentSignal?
+    let state: String
+
+    init(revision: UInt64, changedSignal: AgentSignal?, terminalSignal: AgentSignal?, state: String) {
+      self.revision = revision
+      self.changedSignal = changedSignal
+      self.terminalSignal = terminalSignal
+      self.state = state
+    }
+
+    init(snapshot: AgentConditionSnapshot) {
+      self.init(
+        revision: snapshot.revision,
+        changedSignal: snapshot.changedSignal,
+        terminalSignal: snapshot.signal,
+        state: AgentConditionEvidence.normalizedState(snapshot)
+      )
+    }
+  }
+
+  /// Tracks how long a heuristic candidate state has been unchanged; `auto` accepts it only
+  /// after two seconds so a transient screen never resolves a wait.
+  struct HeuristicStabilizer {
+    static let requiredMilliseconds = 2_000
+
+    private var state: String?
+    private var sinceMilliseconds = 0
+
+    init() {}
+
+    mutating func observe(candidate: String?, elapsedMilliseconds: Int) -> Bool {
+      guard let candidate else {
+        state = nil
+        return false
+      }
+      if state != candidate {
+        state = candidate
+        sinceMilliseconds = elapsedMilliseconds
+        return false
+      }
+      return elapsedMilliseconds - sinceMilliseconds >= Self.requiredMilliseconds
+    }
+  }
+
+  static func normalizedState(_ snapshot: AgentConditionSnapshot) -> String {
+    guard snapshot.isLive else { return "gone" }
+    return snapshot.agent.map { status(for: $0, fallback: .idle).rawValue } ?? "absent"
+  }
+
+  static func status(for agent: ActiveAgentEntry?, fallback: AgentsCommandStatus) -> AgentsCommandStatus {
+    agent.flatMap { AgentsCommandStatus(rawValue: $0.displayState.rawValue) } ?? fallback
+  }
+
+  /// Whether the screen detector currently reports the requested `idle` or `blocked` condition.
+  static func detectorReports(_ condition: AgentWaitCondition, normalizedState: String) -> Bool {
+    switch condition {
+    case .idle:
+      normalizedState == AgentsCommandStatus.idle.rawValue || normalizedState == AgentsCommandStatus.done.rawValue
+    case .blocked:
+      normalizedState == AgentsCommandStatus.blocked.rawValue
+    case .changed, .exit:
+      false
+    }
+  }
+
+  static func accepts(_ confidence: AgentSignal.Confidence, minimum: AgentWaitMinimumConfidence) -> Bool {
+    switch minimum {
+    case .auto, .high: confidence == .exact || confidence == .high
+    case .exact: confidence == .exact
+    case .heuristic: true
+    }
+  }
+
+  /// The signal that satisfies `condition` exactly, or nil. A terminal level that predates the
+  /// baseline counts for `idle`/`blocked` only when the detector corroborates it.
+  static func exactMatch(
+    condition: AgentWaitCondition,
+    snapshot: AgentConditionSnapshot,
+    normalizedState: String,
+    baseline: Baseline,
+    minimumConfidence: AgentWaitMinimumConfidence
+  ) -> AgentSignal? {
+    let signal = condition == .changed ? snapshot.changedSignal : snapshot.signal
+    guard let signal, accepts(signal.confidence, minimum: minimumConfidence) else { return nil }
+    let isPreArmLevel = condition != .changed && signal == baseline.terminalSignal
+    let matches =
+      switch condition {
+      case .idle:
+        signal.event == .turnEnded && (!isPreArmLevel || detectorReports(.idle, normalizedState: normalizedState))
+      case .blocked:
+        signal.event == .needsInput
+          && (!isPreArmLevel || detectorReports(.blocked, normalizedState: normalizedState))
+      case .changed: snapshot.revision > baseline.revision && signal != baseline.changedSignal
+      case .exit: signal.event == .sessionEnd
+      }
+    return matches ? signal : nil
+  }
+
+  /// Whether `auto` may fall back to the stabilized screen detector. A covering `verified_live`
+  /// channel reports the next edge itself (`changed`) and its own `session-end` (`exit`), so
+  /// those never fall back; a channel that cannot report `session-end` (Codex's notifier,
+  /// OpenCode's relay) leaves `exit` to the detector, the only exit evidence once `/quit` has
+  /// returned the shell on a still-live surface. For `idle` and `blocked` the channel is
+  /// authoritative while it holds any terminal level: the condition's own event resolves
+  /// through the exact path, and an opposite event means the runtime disagrees with the
+  /// screen, which a stabilized detector view must not override. Only a channel with no
+  /// terminal level yet — a freshly launched, unprompted Profile that has reported
+  /// `session-start` alone — leaves the current state to the detector.
+  static func allowsHeuristic(
+    _ minimum: AgentWaitMinimumConfidence,
+    condition: AgentWaitCondition,
+    snapshot: AgentConditionSnapshot
+  ) -> Bool {
+    switch minimum {
+    case .exact, .high:
+      return false
+    case .heuristic:
+      return true
+    case .auto:
+      let coveredEvent: AgentSignalEvent =
+        switch condition {
+        case .idle: .turnEnded
+        case .blocked: .needsInput
+        case .exit: .sessionEnd
+        case .changed: .progress
+        }
+      let liveChannelCovers = snapshot.signals.channels.contains {
+        $0.state == .verifiedLive && (condition == .changed || $0.events.contains(coveredEvent))
+      }
+      guard liveChannelCovers else { return true }
+      switch condition {
+      case .changed, .exit:
+        return false
+      case .idle, .blocked:
+        return snapshot.signal == nil
+      }
+    }
+  }
+
+  static func heuristicMatches(
+    condition: AgentWaitCondition,
+    snapshot: AgentConditionSnapshot,
+    normalizedState: String,
+    baseline: Baseline
+  ) -> Bool {
+    switch condition {
+    case .idle, .blocked: detectorReports(condition, normalizedState: normalizedState)
+    case .changed: snapshot.revision > baseline.revision && normalizedState != baseline.state
+    case .exit: !snapshot.isLive || snapshot.agent == nil
+    }
+  }
+}

--- a/supacode/CLIService/AgentDispatchCommandHandler.swift
+++ b/supacode/CLIService/AgentDispatchCommandHandler.swift
@@ -1,11 +1,277 @@
 import Foundation
 
+private let dispatchLogger = SupaLogger("AgentDispatchCommandHandler")
+
+/// `prowl agents dispatch <pane> --prompt -`: creates a pending dispatch for an agent that
+/// already runs in the pane and types the prompt plus the completion protocol into it
+/// (docs-ai 064.014). The precondition reuses the `agents wait --until idle` evidence rules:
+/// a corroborated exact `turn-ended` resolves immediately, a detector-only idle view must
+/// stay unchanged for two seconds, and a working or blocked agent is refused rather than
+/// having text merged into its running turn.
+@MainActor
+final class AgentDispatchCommandHandler: CommandHandler {
+  typealias ResolveTarget = @MainActor (String) -> Result<TabResolvedTarget, TargetResolverError>
+  typealias PendingDispatch = @MainActor (TabResolvedTarget) -> AgentDispatchSnapshot?
+  typealias ConditionSnapshotProvider = @MainActor (TabResolvedTarget) -> AgentConditionSnapshot
+  typealias IssueDispatch = @MainActor (TabResolvedTarget) -> Result<AgentDispatchSnapshot, AgentDispatchStoreError>
+  typealias DeliverPrompt = @MainActor (TabResolvedTarget, String) -> Bool
+  typealias CancelDispatch = @MainActor (String) -> Void
+
+  /// How long the precondition lets the evidence settle before refusing: a runtime
+  /// `turn-ended` the detector has not corroborated yet (its three-second working hold after a
+  /// turn), or a detector-only idle view that still needs its two seconds of stability. A pane
+  /// the evidence already calls working or blocked is refused at once.
+  nonisolated static let idleGraceMilliseconds = 5_000
+
+  private enum IdleVerdict {
+    case idle
+    case busy(AgentWaitObservation)
+    /// Idle by one source only; keep polling within the grace budget.
+    case settling(String)
+  }
+
+  private let resolveTarget: ResolveTarget
+  private let pendingDispatch: PendingDispatch
+  private let conditionSnapshot: ConditionSnapshotProvider
+  private let issueDispatch: IssueDispatch
+  private let deliverPrompt: DeliverPrompt
+  private let cancelDispatch: CancelDispatch
+  private let clock: any Clock<Duration>
+  private let now: @MainActor () -> Date
+  private let formatter: ISO8601DateFormatter
+
+  init(
+    resolveTarget: @escaping ResolveTarget,
+    pendingDispatch: @escaping PendingDispatch = { _ in nil },
+    conditionSnapshot: @escaping ConditionSnapshotProvider = { _ in
+      AgentConditionSnapshot(agent: nil, signal: nil, revision: 0, isLive: false, signals: .empty)
+    },
+    issueDispatch: @escaping IssueDispatch = { _ in .failure(.bindingMissing) },
+    deliverPrompt: @escaping DeliverPrompt = { _, _ in false },
+    cancelDispatch: @escaping CancelDispatch = { _ in },
+    clock: any Clock<Duration> = ContinuousClock(),
+    now: @escaping @MainActor () -> Date = Date.init
+  ) {
+    self.resolveTarget = resolveTarget
+    self.pendingDispatch = pendingDispatch
+    self.conditionSnapshot = conditionSnapshot
+    self.issueDispatch = issueDispatch
+    self.deliverPrompt = deliverPrompt
+    self.cancelDispatch = cancelDispatch
+    self.clock = clock
+    self.now = now
+    self.formatter = AgentDispatchCompleteCommandHandler.makeFormatter()
+  }
+
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    guard case .agentsDispatch(let input) = envelope.command else {
+      return failure(code: CLIErrorCode.invalidArgument, message: "Expected an agents.dispatch command.")
+    }
+    if let message = input.validationErrorMessage {
+      return failure(code: CLIErrorCode.invalidArgument, message: message)
+    }
+    let target: TabResolvedTarget
+    switch resolveTarget(input.pane) {
+    case .failure(.notFound(let message)):
+      return failure(code: CLIErrorCode.targetNotFound, message: message)
+    case .failure(.notUnique(let message)):
+      return failure(code: CLIErrorCode.targetNotUnique, message: message)
+    case .success(let resolved):
+      target = resolved
+    }
+    if let pending = pendingDispatch(target) {
+      return pendingFailure(pending, target: target)
+    }
+    if let refusal = await awaitIdleAgent(target: target) {
+      return refusal
+    }
+
+    let issued: AgentDispatchSnapshot
+    switch issueDispatch(target) {
+    case .success(let snapshot):
+      issued = snapshot
+    case .failure(.capacityExceeded):
+      return failure(
+        code: CLIErrorCode.dispatchCapacityExceeded,
+        message: "All dispatch receipt slots are occupied by pending work; "
+          + "complete or abandon a dispatch before dispatching another task."
+      )
+    case .failure(.surfacePending):
+      if let pending = pendingDispatch(target) {
+        return pendingFailure(pending, target: target)
+      }
+      return failure(code: CLIErrorCode.dispatchPending, message: "The pane already holds a pending dispatch.")
+    case .failure:
+      return failure(
+        code: CLIErrorCode.dispatchFailed,
+        message: "The dispatch could not be bound to the pane's current agent."
+      )
+    }
+    guard deliverPrompt(target, AgentDispatchPrompt.renderInjected(userPrompt: input.prompt)) else {
+      cancelDispatch(issued.record.id)
+      return failure(code: CLIErrorCode.dispatchFailed, message: "The prompt could not be delivered to the pane.")
+    }
+    guard case .pending(let record) = issued.payload(using: formatter) else {
+      return failure(code: CLIErrorCode.dispatchFailed, message: "The dispatch record is not pending.")
+    }
+    do {
+      return try CommandResponse(
+        ok: true,
+        command: "agents.dispatch",
+        schemaVersion: "prowl.cli.agents.dispatch.v1",
+        data: RawJSON(encoding: AgentDispatchCommandPayload(target: TabTarget(from: target), dispatch: record))
+      )
+    } catch {
+      return failure(code: CLIErrorCode.dispatchFailed, message: "Failed to encode the dispatch record.")
+    }
+  }
+
+  /// Nil when the pane hosts an idle agent; otherwise the structured refusal.
+  private func awaitIdleAgent(target: TabResolvedTarget) async -> CommandResponse? {
+    var elapsedMilliseconds = 0
+    var stabilizer = AgentConditionEvidence.HeuristicStabilizer()
+    while true {
+      if Task.isCancelled {
+        return failure(code: CLIErrorCode.timeout, message: "The dispatch was cancelled.")
+      }
+      let snapshot = conditionSnapshot(target)
+      guard snapshot.isLive else {
+        return failure(
+          code: CLIErrorCode.agentGone,
+          message: "The selected agent pane is gone.",
+          details: AgentDispatchErrorDetails(target: TabTarget(from: target), signals: snapshot.signals)
+        )
+      }
+      guard snapshot.agent != nil else {
+        return failure(
+          code: CLIErrorCode.agentNotFound,
+          message: "The selected pane hosts no detected agent; dispatch needs an idle agent to deliver to.",
+          details: AgentDispatchErrorDetails(target: TabTarget(from: target), signals: snapshot.signals)
+        )
+      }
+      switch verdict(for: snapshot) {
+      case .idle:
+        return nil
+      case .busy(let observation):
+        return busyFailure(observation, snapshot: snapshot, target: target)
+      case .settling(let state):
+        let detectorCandidate =
+          AgentConditionEvidence.detectorReports(.idle, normalizedState: state)
+          && AgentConditionEvidence.allowsHeuristic(.auto, condition: .idle, snapshot: snapshot)
+        if stabilizer.observe(candidate: detectorCandidate ? state : nil, elapsedMilliseconds: elapsedMilliseconds) {
+          return nil
+        }
+        guard elapsedMilliseconds < Self.idleGraceMilliseconds else {
+          return busyFailure(heuristicObservation(snapshot, state: state), snapshot: snapshot, target: target)
+        }
+      }
+      do {
+        try await clock.sleep(for: .milliseconds(200))
+      } catch {
+        return failure(code: CLIErrorCode.timeout, message: "The dispatch was cancelled.")
+      }
+      elapsedMilliseconds += 200
+    }
+  }
+
+  /// The arm-time evaluation of `agents wait --until idle` under `auto`: every signal the
+  /// snapshot holds predates this call, so a `turn-ended` counts only with detector
+  /// corroboration, and the detector alone counts only where the wait would fall back to it.
+  /// Either source alone is not a refusal yet — the wait itself would keep polling — so it
+  /// settles within the grace budget; working or blocked without such evidence is refused.
+  private func verdict(for snapshot: AgentConditionSnapshot) -> IdleVerdict {
+    let state = AgentConditionEvidence.normalizedState(snapshot)
+    let baseline = AgentConditionEvidence.Baseline(snapshot: snapshot)
+    if AgentConditionEvidence.exactMatch(
+      condition: .idle,
+      snapshot: snapshot,
+      normalizedState: state,
+      baseline: baseline,
+      minimumConfidence: .auto
+    ) != nil {
+      return .idle
+    }
+    let detectorIdle = AgentConditionEvidence.detectorReports(.idle, normalizedState: state)
+    if detectorIdle, AgentConditionEvidence.allowsHeuristic(.auto, condition: .idle, snapshot: snapshot) {
+      return .settling(state)
+    }
+    if let signal = snapshot.signal,
+      signal.event == .turnEnded,
+      AgentConditionEvidence.accepts(signal.confidence, minimum: .auto),
+      !AgentConditionEvidence.detectorReports(.blocked, normalizedState: state)
+    {
+      return .settling(state)
+    }
+    return .busy(heuristicObservation(snapshot, state: state))
+  }
+
+  private func heuristicObservation(_ snapshot: AgentConditionSnapshot, state: String) -> AgentWaitObservation {
+    AgentWaitObservation(
+      status: AgentConditionEvidence.status(for: snapshot.agent, fallback: .idle),
+      rawState: snapshot.agent?.rawState.rawValue ?? state,
+      source: "detection",
+      confidence: "heuristic",
+      timestamp: formatter.string(from: snapshot.agent?.lastChangedAt ?? now()),
+      revision: Int(clamping: snapshot.revision)
+    )
+  }
+
+  private func busyFailure(
+    _ observation: AgentWaitObservation,
+    snapshot: AgentConditionSnapshot,
+    target: TabResolvedTarget
+  ) -> CommandResponse {
+    let reason: String =
+      if let signal = snapshot.signal, signal.event == .needsInput {
+        "its runtime reported needs-input"
+      } else {
+        "the detector reports \(observation.status.rawValue)"
+      }
+    return failure(
+      code: CLIErrorCode.dispatchTargetBusy,
+      message: "The pane's agent is not idle (\(reason)); wait for it to finish before dispatching.",
+      details: AgentDispatchErrorDetails(
+        target: TabTarget(from: target),
+        observation: observation,
+        signals: snapshot.signals
+      )
+    )
+  }
+
+  private func pendingFailure(_ pending: AgentDispatchSnapshot, target: TabResolvedTarget) -> CommandResponse {
+    failure(
+      code: CLIErrorCode.dispatchPending,
+      message: "The pane already holds pending dispatch \(pending.record.id); "
+        + "wait for its receipt or abandon it before dispatching again.",
+      details: AgentDispatchErrorDetails(
+        target: TabTarget(from: target),
+        record: pending.payload(using: formatter)
+      )
+    )
+  }
+
+  private func failure(
+    code: String,
+    message: String,
+    details: AgentDispatchErrorDetails? = nil
+  ) -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: "agents.dispatch",
+      schemaVersion: "prowl.cli.agents.dispatch.v1",
+      error: CommandError(code: code, message: message, details: details.flatMap { try? RawJSON(encoding: $0) })
+    )
+  }
+}
+
 @MainActor
 final class AgentDispatchCompleteCommandHandler: CommandHandler {
   typealias ResolveCaller = @MainActor (pid_t) -> CallerPane?
+  /// Completes the caller pane's current pending dispatch; the pane, not a public id, is the
+  /// record's address.
   typealias Complete =
     @MainActor (
-      String, DispatchCompletionOutcome, String, UUID
+      UUID, DispatchCompletionOutcome, String
     ) -> Result<AgentDispatchMutationResult, AgentDispatchStoreError>
 
   private let resolveCaller: ResolveCaller
@@ -41,10 +307,16 @@ final class AgentDispatchCompleteCommandHandler: CommandHandler {
         message: "Run dispatch completion from the Prowl pane that owns this dispatch."
       )
     }
-    switch complete(input.dispatchID, input.outcome, input.summary, caller.surfaceID) {
+    switch complete(caller.surfaceID, input.outcome, input.summary) {
     case .failure(let error):
       return map(error)
     case .success(let result):
+      if let launchDispatchID = input.dispatchID, launchDispatchID != result.snapshot.record.id {
+        dispatchLogger.info(
+          "Completed dispatch \(result.snapshot.record.id) for pane \(caller.surfaceID) "
+            + "from a process launched with PROWL_DISPATCH_ID=\(launchDispatchID)"
+        )
+      }
       guard let binding = result.snapshot.binding,
         case .completed(let receipt) = result.snapshot.payload(using: formatter)
       else {
@@ -71,7 +343,7 @@ final class AgentDispatchCompleteCommandHandler: CommandHandler {
   private func map(_ error: AgentDispatchStoreError) -> CommandResponse {
     switch error {
     case .notFound:
-      failure(code: CLIErrorCode.dispatchNotFound, message: "The dispatch receipt was not found.")
+      failure(code: CLIErrorCode.dispatchNotFound, message: "This pane has no dispatch to complete.")
     case .sourceMismatch:
       failure(code: CLIErrorCode.dispatchSourceMismatch, message: "This pane does not own the dispatch receipt.")
     case .alreadyCompleted:
@@ -80,7 +352,7 @@ final class AgentDispatchCompleteCommandHandler: CommandHandler {
       failure(code: CLIErrorCode.dispatchAlreadyTerminal, message: "The dispatch is already terminal.")
     case .bindingMissing:
       failure(code: CLIErrorCode.dispatchFailed, message: "The dispatch has no bound pane.")
-    case .capacityExceeded, .alreadyBound:
+    case .capacityExceeded, .alreadyBound, .surfacePending:
       failure(code: CLIErrorCode.dispatchFailed, message: "The dispatch receipt could not be updated.")
     }
   }

--- a/supacode/CLIService/AgentWaitCommandHandler.swift
+++ b/supacode/CLIService/AgentWaitCommandHandler.swift
@@ -7,32 +7,7 @@ final class AgentWaitCommandHandler: CommandHandler {
       String
     ) -> Result<AgentDispatchObservationStream, AgentDispatchStoreError>
   typealias ObserveCondition = @MainActor (UUID) -> AgentObservationStream
-  struct ConditionSnapshot: Sendable {
-    let agent: ActiveAgentEntry?
-    /// Active terminal evidence for idle, blocked, and exit conditions.
-    let signal: AgentSignal?
-    /// Latest current-epoch signal used only to detect a post-baseline change.
-    let changedSignal: AgentSignal?
-    let revision: UInt64
-    let isLive: Bool
-    let signals: AgentSignalsPayload
-
-    init(
-      agent: ActiveAgentEntry?,
-      signal: AgentSignal?,
-      changedSignal: AgentSignal? = nil,
-      revision: UInt64,
-      isLive: Bool,
-      signals: AgentSignalsPayload
-    ) {
-      self.agent = agent
-      self.signal = signal
-      self.changedSignal = changedSignal ?? signal
-      self.revision = revision
-      self.isLive = isLive
-      self.signals = signals
-    }
-  }
+  typealias ConditionSnapshot = AgentConditionSnapshot
 
   nonisolated private enum DispatchOutcome: Sendable {
     case terminal(AgentDispatchSnapshot)
@@ -326,38 +301,11 @@ final class AgentWaitCommandHandler: CommandHandler {
     }
   }
 
-  private struct ConditionBaseline {
-    let revision: UInt64
-    let changedSignal: AgentSignal?
-    /// Terminal evidence that already existed when the wait was armed; it satisfies `idle` or
-    /// `blocked` only with detector corroboration, so a stale level cannot end a fresh wait.
-    let terminalSignal: AgentSignal?
-    let state: String
-  }
+  private typealias ConditionBaseline = AgentConditionEvidence.Baseline
 
   private enum AgentAppearance {
     case appeared(ConditionSnapshot, elapsedMilliseconds: Int)
     case failed(CommandResponse)
-  }
-
-  /// Tracks how long a heuristic candidate state has been unchanged; `auto` accepts it only
-  /// after two seconds so a transient screen never resolves a wait.
-  private struct HeuristicStabilizer {
-    private var state: String?
-    private var sinceMilliseconds = 0
-
-    mutating func observe(candidate: String?, elapsedMilliseconds: Int) -> Bool {
-      guard let candidate else {
-        state = nil
-        return false
-      }
-      if state != candidate {
-        state = candidate
-        sinceMilliseconds = elapsedMilliseconds
-        return false
-      }
-      return elapsedMilliseconds - sinceMilliseconds >= 2_000
-    }
   }
 
   private func waitForCondition(_ input: AgentWaitInput) async -> CommandResponse {
@@ -404,12 +352,7 @@ final class AgentWaitCommandHandler: CommandHandler {
         elapsedMilliseconds = waited
       }
     }
-    let baseline = ConditionBaseline(
-      revision: initial.revision,
-      changedSignal: initial.changedSignal,
-      terminalSignal: initial.signal,
-      state: normalizedState(initial)
-    )
+    let baseline = ConditionBaseline(snapshot: initial)
     let observationPump = AgentWaitObservationPump()
     observationPump.start(surfaceID: surfaceID, observe: observeCondition)
     defer { observationPump.cancel() }
@@ -440,7 +383,7 @@ final class AgentWaitCommandHandler: CommandHandler {
   ) async -> CommandResponse {
     let minimumConfidence = input.minimumConfidence ?? .auto
     var elapsedMilliseconds = startMilliseconds
-    var stabilizer = HeuristicStabilizer()
+    var stabilizer = AgentConditionEvidence.HeuristicStabilizer()
     while elapsedMilliseconds <= timeoutMilliseconds {
       if Task.isCancelled {
         return failure(code: CLIErrorCode.timeout, message: "The wait was cancelled.")
@@ -465,8 +408,9 @@ final class AgentWaitCommandHandler: CommandHandler {
       )
       if observation == nil {
         let candidate =
-          allowsHeuristic(minimumConfidence, condition: condition, snapshot: snapshot)
-          && heuristicMatches(condition: condition, snapshot: snapshot, normalizedState: state, baseline: baseline)
+          AgentConditionEvidence.allowsHeuristic(minimumConfidence, condition: condition, snapshot: snapshot)
+          && AgentConditionEvidence.heuristicMatches(
+            condition: condition, snapshot: snapshot, normalizedState: state, baseline: baseline)
         if stabilizer.observe(candidate: candidate ? state : nil, elapsedMilliseconds: elapsedMilliseconds) {
           observation = heuristicObservation(snapshot, state: state)
         }
@@ -560,9 +504,14 @@ final class AgentWaitCommandHandler: CommandHandler {
     baseline: ConditionBaseline,
     minimumConfidence: AgentWaitMinimumConfidence
   ) -> AgentWaitObservation? {
-    let signal = condition == .changed ? snapshot.changedSignal : snapshot.signal
-    guard let signal,
-      accepts(signal.confidence, minimum: minimumConfidence)
+    guard
+      let signal = AgentConditionEvidence.exactMatch(
+        condition: condition,
+        snapshot: snapshot,
+        normalizedState: normalizedState,
+        baseline: baseline,
+        minimumConfidence: minimumConfidence
+      )
     else {
       if condition == .exit, !snapshot.isLive {
         return AgentWaitObservation(
@@ -576,18 +525,6 @@ final class AgentWaitCommandHandler: CommandHandler {
       }
       return nil
     }
-    let isPreArmLevel = condition != .changed && signal == baseline.terminalSignal
-    let matches =
-      switch condition {
-      case .idle:
-        signal.event == .turnEnded && (!isPreArmLevel || detectorReports(.idle, normalizedState: normalizedState))
-      case .blocked:
-        signal.event == .needsInput
-          && (!isPreArmLevel || detectorReports(.blocked, normalizedState: normalizedState))
-      case .changed: snapshot.revision > baseline.revision && signal != baseline.changedSignal
-      case .exit: signal.event == .sessionEnd
-      }
-    guard matches else { return nil }
     return AgentWaitObservation(
       status: status(for: snapshot.agent, fallback: condition == .blocked ? .blocked : .done),
       rawState: snapshot.agent?.rawState.rawValue ?? "gone",
@@ -598,89 +535,12 @@ final class AgentWaitCommandHandler: CommandHandler {
     )
   }
 
-  /// Whether the screen detector currently reports the requested `idle` or `blocked` condition.
-  private func detectorReports(_ condition: AgentWaitCondition, normalizedState: String) -> Bool {
-    switch condition {
-    case .idle:
-      normalizedState == AgentsCommandStatus.idle.rawValue || normalizedState == AgentsCommandStatus.done.rawValue
-    case .blocked:
-      normalizedState == AgentsCommandStatus.blocked.rawValue
-    case .changed, .exit:
-      false
-    }
-  }
-  private func accepts(
-    _ confidence: AgentSignal.Confidence,
-    minimum: AgentWaitMinimumConfidence
-  ) -> Bool {
-    switch minimum {
-    case .auto, .high: confidence == .exact || confidence == .high
-    case .exact: confidence == .exact
-    case .heuristic: true
-    }
-  }
-
-  /// Whether `auto` may fall back to the stabilized screen detector. A covering `verified_live`
-  /// channel reports the next edge itself (`changed`) and its own `session-end` (`exit`), so
-  /// those never fall back; a channel that cannot report `session-end` (Codex's notifier,
-  /// OpenCode's relay) leaves `exit` to the detector, the only exit evidence once `/quit` has
-  /// returned the shell on a still-live surface. For `idle` and `blocked` the channel is
-  /// authoritative while it holds
-  /// any terminal level: the condition's own event resolves through the exact path, and an
-  /// opposite event means the runtime disagrees with the screen, which a stabilized detector
-  /// view must not override. Only a channel with no terminal level yet — a freshly launched,
-  /// unprompted Profile that has reported `session-start` alone — leaves the current state to
-  /// the detector.
-  private func allowsHeuristic(
-    _ minimum: AgentWaitMinimumConfidence,
-    condition: AgentWaitCondition,
-    snapshot: ConditionSnapshot
-  ) -> Bool {
-    switch minimum {
-    case .exact, .high:
-      return false
-    case .heuristic:
-      return true
-    case .auto:
-      let coveredEvent: AgentSignalEvent =
-        switch condition {
-        case .idle: .turnEnded
-        case .blocked: .needsInput
-        case .exit: .sessionEnd
-        case .changed: .progress
-        }
-      let liveChannelCovers = snapshot.signals.channels.contains {
-        $0.state == .verifiedLive && (condition == .changed || $0.events.contains(coveredEvent))
-      }
-      guard liveChannelCovers else { return true }
-      switch condition {
-      case .changed, .exit:
-        return false
-      case .idle, .blocked:
-        return snapshot.signal == nil
-      }
-    }
-  }
-
-  private func heuristicMatches(
-    condition: AgentWaitCondition,
-    snapshot: ConditionSnapshot,
-    normalizedState: String,
-    baseline: ConditionBaseline
-  ) -> Bool {
-    switch condition {
-    case .idle, .blocked: detectorReports(condition, normalizedState: normalizedState)
-    case .changed: snapshot.revision > baseline.revision && normalizedState != baseline.state
-    case .exit: !snapshot.isLive || snapshot.agent == nil
-    }
-  }
   private func normalizedState(_ snapshot: ConditionSnapshot) -> String {
-    guard snapshot.isLive else { return "gone" }
-    return snapshot.agent.map { status(for: $0, fallback: .idle).rawValue } ?? "absent"
+    AgentConditionEvidence.normalizedState(snapshot)
   }
 
   private func status(for agent: ActiveAgentEntry?, fallback: AgentsCommandStatus) -> AgentsCommandStatus {
-    agent.flatMap { AgentsCommandStatus(rawValue: $0.displayState.rawValue) } ?? fallback
+    AgentConditionEvidence.status(for: agent, fallback: fallback)
   }
 
   private func heuristicObservation(_ snapshot: ConditionSnapshot, state: String) -> AgentWaitObservation? {

--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -11,6 +11,7 @@ final class CLICommandRouter {
   private let agentsReadHandler: any CommandHandler
   private let agentsSignalHandler: any CommandHandler
   private let agentsHookHandler: any CommandHandler
+  private let agentsDispatchHandler: any CommandHandler
   private let agentsDispatchCompleteHandler: any CommandHandler
   private let agentsDispatchAbandonHandler: any CommandHandler
   private let agentsWaitHandler: any CommandHandler
@@ -32,6 +33,7 @@ final class CLICommandRouter {
     agentsReadHandler: any CommandHandler = StubCommandHandler(command: "agents.read"),
     agentsSignalHandler: any CommandHandler = StubCommandHandler(command: "agents.signal"),
     agentsHookHandler: any CommandHandler = StubCommandHandler(command: "agents._hook"),
+    agentsDispatchHandler: any CommandHandler = StubCommandHandler(command: "agents.dispatch"),
     agentsDispatchCompleteHandler: any CommandHandler = StubCommandHandler(command: "agents.dispatch-complete"),
     agentsDispatchAbandonHandler: any CommandHandler = StubCommandHandler(command: "agents.dispatch-abandon"),
     agentsWaitHandler: any CommandHandler = StubCommandHandler(command: "agents.wait"),
@@ -52,6 +54,7 @@ final class CLICommandRouter {
     self.agentsReadHandler = agentsReadHandler
     self.agentsSignalHandler = agentsSignalHandler
     self.agentsHookHandler = agentsHookHandler
+    self.agentsDispatchHandler = agentsDispatchHandler
     self.agentsDispatchCompleteHandler = agentsDispatchCompleteHandler
     self.agentsDispatchAbandonHandler = agentsDispatchAbandonHandler
     self.agentsWaitHandler = agentsWaitHandler
@@ -81,6 +84,7 @@ final class CLICommandRouter {
     case .agentsRead: handler = agentsReadHandler
     case .agentsSignal: handler = agentsSignalHandler
     case .agentsHook: handler = agentsHookHandler
+    case .agentsDispatch: handler = agentsDispatchHandler
     case .agentsDispatchComplete: handler = agentsDispatchCompleteHandler
     case .agentsDispatchAbandon: handler = agentsDispatchAbandonHandler
     case .agentsWait: handler = agentsWaitHandler

--- a/supacode/CLIService/Shared/CommandEnvelope.swift
+++ b/supacode/CLIService/Shared/CommandEnvelope.swift
@@ -20,6 +20,7 @@ public enum Command: Codable, Sendable {
   case agentsRead(AgentReadInput)
   case agentsSignal(AgentSignalInput)
   case agentsHook(AgentNativeHookInput)
+  case agentsDispatch(DispatchInput)
   case agentsDispatchComplete(DispatchCompleteInput)
   case agentsDispatchAbandon(DispatchAbandonInput)
   case agentsWait(AgentWaitInput)
@@ -42,6 +43,7 @@ public enum Command: Codable, Sendable {
     case .agentsRead: "agents.read"
     case .agentsSignal: "agents.signal"
     case .agentsHook: "agents._hook"
+    case .agentsDispatch: "agents.dispatch"
     case .agentsDispatchComplete: "agents.dispatch-complete"
     case .agentsDispatchAbandon: "agents.dispatch-abandon"
     case .agentsWait: "agents.wait"

--- a/supacode/CLIService/Shared/DispatchCommandPayload.swift
+++ b/supacode/CLIService/Shared/DispatchCommandPayload.swift
@@ -311,6 +311,40 @@ public struct AgentSignalsPayload: Codable, Equatable, Sendable {
   }
 }
 
+/// `agents.dispatch` success: the immutable target snapshot and the new pending record,
+/// shaped like the `create` response so coordinators consume both the same way.
+public struct AgentDispatchCommandPayload: Codable, Equatable, Sendable {
+  public let target: TabTarget
+  public let dispatch: DispatchPendingRecord
+
+  public init(target: TabTarget, dispatch: DispatchPendingRecord) {
+    self.target = target
+    self.dispatch = dispatch
+  }
+}
+
+/// Governed `error.details` for a refused `agents.dispatch`: `record` carries the pane's
+/// current pending dispatch (`DISPATCH_PENDING`); `observation` and `signals` carry the
+/// evidence that made the pane busy or agent-less.
+public struct AgentDispatchErrorDetails: Codable, Equatable, Sendable {
+  public let target: TabTarget
+  public let record: DispatchRecordPayload?
+  public let observation: AgentWaitObservation?
+  public let signals: AgentSignalsPayload?
+
+  public init(
+    target: TabTarget,
+    record: DispatchRecordPayload? = nil,
+    observation: AgentWaitObservation? = nil,
+    signals: AgentSignalsPayload? = nil
+  ) {
+    self.target = target
+    self.record = record
+    self.observation = observation
+    self.signals = signals
+  }
+}
+
 public struct DispatchCompleteCommandPayload: Codable, Equatable, Sendable {
   public let target: TabTarget
   public let receipt: DispatchCompletedRecord

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -36,6 +36,10 @@ public enum CLIErrorCode {
   public static let dispatchAbandoned = "DISPATCH_ABANDONED"
   public static let dispatchNeedsInput = "DISPATCH_NEEDS_INPUT"
   public static let dispatchIncomplete = "DISPATCH_INCOMPLETE"
+  /// `agents dispatch` refused because the pane already holds a pending dispatch.
+  public static let dispatchPending = "DISPATCH_PENDING"
+  /// `agents dispatch` refused because the pane's agent is working or blocked.
+  public static let dispatchTargetBusy = "DISPATCH_TARGET_BUSY"
   public static let blockerUnreadable = "BLOCKER_UNREADABLE"
   public static let sessionUnresolved = "SESSION_UNRESOLVED"
   public static let resultNotFound = "RESULT_NOT_FOUND"

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -39,7 +39,11 @@ public struct DispatchCompleteInput: Codable, Sendable {
   nonisolated public static let environmentKey = "PROWL_DISPATCH_ID"
   public static let maximumSummaryBytes = 32 * 1_024
 
-  public let dispatchID: String
+  /// The launch-scoped `PROWL_DISPATCH_ID` when the caller still carries one. The app
+  /// resolves the receipt from the caller pane's current pending dispatch, so this value
+  /// is compatibility diagnostics only: a process launched with an older id still
+  /// completes the pane's current record.
+  public let dispatchID: String?
   public let outcome: DispatchCompletionOutcome
   public let summary: String
 
@@ -49,19 +53,57 @@ public struct DispatchCompleteInput: Codable, Sendable {
     case summary
   }
 
-  public init(dispatchID: String, outcome: DispatchCompletionOutcome, summary: String) {
+  public init(dispatchID: String?, outcome: DispatchCompletionOutcome, summary: String) {
     self.dispatchID = dispatchID
     self.outcome = outcome
     self.summary = summary
   }
 
   public var validationErrorMessage: String? {
-    CLIInputTextValidator.validateDispatchID(dispatchID, name: DispatchCompleteInput.environmentKey)
+    dispatchID.flatMap {
+      CLIInputTextValidator.validateDispatchID($0, name: DispatchCompleteInput.environmentKey)
+    }
       ?? CLIInputTextValidator.validate(
         summary,
         name: "--summary",
         maximumBytes: Self.maximumSummaryBytes
       )
+  }
+}
+
+/// `prowl agents dispatch <pane> --prompt -`: a new pending dispatch for an agent that
+/// already runs in an existing pane. The prompt reaches the runtime through the pane's
+/// input path as one bracketed paste followed by Enter, so newlines and tabs survive but
+/// every other control character would be stripped or reinterpreted before delivery.
+public struct DispatchInput: Codable, Sendable, Equatable {
+  public static let maximumPromptUTF8ByteCount = CreateLaunchInput.maximumPromptUTF8ByteCount
+
+  public let pane: String
+  public let prompt: String
+
+  public init(pane: String, prompt: String) {
+    self.pane = pane
+    self.prompt = prompt
+  }
+
+  public var validationErrorMessage: String? {
+    guard !pane.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return "agents dispatch requires a pane handle (pN) or pane UUID."
+    }
+    guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return "The dispatch prompt is empty."
+    }
+    guard prompt.utf8.count <= Self.maximumPromptUTF8ByteCount else {
+      return "The dispatch prompt exceeds the 256 KiB UTF-8 limit."
+    }
+    guard !prompt.unicodeScalars.contains(where: Self.isDisallowedScalar) else {
+      return "The dispatch prompt must not contain control characters other than newlines and tabs."
+    }
+    return nil
+  }
+
+  private static func isDisallowedScalar(_ scalar: Unicode.Scalar) -> Bool {
+    scalar != "\n" && scalar != "\t" && CharacterSet.controlCharacters.contains(scalar)
   }
 }
 

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -581,6 +581,15 @@ nonisolated enum AgentProfileLaunchPlanner {
 
 nonisolated enum AgentDispatchPrompt {
   static let protocolVersion = 1
+  /// Origin marker on text Prowl types into a live agent, shared with `HandoffInjection`.
+  static let injectedPrefix = "[Prowl] "
+
+  /// The text `agents dispatch` types into an existing agent pane: the same prompt and
+  /// protocol block a prompted launch passes through argv, behind the origin marker so the
+  /// agent (and a person reading the transcript) can tell Prowl authored the line.
+  static func renderInjected(userPrompt: String) -> String {
+    injectedPrefix + render(userPrompt: userPrompt)
+  }
 
   static func render(userPrompt: String) -> String {
     """

--- a/supacode/Features/Terminal/BusinessLogic/AgentDispatchStore.swift
+++ b/supacode/Features/Terminal/BusinessLogic/AgentDispatchStore.swift
@@ -115,6 +115,9 @@ nonisolated enum AgentDispatchStoreError: Error, Equatable, Sendable {
   case sourceMismatch
   case alreadyCompleted
   case alreadyTerminal
+  /// The surface already holds a pending record; a second one would let two assignments
+  /// race for the same receipt.
+  case surfacePending
 }
 
 typealias AgentDispatchObservationStream = AsyncStream<AgentDispatchObservation>
@@ -189,12 +192,44 @@ final class AgentDispatchStore {
       guard existing == binding else { throw AgentDispatchStoreError.alreadyBound }
       return
     }
+    guard pendingDispatchID(surfaceID: binding.surfaceID) == nil else {
+      throw AgentDispatchStoreError.surfacePending
+    }
     entry.snapshot = AgentDispatchSnapshot(record: entry.snapshot.record, binding: binding)
     entries[dispatchID] = entry
   }
 
   func snapshot(dispatchID: String) -> AgentDispatchSnapshot? {
     entries[dispatchID]?.snapshot
+  }
+
+  /// The one pending record bound to the surface, if any.
+  func pendingSnapshot(surfaceID: UUID) -> AgentDispatchSnapshot? {
+    pendingDispatchID(surfaceID: surfaceID).flatMap { entries[$0]?.snapshot }
+  }
+
+  /// Completes the caller pane's current pending record. Without one, the pane's most
+  /// recently issued record answers instead so an identical retry replays its receipt and
+  /// a conflicting one is rejected exactly as an id-addressed completion would be.
+  func complete(
+    surfaceID: UUID,
+    outcome: DispatchCompletionOutcome,
+    summary: String
+  ) throws -> AgentDispatchMutationResult {
+    guard let dispatchID = pendingDispatchID(surfaceID: surfaceID) ?? latestDispatchID(surfaceID: surfaceID)
+    else { throw AgentDispatchStoreError.notFound }
+    return try complete(dispatchID: dispatchID, outcome: outcome, summary: summary, callerSurfaceID: surfaceID)
+  }
+
+  private func pendingDispatchID(surfaceID: UUID) -> String? {
+    issuanceOrder.first { dispatchID in
+      guard let entry = entries[dispatchID] else { return false }
+      return entry.snapshot.record.state == .pending && entry.snapshot.binding?.surfaceID == surfaceID
+    }
+  }
+
+  private func latestDispatchID(surfaceID: UUID) -> String? {
+    issuanceOrder.last { entries[$0]?.snapshot.binding?.surfaceID == surfaceID }
   }
 
   func complete(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -515,15 +515,7 @@ final class WorktreeTerminalManager {
   @discardableResult
   func recordAgentSignal(_ signal: AgentSignal, caller: CallerPane) -> AgentSignalRecordOutcome {
     guard containsSurface(caller.surfaceID) else { return .paneGone }
-    let evidence = currentAgentEvidence(surfaceID: caller.surfaceID)
-    handleEvidenceEpochUpdate(
-      agentObservationStore.updateEvidenceEpoch(
-        surfaceID: caller.surfaceID,
-        processGeneration: evidence.generation,
-        sessionID: evidence.sessionID
-      ),
-      surfaceID: caller.surfaceID
-    )
+    let evidence = refreshEvidenceEpoch(surfaceID: caller.surfaceID)
     let generationMatches = evidence.generation.map(caller.processAncestry.contains) ?? false
     let binding = agentObservationStore.bindingForSignal(
       surfaceID: caller.surfaceID,
@@ -546,15 +538,7 @@ final class WorktreeTerminalManager {
   @discardableResult
   func recordAgentNativeHook(_ input: AgentNativeHookInput, caller: CallerPane) -> Bool {
     guard containsSurface(caller.surfaceID) else { return false }
-    let evidence = currentAgentEvidence(surfaceID: caller.surfaceID)
-    handleEvidenceEpochUpdate(
-      agentObservationStore.updateEvidenceEpoch(
-        surfaceID: caller.surfaceID,
-        processGeneration: evidence.generation,
-        sessionID: evidence.sessionID
-      ),
-      surfaceID: caller.surfaceID
-    )
+    refreshEvidenceEpoch(surfaceID: caller.surfaceID)
     switch agentObservationStore.recordManagedHook(
       input,
       callerAncestry: caller.processAncestry,
@@ -568,6 +552,24 @@ final class WorktreeTerminalManager {
       noteDispatchEvidence(signal, surfaceID: caller.surfaceID, evidenceEpoch: evidenceEpoch)
       return true
     }
+  }
+
+  /// Reconciles the surface's evidence epoch with the agent generation and session the
+  /// detector currently proves, activating any hook signals that were waiting for it.
+  @discardableResult
+  private func refreshEvidenceEpoch(
+    surfaceID: UUID
+  ) -> (generation: AgentProcessGeneration?, sessionID: String?) {
+    let evidence = currentAgentEvidence(surfaceID: surfaceID)
+    handleEvidenceEpochUpdate(
+      agentObservationStore.updateEvidenceEpoch(
+        surfaceID: surfaceID,
+        processGeneration: evidence.generation,
+        sessionID: evidence.sessionID
+      ),
+      surfaceID: surfaceID
+    )
+    return evidence
   }
 
   private func handleEvidenceEpochUpdate(
@@ -637,15 +639,7 @@ final class WorktreeTerminalManager {
     surfaceID: UUID,
     includeDiagnosticLast: Bool = true
   ) -> AgentSignalsPayload {
-    let evidence = currentAgentEvidence(surfaceID: surfaceID)
-    handleEvidenceEpochUpdate(
-      agentObservationStore.updateEvidenceEpoch(
-        surfaceID: surfaceID,
-        processGeneration: evidence.generation,
-        sessionID: evidence.sessionID
-      ),
-      surfaceID: surfaceID
-    )
+    refreshEvidenceEpoch(surfaceID: surfaceID)
     return agentObservationStore.signalsPayload(
       surfaceID: surfaceID,
       formatter: Self.agentSignalDateFormatter,
@@ -731,12 +725,48 @@ final class WorktreeTerminalManager {
     )
   }
 
+  /// Issues a record for an agent already running in `target` and binds it to the pane's
+  /// current evidence epoch in one main-actor step (docs-ai 064.014). Unlike a prompted
+  /// launch this never begins a new epoch: the generation that will report the receipt is
+  /// the one the pane holds now, so its hook and cooperative signals keep counting.
+  func issueAgentDispatch(boundTo target: TabResolvedTarget) throws -> AgentDispatchSnapshot {
+    guard let surfaceID = UUID(uuidString: target.paneID), containsSurface(surfaceID) else {
+      throw AgentDispatchStoreError.bindingMissing
+    }
+    refreshEvidenceEpoch(surfaceID: surfaceID)
+    guard let evidenceEpoch = agentObservationStore.currentEvidenceEpoch(surfaceID: surfaceID) else {
+      throw AgentDispatchStoreError.bindingMissing
+    }
+    guard agentDispatchStore.pendingSnapshot(surfaceID: surfaceID) == nil else {
+      throw AgentDispatchStoreError.surfacePending
+    }
+    let issued = try agentDispatchStore.issue()
+    do {
+      try agentDispatchStore.bind(
+        dispatchID: issued.record.id,
+        binding: AgentDispatchBinding(
+          surfaceID: surfaceID,
+          target: TabTarget(from: target),
+          evidenceEpoch: evidenceEpoch
+        )
+      )
+    } catch {
+      agentDispatchStore.cancelIssuance(dispatchID: issued.record.id)
+      throw error
+    }
+    return agentDispatchStore.snapshot(dispatchID: issued.record.id) ?? issued
+  }
+
   func cancelAgentDispatchIssuance(dispatchID: String) {
     agentDispatchStore.cancelIssuance(dispatchID: dispatchID)
   }
 
   func agentDispatchSnapshot(dispatchID: String) -> AgentDispatchSnapshot? {
     agentDispatchStore.snapshot(dispatchID: dispatchID)
+  }
+
+  func pendingAgentDispatchSnapshot(surfaceID: UUID) -> AgentDispatchSnapshot? {
+    agentDispatchStore.pendingSnapshot(surfaceID: surfaceID)
   }
 
   func completeAgentDispatch(
@@ -751,6 +781,15 @@ final class WorktreeTerminalManager {
       summary: summary,
       callerSurfaceID: callerSurfaceID
     )
+  }
+
+  /// Completes the caller pane's current pending dispatch (see `AgentDispatchStore.complete(surfaceID:)`).
+  func completeAgentDispatch(
+    surfaceID: UUID,
+    outcome: DispatchCompletionOutcome,
+    summary: String
+  ) throws -> AgentDispatchMutationResult {
+    try agentDispatchStore.complete(surfaceID: surfaceID, outcome: outcome, summary: summary)
   }
 
   func abandonAgentDispatch(dispatchID: String, reason: String) throws -> AgentDispatchMutationResult {
@@ -871,15 +910,7 @@ final class WorktreeTerminalManager {
     state.onAgentEntryChanged = { [weak self] entry in
       guard let self else { return }
       let beganWorking = agentObservationStore.publishAgentChanged(entry)
-      let evidence = currentAgentEvidence(surfaceID: entry.surfaceID)
-      handleEvidenceEpochUpdate(
-        agentObservationStore.updateEvidenceEpoch(
-          surfaceID: entry.surfaceID,
-          processGeneration: evidence.generation,
-          sessionID: evidence.sessionID
-        ),
-        surfaceID: entry.surfaceID
-      )
+      refreshEvidenceEpoch(surfaceID: entry.surfaceID)
       if beganWorking,
         let evidenceEpoch = agentObservationStore.currentEvidenceEpoch(surfaceID: entry.surfaceID)
       {

--- a/supacodeTests/AgentDispatchCommandHandlerTests.swift
+++ b/supacodeTests/AgentDispatchCommandHandlerTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Foundation
 import Testing
 
@@ -20,11 +21,10 @@ struct AgentDispatchCommandHandlerTests {
     )
     let handler = AgentDispatchCompleteCommandHandler(
       resolveCaller: { _ in caller },
-      complete: { id, outcome, summary, surfaceID in
-        #expect(id == "d1")
+      complete: { surfaceID, outcome, summary in
+        #expect(surfaceID == caller.surfaceID)
         #expect(outcome == .succeeded)
         #expect(summary == "Done")
-        #expect(surfaceID == caller.surfaceID)
         return .success(AgentDispatchMutationResult(snapshot: snapshot, replayed: false))
       },
       now: { Self.start }
@@ -46,6 +46,35 @@ struct AgentDispatchCommandHandlerTests {
     #expect(!payload.replayed)
   }
 
+  /// A worker launched with an older `PROWL_DISPATCH_ID` — or none at all — still completes
+  /// whatever its pane currently holds: the pane, not the id, addresses the record.
+  @Test func completionResolvesThePaneRecordRegardlessOfLaunchDispatchID() async throws {
+    let caller = CallerPane(worktreeID: "w1", surfaceID: UUID())
+    let target = makeTarget(paneID: caller.surfaceID.uuidString)
+    let current = AgentDispatchSnapshot(
+      record: .completed(id: "d2", outcome: .failed, summary: "No", createdAt: Self.start, completedAt: Self.start),
+      binding: AgentDispatchBinding(surfaceID: caller.surfaceID, target: target, evidenceEpoch: UUID())
+    )
+    var completedSurfaces: [UUID] = []
+    let handler = AgentDispatchCompleteCommandHandler(
+      resolveCaller: { _ in caller },
+      complete: { surfaceID, _, _ in
+        completedSurfaces.append(surfaceID)
+        return .success(AgentDispatchMutationResult(snapshot: current, replayed: false))
+      }
+    )
+    for launchID in ["d1", nil] {
+      let response = await handler.handle(
+        envelope: envelope(.agentsDispatchComplete(.init(dispatchID: launchID, outcome: .failed, summary: "No"))),
+        context: CLICommandContext(callerProcessID: 123)
+      )
+      #expect(response.ok)
+      let payload = try #require(response.data).decode(as: DispatchCompleteCommandPayload.self)
+      #expect(payload.receipt.id == "d2")
+    }
+    #expect(completedSurfaces == [caller.surfaceID, caller.surfaceID])
+  }
+
   @Test func completionMapsStoreFailuresToStableCodes() async {
     let caller = CallerPane(worktreeID: "w1", surfaceID: UUID())
     for (error, code) in [
@@ -56,7 +85,7 @@ struct AgentDispatchCommandHandlerTests {
     ] {
       let handler = AgentDispatchCompleteCommandHandler(
         resolveCaller: { _ in caller },
-        complete: { _, _, _, _ in .failure(error) }
+        complete: { _, _, _ in .failure(error) }
       )
       let response = await handler.handle(
         envelope: envelope(.agentsDispatchComplete(.init(dispatchID: "d1", outcome: .failed, summary: "No"))),
@@ -89,10 +118,406 @@ struct AgentDispatchCommandHandlerTests {
     #expect(payload.replayed)
   }
 
+  // MARK: - agents dispatch
+
+  @Test func dispatchRejectsInvalidPromptsBeforeResolvingAnything() async {
+    var resolved = 0
+    let handler = AgentDispatchCommandHandler(resolveTarget: { _ in
+      resolved += 1
+      return .failure(.notFound("unused"))
+    })
+    for prompt in ["", "   \n", "bad\u{1B}[201~", "bell\u{07}", "cr\r\n"] {
+      let response = await handler.handle(envelope: envelope(.agentsDispatch(.init(pane: "p7", prompt: prompt))))
+      #expect(response.error?.code == CLIErrorCode.invalidArgument, "prompt: \(prompt.debugDescription)")
+    }
+    #expect(resolved == 0)
+    #expect(DispatchInput(pane: "p7", prompt: "line one\n\tline two").validationErrorMessage == nil)
+  }
+
+  @Test func dispatchMapsTargetResolutionFailures() async {
+    let notFound = AgentDispatchCommandHandler(resolveTarget: { _ in .failure(.notFound("No pane p9.")) })
+    let response = await notFound.handle(envelope: dispatch(pane: "p9"))
+    #expect(response.error?.code == CLIErrorCode.targetNotFound)
+    #expect(response.error?.message == "No pane p9.")
+
+    let notUnique = AgentDispatchCommandHandler(resolveTarget: { _ in .failure(.notUnique("Ambiguous.")) })
+    #expect(await notUnique.handle(envelope: dispatch(pane: "p9")).error?.code == CLIErrorCode.targetNotUnique)
+  }
+
+  @Test func dispatchRefusesWhileThePaneHoldsAPendingRecordAndNeverIssuesAnother() async throws {
+    let target = resolvedTarget()
+    let pending = AgentDispatchSnapshot(
+      record: .pending(id: "d1", createdAt: Self.start),
+      binding: AgentDispatchBinding(
+        surfaceID: surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+    )
+    var issued = 0
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      pendingDispatch: { _ in pending },
+      conditionSnapshot: { _ in self.snapshot(target, status: .idle, signal: self.turnEnded) },
+      issueDispatch: { _ in
+        issued += 1
+        return .failure(.surfacePending)
+      }
+    )
+    let response = await handler.handle(envelope: dispatch(pane: target.paneID))
+    #expect(response.error?.code == CLIErrorCode.dispatchPending)
+    #expect(issued == 0)
+    let details = try #require(response.error?.details).decode(as: AgentDispatchErrorDetails.self)
+    #expect(details.record?.id == "d1")
+    #expect(details.record?.state == .pending)
+    #expect(details.target == TabTarget(from: target))
+  }
+
+  @Test func dispatchNeedsADetectedAgentAndALiveSurface() async throws {
+    let target = resolvedTarget()
+    let absent = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in .init(agent: nil, signal: nil, revision: 1, isLive: true, signals: .empty) }
+    )
+    let notFound = await absent.handle(envelope: dispatch(pane: target.paneID))
+    #expect(notFound.error?.code == CLIErrorCode.agentNotFound)
+    let details = try #require(notFound.error?.details).decode(as: AgentDispatchErrorDetails.self)
+    #expect(details.target == TabTarget(from: target))
+    #expect(details.record == nil)
+
+    let closed = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in .init(agent: nil, signal: nil, revision: 0, isLive: false, signals: .empty) }
+    )
+    #expect(await closed.handle(envelope: dispatch(pane: target.paneID)).error?.code == CLIErrorCode.agentGone)
+  }
+
+  @Test func dispatchRefusesWorkingBlockedAndRuntimeNeedsInputAgents() async throws {
+    struct BusyCase {
+      let status: AgentDisplayState
+      let signal: AgentSignal?
+      let label: String
+    }
+    let target = resolvedTarget()
+    let cases = [
+      BusyCase(status: .working, signal: nil, label: "working"),
+      BusyCase(status: .blocked, signal: nil, label: "blocked"),
+      BusyCase(status: .blocked, signal: turnEnded, label: "blocked despite an old turn-ended"),
+      BusyCase(status: .idle, signal: needsInput, label: "runtime needs-input while the screen looks idle"),
+    ]
+    for busy in cases {
+      var issued = 0
+      let handler = AgentDispatchCommandHandler(
+        resolveTarget: { _ in .success(target) },
+        conditionSnapshot: { _ in
+          self.snapshot(target, status: busy.status, signal: busy.signal, channels: [self.liveClaudeChannel])
+        },
+        issueDispatch: { _ in
+          issued += 1
+          return .failure(.bindingMissing)
+        }
+      )
+      let response = await handler.handle(envelope: dispatch(pane: target.paneID))
+      let comment = Comment(rawValue: busy.label)
+      #expect(response.error?.code == CLIErrorCode.dispatchTargetBusy, comment)
+      #expect(issued == 0, comment)
+      let details = try #require(response.error?.details).decode(as: AgentDispatchErrorDetails.self)
+      #expect(details.observation?.status.rawValue == busy.status.rawValue, comment)
+      #expect(details.signals?.channels.count == 1, comment)
+    }
+  }
+
+  @Test func dispatchWithCorroboratedTurnEndedIssuesBindsThenDeliversPrefixedProtocol() async throws {
+    let target = resolvedTarget()
+    let issued = AgentDispatchSnapshot(
+      record: .pending(id: "d7", createdAt: Self.start),
+      binding: AgentDispatchBinding(
+        surfaceID: surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+    )
+    var lifecycle: [String] = []
+    var delivered: String?
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        self.snapshot(target, status: .done, signal: self.turnEnded, channels: [self.liveClaudeChannel])
+      },
+      issueDispatch: { resolved in
+        lifecycle.append("issue:\(resolved.paneID)")
+        return .success(issued)
+      },
+      deliverPrompt: { _, text in
+        lifecycle.append("deliver")
+        delivered = text
+        return true
+      },
+      cancelDispatch: { lifecycle.append("cancel:\($0)") },
+      now: { Self.start }
+    )
+    let response = await handler.handle(
+      envelope: envelope(.agentsDispatch(.init(pane: target.paneID, prompt: "Round two: re-review the diff.")))
+    )
+    #expect(response.ok)
+    #expect(response.command == "agents.dispatch")
+    #expect(response.schemaVersion == "prowl.cli.agents.dispatch.v1")
+    #expect(lifecycle == ["issue:\(target.paneID)", "deliver"])
+    let payload = try #require(response.data).decode(as: AgentDispatchCommandPayload.self)
+    #expect(payload.dispatch.id == "d7")
+    #expect(payload.dispatch.state == .pending)
+    #expect(payload.target == TabTarget(from: target))
+
+    let text = try #require(delivered)
+    #expect(text == AgentDispatchPrompt.renderInjected(userPrompt: "Round two: re-review the diff."))
+    #expect(text.hasPrefix("[Prowl] Round two: re-review the diff.\n"))
+    #expect(text.contains("Prowl dispatch completion protocol v\(AgentDispatchPrompt.protocolVersion)"))
+    #expect(text.contains("prowl agents dispatch-complete --outcome succeeded|failed"))
+    #expect(!text.contains("d7"))
+  }
+
+  /// Right after a turn the detector still shows `working` for its hold period although the
+  /// runtime already reported `turn-ended`; the precondition waits for the corroboration
+  /// instead of refusing, like `--until idle` would keep polling.
+  @Test func dispatchWaitsForTheDetectorToCorroborateAFreshTurnEnded() async throws {
+    let clock = TestClock()
+    let target = resolvedTarget()
+    let issued = AgentDispatchSnapshot(
+      record: .pending(id: "d11", createdAt: Self.start),
+      binding: AgentDispatchBinding(
+        surfaceID: surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+    )
+    var reads = 0
+    var delivered = 0
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        reads += 1
+        return self.snapshot(
+          target, status: reads > 3 ? .done : .working, signal: self.turnEnded, channels: [self.liveClaudeChannel])
+      },
+      issueDispatch: { _ in .success(issued) },
+      deliverPrompt: { _, _ in
+        delivered += 1
+        return true
+      },
+      clock: clock,
+      now: { Self.start }
+    )
+    let task = Task { await handler.handle(envelope: self.dispatch(pane: target.paneID)) }
+    for _ in 0..<3 {
+      await Task.yield()
+      await clock.advance(by: .milliseconds(200))
+    }
+    let response = await task.value
+    #expect(response.ok)
+    #expect(reads == 4)
+    #expect(delivered == 1)
+  }
+
+  @Test func dispatchRefusesWhenTheDetectorNeverCorroboratesWithinTheGrace() async throws {
+    let clock = TestClock()
+    let target = resolvedTarget()
+    var issued = 0
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        self.snapshot(target, status: .working, signal: self.turnEnded, channels: [self.liveClaudeChannel])
+      },
+      issueDispatch: { _ in
+        issued += 1
+        return .failure(.bindingMissing)
+      },
+      clock: clock,
+      now: { Self.start }
+    )
+    let task = Task { await handler.handle(envelope: self.dispatch(pane: target.paneID)) }
+    for _ in 0..<(AgentDispatchCommandHandler.idleGraceMilliseconds / 200) {
+      await Task.yield()
+      await clock.advance(by: .milliseconds(200))
+    }
+    let response = await task.value
+    #expect(response.error?.code == CLIErrorCode.dispatchTargetBusy)
+    #expect(issued == 0)
+    let details = try #require(response.error?.details).decode(as: AgentDispatchErrorDetails.self)
+    #expect(details.observation?.status == .working)
+  }
+
+  @Test func dispatchWithoutRuntimeEvidenceWaitsForTwoSecondsOfStableIdleDetection() async throws {
+    let clock = TestClock()
+    let target = resolvedTarget()
+    let issued = AgentDispatchSnapshot(
+      record: .pending(id: "d8", createdAt: Self.start),
+      binding: AgentDispatchBinding(
+        surfaceID: surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+    )
+    var reads = 0
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        reads += 1
+        return self.snapshot(target, status: .idle, signal: nil)
+      },
+      issueDispatch: { _ in .success(issued) },
+      deliverPrompt: { _, _ in true },
+      clock: clock,
+      now: { Self.start }
+    )
+    let task = Task { await handler.handle(envelope: self.dispatch(pane: target.paneID)) }
+    for _ in 0..<9 {
+      await Task.yield()
+      await clock.advance(by: .milliseconds(200))
+    }
+    #expect(!task.isCancelled)
+    await Task.yield()
+    await clock.advance(by: .milliseconds(200))
+    let response = await task.value
+    #expect(response.ok)
+    #expect(reads == 11)
+  }
+
+  @Test func dispatchStabilizationAbortsWhenTheAgentStartsWorking() async throws {
+    let clock = TestClock()
+    let target = resolvedTarget()
+    var reads = 0
+    var issued = 0
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        reads += 1
+        return self.snapshot(target, status: reads > 3 ? .working : .idle, signal: nil)
+      },
+      issueDispatch: { _ in
+        issued += 1
+        return .failure(.bindingMissing)
+      },
+      clock: clock,
+      now: { Self.start }
+    )
+    let task = Task { await handler.handle(envelope: self.dispatch(pane: target.paneID)) }
+    for _ in 0..<4 {
+      await Task.yield()
+      await clock.advance(by: .milliseconds(200))
+    }
+    let response = await task.value
+    #expect(response.error?.code == CLIErrorCode.dispatchTargetBusy)
+    #expect(issued == 0)
+  }
+
+  @Test func dispatchWithALiveChannelHoldingNoLevelStillUsesTheStabilizedDetector() async throws {
+    let clock = TestClock()
+    let target = resolvedTarget()
+    let issued = AgentDispatchSnapshot(
+      record: .pending(id: "d9", createdAt: Self.start),
+      binding: AgentDispatchBinding(
+        surfaceID: surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+    )
+    let handler = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: { _ in
+        self.snapshot(target, status: .idle, signal: nil, channels: [self.liveClaudeChannel])
+      },
+      issueDispatch: { _ in .success(issued) },
+      deliverPrompt: { _, _ in true },
+      clock: clock,
+      now: { Self.start }
+    )
+    let task = Task { await handler.handle(envelope: self.dispatch(pane: target.paneID)) }
+    for _ in 0..<10 {
+      await Task.yield()
+      await clock.advance(by: .milliseconds(200))
+    }
+    let response = await task.value
+    #expect(response.ok)
+  }
+
+  @Test func dispatchMapsIssuanceFailuresAndRollsBackAFailedDelivery() async throws {
+    let target = resolvedTarget()
+    let idle: AgentDispatchCommandHandler.ConditionSnapshotProvider = { _ in
+      self.snapshot(target, status: .idle, signal: self.turnEnded)
+    }
+    let capacity = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: idle,
+      issueDispatch: { _ in .failure(.capacityExceeded) }
+    )
+    #expect(
+      await capacity.handle(envelope: dispatch(pane: target.paneID)).error?.code
+        == CLIErrorCode.dispatchCapacityExceeded
+    )
+
+    let raced = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: idle,
+      issueDispatch: { _ in .failure(.surfacePending) }
+    )
+    #expect(await raced.handle(envelope: dispatch(pane: target.paneID)).error?.code == CLIErrorCode.dispatchPending)
+
+    let unbound = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: idle,
+      issueDispatch: { _ in .failure(.bindingMissing) }
+    )
+    #expect(await unbound.handle(envelope: dispatch(pane: target.paneID)).error?.code == CLIErrorCode.dispatchFailed)
+
+    var cancelled: [String] = []
+    let undeliverable = AgentDispatchCommandHandler(
+      resolveTarget: { _ in .success(target) },
+      conditionSnapshot: idle,
+      issueDispatch: { _ in
+        .success(
+          AgentDispatchSnapshot(
+            record: .pending(id: "d10", createdAt: Self.start),
+            binding: AgentDispatchBinding(
+              surfaceID: self.surfaceID(of: target), target: TabTarget(from: target), evidenceEpoch: UUID())
+          ))
+      },
+      deliverPrompt: { _, _ in false },
+      cancelDispatch: { cancelled.append($0) }
+    )
+    let response = await undeliverable.handle(envelope: dispatch(pane: target.paneID))
+    #expect(response.error?.code == CLIErrorCode.dispatchFailed)
+    #expect(cancelled == ["d10"])
+  }
+
+  // MARK: - Helpers
+
   private static let start = Date(timeIntervalSince1970: 1_000)
+
+  private var turnEnded: AgentSignal {
+    AgentSignal(
+      kind: .turnEnded,
+      source: .hook(runtime: .claude, event: "Stop"),
+      confidence: .exact,
+      timestamp: Self.start,
+      sessionID: nil,
+      detail: nil,
+      claimedOrigin: nil
+    )
+  }
+
+  private var needsInput: AgentSignal {
+    AgentSignal(
+      kind: .needsInput,
+      source: .hook(runtime: .claude, event: "Notification"),
+      confidence: .exact,
+      timestamp: Self.start,
+      sessionID: nil,
+      detail: nil,
+      claimedOrigin: nil
+    )
+  }
+
+  private var liveClaudeChannel: AgentSignalChannelPayload {
+    AgentSignalChannelPayload(
+      source: "hook_claude",
+      state: .verifiedLive,
+      confidence: "exact",
+      events: [.sessionStart, .turnEnded, .needsInput, .sessionEnd],
+      lastSeenAt: "2026-08-29T00:00:00.000Z"
+    )
+  }
 
   private func envelope(_ command: Command) -> CommandEnvelope {
     CommandEnvelope(output: .json, command: command)
+  }
+
+  private func dispatch(pane: String) -> CommandEnvelope {
+    envelope(.agentsDispatch(.init(pane: pane, prompt: "Round two.")))
   }
 
   private func makeTarget(paneID: String) -> TabTarget {
@@ -100,6 +525,61 @@ struct AgentDispatchCommandHandlerTests {
       worktree: .init(id: "w1", name: "App", path: "/App", rootPath: "/App", kind: "worktree"),
       tab: .init(id: "t1", title: "Agent", selected: true),
       pane: .init(id: paneID, title: "Agent", cwd: "/App", focused: true)
+    )
+  }
+
+  private func resolvedTarget() -> TabResolvedTarget {
+    let value = makeTarget(paneID: UUID().uuidString)
+    return TabResolvedTarget(
+      worktreeID: value.worktree.id,
+      worktreeName: value.worktree.name,
+      worktreePath: value.worktree.path,
+      worktreeRootPath: value.worktree.rootPath,
+      worktreeKind: value.worktree.kind,
+      tabID: value.tab.id,
+      tabTitle: value.tab.title,
+      tabSelected: value.tab.selected,
+      paneID: value.pane.id,
+      paneTitle: value.pane.title,
+      paneCWD: value.pane.cwd,
+      paneFocused: value.pane.focused
+    )
+  }
+
+  private func surfaceID(of target: TabResolvedTarget) -> UUID {
+    UUID(uuidString: target.paneID)!
+  }
+
+  private func snapshot(
+    _ target: TabResolvedTarget,
+    status: AgentDisplayState,
+    signal: AgentSignal?,
+    channels: [AgentSignalChannelPayload] = []
+  ) -> AgentConditionSnapshot {
+    AgentConditionSnapshot(
+      agent: agentEntry(surfaceID: surfaceID(of: target), status: status),
+      signal: signal,
+      revision: 3,
+      isLive: true,
+      signals: AgentSignalsPayload(channels: channels, last: nil, lastBinding: nil)
+    )
+  }
+
+  private func agentEntry(surfaceID: UUID, status: AgentDisplayState) -> ActiveAgentEntry {
+    ActiveAgentEntry(
+      id: surfaceID,
+      worktreeID: "w1",
+      worktreeName: "App",
+      workingDirectory: URL(fileURLWithPath: "/App"),
+      tabID: TerminalTabID(rawValue: UUID()),
+      paneTitle: "Agent",
+      surfaceID: surfaceID,
+      paneIndex: 0,
+      iconLookupToken: "claude",
+      agent: .claude,
+      rawState: status == .working ? .working : status == .blocked ? .blocked : .idle,
+      displayState: status,
+      lastChangedAt: Self.start
     )
   }
 }

--- a/supacodeTests/AgentDispatchStoreTests.swift
+++ b/supacodeTests/AgentDispatchStoreTests.swift
@@ -263,6 +263,62 @@ struct AgentDispatchStoreTests {
     #expect(await waiter.next() == .changed(completed.snapshot))
   }
 
+  @Test func oneSurfaceHoldsAtMostOnePendingRecord() throws {
+    let store = makeStore(ids: ["d1", "d2"])
+    let surfaceID = UUID()
+    let binding = binding(surfaceID: surfaceID)
+    _ = try store.issue()
+    try store.bind(dispatchID: "d1", binding: binding)
+    #expect(store.pendingSnapshot(surfaceID: surfaceID)?.record.id == "d1")
+    #expect(store.pendingSnapshot(surfaceID: UUID()) == nil)
+
+    _ = try store.issue()
+    #expect(throws: AgentDispatchStoreError.surfacePending) {
+      try store.bind(dispatchID: "d2", binding: binding)
+    }
+    #expect(store.pendingSnapshot(surfaceID: surfaceID)?.record.id == "d1")
+    #expect(store.snapshot(dispatchID: "d2")?.binding == nil)
+    // Rebinding the pending record itself stays idempotent.
+    try store.bind(dispatchID: "d1", binding: binding)
+
+    _ = try store.complete(dispatchID: "d1", outcome: .succeeded, summary: "Done", callerSurfaceID: surfaceID)
+    #expect(store.pendingSnapshot(surfaceID: surfaceID) == nil)
+    try store.bind(dispatchID: "d2", binding: binding)
+    #expect(store.pendingSnapshot(surfaceID: surfaceID)?.record.id == "d2")
+  }
+
+  @Test func completionBySurfaceResolvesThePendingRecordThenReplaysTheLatestOne() throws {
+    let store = makeStore(ids: ["d1", "d2"])
+    let surfaceID = UUID()
+    let binding = binding(surfaceID: surfaceID)
+    _ = try store.issue()
+    try store.bind(dispatchID: "d1", binding: binding)
+    #expect(throws: AgentDispatchStoreError.notFound) {
+      try store.complete(surfaceID: UUID(), outcome: .succeeded, summary: "Done")
+    }
+
+    let first = try store.complete(surfaceID: surfaceID, outcome: .succeeded, summary: "Round one")
+    #expect(first.snapshot.record.id == "d1")
+    #expect(!first.replayed)
+    // With no pending record left, a retry replays the pane's latest receipt and a
+    // conflicting retry is still rejected.
+    let replay = try store.complete(surfaceID: surfaceID, outcome: .succeeded, summary: "Round one")
+    #expect(replay.replayed)
+    #expect(throws: AgentDispatchStoreError.alreadyCompleted) {
+      try store.complete(surfaceID: surfaceID, outcome: .failed, summary: "Different")
+    }
+
+    _ = try store.issue()
+    try store.bind(
+      dispatchID: "d2",
+      binding: AgentDispatchBinding(surfaceID: surfaceID, target: Self.target, evidenceEpoch: UUID())
+    )
+    let second = try store.complete(surfaceID: surfaceID, outcome: .failed, summary: "Round two")
+    #expect(second.snapshot.record.id == "d2")
+    #expect(!second.replayed)
+    #expect(store.snapshot(dispatchID: "d1")?.record.state == .completed)
+  }
+
   @Test func storeResetIsAppLifetimeReset() throws {
     let first = makeStore(ids: ["d1"])
     _ = try first.issue()


### PR DESCRIPTION
## Summary

Closes #733.

- `prowl agents dispatch <pane|pN> --prompt -` creates a **new pending dispatch for an agent that already runs in a pane**, types the prompt plus the completion protocol into it (prefixed `[Prowl] `, one bracketed paste + Enter through the `send` path), and returns `.data.target` + `.data.dispatch.{id,state,created_at}` like a prompted `create`. Every later rule — `agents wait --dispatch`, `dispatch-abandon`, `DISPATCH_NEEDS_INPUT` / `DISPATCH_INCOMPLETE` / `AGENT_GONE`, capacity — applies to the new record unchanged; it binds to the pane's *current* evidence epoch.
- **One pending record per surface**, enforced in `AgentDispatchStore.bind` (`surfacePending`): a second `dispatch` fails with `DISPATCH_PENDING` (record in `.error.details.record`) and never overwrites.
- **Precondition = the `agents wait --until idle` evidence rules**, shared through the new `AgentConditionEvidence` (moved out of `AgentWaitCommandHandler`, which keeps its behavior and tests): a corroborated `turn-ended` resolves at once; a `turn-ended` the detector has not caught up with, or a detector-only idle view still stabilizing, settles within a five-second grace; working/blocked without such evidence (including a runtime `needs-input`) is refused with `DISPATCH_TARGET_BUSY` before anything is typed; no detected agent is `AGENT_NOT_FOUND`.
- `agents dispatch-complete` resolves the record from the **caller's process ancestry → pane → that pane's current pending record** (then the pane's latest record, so an identical retry still replays). `PROWL_DISPATCH_ID` stays launch-scoped diagnostics: the CLI no longer requires it, forwards it when present, and a worker launched with an older id completes the pane's current record.
- New error codes: `DISPATCH_PENDING`, `DISPATCH_TARGET_BUSY`. `DISPATCH_CONTEXT_REQUIRED` now means "caller outside any pane"; `DISPATCH_NOT_FOUND` also covers a pane that never held a dispatch.
- Docs: `docs/components/cli.md`, contract pages under `docs-ai/013-prowl-cli/contracts/` (`agents-wait.md`, `input.md`, `schema.md`, `agents.md`), the executable schema (`agentsDispatchResponse`, `agentsDispatchErrorDetails`), the `prowl-cli` skill's "reuse one reviewer across rounds" recipe, and the record `docs-ai/064-agent-completion-signals/014-re-dispatch.md` (+ one Amendments line in `000-plan.md`).

Not implemented (non-goals): the workflow engine, new runtime hooks, any change to how a launch dispatch is created.

## Design measurements

- **Delivery of a multi-line prompt into a live TUI.** `insertCommittedText` → `ghostty_surface_text` → `Surface.completeClipboardPaste` → `input.paste.encode`, which wraps the text in bracketed paste (`\x1b[200~ … \x1b[201~`) whenever the TUI has mode 2004 on and otherwise rewrites `\n` as `\r`; ESC and the C0 bytes are stripped to spaces. Live: `printf '%s\n' <three lines> | prowl send --pane … --no-wait` reached **Claude Code 2.1.251 and Codex 0.149.1 as one message** (both replied `RECEIVED 3 lines`). So multi-line `--prompt -` is accepted; the CLI normalizes CRLF and drops trailing newlines; the app rejects control characters other than newline/tab with `INVALID_ARGUMENT`; cap 256 KiB.
- **Idle precondition timing.** In the first live run `agents wait --until idle` resolved on a fresh `hook_claude` / `hook_codex` `turn-ended` while the detector still held `working` (its post-turn hold), and a dispatch issued in the same second was refused. The precondition therefore settles up to five seconds when idle by one source only — the same polling the wait does — and refuses immediately otherwise; the final run issued the record 3 s after the wait resolved, for both runtimes.

## Validation

All commands run on this branch (worktree `feat/agent-redispatch`, Xcode 26.6):

- `make check` → exit 0 (format-changed, swift-format lint --strict, swiftlint, 44 script tests OK).
- `make build-cli` → exit 0; `make test-cli-unit` → 141 tests, 0 failures; `make test-cli-smoke` → exit 0; `make test-cli-integration` → 105 tests, 0 failures (includes the new `agents dispatch` stdin round-trip, refusal rendering, and `dispatch-complete` without `PROWL_DISPATCH_ID`).
- `xcodebuild test … -only-testing:supacodeTests/{AgentDispatchStoreTests,AgentDispatchCommandHandlerTests,AgentWaitCommandHandlerTests,CLILifecycleCommandHandlerTests,CLIAgentSignalCommandHandlerTests,AgentProfileHookCarrierTests}` → status success, 86 passed, 0 failed (new: 2 store tests, 12 dispatch-handler tests incl. TestClock-driven grace/stabilization).
- `make build-app` → status success (after an `xcodebuild clean`, see below).
- Live, isolated Debug instance (`CFFIXED_USER_HOME` scratch home, `PROWL_CLI_SOCKET=/tmp/redispatch.sock`, `caffeinate`), "Claude Code" and "Codex" Profiles with the branch CLI on their `PATH`:
  - `create tab … --prompt -` → `wait --dispatch` succeeded (Claude 5 s; Codex `DISPATCH_INCOMPLETE` first because its `turn-ended` preceded the completion command, then the receipt on re-arm — pre-existing S2 flow).
  - `wait --until idle` (exact hook) → `agents dispatch <pane> --prompt -` → pending → **second `dispatch` in the same second refused `DISPATCH_PENDING`** → `wait --dispatch` succeeded (Claude 2.8 s: "R2: round 2 … in the same session after round 1"; Codex 4.0 s), i.e. the process launched with the round-1 `PROWL_DISPATCH_ID` completed the round-2 record.
  - plain `send` keeping the agent busy (`sleep 20`) → `dispatch` refused **`DISPATCH_TARGET_BUSY`** (`observation.status: working`) for both runtimes → `wait --until idle` → back-to-back `dispatch` issued (settled within the grace) → round 3 asked for `--outcome failed` → `wait --dispatch` returned `DISPATCH_FAILED` with the failed receipt, both runtimes.
  - `dispatch-complete` from the coordinator's own shell → `DISPATCH_CONTEXT_REQUIRED`; from a plain shell pane inside the instance → `DISPATCH_NOT_FOUND`.
  - The trust entries the two runtimes wrote for the scratch repo were removed from `~/.claude.json` / `~/.codex/config.toml` afterwards; the instance was quit.
- Build hygiene finding: the first *incremental* Debug build of this branch on top of a `main` build crashed (`EXC_BAD_ACCESS` in `swift_release` while a completed `send --capture` route task released its `CommandEnvelope`). `CLISocketServer.o` had not been recompiled after `Command` gained the `agentsDispatch` case, so its stale outlined destroy released the new `.send` payload with the old `.key` layout. `xcodebuild clean` + `make build-app` does not reproduce it (3/3 `send --capture` alive; the baseline build never crashed). Reviewers building this branch on top of an older DerivedData should clean first.

## Not changed

- Codex emits a `turn-ended` before running the completion command on its first prompted turn (the usage-limit notice precedes the tool call), so the first `wait --dispatch` can return `DISPATCH_INCOMPLETE`; re-arming returns the receipt. Unchanged S2 behavior, noted in the record.
- A re-dispatch into a manually launched agent (no `verified_live` channel) takes the two-second detector stabilization every time; the exact path resolves at once after a cooperative `turn-ended`.
- `agents dispatch` types into the pane without focusing it, like `send`.

https://claude.ai/code/session_01YSXSCVNoycSbCmwPMvcCnw
