### PR TITLE
Add the workflow runner core (063 B2)

### DIFF
--- a/ProwlCLIContracts/Resources/workflow-definition-schema.json
+++ b/ProwlCLIContracts/Resources/workflow-definition-schema.json
@@ -524,6 +524,9 @@
             "skip",
             "cancel"
           ]
+        },
+        "strict": {
+          "type": "boolean"
         }
       },
       "dependentRequired": {

--- a/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
+++ b/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
@@ -37,6 +37,21 @@ final class MarkdownArtifactNormalizerTests: XCTestCase {
     XCTAssertEqual(MarkdownArtifactNormalizer.normalized("just prose\nno headings"), "just prose\nno headings")
   }
 
+  func testTildeFencesAreUnwrappedLikeBackticks() {
+    let text = "~~~markdown\n## Findings\nx\n## Verdict\ny\n~~~\nchat trailer"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(text), "## Findings\nx\n## Verdict\ny")
+    let mixed = "Intro\n~~~\n# Doc\n```swift\nlet x = 1\n```\n~~~\nbye"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(mixed), "# Doc\n```swift\nlet x = 1\n```")
+  }
+
+  func testHeadingsOutsideFencesAndSectionMatching() {
+    let text = "# Doc\n```text\n## Hidden\n```\n~~~\n## Also hidden\n~~~\n## Visible (2)\nbody\n"
+    XCTAssertEqual(MarkdownArtifactNormalizer.headings(outsideFences: text), ["# Doc", "## Visible (2)"])
+    XCTAssertTrue(MarkdownArtifactNormalizer.hasSections(["## Visible"], in: text))
+    XCTAssertFalse(MarkdownArtifactNormalizer.hasSections(["## Hidden"], in: text))
+    XCTAssertFalse(MarkdownArtifactNormalizer.hasSections(["## Vis"], in: text))
+  }
+
   func testEmptyInputStaysEmpty() {
     XCTAssertEqual(MarkdownArtifactNormalizer.normalized("   \n  "), "")
   }

--- a/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
+++ b/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
@@ -1,0 +1,43 @@
+import ProwlCLIShared
+import XCTest
+
+final class MarkdownArtifactNormalizerTests: XCTestCase {
+  func testStripsOpeningFencePreambleAndTrailerAfterClosingFence() {
+    let text = """
+      Sure, here's the file:
+      ```markdown
+      # Handoff
+      ## Objective
+      Ship.
+      ```
+      Let me know if you need anything else.
+      """
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(text), "# Handoff\n## Objective\nShip.")
+  }
+
+  func testWithoutOpeningFenceOnlyAnExactTrailingFenceIsRemoved() {
+    let text = """
+      Intro chatter
+      # Doc
+      ```swift
+      let x = 1
+      ```
+      ## More
+      text
+      ```
+      """
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(text), "# Doc\n```swift\nlet x = 1\n```\n## More\ntext")
+  }
+
+  func testTextStartingWithAHeadingIsOnlyTrimmed() {
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized("\n\n# Doc\nbody\n\n"), "# Doc\nbody")
+  }
+
+  func testTextWithoutHeadingsIsKept() {
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized("just prose\nno headings"), "just prose\nno headings")
+  }
+
+  func testEmptyInputStaysEmpty() {
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized("   \n  "), "")
+  }
+}

--- a/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
+++ b/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
@@ -64,6 +64,22 @@ final class MarkdownArtifactNormalizerTests: XCTestCase {
     XCTAssertEqual(MarkdownArtifactNormalizer.normalized(mismatched), "# Doc\n~~~\nbye")
   }
 
+  func testHeadingsFollowATXSyntaxAndIndentedCodeIsNotAHeading() {
+    let indented = "# Handoff\n    ## Objective\n    ## Current State\n    ## Next Steps\n"
+    XCTAssertEqual(MarkdownArtifactNormalizer.headings(outsideFences: indented), ["# Handoff"])
+    XCTAssertFalse(MarkdownArtifactNormalizer.hasSections(["## Objective"], in: indented))
+    XCTAssertEqual(MarkdownArtifactNormalizer.headings(outsideFences: "   ## Three spaces\n#nospace\n####### seven\n#\n"), ["## Three spaces", "#"])
+    let wrapped = "Intro\n```markdown\n   ## Objective\ntext\n```\n"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(wrapped), "## Objective\ntext")
+  }
+
+  func testWrapperClosesAtItsFirstMatchingCloserOutsideInnerBlocks() {
+    let reply = "```markdown\n# Handoff\n## Objective\nShip.\n```\nExample command:\n```sh\necho trailer\n```"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(reply), "# Handoff\n## Objective\nShip.")
+    let nested = "```markdown\n# Doc\n```swift\nlet x = 1\n```\n## More\n```\nbye"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(nested), "# Doc\n```swift\nlet x = 1\n```\n## More")
+  }
+
   func testEmptyInputStaysEmpty() {
     XCTAssertEqual(MarkdownArtifactNormalizer.normalized("   \n  "), "")
   }

--- a/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
+++ b/ProwlCLITests/MarkdownArtifactNormalizerTests.swift
@@ -52,6 +52,18 @@ final class MarkdownArtifactNormalizerTests: XCTestCase {
     XCTAssertFalse(MarkdownArtifactNormalizer.hasSections(["## Vis"], in: text))
   }
 
+  func testFenceClosersMustBeBareRunsOfAtLeastTheOpeningLength() {
+    let fake = "# Handoff\n```text\n```still code\n## Objective\n## Current State\n## Next Steps\n```\n"
+    XCTAssertEqual(MarkdownArtifactNormalizer.headings(outsideFences: fake), ["# Handoff"])
+    XCTAssertFalse(MarkdownArtifactNormalizer.hasSections(["## Objective"], in: fake))
+    let longer = "# Doc\n````\n```\n## Hidden\n```\n````\n## Shown\n"
+    XCTAssertEqual(MarkdownArtifactNormalizer.headings(outsideFences: longer), ["# Doc", "## Shown"])
+    let wrapped = "````markdown\n# Doc\n```swift\nlet x = 1\n```\n````\ntrailer"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(wrapped), "# Doc\n```swift\nlet x = 1\n```")
+    let mismatched = "```markdown\n# Doc\n~~~\nbye"
+    XCTAssertEqual(MarkdownArtifactNormalizer.normalized(mismatched), "# Doc\n~~~\nbye")
+  }
+
   func testEmptyInputStaysEmpty() {
     XCTAssertEqual(MarkdownArtifactNormalizer.normalized("   \n  "), "")
   }

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -5,6 +5,20 @@ import XCTest
 final class WorkflowDocumentParserTests: XCTestCase {
   // MARK: - The spec example
 
+  func testExpectStrictParsesAndDefaultsToFalse() throws {
+    let yaml = WorkflowFixtures.minimal(
+      extraSteps: "  - id: a\n    message: author\n    text: x\n    expect: { output: a, strict: true }\n"
+        + "  - id: b\n    message: author\n    text: y\n    expect: { output: b }")
+    let workflow = try WorkflowFixtures.parse(yaml)
+    XCTAssertEqual(workflow.steps[1].action.expect?.strict, true)
+    XCTAssertEqual(workflow.steps[2].action.expect?.strict, false)
+    XCTAssertEqual(
+      WorkflowFixtures.codes(
+        WorkflowFixtures.minimal(
+          extraSteps: "  - id: a\n    message: author\n    text: x\n    expect: { strict: yes please }")),
+      ["type_mismatch"])
+  }
+
   func testParsesTheSpecExample() throws {
     let result = WorkflowDocumentParser.parse(WorkflowFixtures.adversarialReview)
     XCTAssertEqual(result.diagnostics, [])

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -105,6 +105,9 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal() + "inputs:\n  s: { type: string, default: \"two\\nlines\" }\n"),
       ["input_default_multiline"])
+    XCTAssertEqual(
+      WorkflowFixtures.codes(minimal() + "inputs:\n  m: { type: enum, values: [a, \"two\\nlines\"] }\n"),
+      ["enum_value_multiline"])
   }
 
   // MARK: - Templates

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -2,9 +2,9 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — R1 shipped in v2026.8.29; R2a under way: B1 implemented (definitions in `ProwlCLIShared`, `prowl workflow list/validate/schema`; [006](006-b1-definitions.md)), #733 and #726 T0 in flight; B2 next |
+| **Status** | In progress — R1 shipped in v2026.8.29; R2a under way: B1 (#740, [006](006-b1-definitions.md)), #733 (#741), and #726 T0 (#739) merged; B2 runner core implemented ([007](007-b2-runner-core.md)); B3 next |
 | **Anchor date** | 2026-08-21 |
-| **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a/R2b/R3 (B1–D3) TBD |
+| **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a: #740 (B1), B2 (this record's PR, see [007](007-b2-runner-core.md)); B3–D3 TBD |
 | **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), [release plan (living)](release-plan.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
 
 ## Background
@@ -596,6 +596,13 @@ attaches hooks through A2's launch boundary.
 
 ## Amendments
 
+- Updated 2026-08-29 (B2, grilled): the runner core is a pure reducer (`WorkflowRunMachine`)
+  whose effects B3 interprets; activation tokens are checked in the machine, the dispatch store
+  stays untouched; the watchdog observes each activation through `observeAgentDispatch` +
+  `observeAgentState` on an injected clock; `run.json` v1 records dispatch ids but never tokens;
+  Relaunch is offered for `launch` roles only; a Skip resolves its §5 consequence immediately;
+  binding resolution is a pure resolver (memory storage and the sheet stay with B3/C2). The
+  spec's §4/§5/§8/§10 were clarified accordingly — see [007-b2-runner-core.md](007-b2-runner-core.md).
 - Updated 2026-08-29 (B1 kickoff, grilled): the DSL spec was aligned with what R1 shipped.
   (1) `expect` activations are records in the shared dispatch store — `launch` via the S2
   prompted-launch path, `message` via #733's re-dispatch — and `workflow done` is the

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | In progress — R1 shipped in v2026.8.29; R2a under way: B1 (#740, [006](006-b1-definitions.md)), #733 (#741), and #726 T0 (#739) merged; B2 runner core implemented ([007](007-b2-runner-core.md)); B3 next |
 | **Anchor date** | 2026-08-21 |
-| **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a: #740 (B1), B2 (this record's PR, see [007](007-b2-runner-core.md)); B3–D3 TBD |
+| **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a: #740 (B1), #743 (B2, [007](007-b2-runner-core.md)); B3–D3 TBD |
 | **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), [release plan (living)](release-plan.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
 
 ## Background

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -603,6 +603,10 @@ attaches hooks through A2's launch boundary.
   Relaunch is offered for `launch` roles only; a Skip resolves its §5 consequence immediately;
   binding resolution is a pure resolver (memory storage and the sheet stay with B3/C2). The
   spec's §4/§5/§8/§10 were clarified accordingly — see [007-b2-runner-core.md](007-b2-runner-core.md).
+- Updated 2026-08-29 (B2, H14): `prowl workflow done` validation became a review gate — a
+  delivery that misses `sections` / `format` / `verdict` is kept as provisional and the run asks
+  the user (Accept / Accept with verdict / Ask again / Skip); `expect.strict: true` restores the
+  hard rejection. Spec §5/§9/§10 amended; see [007-b2-runner-core.md](007-b2-runner-core.md).
 - Updated 2026-08-29 (B1 kickoff, grilled): the DSL spec was aligned with what R1 shipped.
   (1) `expect` activations are records in the shared dispatch store — `launch` via the S2
   prompted-launch path, `message` via #733's re-dispatch — and `workflow done` is the

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -252,7 +252,7 @@ dispatch record (the machine ignores events on terminal runs).
   `WorkflowBindingResolverTests`, `WorkflowRunHarnessTests`, plus the untouched
   `HandoffStoreTests` over the moved normalizer.
 - Gates: `make check` (swift-format + SwiftLint strict) clean; `make build-cli`;
-  `make test-cli-unit` (224 tests); `make test-cli-smoke`; `make test-cli-integration` (109
+  `make test-cli-unit` (226 tests); `make test-cli-smoke`; `make test-cli-integration` (109
   tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round (2796 → 2808 → 2816 → 2819 tests, zero failures).
 
 ## Review

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -139,14 +139,116 @@ protocol block and `PROWL_WORKFLOW_TOKEN` in the child environment only; the wat
 and attention timings on hooked and unhooked runtimes; `dispatch-complete` refused with
 `WORKFLOW_DELIVERY_REQUIRED`; run directory contents after a full `prowl.adversarial-review`.
 
+## Delivered
+
+Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared touches:
+
+- `WorkflowRun.swift` — the run value (`WorkflowRun`), bindings (`WorkflowRoleBinding` with
+  `WorkflowPaneIdentity` / `WorkflowProfileBinding`), context (`WorkflowRunContext`,
+  `WorkflowRunScope`, `WorkflowRunWorktree`), path derivation (`WorkflowRunPaths`),
+  invocations / activations / outputs, the position cursor with loop state, step records,
+  attention (`WorkflowAttention`, reasons, actions), status and phase.
+- `WorkflowRunMachine.swift` — `WorkflowRunStartRequest` + `start(_:now:makeToken:)` (input
+  defaults / ranges / single-line, `UNSAFE_PATH`, `repeat.max` in 1…20, `--skip` legality,
+  missing bindings), `apply(_:)`, `deliver(ordinal:selector:body:verdict:)`,
+  `skipConsequence(forStep:)`, `activation(forDispatchID:)`, `templateContext()`; the effect
+  vocabulary (`WorkflowRunEffect`, `WorkflowLaunchRequest`, `WorkflowWatchdogRequest`) and the
+  event vocabulary (`WorkflowRunEvent`, `WorkflowUserAction`, `WorkflowInjectionFailure`,
+  `WorkflowWatchdogVerdict`).
+- `WorkflowLineRenderer.swift` — `WorkflowCompletionCommand` (message form, launch form, typed
+  suffix, instruction trailer, protocol block, nudge, `WORKFLOW_DELIVERY_REQUIRED` message),
+  `WorkflowTypedLine` (`[Prowl] ` prefix from `AgentDispatchPrompt.injectedPrefix`),
+  `WorkflowRenderedText` (the §10 boundary over `WorkflowValidator.isSingleLine`),
+  `WorkflowLaunchPrompt` (NUL, 32 KiB).
+- `WorkflowTemplateRenderer.swift` — `WorkflowTemplateContext` and `WorkflowTemplate.render`;
+  `missingOutput` is the runtime Skip-rule signal; substituted values are never re-scanned.
+- `WorkflowDeliveryValidator.swift` — `WorkflowDeliveryLimits` (1 MiB default, 4 MiB hard
+  max), `WorkflowDeliveryError` with the §9 codes, markdown normalization through the Shared
+  `MarkdownArtifactNormalizer`, `text`, `json`.
+- `WorkflowRunStore.swift` — `WorkflowRunRecord` v1 (+ `WorkflowRunRecordInfo` /
+  `Invocation` / `Activation`), `WorkflowRunStore` (layout + `.gitignore`, `run.json`, `log.md`,
+  instructions, versioned outputs with `rename(2)` latest view, bundled-skill copy, the
+  `AgentProfileHomeProvisioner` containment gate on the run directory and a symlink check on
+  every subdirectory, `markInterruptedRuns(now:)`).
+- `WorkflowWatchdog.swift` — `WorkflowWatchdogSettings` (15 s / 5 s floor, 3 min, 30 s), the
+  pure `WorkflowWatchdogPolicy`, and the `WorkflowWatchdog` driver (two streams + deadlines on
+  an injected clock; `snapshot(from:)` maps `AgentConditionSnapshot` so the watchdog and
+  `agents wait` agree on what a live channel is).
+- `WorkflowNativeActions.swift` — `WorkflowActionExecuting`, `WorkflowActionContext`,
+  `WorkflowNativeActionRunner` (`handoff.transition`, `handoff.checkpoint`, `git.context`; path
+  inputs must resolve inside the worktree, canonical comparison).
+- `WorkflowBindingResolver.swift` — `WorkflowBindingMemoryKey`, `requirementsDigest`
+  (canonical JSON via `JSONSerialization.sortedKeys` + SHA-256), `resolve(role:remembered:override:context:)`
+  returning `.resolved(profile, tier:)` / `.ask(candidates:suggestion:)` plus the rejections a
+  CLI override should warn about; the seeded-prompt probe goes through
+  `AgentRuntimeAdapterRegistry` (Amp rejects).
+- `WorkflowActivationBridge.swift` — the protocol of H3 (`openMessageActivation`,
+  `cancelActivation`, `abandonActivation`, `completeActivation`, `observeActivation`).
+- Shared: `MarkdownArtifactNormalizer` (moved out of `HandoffStore`, which now calls it; it
+  additionally recognizes chatter *before* the opening fence), `WorkflowSchema.tokenEnvironmentKey`
+  / `runEnvironmentKey` / `roleEnvironmentKey`, and the §9 error-code constants in `CLIErrorCode`
+  (`STEP_NOT_EXPECTING`, `TOKEN_REQUIRED`, `TOKEN_INVALID`, `OUTPUT_INVALID`, `OUTPUT_TOO_LARGE`,
+  `VERDICT_REQUIRED`, `RENDERED_TEXT_INVALID`, `UNSAFE_PATH`, `PROMPT_TOO_LARGE`,
+  `WORKFLOW_DELIVERY_REQUIRED`, `RUN_NOT_FOUND`, `PANE_BUSY`, `ROLE_MISMATCH`). `CLIErrorCode`
+  itself became `nonisolated` so nonisolated domain code can read it.
+
+### Behaviors worth knowing (beyond the spec text)
+
+- A `repeat` without `until` ends the run as `max_rounds_reached` after `max` iterations, as
+  §4 says; it never falls through to the steps after it.
+- `roleBusy` from the bridge (the #733 refusal) is not attention: the step returns to
+  `waitingForRole` with the same invocation and token.
+- After the automatic nudge is spent (or after "Keep waiting"), a later `turn-ended` still earns
+  `idle_grace` before the run asks for attention; only an `idle_grace` that expires idle
+  escalates. `needs-input` and heuristic `blocked` raise attention but keep watching, so a
+  later `turn-ended` without delivery can still nudge.
+- Skip of an `action` step is not offered (Retry / Cancel); Skip of a `launch` step leaves the
+  role without a pane, and a later `message` to it raises `agent_gone:not_launched` with
+  Relaunch.
+- `git.context`'s `root` and `handoff.*`'s `briefing` must resolve inside the worktree
+  (`UNSAFE_PATH` otherwise), so a repo-scoped workflow cannot point an action elsewhere.
+
+### What B3 must do with each effect (the harness is the reference)
+
+`awaitRoleIdle` → the #733 idle precondition without its 5 s cap, then `.roleIdle`;
+`inject` → `openMessageActivation` (issue + bind) then `insertCommittedText` + `submitLine`,
+`.injectionSucceeded(dispatchID)` or `.injectionFailed` (cancelling the issuance);
+`openActivation` → issue + bind only (self-initiated first step; the line is in
+`run.selfInitiatedLine`); `materializeInstruction` before the inject that names it;
+`launch` → plan the frozen profile with `.prompt`, attach the environment values as child-only
+carriers (like `attachingDispatch`), issue the dispatch when `expectsDelivery`, then `.launched`;
+`runAction` → `WorkflowNativeActionRunner`; `armWatchdog` → one `WorkflowWatchdog` per request,
+`disarmWatchdog` → `cancel()`; `persist` / `persistOutput` / `log` → `WorkflowRunStore`;
+`abandonActivation` / `completeActivation` → the bridge; `cancelRoleWait` → stop the idle wait;
+`finished` → tear down. A `.launched` that arrives after the run ended must abandon its
+dispatch record (the machine ignores events on terminal runs).
+
 ## Verification
 
-(filled in when the slice lands)
+- Red first: every suite was written before its implementation compiled (the first
+  `xcodebuild build-for-testing` of batch A failed on the missing types; the normalizer test
+  failed on the "preamble before the opening fence" case, which the normalizer then learned);
+  the machine suite (29 tests) was authored from this record's test plan and passed on its
+  first full run; the watchdog policy suite caught two real semantics errors on its first run
+  (`sawActivity` not reset per heuristic window; a spent nudge escalating straight to
+  attention on the next `turn-ended`), both fixed in the policy.
+- App suites (`xcodebuild test`, 132 tests, all passing): `WorkflowLineRendererTests`,
+  `WorkflowTemplateRendererTests`, `WorkflowDeliveryValidatorTests`, `WorkflowRunMachineTests`,
+  `WorkflowRunStoreTests`, `WorkflowWatchdogPolicyTests`, `WorkflowWatchdogDriverTests`
+  (TestClock), `WorkflowNativeActionsTests` (temp git repositories),
+  `WorkflowBindingResolverTests`, `WorkflowRunHarnessTests`, plus the untouched
+  `HandoffStoreTests` over the moved normalizer.
+- Gates: `make check` (swift-format + SwiftLint strict) clean; `make build-cli`;
+  `make test-cli-unit` (221 tests); `make test-cli-smoke`; `make test-cli-integration` (109
+  tests); `make build-app` (0 warnings after the last fix); full `make test` — see the PR.
 
 ## Review
 
-(filled in when the slice lands)
+(adversarial rounds recorded below as they complete)
 
 ## Open items
 
-(filled in when the slice lands)
+- B3 verifies live what B2 cannot (listed above); the bundled `prowl.adversarial-review` and
+  the reviewer skill are D2.
+- Watchdog grace values are constructor settings; the Settings › Workflows page (D1) will
+  feed them from `@Shared`.

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -251,8 +251,8 @@ dispatch record (the machine ignores events on terminal runs).
   `WorkflowBindingResolverTests`, `WorkflowRunHarnessTests`, plus the untouched
   `HandoffStoreTests` over the moved normalizer.
 - Gates: `make check` (swift-format + SwiftLint strict) clean; `make build-cli`;
-  `make test-cli-unit` (221 tests); `make test-cli-smoke`; `make test-cli-integration` (109
-  tests); `make build-app` (0 warnings after the last fix); full `make test` — see the PR.
+  `make test-cli-unit` (223 tests); `make test-cli-smoke`; `make test-cli-integration` (109
+  tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round (2796 → 2808 → 2816 tests, zero failures).
 
 ## Review
 

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -243,8 +243,8 @@ dispatch record (the machine ignores events on terminal runs).
   first full run; the watchdog policy suite caught two real semantics errors on its first run
   (`sawActivity` not reset per heuristic window; a spent nudge escalating straight to
   attention on the next `turn-ended`), both fixed in the policy.
-- App suites (`xcodebuild test`, 152 workflow tests after two review rounds — 182 together
-  with the three handoff suites the normalizer change touches — all passing): `WorkflowLineRendererTests`,
+- App suites (`xcodebuild test`, 157 workflow tests after three review rounds — together
+  with the handoff suites the normalizer change touches — all passing): `WorkflowLineRendererTests`,
   `WorkflowTemplateRendererTests`, `WorkflowDeliveryValidatorTests`, `WorkflowRunMachineTests`,
   `WorkflowRunStoreTests`, `WorkflowWatchdogPolicyTests`, `WorkflowWatchdogDriverTests`
   (TestClock), `WorkflowNativeActionsTests` (temp git repositories),
@@ -300,6 +300,18 @@ SwiftPM-only so it could run beside the app builds; briefs and findings under
   path-based writes under `.prowl/handoff/` keep the pre-existing handoff trust model, and a
   concurrent local process racing directory swaps is outside B2's threat model (it already
   runs as the user) — static links from a repository are what the gates close.
+- **Round 3 — 5 findings (0 P0, 2 P1, 3 P2), all accepted and fixed; round-2 fixes verified.**
+  P1: the launch-time restart scan enumerated and decoded records through a linked base before
+  the new gate (it now checks the owned base first and gates every run directory); an
+  activation armed on a live pane without a detected agent (`absent`) still waited forever
+  (a 10 s `appearanceGrace` now ends in `agent_gone:process_gone`, while a launch that has not
+  settled gets time to appear — immediate attention was rejected for that reason). P2: the
+  restart scan decoded whole records instead of the header H5 promised (a `version` /
+  `run.status.state` header is read first and other versions are left untouched); the fence
+  scanner accepted a fake closer such as `` ```still code `` (CommonMark closers now: same
+  character, at least the opening length, whitespace only after the run); the observer reader
+  gave up after three buffer overflows (it re-subscribes while the watchdog runs). Fresh pass
+  over the binding resolver, the template renderer, and the harness found nothing at P0–P2.
 
 ## Open items
 

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -209,7 +209,13 @@ Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared t
   role without a pane, and a later `message` to it raises `agent_gone:not_launched` with
   Relaunch.
 - `git.context`'s `root` and `handoff.*`'s `briefing` must resolve inside the worktree
-  (`UNSAFE_PATH` otherwise), so a repo-scoped workflow cannot point an action elsewhere.
+  (`UNSAFE_PATH` otherwise), so a repo-scoped workflow cannot point an action elsewhere; both
+  are re-walked from the worktree root without following links right before use.
+- The run store refuses a `<root>/.prowl` or `<root>/.prowl/workflow-runs` that is a symbolic
+  link, and every leaf it writes or reads (`run.json`, `log.md`, instructions, outputs).
+- A watchdog armed on a pane that is already gone raises `agent_gone:pane_closed` at once; an
+  explicit `expect.timeout` keeps counting through grace-based attention, and a deadline that
+  already passed applies its policy on Keep waiting / Nudge.
 
 ### What B3 must do with each effect (the harness is the reference)
 
@@ -237,7 +243,8 @@ dispatch record (the machine ignores events on terminal runs).
   first full run; the watchdog policy suite caught two real semantics errors on its first run
   (`sawActivity` not reset per heuristic window; a spent nudge escalating straight to
   attention on the next `turn-ended`), both fixed in the policy.
-- App suites (`xcodebuild test`, 144 tests after the review round, all passing): `WorkflowLineRendererTests`,
+- App suites (`xcodebuild test`, 152 workflow tests after two review rounds — 182 together
+  with the three handoff suites the normalizer change touches — all passing): `WorkflowLineRendererTests`,
   `WorkflowTemplateRendererTests`, `WorkflowDeliveryValidatorTests`, `WorkflowRunMachineTests`,
   `WorkflowRunStoreTests`, `WorkflowWatchdogPolicyTests`, `WorkflowWatchdogDriverTests`
   (TestClock), `WorkflowNativeActionsTests` (temp git repositories),
@@ -275,6 +282,24 @@ SwiftPM-only so it could run beside the app builds; briefs and findings under
   never run again (position-aware now: later in the iteration, earlier only when another
   iteration follows, after the loop only when an `until` can exit it). Every fix carries a
   regression test; the two-phase delivery reshaped the machine tests (`deliverPersisted`).
+- **Round 2 — 8 findings (1 P0, 3 P1, 4 P2), all accepted and fixed; round-1 fixes verified
+  (three with objections that became these findings).** P0: a `<root>/.prowl` or
+  `workflow-runs` that is a symbolic link (a repository can ship one) moved the whole run
+  directory elsewhere, and `readRecord` bypassed the run-directory gate (both refused now;
+  the interrupted scan reports a linked run directory as unreadable). P1: watchdog verdicts
+  were still applied while a delivery was `persisting` (`deliver` disarms first, verdicts
+  need a `.waiting` activation, a persist Retry never re-arms); the canonical-path fix of
+  round 1 did not cover a parent directory swapped for a link (briefing and `git.context` root
+  are now walked from the worktree root with `openat(O_NOFOLLOW | O_DIRECTORY)` right before
+  use); a watchdog armed on a pane that was already gone waited forever (arm-time `gone`
+  raises attention). P2: re-arming after an expired hard deadline granted a one-second window
+  (the timeout policy runs instead); start-time `--skip` still scanned readers after a
+  `repeat` without `until`; `HandoffStore.validatedBriefing` still matched sections by
+  substring (heading lines outside fences now, through the shared normalizer); tilde-fenced
+  replies were not unwrapped. Residual, recorded rather than fixed: `HandoffStore`'s own
+  path-based writes under `.prowl/handoff/` keep the pre-existing handoff trust model, and a
+  concurrent local process racing directory swaps is outside B2's threat model (it already
+  runs as the user) — static links from a repository are what the gates close.
 
 ## Open items
 

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented on `feat/workflow-runner-core-b2` (2026-08-29), opened as a PR against the fork.
+Implemented on `feat/workflow-runner-core-b2` (2026-08-29); PR [#743](https://github.com/onevcat/Prowl/pull/743).
 The decisions below were grilled with onevcat on 2026-08-29 before code (H2, H4, H5, H6, H8,
 H10, H11, H12, H7 each settled on the recommended option); "Delivered", "Verification", and
 "Review" record what landed after four adversarial rounds.

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -1,0 +1,152 @@
+# 063.007 — Workflow Runner Core (B2): Plan
+
+## Status
+
+In progress on `feat/workflow-runner-core-b2` (2026-08-29). The decisions below were grilled with
+onevcat on 2026-08-29 before code (H2, H4, H5, H6, H8, H10, H11, H12, H7 each settled on the
+recommended option); the "Delivered" section is written when the slice lands.
+
+## Context
+
+B1 (#740) made a workflow file parseable, validatable, and listable; #733 (#741) gave the
+dispatch store a re-dispatch into an existing pane; #726 T0 (#739) added the version attestation.
+B2 is the engine that turns a validated `WorkflowDefinition` into a run: the state machine,
+the run directory, the renderers, delivery validation, the exact-signal-first watchdog, the native
+actions, and pure binding resolution. It ships no user-facing surface and stays dormant on `main`:
+B3 wires it into TCA and the CLI (`prowl workflow run/status/done/cancel`), C1 makes runs visible.
+
+Decisions G1–G6 ([006](006-b1-definitions.md)) and the 2026-08-29 spec amendments are inputs, not
+subjects: activation = dispatch record, no `WorkflowRequestRegistry`, `message` injects only into an
+idle role, `launch.prompt` may be multi-line, the watchdog consumes exact signals first.
+
+## Decisions
+
+Every row was either a default derivable from the code base (H1, H3, H9, H13) or grilled on 2026-08-29; the
+"Alternatives rejected" column records what the grill turned down.
+
+| # | Decision | Alternatives rejected |
+| --- | --- | --- |
+| H1 | **B2 lives in `supacode/Domain/Workflow/` (app target), tests in `supacodeTests/`.** It depends on app types (`AgentSignal`, `ObservedAgentState`, `AgentProfile`, `HandoffStore`, dispatch records) that never enter `ProwlCLIShared`. Two additions go to Shared: `WorkflowSchema.tokenEnvironmentKey` (`PROWL_WORKFLOW_TOKEN`, read by B3's CLI `done`) and the markdown fence/preamble normalizer that `HandoffStore.validatedBriefing` and the delivery validator share. | Putting the text-level helpers (template renderer, completion command, delivery validation) in Shared so `swift test` covers them: nothing in the CLI consumes them in V1 and Shared carries the `nonisolated` / name-collision tax; revisit if B3 wants a local pre-validation in `done`. |
+| H2 | **Reducer-style core.** `WorkflowRunMachine.apply(_ event) -> [WorkflowRunEffect]` is a pure, synchronous transition over a `WorkflowRun` value; every transport concern (idle wait, injection, launch, native action, notify, close, persistence, watchdog arming) is an *effect* B3's `WorkflowRunsFeature` interprets with the terminal boundaries. B2 tests drive the machine directly and, for the composition, through a test harness that interprets effects against fakes (store on a temp directory, fake bridge, `TestClock`). The harness is the executable specification of how B3 must interpret each effect. | A stateful `WorkflowRunner` class in B2 that owns state and calls the boundaries itself (B3 would either wrap it as an `@Observable` store beside TCA or discard it; the plan says the runner is reducer-owned). Async methods on the machine (transitions entangled with I/O; the Retry/Relaunch/Skip/Cancel × phase matrix becomes hard to pin). |
+| H3 | **Activation bridge = one protocol, `WorkflowActivationBridge`**, with exactly the dispatch-store operations the effects need: open a message activation (issue + bind to the pane's current epoch, #733's `issueAgentDispatch(boundTo:)`), abandon with a reason, observe a record, complete a record on delivery. The launch activation is opened by the launch boundary itself (S2's issue → attach → launch → bind), so the `.launch` effect carries the token and the environment values and receives the dispatch id back in `.launched`. B2 tests use a fake. | Folding the operations into `TerminalClient` closures now (that is B3's wiring); a second registry (rejected in G1). |
+| H4 | **Token check lives in the machine, not in the store.** Each activation holds its token in `WorkflowRun` state; `done` in B3 resolves the caller pane → its pending dispatch id → the run and activation (through `WorkflowRun.activation(forDispatchID:)`) → `machine.deliver(ordinal:token:body:verdict:)`, which answers `STEP_NOT_EXPECTING` / `TOKEN_REQUIRED` / `TOKEN_INVALID` / `OUTPUT_*` / `VERDICT_REQUIRED` itself. `dispatch-complete` against a workflow activation is refused by B3's handler from the same index (`WORKFLOW_DELIVERY_REQUIRED` with the replacement command rendered by B2). The dispatch store (064 code) is untouched. | Storing the token in `AgentDispatchBinding` and checking it in `AgentDispatchStore.complete` (the store would learn workflow semantics; every 064 completion path would grow a branch). |
+| H5 | **`run.json` is `WorkflowRunRecord` v1**: top-level `version: 1`; `run` (id, workflow id/name, scope, definition path, status, started/updated/finished), `worktree` (id, name, branch, path), `inputs`, `bindings` (per role: source; launch → profile id/name/agent, pane id/handle once launched; current/pick → pane id/handle, detected agent), `invocations` (ordinal, step, iteration, role, kind, instruction path, activation → dispatch id + state `waiting/delivered/skipped/revoked` + output name/path/verdict), `outputs` (latest per name), `actions` (step → declared keys), `loop` (count), `steps` (entered step records with state). **Delivery tokens are not persisted** (correlation only, useless after restart, and the file then carries nothing a reader could replay); dispatch ids are (needed by `status` / `agents wait --dispatch`). No environment values, extra arguments, home paths, or credentials — the frozen launch *plan* stays in memory with B3, only profile id/name/agent reach the file. Readers tolerate unknown keys; the launch-time `interrupted` scan reads only `version` and `run.status`. | Persisting the token (no consumer); persisting the launch plan (its surface environment carries override values); a schemaless dictionary. |
+| H6 | **Watchdog observes per activation**: `observeAgentDispatch(id)` (already epoch-gated by the store: `.needsInput`, `.incomplete` = coalesced `turn-ended`, `.changed(gone)`) for exact evidence and `observeAgentState(surfaceID)` for detector levels, `removed`, `surfaceClosed`, plus a `snapshot(surfaceID:)` re-read at every grace expiry. Two streams and an injected clock per waiting activation, torn down with it. | One bus through `AppFeature`'s single `eventStream` subscription (the 2026-08-22 topology, written before 064-S1 shipped the multicast observer; the spec §10 already names `observeAgentState` / `observeAgentDispatch`). |
+| H7 | **Attention and nudge copy** (the only strings agents and users see from B2): nudge `[Prowl] When your work for this step is fully complete, finish with: <commands>`; attention reasons (panel text, C1 renders): *needs input* "The reviewer is waiting for input in its pane" (Focus pane / Cancel), *idle without delivery* "The reviewer has been idle for 3 min without delivering findings — nudged once" (Nudge again / Keep waiting / Skip / Cancel), *blocked* (heuristic) "The reviewer looks blocked (screen) for 30 s" (Focus pane / Cancel), *agent gone* "The reviewer's agent session ended" / "…pane was closed" / "…process is gone" (Relaunch / Skip / Cancel for launch roles; Skip / Cancel otherwise), *injection failed* "The line could not be typed into the author's pane" with the unsubmitted-line hint when the insert succeeded (Retry / Skip / Cancel), *launch failed* (Retry / Skip / Cancel), *rendered text invalid* (Skip / Cancel), *action failed* (Retry / Cancel), *timeout* (`on_timeout: attention`: Nudge / Keep waiting / Skip / Cancel). | Free-form strings composed in C1 (two places to keep in sync). |
+| H8 | **Relaunch is offered for `launch` roles only.** It abandons the current activation, mints a new invocation for the *current* step, and re-delivers it as the kickoff prompt of a fresh launch of the frozen profile (message content + workflow protocol block); the role's pane is rebound on `.launched`. A `current` / `pick` role that is gone offers Skip / Cancel (a "Rebind pane" action is V2). | Relaunching a `pick` role by re-running the picker (needs C2's sheet; not a runner concern). |
+| H9 | **`agents wait --dispatch <id>` works on activations, so B2 records the dispatch id per activation** in state and `run.json`; the `run`/`status` responses (B3) read it from there. | Exposing only the token (the store is addressed by dispatch id). |
+| H10 | **Binding resolution in B2 = the pure resolver**: `WorkflowBindingResolver.resolve(role:remembered:override:context:)` walks remembered → `suggest` exact match → Recommended (053: designated → last launched → first enabled, over the `agents`-filtered set) → `.ask(candidates:)`; every candidate is re-validated (exists, enabled, satisfies `agents`, adapter renders a seeded prompt — probed through `AgentRuntimeAdapterRegistry.makeStartInvocation(.prompt)`, injectable); the memory key is `(scope, workflow id, role, SHA-256 of canonical `{source, kind, agents, suggest}` JSON)`. B3 owns the `@Shared` memory, `--role` parsing, and freezing the plan; C2 owns the sheet. | Reading profiles/settings inside B2 (no `@Shared` in a pure module). |
+| H11 | **Skip resolves its consequence immediately.** Skipping an activation (panel, `on_timeout: skip`, `--skip` at start) computes the §5 consequence from the remaining steps: a later template / `until` / required action input → the run ends `skipped(step, dependent)` at once; only optional action inputs continue (key absent). The same query (`WorkflowRun.skipConsequence(for:)`) feeds the panel's confirmation text. | Ending the run lazily when the consumer is reached (a `notify` or `close` between them would still run). |
+| H12 | **Native actions run through `WorkflowActionExecuting`**; `WorkflowNativeActionRunner` implements `handoff.transition` / `handoff.checkpoint` over `HandoffCoordinator` (archive-first; absent `briefing` → context-only; transition removes `current.md`) and `git.context` over `HandoffStore.save` (the existing `context.md` generator; outputs `path`, `branch`). `to`'s agent token is the frozen profile binding's agent; an invalid briefing file fails the action (Retry / Cancel). | A separate context generator writing under the run directory (a second generator for the same document). |
+| H13 | **The hard `expect.timeout` is scheduled by the watchdog driver** on the same injected clock; it fires `.timeout(policy)` into the machine. | A separate timer effect. |
+
+## Design outline
+
+All new types are `nonisolated` where the app target's MainActor default would otherwise apply,
+`Sendable`, and `Equatable` where they enter state.
+
+- `WorkflowRun.swift` — `WorkflowRun` (id, definition, `WorkflowRunContext` {scope, worktree
+  facts, inputs, run directory}, `bindings: [String: WorkflowRoleBinding]`, `status:
+  WorkflowRunStatus`, `phase: WorkflowRunPhase`, position cursor with loop state, `invocations:
+  [WorkflowInvocation]`, `outputs: [String: WorkflowOutputRecord]`, `actionOutputs`,
+  `skippedOutputs`, `loopCount`, `stepRecords`), `WorkflowRoleBinding` (`current(pane)`,
+  `pick(pane)`, `launch(profile, pane?)`), `WorkflowPaneIdentity` (surface id, tab id, handle,
+  display name, agent token), `WorkflowActivation` (ordinal, step, role, token, dispatch id?,
+  expect, state), `WorkflowAttention` (reason + `Set<WorkflowAttentionAction>`),
+  `WorkflowRunStatus` (`running`, `needsAttention`, `completed`, `cancelled`, `skipped`,
+  `maxRoundsReached`, `interrupted`).
+- `WorkflowRunMachine.swift` — `WorkflowRunEvent` (`roleIdle`, `injectionSucceeded/Failed`,
+  `launched/launchFailed`, `actionCompleted/Failed`, `watchdog(ordinal, verdict)`,
+  `timeout`, `user(action)`), `WorkflowRunEffect` (`awaitRoleIdle`, `materializeInstruction`,
+  `inject`, `launch`, `runAction`, `notify`, `close`, `abandonActivation`, `completeActivation`,
+  `armWatchdog`, `disarmWatchdog`, `persistOutput`, `persist`, `log`, `finished`), `start(...)`,
+  `apply(_:)`, `deliver(...) -> Result<WorkflowDeliveryReceipt, WorkflowDeliveryError>`,
+  `skipConsequence(for:)`, `activation(forDispatchID:)`.
+- `WorkflowTemplateRenderer.swift` — `WorkflowTemplateContext` (typed §6 whitelist) and
+  `WorkflowTemplate.render(_:context:)`; `WorkflowTemplateError.missingOutput` is the Skip rule's
+  runtime signal.
+- `WorkflowLineRenderer.swift` — `WorkflowCompletionCommand` (message form with the env prefix,
+  launch protocol block, nudge, instruction-file trailer, `WORKFLOW_DELIVERY_REQUIRED` message),
+  typed-line formats with `AgentDispatchPrompt.injectedPrefix`, `WorkflowRenderedText.validate`
+  (no line terminators, no C0/C1; `RENDERED_TEXT_INVALID`), the 32 KiB / NUL prompt gate
+  (`PROMPT_TOO_LARGE`).
+- `WorkflowDeliveryValidator.swift` — format (`markdown` normalized like
+  `HandoffStore.validatedBriefing`, `text`, `json`), `sections`, `verdict` (`VERDICT_REQUIRED`,
+  undeclared → `OUTPUT_INVALID`), size (`WorkflowDeliveryLimits`: default 1 MiB, hard max 4 MiB →
+  `OUTPUT_TOO_LARGE`).
+- `WorkflowRunStore.swift` — `<root>/.prowl/workflow-runs/<run-id>/` layout, self-ignoring
+  `.gitignore`, `WorkflowRunRecord` (Codable, `version` 1), append-only `log.md`,
+  `instructions/<step>.<ordinal>.md`, `outputs/<name>.<ordinal>.md` + atomically replaced
+  `outputs/<name>.md`, `skills/<id>/` copied from the bundle, every path from validated slugs and
+  the run UUID under `AgentProfileHomeProvisioner.validatePhysicalContainment`, and
+  `markInterruptedRuns()` for launch.
+- `WorkflowWatchdog.swift` — `WorkflowWatchdogSettings` (`turnGrace` 15 s floor 5 s, `idleGrace`
+  3 min, `blockedGrace` 30 s), the pure `WorkflowWatchdogPolicy` (phase machine over observation
+  events and deadline expiries; exact mode when a `verified_live` channel covers `turn-ended`,
+  heuristic otherwise; one automatic nudge per activation), and the `WorkflowWatchdog` driver that
+  merges the two streams, schedules cancellable deadlines on the injected clock, and yields
+  `WorkflowWatchdogVerdict`s (`nudge`, `attention(reason)`, `timeout`).
+- `WorkflowActivationBridge.swift` — the protocol of H3 and the failure enums the machine maps
+  (`roleBusy` → back to `awaitRoleIdle`, `surfaceMissing`, `insertFailed`, `submitFailed`,
+  `capacityExceeded`).
+- `WorkflowNativeActions.swift` — H12.
+- `WorkflowBindingResolver.swift` — H10; `WorkflowBindingMemoryKey` (Codable) with the digest.
+- Shared: `WorkflowSchema.tokenEnvironmentKey`; `MarkdownArtifactNormalizer` (fence/preamble
+  stripping moved out of `HandoffStore`, which now calls it).
+
+## Test plan (red first)
+
+- Machine: linear run through message → launch → repeat → action → notify → close; `until`
+  before entry (satisfied → loop skipped, `loop.count` 0) and after each iteration; `max`
+  reached → `maxRoundsReached`; latest-wins outputs across steps with the same name; `until`
+  reading the body's final producer; Skip consequences (template / `until` / required input end
+  the run, optional input continues with the key absent, `--skip` at start); every attention
+  reason with its action set; Retry mints a new ordinal and token; Relaunch re-delivers the
+  current step as a launch prompt and rebinds the pane; Cancel abandons with a reason naming run
+  and step and keeps outputs; late delivery during attention accepted; delivery after Skip →
+  `STEP_NOT_EXPECTING`; wrong / missing token; duplicate delivery; `roleBusy` returns to the
+  idle wait; message advances only after `injectionSucceeded`; self-initiated first step.
+- Renderers: every §6 variable; `roles.<r>.pane` after launch; single-line boundary rejects
+  `\n`, `\r`, U+2028/2029, C0/C1 (tab included) without partial output; completion command with
+  and without verdict, joined per value; nudge; launch protocol block; instruction trailer;
+  prompt cap and NUL.
+- Delivery validation: markdown fence/preamble stripping, missing section, `text`, `json`
+  parse failure, empty body, verdict required / undeclared / not declared, 1 MiB default, 4 MiB
+  hard max.
+- Store: layout and `.gitignore`; versioned + latest outputs (atomic replace); instruction and
+  skill materialization; unsafe slugs rejected; symlinked run-directory leaf rejected; escaping
+  path rejected; `run.json` round trip without tokens/env; interrupted scan flips only
+  non-terminal runs.
+- Watchdog (TestClock): exact mode — `needs-input` immediate; `incomplete` → 15 s → re-read
+  `working`/`session-start`/`progress` re-arms, idle → nudge → 3 min → attention; `session-end`,
+  `surfaceClosed`, dispatch `gone` → attention; `removed` diagnostic only when a channel covers
+  `session-end`; heuristic mode — `blocked` 30 s, `idle` 3 min → nudge → 3 min → attention,
+  `working` cancels; `turn_grace` floor 5 s; hard timeout; keep-waiting never nudges twice.
+- Actions (temp git repo): transition with and without briefing (archive first, `current.md`
+  removed, `has_briefing`), checkpoint keeps an earlier `current.md`, `git.context` outputs.
+- Binding: digest canonical form (sorted `agents`, absent keys omitted, prompt edits keep the
+  key); remembered → suggest → recommended → ask; a disabled / missing / `agents`-violating /
+  prompt-less candidate falls through.
+- Harness: the §4 example end to end against fakes, and the `prowl.handoff` shape with
+  `--skip brief` (context-only through the optional input).
+
+## What B3 verifies live (B2 has no surface)
+
+Idle wait and re-dispatch against real Claude Code / Codex panes; the typed line reaching the
+composer as one entry with the token prefix; a real `prowl workflow done -` resolving through
+caller ancestry to the activation; `agents wait --dispatch` on an activation id; the launch
+protocol block and `PROWL_WORKFLOW_TOKEN` in the child environment only; the watchdog's nudge
+and attention timings on hooked and unhooked runtimes; `dispatch-complete` refused with
+`WORKFLOW_DELIVERY_REQUIRED`; run directory contents after a full `prowl.adversarial-review`.
+
+## Verification
+
+(filled in when the slice lands)
+
+## Review
+
+(filled in when the slice lands)
+
+## Open items
+
+(filled in when the slice lands)

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -40,6 +40,7 @@ Every row was either a default derivable from the code base (H1, H3, H9, H13) or
 | H11 | **Skip resolves its consequence immediately.** Skipping an activation (panel, `on_timeout: skip`, `--skip` at start) computes the §5 consequence from the remaining steps: a later template / `until` / required action input → the run ends `skipped(step, dependent)` at once; only optional action inputs continue (key absent). The same query (`WorkflowRun.skipConsequence(for:)`) feeds the panel's confirmation text. | Ending the run lazily when the consumer is reached (a `notify` or `close` between them would still run). |
 | H12 | **Native actions run through `WorkflowActionExecuting`**; `WorkflowNativeActionRunner` implements `handoff.transition` / `handoff.checkpoint` over `HandoffCoordinator` (archive-first; absent `briefing` → context-only; transition removes `current.md`) and `git.context` over `HandoffStore.save` (the existing `context.md` generator; outputs `path`, `branch`). `to`'s agent token is the frozen profile binding's agent; an invalid briefing file fails the action (Retry / Cancel). | A separate context generator writing under the run directory (a second generator for the same document). |
 | H13 | **The hard `expect.timeout` is scheduled by the watchdog driver** on the same injected clock; it fires `.timeout(policy)` into the machine. | A separate timer effect. |
+| H14 | **Delivery validation is a review gate, not a wall** (decided with onevcat after the PR was opened). Token, empty body, and the size cap always reject; `sections` / `format` / `verdict` findings are *issues*: the body is persisted as provisional, the CLI answers `ok` + `warnings`, and the run asks the user — Accept as delivered, Accept with verdict (when a declared verdict is missing or undeclared), Ask again (re-types the requirements, same token), Skip, Cancel. `expect.strict: true` restores the hard rejection for outputs a tool must be able to read. Section matching also forgives heading level and case. | Keeping the hard rejection as the default (an agent with weak instruction following gets bounced and may never retry; the user had no way to accept work that was actually done). Inferring the verdict from prose (rejected in the plan: termination must read a machine-declared verdict). |
 
 ## Design outline
 
@@ -202,6 +203,10 @@ Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared t
 - A delivery is two-phase: `deliver` validates and emits `.persistOutput`; the run advances
   and the dispatch record completes only on `.outputPersisted`. While `persisting`, a second
   `done` is `STEP_NOT_EXPECTING`; Skip / Cancel abandon the record as they would a waiting one.
+- A delivery with issues (H14) becomes `provisional` after persistence: the dispatch record
+  stays pending, `outputs[name]` is not set, and the run waits for Accept / Accept with verdict
+  / Ask again. Ask again returns the same activation to `waiting` and re-arms the watchdog with
+  a fresh nudge; `run.json` records the issue codes under `status.attention.issues`.
 - After the automatic nudge is spent (or after "Keep waiting"), a later `turn-ended` still earns
   `idle_grace` before the run asks for attention; only an `idle_grace` that expires idle
   escalates. `needs-input` and heuristic `blocked` raise attention but keep watching, so a

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -249,7 +249,7 @@ dispatch record (the machine ignores events on terminal runs).
   first full run; the watchdog policy suite caught two real semantics errors on its first run
   (`sawActivity` not reset per heuristic window; a spent nudge escalating straight to
   attention on the next `turn-ended`), both fixed in the policy.
-- App suites (`xcodebuild test`, 157 workflow tests after three review rounds — together
+- App suites (`xcodebuild test`, 165 workflow tests after four review rounds and H14 — together
   with the handoff suites the normalizer change touches — all passing): `WorkflowLineRendererTests`,
   `WorkflowTemplateRendererTests`, `WorkflowDeliveryValidatorTests`, `WorkflowRunMachineTests`,
   `WorkflowRunStoreTests`, `WorkflowWatchdogPolicyTests`, `WorkflowWatchdogDriverTests`
@@ -257,8 +257,8 @@ dispatch record (the machine ignores events on terminal runs).
   `WorkflowBindingResolverTests`, `WorkflowRunHarnessTests`, plus the untouched
   `HandoffStoreTests` over the moved normalizer.
 - Gates: `make check` (swift-format + SwiftLint strict) clean; `make build-cli`;
-  `make test-cli-unit` (226 tests); `make test-cli-smoke`; `make test-cli-integration` (109
-  tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round (2796 → 2808 → 2816 → 2819 tests, zero failures).
+  `make test-cli-unit` (227 tests); `make test-cli-smoke`; `make test-cli-integration` (109
+  tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round and after H14 (2796 → 2808 → 2816 → 2819 → 2827 tests, zero failures).
 
 ## Review
 

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -198,6 +198,9 @@ Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared t
   §4 says; it never falls through to the steps after it.
 - `roleBusy` from the bridge (the #733 refusal) is not attention: the step returns to
   `waitingForRole` with the same invocation and token.
+- A delivery is two-phase: `deliver` validates and emits `.persistOutput`; the run advances
+  and the dispatch record completes only on `.outputPersisted`. While `persisting`, a second
+  `done` is `STEP_NOT_EXPECTING`; Skip / Cancel abandon the record as they would a waiting one.
 - After the automatic nudge is spent (or after "Keep waiting"), a later `turn-ended` still earns
   `idle_grace` before the run asks for attention; only an `idle_grace` that expires idle
   escalates. `needs-input` and heuristic `blocked` raise attention but keep watching, so a
@@ -218,7 +221,9 @@ Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared t
 `launch` → plan the frozen profile with `.prompt`, attach the environment values as child-only
 carriers (like `attachingDispatch`), issue the dispatch when `expectsDelivery`, then `.launched`;
 `runAction` → `WorkflowNativeActionRunner`; `armWatchdog` → one `WorkflowWatchdog` per request,
-`disarmWatchdog` → `cancel()`; `persist` / `persistOutput` / `log` → `WorkflowRunStore`;
+`disarmWatchdog` → `cancel()`; `persist` / `log` → `WorkflowRunStore`; `persistOutput` → `WorkflowRunStore.writeOutput`
+then `.outputPersisted(ordinal)` (or `.outputPersistFailed`), and the CLI `done` response is
+sent only after that event;
 `abandonActivation` / `completeActivation` → the bridge; `cancelRoleWait` → stop the idle wait;
 `finished` → tear down. A `.launched` that arrives after the run ended must abandon its
 dispatch record (the machine ignores events on terminal runs).
@@ -232,7 +237,7 @@ dispatch record (the machine ignores events on terminal runs).
   first full run; the watchdog policy suite caught two real semantics errors on its first run
   (`sawActivity` not reset per heuristic window; a spent nudge escalating straight to
   attention on the next `turn-ended`), both fixed in the policy.
-- App suites (`xcodebuild test`, 132 tests, all passing): `WorkflowLineRendererTests`,
+- App suites (`xcodebuild test`, 144 tests after the review round, all passing): `WorkflowLineRendererTests`,
   `WorkflowTemplateRendererTests`, `WorkflowDeliveryValidatorTests`, `WorkflowRunMachineTests`,
   `WorkflowRunStoreTests`, `WorkflowWatchdogPolicyTests`, `WorkflowWatchdogDriverTests`
   (TestClock), `WorkflowNativeActionsTests` (temp git repositories),
@@ -244,7 +249,32 @@ dispatch record (the machine ignores events on terminal runs).
 
 ## Review
 
-(adversarial rounds recorded below as they complete)
+Adversarial review with the `Pi Reviewer` Profile in a split beside the implementing pane
+(`prowl create pane … --profile "Pi Reviewer" --prompt -` for round 1, `prowl agents dispatch`
+into the same pane for round 2, awaited with `agents wait --dispatch`), read-only and
+SwiftPM-only so it could run beside the app builds; briefs and findings under
+`/tmp/prowl-b2-review/`.
+
+- **Round 1 — 10 findings (1 P0, 6 P1, 3 P2), all accepted and fixed.** P0: `appendLog` and
+  `readRecord` followed a symbolic-link leaf (now `O_NOFOLLOW` + `fstat` on the log, and every
+  leaf the store writes or reads refuses a link). P1: a `roleBusy` refusal re-rendered the same
+  invocation with a *second* token (the `.waiting` activation is reused now); `--skip` was
+  accepted for steps without an `expect` (`skipNotExpecting`); `deliver` advanced before the
+  output was on disk (delivery is two-phase now — `deliver` validates and emits
+  `.persistOutput`, `.outputPersisted` completes the dispatch record and advances,
+  `.outputPersistFailed` raises `persist_failed` with Retry / Cancel; B3 answers the CLI only
+  after persistence); an idle-grace attention cancelled the explicit `expect.timeout` (the
+  policy keeps the timeout deadline alive and the machine re-arms with the *remaining* time
+  of an absolute deadline); native-action paths were check-then-use (the canonical URL is
+  what the action uses, the briefing is read through `O_NOFOLLOW` + regular-file check;
+  `HandoffStore`'s own writes under `.prowl/handoff/` stay on the pre-existing handoff trust
+  model); `run.json` persisted input values (names only now). P2: required sections were
+  matched with `contains` (heading lines outside fences now); enum inputs skipped the
+  rendered-text boundary at start (checked, and the validator rejects multi-line enum values
+  with `enum_value_multiline`); the Skip consequence inside a loop scanned readers that could
+  never run again (position-aware now: later in the iteration, earlier only when another
+  iteration follows, after the loop only when an `until` can exit it). Every fix carries a
+  regression test; the two-phase delivery reshaped the machine tests (`deliverPersisted`).
 
 ## Open items
 

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-In progress on `feat/workflow-runner-core-b2` (2026-08-29). The decisions below were grilled with
-onevcat on 2026-08-29 before code (H2, H4, H5, H6, H8, H10, H11, H12, H7 each settled on the
-recommended option); the "Delivered" section is written when the slice lands.
+Implemented on `feat/workflow-runner-core-b2` (2026-08-29), opened as a PR against the fork.
+The decisions below were grilled with onevcat on 2026-08-29 before code (H2, H4, H5, H6, H8,
+H10, H11, H12, H7 each settled on the recommended option); "Delivered", "Verification", and
+"Review" record what landed after four adversarial rounds.
 
 ## Context
 
@@ -251,8 +252,8 @@ dispatch record (the machine ignores events on terminal runs).
   `WorkflowBindingResolverTests`, `WorkflowRunHarnessTests`, plus the untouched
   `HandoffStoreTests` over the moved normalizer.
 - Gates: `make check` (swift-format + SwiftLint strict) clean; `make build-cli`;
-  `make test-cli-unit` (223 tests); `make test-cli-smoke`; `make test-cli-integration` (109
-  tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round (2796 → 2808 → 2816 tests, zero failures).
+  `make test-cli-unit` (224 tests); `make test-cli-smoke`; `make test-cli-integration` (109
+  tests); `make build-app` (0 warnings in the changed files); full `make test` after each review round (2796 → 2808 → 2816 → 2819 tests, zero failures).
 
 ## Review
 
@@ -312,10 +313,23 @@ SwiftPM-only so it could run beside the app builds; briefs and findings under
   character, at least the opening length, whitespace only after the run); the observer reader
   gave up after three buffer overflows (it re-subscribes while the watchdog runs). Fresh pass
   over the binding resolver, the template renderer, and the harness found nothing at P0–P2.
+- **Round 4 (verification) — round-3 fixes verified; 0 P0, 0 P1, 2 P2, both fixed.** The
+  heading scan treated any trimmed `#` line as a heading (four-space-indented code satisfied a
+  section) and missed a validly indented heading inside a wrapper; and a code block in a
+  reply's trailer kept the wrapper closer and the trailer in the persisted artifact. The
+  normalizer now parses CommonMark ATX headings and closes a wrapper at the last matching bare
+  run before a trailer code block opens — the embedded bare code blocks the handoff tests pin
+  still survive. The loop is closed here: nothing at P0–P2 remains.
 
 ## Open items
 
 - B3 verifies live what B2 cannot (listed above); the bundled `prowl.adversarial-review` and
   the reviewer skill are D2.
-- Watchdog grace values are constructor settings; the Settings › Workflows page (D1) will
-  feed them from `@Shared`.
+- Watchdog grace values (including the 10 s appearance grace) are constructor settings; the
+  Settings › Workflows page (D1) will feed them from `@Shared`.
+- `HandoffStore` still performs ordinary path-based writes under `<root>/.prowl/handoff/`
+  (the pre-existing handoff contract); moving it to descriptor-rooted I/O would close the
+  remaining check-then-use window that `git.context` inherits from it. Recorded as a follow-up
+  for D3, when the handoff actions become the shipped path.
+- B3 must answer `prowl workflow done` only after `.outputPersisted`, cancel a run's watchdog
+  on acceptance, and abandon the dispatch of a `.launched` that arrives after the run ended.

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -4,9 +4,11 @@
 > and the CLI participant protocol. Updated in place as the design settles and the
 > implementation lands; history and rationale live in [000-plan.md](000-plan.md).
 >
-> Status: **draft, revised 2026-08-29** after R1 shipped — B1 (definitions) is next; §4, §5, §9,
+> Status: **draft, revised 2026-08-29** after R1 shipped — B1 (definitions) landed in #740; §4, §5, §9,
 > §10, and §12 were aligned with the shipped dispatch model (064-S2/S3, #733) on 2026-08-29
-> (decisions in [006-b1-definitions.md](006-b1-definitions.md)). Sections marked *TBD* are open.
+> (decisions in [006-b1-definitions.md](006-b1-definitions.md)); the B2 runner decisions of
+> [007-b2-runner-core.md](007-b2-runner-core.md) (Relaunch scope, immediate Skip consequence, `run.json`
+> contents, `git.context` location, action failure) were folded in the same day. Sections marked *TBD* are open.
 
 ## 1. Principles
 
@@ -184,7 +186,7 @@ JSON Schema):
 | --- | --- | --- |
 | `handoff.transition` | `briefing` (path, optional — **absent = context-only transition**: archive the outgoing `current.md`/`context.md`, then *remove* `current.md` so a stale briefing can never impersonate a fresh one, regenerate `context.md`, and select the context/archive-only kickoff prompt), `from` (role, required), `to` (role, required; its agent token is the frozen profile binding's agent), `note` (string, optional) | `kickoff_prompt` (string; briefing or context-only variant), `artifact_path` (path), `has_briefing` (bool) |
 | `handoff.checkpoint` | `briefing` (path, optional — absent = context-only checkpoint: regenerate `context.md`, keep an earlier valid `current.md` if present), `note` (string, optional) | `artifact_path` (path), `has_briefing` (bool, for this invocation) |
-| `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary), `branch` (string) |
+| `git.context` | `root` (path, optional; default worktree) | `path` (path to the generated markdown summary — the handoff context generator: it writes `<root>/.prowl/handoff/context.md` and appends one line to the handoff log), `branch` (string) |
 
 ## 5. `expect`
 
@@ -233,7 +235,9 @@ expect:
   degrades to a context-only transition, i.e. the old HUD's "Context Only"). Every other
   reference — `text` / `instruction` / `prompt` / `notify` templates, required action
   inputs, or the `until` of an enclosing `repeat` — makes the run end as `skipped` instead
-  of advancing, because V1 has no optional template values. The panel states the
+  of advancing, because V1 has no optional template values; the consequence is resolved at the
+  moment of the skip (the remaining steps, including the enclosing loop body and its `until`,
+  are scanned for a non-optional reader), not when the reader is reached. The panel states the
   consequence ("continues without a briefing" vs. "ends the run; step X depends on it")
   before the user confirms Skip; the validator warns when `on_timeout: skip` would end the
   run this way.
@@ -282,8 +286,9 @@ non-optional consumer references (the run would end as `skipped`).
 
 ```
 <root>/.prowl/workflow-runs/<run-id>/
-  run.json                  # state snapshot: workflow id/version, frozen role bindings (profile UUID/name, pane ids), invocation records,
-                            # step states, timestamps; no env values, no extra arguments, no credentials
+  run.json                  # state snapshot (`version: 1`): workflow id/name/scope, frozen role bindings (profile UUID/name/agent, pane ids),
+                            # invocation records with their activation's dispatch id and output, step states, timestamps;
+                            # never delivery tokens, env values, extra arguments, home paths, or credentials
   log.md                    # human-readable, append-only
   instructions/<step>.<ordinal>.md   # materialized `instruction` / `prompt` text, one per invocation (run-global ordinal, §5)
   skills/<id>/SKILL.md      # materialized bundled skills
@@ -400,11 +405,11 @@ changed` / `exit` was requested.
 | Binding scope | As defined in §3 (four-tuple key with the canonical role-requirements digest); §3 is normative. |
 | Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
-| Watchdog | Exact signals first, heuristics as fallback (decision 2026-08-29; 064-S5's watchdog part). The runner subscribes to the role's surface through `TerminalClient.observeAgentState` (064-S1 multicast: `snapshot` first, then `changed` / `removed` / `surfaceClosed` / `.signal`) and to the activation through `observeAgentDispatch`, plus an injected clock. When a step starts waiting the watchdog reads the current state first and schedules cancellable deadlines; it never depends on a later event alone. With a `verified_live` channel: `needs-input` → `needsAttention` immediately (Focus pane / Cancel); `turn-ended` without a delivery → `turn_grace` (default 15 s, floor 5 s; at expiry the state is re-read, and a role that is `working` again or has since reported `session-start` / `progress` re-arms instead of nudging) → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`) → `idle_grace` (default 3 min) → `needsAttention` (Nudge again / Keep waiting / Skip / Cancel); `session-end` or agent process gone → `needsAttention` (Relaunch role / Skip / Cancel). Without a channel (manually launched or tier-B runtimes) the heuristic rules apply, using 064.012's corroboration for arm-time state: `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention`; `idle`/`done` ≥ `idle_grace` without a delivery → nudge, then `needsAttention` after another `idle_grace`. `working` never triggers anything. Grace values are global settings. |
+| Watchdog | Exact signals first, heuristics as fallback (decision 2026-08-29; 064-S5's watchdog part). The runner subscribes to the role's surface through `TerminalClient.observeAgentState` (064-S1 multicast: `snapshot` first, then `changed` / `removed` / `surfaceClosed` / `.signal`) and to the activation through `observeAgentDispatch`, plus an injected clock. When a step starts waiting the watchdog reads the current state first and schedules cancellable deadlines; it never depends on a later event alone. With a `verified_live` channel: `needs-input` → `needsAttention` immediately (Focus pane / Cancel); `turn-ended` without a delivery → `turn_grace` (default 15 s, floor 5 s; at expiry the state is re-read, and a role that is `working` again or has since reported `session-start` / `progress` re-arms instead of nudging) → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`) → `idle_grace` (default 3 min) → `needsAttention` (Nudge again / Keep waiting / Skip / Cancel); `session-end` or agent process gone → `needsAttention` (Relaunch role / Skip / Cancel; Relaunch is offered for `launch` roles only — it abandons the current activation, mints a new invocation of the *current* step, and re-delivers that step's content as the kickoff prompt of a fresh launch of the frozen profile, rebinding the role's pane; a gone `current` / `pick` role offers Skip / Cancel). Without a channel (manually launched or tier-B runtimes) the heuristic rules apply, using 064.012's corroboration for arm-time state: `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention`; `idle`/`done` ≥ `idle_grace` without a delivery → nudge, then `needsAttention` after another `idle_grace`. `working` never triggers anything. Grace values are global settings. |
 | `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |
 | Explicit `timeout` | Only when an author sets `expect.timeout`: `attention` (default) enters `needsAttention`; `skip` / `cancel` act automatically. |
 | Cancel | Stops advancing and injecting; keeps all panes and outputs; logs. |
-| Failure | Launch/plan/provision failure → `needsAttention` with Retry / Skip role / Cancel; outputs already delivered are kept. |
+| Failure | Launch/plan/provision failure → `needsAttention` with Retry / Skip role / Cancel; a native action failure → `needsAttention` with Retry / Cancel (action outputs have no "missing" semantics, so an action cannot be skipped); outputs already delivered are kept. |
 | Concurrency | One run per pane; many runs per worktree; the status center shows the selected worktree's most recent active run, the panel lists all. |
 | Restart | V1: runs found on disk at launch are marked `interrupted`; no resume. |
 | Privacy | Prowl-authored response metadata and persisted metadata (`run.json`, logs, the non-body fields of CLI payloads) carry profile UUID/name and agent tokens only — never extra arguments, environment values, home paths, or credentials. The agent-provided output body of `workflow done` is explicitly excluded from that claim: it is persisted as delivered, under the self-ignored run directory, within the size caps of §5. |

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -198,7 +198,24 @@ expect:
   verdict: [clean, issues]  # declares 2–4 allowed values (safe slugs); the rendered completion command then carries `--verdict <value>` and it becomes mandatory
   timeout: 2h               # optional hard cap; NO default — without it Prowl waits as long as the agent works
   on_timeout: attention     # only with `timeout`: attention (default) | skip | cancel
+  strict: false             # default false: a delivery that misses sections/format/verdict is kept as
+                            # provisional and the run asks the user; true: it is rejected outright
 ```
+
+- **Validation is a review gate, not a wall (decision 2026-08-29, [007](007-b2-runner-core.md) H14).**
+  `prowl workflow done` always rejects what the pipeline cannot use at all — a missing or
+  wrong token, an empty body, a body above the size cap. Everything the *author* declared —
+  `sections`, `format`, `verdict` — is checked too, but by default a delivery that misses
+  them is **persisted as provisional** (`outputs/<name>.<ordinal>.md` is written, the CLI
+  answers `ok` with `warnings`), the dispatch record stays pending, and the run enters
+  `needsAttention` with **Accept as delivered** (or **Accept with verdict …** when a declared
+  verdict is missing or not one of the declared values — the user picks one), **Ask again**
+  (Prowl types what was missing plus the completion command into the role's pane; the same
+  activation and token keep waiting), Skip, and Cancel. Only `strict: true` turns those
+  findings into `OUTPUT_INVALID` / `VERDICT_REQUIRED` rejections; use it when a downstream
+  consumer needs a machine guarantee (a `json` output read by a tool). Section matching is
+  forgiving about heading level and letter case (`### findings` satisfies `## Findings`), but
+  a heading inside a code fence never counts.
 
 - **Activation = dispatch (decision 2026-08-29).** Every activation is a record in the shared
   dispatch store (`AgentDispatchStore`, 064-S2): a `launch` step creates it through the
@@ -372,7 +389,8 @@ makes a self-handoff two commands: `prowl workflow run prowl.handoff`, then the 
 
 Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BUSY`,
 `ROLE_MISMATCH`, `STEP_NOT_EXPECTING`, `TOKEN_REQUIRED`, `TOKEN_INVALID`,
-`OUTPUT_INVALID` (sections/format/verdict), `OUTPUT_TOO_LARGE`, `VERDICT_REQUIRED`,
+`OUTPUT_INVALID` (empty body; sections/format/verdict only under `strict: true`), `OUTPUT_TOO_LARGE`,
+`VERDICT_REQUIRED` (`strict: true` only),
 `PROFILE_NOT_FOUND`, `PROFILE_NOT_UNIQUE`, `SKILL_NOT_FOUND`, `RENDERED_TEXT_INVALID`
 (a rendered `text`/pointer/`--input` value would not survive as one terminal line),
 `UNSAFE_PATH`, `PROMPT_TOO_LARGE` (a rendered `launch` prompt above 32 KiB),
@@ -406,7 +424,7 @@ changed` / `exit` was requested.
 | Invocation / activation | Defined in §5: every `message`/`launch` execution mints a run-global invocation ordinal (artifact naming); a waiting invocation is an activation with its own token; one delivery per activation; revocation is per activation; outputs and instructions are versioned by ordinal. |
 | Rendered-text boundary | Every string that reaches `insertCommittedText` + submit — rendered `text`, pointer lines, completion commands, nudges — is validated after template substitution: no line terminators (`\n`, `\r`, U+2028/2029) and no C0/C1 control characters; violations stop the step with `RENDERED_TEXT_INVALID` (`needsAttention`, never a partial injection). String inputs and `--input` values are validated the same way at start; a worktree path that cannot be rendered on one line is rejected at start (`UNSAFE_PATH`). Multi-line content always goes through `instruction` / materialized files. |
 | Watchdog | Exact signals first, heuristics as fallback (decision 2026-08-29; 064-S5's watchdog part). The runner subscribes to the role's surface through `TerminalClient.observeAgentState` (064-S1 multicast: `snapshot` first, then `changed` / `removed` / `surfaceClosed` / `.signal`) and to the activation through `observeAgentDispatch`, plus an injected clock. When a step starts waiting the watchdog reads the current state first and schedules cancellable deadlines; it never depends on a later event alone. With a `verified_live` channel: `needs-input` → `needsAttention` immediately (Focus pane / Cancel); `turn-ended` without a delivery → `turn_grace` (default 15 s, floor 5 s; at expiry the state is re-read, and a role that is `working` again or has since reported `session-start` / `progress` re-arms instead of nudging) → one automatic nudge (`[Prowl] When your work for this step is fully complete, finish with: <the active activation's completion command, from the §4 renderer — token and verdict choices included>`) → `idle_grace` (default 3 min) → `needsAttention` (Nudge again / Keep waiting / Skip / Cancel); `session-end` or agent process gone → `needsAttention` (Relaunch role / Skip / Cancel; Relaunch is offered for `launch` roles only — it abandons the current activation, mints a new invocation of the *current* step, and re-delivers that step's content as the kickoff prompt of a fresh launch of the frozen profile, rebinding the role's pane; a gone `current` / `pick` role offers Skip / Cancel). Without a channel (manually launched or tier-B runtimes) the heuristic rules apply, using 064.012's corroboration for arm-time state: `blocked` ≥ `blocked_grace` (default 30 s) → `needsAttention`; `idle`/`done` ≥ `idle_grace` without a delivery → nudge, then `needsAttention` after another `idle_grace`. `working` never triggers anything. Grace values are global settings. |
-| `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. |
+| `needsAttention` | A UI state (orange status slot + notification), never a deadline: a late `done` is still accepted; only an explicit Skip marks the output missing and rejects later deliveries. A provisional delivery (§5) is a `needsAttention` of its own with Accept / Accept with verdict / Ask again / Skip / Cancel; until the user accepts it the output is on disk but not yet the step's output. |
 | Explicit `timeout` | Only when an author sets `expect.timeout`: `attention` (default) enters `needsAttention`; `skip` / `cancel` act automatically. |
 | Cancel | Stops advancing and injecting; keeps all panes and outputs; logs. |
 | Failure | Launch/plan/provision failure → `needsAttention` with Retry / Skip role / Cancel; a native action failure → `needsAttention` with Retry / Cancel (action outputs have no "missing" semantics, so an action cannot be skipped); outputs already delivered are kept. |

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -34,7 +34,7 @@ say when each is cut:
 | Release | State | Next action |
 | --- | --- | --- |
 | R1 | **Shipped** — v2026.8.29 (2026-08-29) | — |
-| R2a | In progress | B1 = #740 (review); #726 T0 = #739 (review); #733 in progress on `feat/agent-redispatch`; B2 next |
+| R2a | In progress | B1 #740, #726 T0 #739, #733 #741 merged; B2 implemented on `feat/workflow-runner-core-b2` (record [063.007](007-b2-runner-core.md)); B3 next |
 | R2b | Planned | after R2a ships |
 | R3 | Planned | after R2b ships |
 
@@ -104,7 +104,7 @@ User-visible result: onevcat's daily CLI-driven orchestration is first-class
 | 1 | **B1** definitions (Yams, model, validator, JSON Schema, three-source discovery, `workflow list/validate/schema`) — #740, record [063.006](006-b1-definitions.md) | 063 | — | DSL authorable and validatable; dormant until B3 |
 | 1 | **#733** `prowl agents dispatch <pane> --prompt -`: a new pending dispatch bound to an existing surface, one pending per surface, `dispatch-complete` resolved from the caller's ancestry to the pane's current record, refused while the agent is working or blocked | 064 | S2, 064.012 | a reviewer launched once takes N assignments, each with its own receipt — the transport B3's `message` + `expect` rides on (decision 2026-08-29), and usable from the CLI recipe as soon as it merges |
 | 1 | **#726 T0** version attestation: per-runtime attested version record beside the research matrix + `make agent-versions` | 064 | S3 wave 1 | an installed runtime newer than its attested contract warns before a release |
-| 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) | 063 | B1 | watchdog on exact signals (064-S5 watchdog part, moved from D2) |
+| 2 | **B2** runner core (pure state machine, run store, templates, registry, watchdog) — record [063.007](007-b2-runner-core.md) | 063 | B1 | watchdog on exact signals (064-S5 watchdog part, moved from D2); dormant until B3 |
 | 3 | **B3** runner wiring + `workflow run/status/done/cancel` | 063 | A2, S1, B2, #733 | engine powered on |
 | 4 | **C1** status center + run panel + notifications | 063 | B3 | runs visible |
 
@@ -192,6 +192,12 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-08-29 — B2 implemented on `feat/workflow-runner-core-b2` after a grill session that
+  settled the runner shape (pure reducer + effects, token check in the machine, per-activation
+  watchdog streams, `run.json` v1 without tokens, Relaunch for launch roles only, immediate Skip
+  consequence, pure binding resolver); the DSL spec was clarified in the same PR. Record:
+  [063.007](007-b2-runner-core.md). B1 (#740), #733 (#741), and #726 T0 (#739) merged before it;
+  B3 is next.
 - 2026-08-29 — B1 kickoff: the DSL spec was aligned with the shipped dispatch model (grilled
   decisions in [063.006](006-b1-definitions.md)). #733 becomes a hard prerequisite of B3
   (activations ride on re-dispatch), and 064-S5's watchdog part moves from D2 into B2 so the

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -34,7 +34,7 @@ say when each is cut:
 | Release | State | Next action |
 | --- | --- | --- |
 | R1 | **Shipped** — v2026.8.29 (2026-08-29) | — |
-| R2a | In progress | B1 #740, #726 T0 #739, #733 #741 merged; B2 implemented on `feat/workflow-runner-core-b2` (record [063.007](007-b2-runner-core.md)); B3 next |
+| R2a | In progress | B1 #740, #726 T0 #739, #733 #741 merged; B2 = #743 (review; record [063.007](007-b2-runner-core.md)); B3 next |
 | R2b | Planned | after R2a ships |
 | R3 | Planned | after R2b ships |
 
@@ -192,7 +192,7 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
-- 2026-08-29 — B2 implemented on `feat/workflow-runner-core-b2` after a grill session that
+- 2026-08-29 — B2 implemented on `feat/workflow-runner-core-b2` and opened as #743 after a grill session that
   settled the runner shape (pure reducer + effects, token check in the machine, per-activation
   watchdog streams, `run.json` v1 without tokens, Relaunch for launch roles only, immediate Skip
   consequence, pure binding resolver); the DSL spec was clarified in the same PR. Record:

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-public enum CLIErrorCode {
+nonisolated public enum CLIErrorCode {
   // Common
   public static let appNotRunning = "APP_NOT_RUNNING"
   public static let invalidArgument = "INVALID_ARGUMENT"
@@ -102,6 +102,23 @@ public enum CLIErrorCode {
   public static let workflowNotFound = "WORKFLOW_NOT_FOUND"
   /// The file parsed or validated with errors; `details` carries the validate payload.
   public static let workflowInvalid = "WORKFLOW_INVALID"
+  // Run-time codes of the workflow runner (dsl-spec §9); emitted by `workflow run/done` from B3 on.
+  public static let runNotFound = "RUN_NOT_FOUND"
+  public static let paneBusy = "PANE_BUSY"
+  public static let roleMismatch = "ROLE_MISMATCH"
+  public static let stepNotExpecting = "STEP_NOT_EXPECTING"
+  public static let tokenRequired = "TOKEN_REQUIRED"
+  public static let tokenInvalid = "TOKEN_INVALID"
+  public static let outputInvalid = "OUTPUT_INVALID"
+  public static let outputTooLarge = "OUTPUT_TOO_LARGE"
+  public static let verdictRequired = "VERDICT_REQUIRED"
+  /// A rendered `text` / pointer / `--input` value would not survive as one terminal line.
+  public static let renderedTextInvalid = "RENDERED_TEXT_INVALID"
+  public static let unsafePath = "UNSAFE_PATH"
+  /// A rendered `launch` prompt above 32 KiB.
+  public static let promptTooLarge = "PROMPT_TOO_LARGE"
+  /// `agents dispatch-complete` from a pane whose pending record is a workflow activation.
+  public static let workflowDeliveryRequired = "WORKFLOW_DELIVERY_REQUIRED"
 
   // Transport
   public static let transportFailed = "TRANSPORT_FAILED"

--- a/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
+++ b/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
@@ -17,23 +17,24 @@ nonisolated public enum MarkdownArtifactNormalizer {
     return text
   }
 
-  /// Heading lines (`#…`) outside fenced code blocks, trimmed. A heading quoted inside a
-  /// fence is code, not structure, so it never satisfies a required section.
+  /// ATX heading lines outside fenced code blocks, trimmed (`## Findings (2)`). A heading
+  /// quoted inside a fence — or indented four spaces, which is code — is not structure and
+  /// never satisfies a required section.
   public static func headings(outsideFences text: String) -> [String] {
     var headings: [String] = []
     var open: Fence?
     for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
-      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      let line = String(rawLine)
       if let fence = open {
-        if closes(line, fence) { open = nil }
+        if closes(line.trimmingCharacters(in: .whitespaces), fence) { open = nil }
         continue
       }
-      if let fence = fence(opening: line) {
+      if let fence = fence(opening: line.trimmingCharacters(in: .whitespaces)) {
         open = fence
         continue
       }
-      if line.hasPrefix("#") {
-        headings.append(line)
+      if let heading = atxHeading(line) {
+        headings.append(heading)
       }
     }
     return headings
@@ -49,19 +50,35 @@ nonisolated public enum MarkdownArtifactNormalizer {
     }
   }
 
+  /// The heading text of a CommonMark ATX heading line: up to three spaces of indentation,
+  /// one to six `#`, then a space or the end of the line. Four spaces of indentation is code.
+  static func atxHeading(_ line: String) -> String? {
+    let indentation = line.prefix { $0 == " " }.count
+    guard indentation <= 3 else { return nil }
+    let body = line.dropFirst(indentation)
+    let hashes = body.prefix { $0 == "#" }.count
+    guard (1...6).contains(hashes) else { return nil }
+    let rest = body.dropFirst(hashes)
+    guard rest.isEmpty || rest.first == " " || rest.first == "\t" else { return nil }
+    return body.trimmingCharacters(in: .whitespaces)
+  }
+
   /// A fenced-code delimiter: the fence character and the length of its run (CommonMark: at
   /// least three backticks or tildes; the closer uses the same character, at least as long,
   /// and carries nothing but whitespace after the run).
   private struct Fence: Equatable {
     let character: Character
     let length: Int
+    /// The line carried an info string (```` ```swift ````); a bare run has none.
+    let hasInfoString: Bool
   }
 
   private static func fence(opening line: String) -> Fence? {
     guard let first = line.first, first == "`" || first == "~" else { return nil }
     let length = line.prefix { $0 == first }.count
     guard length >= 3 else { return nil }
-    return Fence(character: first, length: length)
+    let info = line.dropFirst(length)
+    return Fence(character: first, length: length, hasInfoString: !info.allSatisfy(\.isWhitespace))
   }
 
   private static func closes(_ line: String, _ fence: Fence) -> Bool {
@@ -76,13 +93,17 @@ nonisolated public enum MarkdownArtifactNormalizer {
     return closes(line, fence)
   }
 
+  private static func isHeading(_ line: Substring) -> Bool {
+    atxHeading(String(line)) != nil
+  }
+
   /// A reply may put chatter *before* the fence that wraps the document ("Sure, here it is:"
   /// then "```markdown"). When a fence line precedes the first heading, everything up to that
   /// fence is preamble and the fence becomes the opening fence.
   private static func droppingPreambleBeforeOpeningFence(_ text: String) -> String {
-    guard fence(opening: text.firstLine) == nil, !text.hasPrefix("#") else { return text }
+    guard fence(opening: text.firstLine) == nil, !isHeading(Substring(text.firstLine)) else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    guard let heading = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }),
+    guard let heading = lines.firstIndex(where: isHeading),
       let fenceIndex = lines.firstIndex(where: { fence(opening: String($0)) != nil }), fenceIndex < heading
     else { return text }
     return lines[fenceIndex...].joined(separator: "\n")
@@ -97,33 +118,53 @@ nonisolated public enum MarkdownArtifactNormalizer {
 
   /// Drops chat preamble ahead of the document ("Sure, here's the file: …").
   private static func droppingPreamble(_ text: String) -> String {
-    guard !text.hasPrefix("#") else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    guard let start = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }) else {
-      return text
-    }
+    guard let first = lines.first, !isHeading(first) else { return text }
+    guard let start = lines.firstIndex(where: isHeading) else { return text }
     return lines[start...].joined(separator: "\n")
   }
 
-  /// Drops a trailing fence line left over after preamble removal. When the reply opened
-  /// with a fence, the *last* line that closes that fence is the wrapper's closer, so any
-  /// chatter after it is also discarded — embedded code blocks inside the document close in
-  /// pairs before it. Without an opening fence only an exact trailing bare fence line is
-  /// removed, so a fence inside a document body is never a cut point.
+  /// Drops the wrapper's closing fence and the chatter after it. With an opening wrapper fence
+  /// the candidates are the bare runs that match it while no inner block opened with an info
+  /// string (```` ```swift ````) is still open. Agents also embed *bare* code blocks, so the cut
+  /// is the last candidate — unless a block with an info string opens after a candidate, which
+  /// is a code block in the trailer: then the last candidate before it closes the wrapper.
+  /// Without an opening fence only an exact trailing bare fence line is removed, so a fence
+  /// inside a document body is never a cut point.
   private static func droppingClosingFence(_ text: String, openingFence: Fence?) -> String {
     var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    let isCloser: (Substring) -> Bool = { line in
-      let trimmed = line.trimmingCharacters(in: .whitespaces)
-      if let openingFence { return closes(trimmed, openingFence) }
-      return isBareFence(trimmed)
+    guard let openingFence else {
+      if let last = lines.last, isBareFence(last.trimmingCharacters(in: .whitespaces)) {
+        lines.removeLast()
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+      return text
     }
-    guard let lastFence = lines.lastIndex(where: isCloser) else { return text }
-    if lastFence == lines.indices.last {
-      lines.removeLast()
-      return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    var depth = 0
+    var candidates: [Int] = []
+    var trailerStart: Int?
+    for (index, rawLine) in lines.enumerated() {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      if closes(line, openingFence) {
+        if depth == 0 {
+          candidates.append(index)
+        } else {
+          depth -= 1
+        }
+      } else if let inner = fence(opening: line) {
+        if inner.hasInfoString {
+          if depth == 0, !candidates.isEmpty, trailerStart == nil {
+            trailerStart = index
+          }
+          depth += 1
+        } else if depth > 0 {
+          depth -= 1
+        }
+      }
     }
-    guard openingFence != nil else { return text }
-    return lines[..<lastFence].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    let cut = trailerStart.map { start in candidates.last { $0 < start } } ?? candidates.last
+    guard let cut else { return text }
+    return lines[..<cut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }
 

--- a/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
+++ b/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
@@ -40,14 +40,24 @@ nonisolated public enum MarkdownArtifactNormalizer {
     return headings
   }
 
-  /// Whether every required section is present as a heading line outside fences; a heading
-  /// may carry trailing text after a space (`## Findings (2)`).
+  /// Whether every required section is present as a heading line outside fences. Matching is
+  /// forgiving about what does not change meaning: the heading level (`##` vs `###`), letter
+  /// case, and trailing text after a space (`## Findings (2)`).
   public static func hasSections(_ sections: [String], in text: String) -> Bool {
-    let headings = headings(outsideFences: text)
-    return sections.allSatisfy { section in
-      let wanted = section.trimmingCharacters(in: .whitespaces)
-      return headings.contains { $0 == wanted || $0.hasPrefix(wanted + " ") }
+    missingSections(sections, in: text).isEmpty
+  }
+
+  /// The required sections that no heading outside a fence satisfies, in declaration order.
+  public static func missingSections(_ sections: [String], in text: String) -> [String] {
+    let headings = headings(outsideFences: text).map(headingKey)
+    return sections.filter { section in
+      let wanted = headingKey(section)
+      return !headings.contains { $0 == wanted || $0.hasPrefix(wanted + " ") }
     }
+  }
+
+  private static func headingKey(_ heading: String) -> String {
+    heading.trimmingCharacters(in: .whitespaces).drop { $0 == "#" }.trimmingCharacters(in: .whitespaces).lowercased()
   }
 
   /// The heading text of a CommonMark ATX heading line: up to three spaces of indentation,

--- a/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
+++ b/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
@@ -10,7 +10,7 @@ nonisolated public enum MarkdownArtifactNormalizer {
   /// authors prose here: only wrapping is removed, the document body is kept verbatim.
   public static func normalized(_ text: String) -> String {
     var text = droppingPreambleBeforeOpeningFence(text.trimmingCharacters(in: .whitespacesAndNewlines))
-    let openingFence = fenceMarker(of: text)
+    let openingFence = fence(opening: text.firstLine)
     text = droppingOpeningFence(text)
     text = droppingPreamble(text)
     text = droppingClosingFence(text, openingFence: openingFence)
@@ -21,15 +21,15 @@ nonisolated public enum MarkdownArtifactNormalizer {
   /// fence is code, not structure, so it never satisfies a required section.
   public static func headings(outsideFences text: String) -> [String] {
     var headings: [String] = []
-    var open: String?
+    var open: Fence?
     for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
       let line = rawLine.trimmingCharacters(in: .whitespaces)
-      if let marker = open {
-        if line.hasPrefix(marker) { open = nil }
+      if let fence = open {
+        if closes(line, fence) { open = nil }
         continue
       }
-      if let marker = fenceMarker(of: line) {
-        open = marker
+      if let fence = fence(opening: line) {
+        open = fence
         continue
       }
       if line.hasPrefix("#") {
@@ -49,28 +49,48 @@ nonisolated public enum MarkdownArtifactNormalizer {
     }
   }
 
-  /// The fence marker (` ``` ` or `~~~`) a line opens with, or nil.
-  private static func fenceMarker(of text: String) -> String? {
-    if text.hasPrefix("```") { return "```" }
-    if text.hasPrefix("~~~") { return "~~~" }
-    return nil
+  /// A fenced-code delimiter: the fence character and the length of its run (CommonMark: at
+  /// least three backticks or tildes; the closer uses the same character, at least as long,
+  /// and carries nothing but whitespace after the run).
+  private struct Fence: Equatable {
+    let character: Character
+    let length: Int
+  }
+
+  private static func fence(opening line: String) -> Fence? {
+    guard let first = line.first, first == "`" || first == "~" else { return nil }
+    let length = line.prefix { $0 == first }.count
+    guard length >= 3 else { return nil }
+    return Fence(character: first, length: length)
+  }
+
+  private static func closes(_ line: String, _ fence: Fence) -> Bool {
+    let run = line.prefix { $0 == fence.character }
+    guard run.count >= fence.length else { return false }
+    return line.dropFirst(run.count).allSatisfy(\.isWhitespace)
+  }
+
+  /// A line that is nothing but a fence run (any length ≥ 3, backticks or tildes).
+  private static func isBareFence(_ line: String) -> Bool {
+    guard let fence = fence(opening: line) else { return false }
+    return closes(line, fence)
   }
 
   /// A reply may put chatter *before* the fence that wraps the document ("Sure, here it is:"
   /// then "```markdown"). When a fence line precedes the first heading, everything up to that
   /// fence is preamble and the fence becomes the opening fence.
   private static func droppingPreambleBeforeOpeningFence(_ text: String) -> String {
-    guard fenceMarker(of: text) == nil, !text.hasPrefix("#") else { return text }
+    guard fence(opening: text.firstLine) == nil, !text.hasPrefix("#") else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
     guard let heading = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }),
-      let fence = lines.firstIndex(where: { fenceMarker(of: String($0)) != nil }), fence < heading
+      let fenceIndex = lines.firstIndex(where: { fence(opening: String($0)) != nil }), fenceIndex < heading
     else { return text }
-    return lines[fence...].joined(separator: "\n")
+    return lines[fenceIndex...].joined(separator: "\n")
   }
 
   /// Unwraps the opening line of a markdown code fence ("```markdown" / "~~~markdown").
   private static func droppingOpeningFence(_ text: String) -> String {
-    guard fenceMarker(of: text) != nil else { return text }
+    guard fence(opening: text.firstLine) != nil else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
     return lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -86,20 +106,29 @@ nonisolated public enum MarkdownArtifactNormalizer {
   }
 
   /// Drops a trailing fence line left over after preamble removal. When the reply opened
-  /// with a fence, the *last* line made of that marker is the wrapper's closer, so any chatter
-  /// after it is also discarded — embedded code blocks inside the document close in pairs
-  /// before it. Without an opening fence only an exact trailing fence line is removed, so a
-  /// fence inside a document body is never a cut point.
-  private static func droppingClosingFence(_ text: String, openingFence: String?) -> String {
+  /// with a fence, the *last* line that closes that fence is the wrapper's closer, so any
+  /// chatter after it is also discarded — embedded code blocks inside the document close in
+  /// pairs before it. Without an opening fence only an exact trailing bare fence line is
+  /// removed, so a fence inside a document body is never a cut point.
+  private static func droppingClosingFence(_ text: String, openingFence: Fence?) -> String {
     var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    let closers = openingFence.map { [$0] } ?? ["```", "~~~"]
-    guard let lastFence = lines.lastIndex(where: { closers.contains($0.trimmingCharacters(in: .whitespaces)) })
-    else { return text }
+    let isCloser: (Substring) -> Bool = { line in
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      if let openingFence { return closes(trimmed, openingFence) }
+      return isBareFence(trimmed)
+    }
+    guard let lastFence = lines.lastIndex(where: isCloser) else { return text }
     if lastFence == lines.indices.last {
       lines.removeLast()
       return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
     guard openingFence != nil else { return text }
     return lines[..<lastFence].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+nonisolated extension String {
+  fileprivate var firstLine: String {
+    String(prefix { $0 != "\n" })
   }
 }

--- a/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
+++ b/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
@@ -1,0 +1,65 @@
+// ProwlShared/MarkdownArtifactNormalizer.swift
+// Strips the chat wrapping agents put around a markdown document (an opening fence, preamble
+// before the first heading, the closing fence and any trailer after it). Shared by the handoff
+// briefing validation and the workflow delivery validation so both accept the same replies.
+
+import Foundation
+
+nonisolated public enum MarkdownArtifactNormalizer {
+  /// The document without chat wrapping, trimmed; empty when nothing remains. Prowl never
+  /// authors prose here: only wrapping is removed, the document body is kept verbatim.
+  public static func normalized(_ text: String) -> String {
+    var text = droppingPreambleBeforeOpeningFence(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    let hadOpeningFence = text.hasPrefix("```")
+    text = droppingOpeningFence(text)
+    text = droppingPreamble(text)
+    text = droppingClosingFence(text, truncatingTrailer: hadOpeningFence)
+    return text
+  }
+
+  /// A reply may put chatter *before* the fence that wraps the document ("Sure, here it is:"
+  /// then "```markdown"). When a fence line precedes the first heading, everything up to that
+  /// fence is preamble and the fence becomes the opening fence.
+  private static func droppingPreambleBeforeOpeningFence(_ text: String) -> String {
+    guard !text.hasPrefix("```"), !text.hasPrefix("#") else { return text }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    guard let heading = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }),
+      let fence = lines.firstIndex(where: { $0.hasPrefix("```") }), fence < heading
+    else { return text }
+    return lines[fence...].joined(separator: "\n")
+  }
+
+  /// Unwraps the opening line of a markdown code fence ("```markdown").
+  private static func droppingOpeningFence(_ text: String) -> String {
+    guard text.hasPrefix("```") else { return text }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    return lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /// Drops chat preamble ahead of the document ("Sure, here's the file: …").
+  private static func droppingPreamble(_ text: String) -> String {
+    guard !text.hasPrefix("#") else { return text }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    guard let start = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }) else {
+      return text
+    }
+    return lines[start...].joined(separator: "\n")
+  }
+
+  /// Drops a trailing code-fence line left over after preamble removal. When the reply opened
+  /// with a fence, the *last* fence line is that wrapper's closer, so any chatter after it is
+  /// also discarded — embedded code blocks inside the document close in pairs before it.
+  /// Without an opening fence only an exact trailing fence line is removed, so a fence inside
+  /// a document body is never a cut point.
+  private static func droppingClosingFence(_ text: String, truncatingTrailer: Bool) -> String {
+    var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    guard let lastFence = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "```" })
+    else { return text }
+    if lastFence == lines.indices.last {
+      lines.removeLast()
+      return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    guard truncatingTrailer else { return text }
+    return lines[..<lastFence].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
+++ b/supacode/CLIService/Shared/MarkdownArtifactNormalizer.swift
@@ -10,28 +10,67 @@ nonisolated public enum MarkdownArtifactNormalizer {
   /// authors prose here: only wrapping is removed, the document body is kept verbatim.
   public static func normalized(_ text: String) -> String {
     var text = droppingPreambleBeforeOpeningFence(text.trimmingCharacters(in: .whitespacesAndNewlines))
-    let hadOpeningFence = text.hasPrefix("```")
+    let openingFence = fenceMarker(of: text)
     text = droppingOpeningFence(text)
     text = droppingPreamble(text)
-    text = droppingClosingFence(text, truncatingTrailer: hadOpeningFence)
+    text = droppingClosingFence(text, openingFence: openingFence)
     return text
+  }
+
+  /// Heading lines (`#…`) outside fenced code blocks, trimmed. A heading quoted inside a
+  /// fence is code, not structure, so it never satisfies a required section.
+  public static func headings(outsideFences text: String) -> [String] {
+    var headings: [String] = []
+    var open: String?
+    for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      if let marker = open {
+        if line.hasPrefix(marker) { open = nil }
+        continue
+      }
+      if let marker = fenceMarker(of: line) {
+        open = marker
+        continue
+      }
+      if line.hasPrefix("#") {
+        headings.append(line)
+      }
+    }
+    return headings
+  }
+
+  /// Whether every required section is present as a heading line outside fences; a heading
+  /// may carry trailing text after a space (`## Findings (2)`).
+  public static func hasSections(_ sections: [String], in text: String) -> Bool {
+    let headings = headings(outsideFences: text)
+    return sections.allSatisfy { section in
+      let wanted = section.trimmingCharacters(in: .whitespaces)
+      return headings.contains { $0 == wanted || $0.hasPrefix(wanted + " ") }
+    }
+  }
+
+  /// The fence marker (` ``` ` or `~~~`) a line opens with, or nil.
+  private static func fenceMarker(of text: String) -> String? {
+    if text.hasPrefix("```") { return "```" }
+    if text.hasPrefix("~~~") { return "~~~" }
+    return nil
   }
 
   /// A reply may put chatter *before* the fence that wraps the document ("Sure, here it is:"
   /// then "```markdown"). When a fence line precedes the first heading, everything up to that
   /// fence is preamble and the fence becomes the opening fence.
   private static func droppingPreambleBeforeOpeningFence(_ text: String) -> String {
-    guard !text.hasPrefix("```"), !text.hasPrefix("#") else { return text }
+    guard fenceMarker(of: text) == nil, !text.hasPrefix("#") else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
     guard let heading = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }),
-      let fence = lines.firstIndex(where: { $0.hasPrefix("```") }), fence < heading
+      let fence = lines.firstIndex(where: { fenceMarker(of: String($0)) != nil }), fence < heading
     else { return text }
     return lines[fence...].joined(separator: "\n")
   }
 
-  /// Unwraps the opening line of a markdown code fence ("```markdown").
+  /// Unwraps the opening line of a markdown code fence ("```markdown" / "~~~markdown").
   private static func droppingOpeningFence(_ text: String) -> String {
-    guard text.hasPrefix("```") else { return text }
+    guard fenceMarker(of: text) != nil else { return text }
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
     return lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -46,20 +85,21 @@ nonisolated public enum MarkdownArtifactNormalizer {
     return lines[start...].joined(separator: "\n")
   }
 
-  /// Drops a trailing code-fence line left over after preamble removal. When the reply opened
-  /// with a fence, the *last* fence line is that wrapper's closer, so any chatter after it is
-  /// also discarded — embedded code blocks inside the document close in pairs before it.
-  /// Without an opening fence only an exact trailing fence line is removed, so a fence inside
-  /// a document body is never a cut point.
-  private static func droppingClosingFence(_ text: String, truncatingTrailer: Bool) -> String {
+  /// Drops a trailing fence line left over after preamble removal. When the reply opened
+  /// with a fence, the *last* line made of that marker is the wrapper's closer, so any chatter
+  /// after it is also discarded — embedded code blocks inside the document close in pairs
+  /// before it. Without an opening fence only an exact trailing fence line is removed, so a
+  /// fence inside a document body is never a cut point.
+  private static func droppingClosingFence(_ text: String, openingFence: String?) -> String {
     var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    guard let lastFence = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "```" })
+    let closers = openingFence.map { [$0] } ?? ["```", "~~~"]
+    guard let lastFence = lines.lastIndex(where: { closers.contains($0.trimmingCharacters(in: .whitespaces)) })
     else { return text }
     if lastFence == lines.indices.last {
       lines.removeLast()
       return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    guard truncatingTrailer else { return text }
+    guard openingFence != nil else { return text }
     return lines[..<lastFence].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }

--- a/supacode/CLIService/Shared/WorkflowDefinition.swift
+++ b/supacode/CLIService/Shared/WorkflowDefinition.swift
@@ -10,6 +10,12 @@ nonisolated public enum WorkflowSchema {
   public static let reservedIDPrefix = "prowl."
   public static let repeatMaximum = 20
   public static let verdictRange = 2...4
+  /// Carries an activation's delivery token to `prowl workflow done`: typed as the line's
+  /// environment prefix for a `message` step, set in the child environment for a `launch` step.
+  public static let tokenEnvironmentKey = "PROWL_WORKFLOW_TOKEN"
+  /// Cross-check hints in a launched surface's child environment; the dispatch store stays the authority.
+  public static let runEnvironmentKey = "PROWL_WORKFLOW_RUN"
+  public static let roleEnvironmentKey = "PROWL_WORKFLOW_ROLE"
   /// Workflow and skill ids may contain dots; a leading alphanumeric rules out `.` and `..`.
   public static var workflowIDPattern: Regex<Substring> { /^[a-z0-9][a-z0-9_.-]{0,63}$/ }
   /// Step ids, role names, output names, input names, and verdict values become path

--- a/supacode/CLIService/Shared/WorkflowDefinition.swift
+++ b/supacode/CLIService/Shared/WorkflowDefinition.swift
@@ -303,6 +303,9 @@ nonisolated public struct WorkflowExpectation: Equatable, Sendable {
   /// Hard cap in seconds; nil = wait as long as the agent works.
   public let timeoutSeconds: Int?
   public let onTimeout: WorkflowTimeoutPolicy?
+  /// `true`: a delivery that misses `sections`, `format`, or `verdict` is rejected. `false`
+  /// (default): it is kept as provisional and the run asks the user to accept, ask again, or skip.
+  public let strict: Bool
   public let location: WorkflowSourceLocation?
 
   public init(
@@ -312,6 +315,7 @@ nonisolated public struct WorkflowExpectation: Equatable, Sendable {
     verdict: [String]? = nil,
     timeoutSeconds: Int? = nil,
     onTimeout: WorkflowTimeoutPolicy? = nil,
+    strict: Bool = false,
     location: WorkflowSourceLocation? = nil
   ) {
     self.output = output
@@ -320,6 +324,7 @@ nonisolated public struct WorkflowExpectation: Equatable, Sendable {
     self.verdict = verdict
     self.timeoutSeconds = timeoutSeconds
     self.onTimeout = onTimeout
+    self.strict = strict
     self.location = location
   }
 }

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -338,7 +338,7 @@ nonisolated public enum WorkflowDocumentParser {
     guard let expect = MappingReader(node: step.node(for: "expect"), collector: step.collector, path: "expect") else {
       return nil
     }
-    expect.checkKeys(["output", "format", "sections", "verdict", "timeout", "on_timeout"])
+    expect.checkKeys(["output", "format", "sections", "verdict", "timeout", "on_timeout", "strict"])
     let timeout = expect.string("timeout").flatMap { text -> Int? in
       guard let seconds = parseDuration(text) else {
         expect.collector.error(
@@ -360,6 +360,7 @@ nonisolated public enum WorkflowDocumentParser {
       verdict: expect.stringList("verdict"),
       timeoutSeconds: timeout,
       onTimeout: onTimeout,
+      strict: expect.bool("strict") ?? false,
       location: expect.location
     )
   }

--- a/supacode/CLIService/Shared/WorkflowJSONSchema.swift
+++ b/supacode/CLIService/Shared/WorkflowJSONSchema.swift
@@ -255,7 +255,8 @@ nonisolated public enum WorkflowJSONSchema {
               "type": "array", "minItems": 2, "maxItems": 4, "uniqueItems": true, "items": { "$ref": "#/$defs/slug" }
             },
             "timeout": { "type": "string", "pattern": "^\\d+\\s*[smh]$" },
-            "on_timeout": { "enum": ["attention", "skip", "cancel"] }
+            "on_timeout": { "enum": ["attention", "skip", "cancel"] },
+            "strict": { "type": "boolean" }
           },
           "dependentRequired": { "on_timeout": ["timeout"] }
         }

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -172,6 +172,12 @@ nonisolated private final class Walker {
       if Set(input.values).count != input.values.count {
         collector.error("enum_values_duplicate", "Enum input '\(input.name)' repeats a value.", at: input.location)
       }
+      if input.values.contains(where: { !WorkflowValidator.isSingleLine($0) }) {
+        collector.error(
+          "enum_value_multiline",
+          "Enum input '\(input.name)' values must be one line without control characters.",
+          at: input.location)
+      }
       if case .string(let value)? = input.defaultValue, !input.values.contains(value) {
         collector.error(
           "enum_default", "Enum input '\(input.name)' default '\(value)' is not one of its values.", at: input.location)

--- a/supacode/Domain/Handoff/HandoffStore.swift
+++ b/supacode/Domain/Handoff/HandoffStore.swift
@@ -193,11 +193,7 @@ nonisolated struct HandoffStore: Sendable {
   /// authors semantic prose: this only strips chat wrapping (fences, preamble)
   /// and checks that the core sections are present.
   static func validatedBriefing(from text: String) -> String? {
-    var text = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    let hadOpeningFence = text.hasPrefix("```")
-    text = droppingOpeningFence(text)
-    text = droppingPreamble(text)
-    text = droppingClosingFence(text, truncatingTrailer: hadOpeningFence)
+    let text = MarkdownArtifactNormalizer.normalized(text)
     let requiredSections = ["## Objective", "## Current State", "## Next Steps"]
     guard !text.isEmpty, requiredSections.allSatisfy(text.contains) else { return nil }
     return text + "\n"
@@ -241,41 +237,6 @@ nonisolated struct HandoffStore: Sendable {
     }
     try existing.write(to: destination, atomically: true, encoding: .utf8)
     didWrite = true
-  }
-
-  /// Unwraps the opening line of a markdown code fence ("```markdown").
-  private static func droppingOpeningFence(_ text: String) -> String {
-    guard text.hasPrefix("```") else { return text }
-    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    return lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
-  /// Drops chat preamble ahead of the artifact ("Sure, here's the file: …").
-  private static func droppingPreamble(_ text: String) -> String {
-    guard !text.hasPrefix("#") else { return text }
-    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    guard let start = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }) else {
-      return text
-    }
-    return lines[start...].joined(separator: "\n")
-  }
-
-  /// Drops a trailing code-fence line left over after preamble removal.
-  /// When the reply opened with a fence, the *last* fence line is that
-  /// wrapper's closer, so any chatter after it ("Let me know if…") is also
-  /// discarded — embedded code blocks inside the document close in pairs
-  /// before it. Without an opening fence only an exact trailing fence line
-  /// is removed, so a fence inside a document body is never a cut point.
-  private static func droppingClosingFence(_ text: String, truncatingTrailer: Bool) -> String {
-    var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    guard let lastFence = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "```" })
-    else { return text }
-    if lastFence == lines.indices.last {
-      lines.removeLast()
-      return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    guard truncatingTrailer else { return text }
-    return lines[..<lastFence].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   // MARK: - Archive

--- a/supacode/Domain/Handoff/HandoffStore.swift
+++ b/supacode/Domain/Handoff/HandoffStore.swift
@@ -195,7 +195,7 @@ nonisolated struct HandoffStore: Sendable {
   static func validatedBriefing(from text: String) -> String? {
     let text = MarkdownArtifactNormalizer.normalized(text)
     let requiredSections = ["## Objective", "## Current State", "## Next Steps"]
-    guard !text.isEmpty, requiredSections.allSatisfy(text.contains) else { return nil }
+    guard !text.isEmpty, MarkdownArtifactNormalizer.hasSections(requiredSections, in: text) else { return nil }
     return text + "\n"
   }
 

--- a/supacode/Domain/Workflow/WorkflowActivationBridge.swift
+++ b/supacode/Domain/Workflow/WorkflowActivationBridge.swift
@@ -1,0 +1,40 @@
+// supacode/Domain/Workflow/WorkflowActivationBridge.swift
+// The dispatch-store seam of the run machine's effects (docs-ai 063.007, decision H3). B3
+// implements it over `WorktreeTerminalManager` / `AgentDispatchStore`; B2 tests use a fake.
+// Trust never comes from here: a delivery is attributed by the caller pane's pending record,
+// the token only correlates it with the activation.
+
+import Foundation
+
+/// The outcome of opening a `message` activation on the role's surface (#733's re-dispatch:
+/// issue a record and bind it to the pane's current evidence epoch).
+nonisolated enum WorkflowActivationOpenFailure: Error, Equatable, Sendable {
+  /// The pane already holds a pending record or its agent is working / blocked.
+  case roleBusy
+  case surfaceMissing
+  case capacityExceeded
+  case failed(String)
+
+  var injectionFailure: WorkflowInjectionFailure {
+    switch self {
+    case .roleBusy: .roleBusy
+    case .surfaceMissing: .surfaceMissing
+    case .capacityExceeded: .activationUnavailable("all dispatch receipt slots are occupied")
+    case .failed(let detail): .activationUnavailable(detail)
+    }
+  }
+}
+
+@MainActor
+protocol WorkflowActivationBridge: AnyObject {
+  /// Issues and binds a pending dispatch record for an agent already running in the pane.
+  func openMessageActivation(surfaceID: UUID) -> Result<String, WorkflowActivationOpenFailure>
+  /// Rolls back an issuance whose line could not be typed.
+  func cancelActivation(dispatchID: String)
+  /// Skip / Cancel / Relaunch: the record ends `abandoned` with a reason naming run and step.
+  func abandonActivation(dispatchID: String, reason: String)
+  /// A validated delivery completes the record with a `succeeded` receipt.
+  func completeActivation(dispatchID: String, summary: String)
+  /// The epoch-gated observation the watchdog consumes; nil when the record is unknown.
+  func observeActivation(dispatchID: String) -> AgentDispatchObservationStream?
+}

--- a/supacode/Domain/Workflow/WorkflowBindingResolver.swift
+++ b/supacode/Domain/Workflow/WorkflowBindingResolver.swift
@@ -1,0 +1,244 @@
+// supacode/Domain/Workflow/WorkflowBindingResolver.swift
+// Pure binding resolution for `launch` roles (dsl-spec §3, decision H10): remembered binding →
+// enabled profile matching `suggest` exactly → 053 Recommended over the `agents`-filtered set →
+// ask. Every candidate is re-validated; the memory key carries a digest of the role's
+// requirement block so an edited requirement never reuses a stale binding.
+
+import CryptoKit
+import Foundation
+
+/// The four-tuple key of the binding memory. Codable so the wiring layer can keep it in
+/// `@Shared` storage; the digest is SHA-256 over the canonical requirement JSON.
+nonisolated struct WorkflowBindingMemoryKey: Hashable, Codable, Sendable {
+  let scope: String
+  let workflowID: String
+  let role: String
+  let digest: String
+
+  enum CodingKeys: String, CodingKey {
+    case scope
+    case workflowID = "workflow_id"
+    case role
+    case digest
+  }
+}
+
+nonisolated enum WorkflowBindingOverride: Equatable, Sendable {
+  case profileID(UUID)
+  case profileName(String)
+  case auto
+}
+
+nonisolated enum WorkflowBindingTier: Hashable, Sendable {
+  case override
+  case remembered
+  case suggestion
+  case recommended
+}
+
+nonisolated enum WorkflowBindingResolution: Equatable, Sendable {
+  case resolved(AgentProfile, tier: WorkflowBindingTier)
+  /// Nothing resolved unambiguously: the admissible candidates for a picker, plus the
+  /// suggestion a "Create profile from suggestion…" action would start from.
+  case ask(candidates: [AgentProfile], suggestion: WorkflowProfileSuggestion?)
+}
+
+nonisolated enum WorkflowBindingError: Error, Equatable, Sendable {
+  case profileNotFound(String)
+  case profileNotUnique(String)
+  case roleNotLaunchable(String)
+
+  var code: String {
+    switch self {
+    case .profileNotFound: CLIErrorCode.profileNotFound
+    case .profileNotUnique: CLIErrorCode.profileNotUnique
+    case .roleNotLaunchable: CLIErrorCode.invalidArgument
+    }
+  }
+}
+
+/// Why a candidate was rejected; reported so a CLI override that fell through can warn.
+nonisolated enum WorkflowBindingRejection: Equatable, Sendable {
+  case missing
+  case disabled
+  case agentNotAllowed(String)
+  case promptUnsupported
+}
+
+nonisolated struct WorkflowBindingResolverContext: Sendable {
+  let profiles: [AgentProfile]
+  /// The 053 Recommended inputs of the source repository.
+  let designatedProfileID: UUID?
+  let lastLaunchedProfileID: UUID?
+  /// Whether the runtime's adapter renders a seeded prompt; the default probes the registry.
+  let supportsSeededPrompt: @Sendable (AgentProfile) -> Bool
+
+  init(
+    profiles: [AgentProfile],
+    designatedProfileID: UUID? = nil,
+    lastLaunchedProfileID: UUID? = nil,
+    supportsSeededPrompt: @escaping @Sendable (AgentProfile) -> Bool = WorkflowBindingResolver
+      .adapterSupportsSeededPrompt
+  ) {
+    self.profiles = profiles
+    self.designatedProfileID = designatedProfileID
+    self.lastLaunchedProfileID = lastLaunchedProfileID
+    self.supportsSeededPrompt = supportsSeededPrompt
+  }
+}
+
+nonisolated struct WorkflowBindingResult: Equatable, Sendable {
+  let resolution: WorkflowBindingResolution
+  /// The explicit override or remembered binding that failed re-validation, if any.
+  let rejected: [WorkflowBindingTier: WorkflowBindingRejection]
+}
+
+nonisolated enum WorkflowBindingResolver {
+  // MARK: Memory key
+
+  static func memoryKey(scope: WorkflowRunScope, workflowID: String, role: WorkflowRoleDefinition)
+    -> WorkflowBindingMemoryKey
+  {
+    WorkflowBindingMemoryKey(
+      scope: scope.key, workflowID: workflowID, role: role.name, digest: requirementsDigest(role))
+  }
+
+  /// SHA-256 over the canonical JSON of `{source, kind, agents, suggest}`: sorted keys,
+  /// `agents` sorted, absent keys omitted. Prompt-only edits keep the digest.
+  static func requirementsDigest(_ role: WorkflowRoleDefinition) -> String {
+    let json = canonicalRequirements(role)
+    let digest = SHA256.hash(data: Data(json.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+  }
+
+  static func canonicalRequirements(_ role: WorkflowRoleDefinition) -> String {
+    var fields: [String: Any] = ["source": role.source.rawValue]
+    if let launch = role.launch {
+      fields["kind"] = launch.kind.rawValue
+      if let agents = launch.agents {
+        fields["agents"] = agents.sorted()
+      }
+      if let suggest = launch.suggest {
+        var suggestion: [String: String] = [:]
+        suggestion["agent"] = suggest.agent
+        suggestion["model"] = suggest.model
+        suggestion["reasoning_effort"] = suggest.reasoningEffort
+        suggestion["execution_mode"] = suggest.executionMode
+        fields["suggest"] = suggestion
+      }
+    }
+    // JSONSerialization with sortedKeys is deterministic for string/array/dictionary values.
+    guard
+      let data = try? JSONSerialization.data(withJSONObject: fields, options: [.sortedKeys, .withoutEscapingSlashes]),
+      let json = String(data: data, encoding: .utf8)
+    else { return "" }
+    return json
+  }
+
+  // MARK: Resolution
+
+  static func resolve(
+    role: WorkflowRoleDefinition,
+    remembered: UUID?,
+    override: WorkflowBindingOverride?,
+    context: WorkflowBindingResolverContext
+  ) -> Result<WorkflowBindingResult, WorkflowBindingError> {
+    guard role.source == .launch, let requirements = role.launch else {
+      return .failure(.roleNotLaunchable(role.name))
+    }
+    var rejected: [WorkflowBindingTier: WorkflowBindingRejection] = [:]
+    if let override, override != .auto {
+      let profile: AgentProfile?
+      switch override {
+      case .profileID(let id):
+        profile = context.profiles.first { $0.id == id }
+        guard profile != nil else { return .failure(.profileNotFound(id.uuidString)) }
+      case .profileName(let name):
+        let matches = context.profiles.filter { $0.name == name }
+        guard !matches.isEmpty else { return .failure(.profileNotFound(name)) }
+        guard matches.count == 1 else { return .failure(.profileNotUnique(name)) }
+        profile = matches.first
+      case .auto:
+        profile = nil
+      }
+      if let profile {
+        if let rejection = rejection(of: profile, requirements: requirements, context: context) {
+          rejected[.override] = rejection
+        } else {
+          return .success(WorkflowBindingResult(resolution: .resolved(profile, tier: .override), rejected: rejected))
+        }
+      }
+    }
+    if let remembered {
+      if let profile = context.profiles.first(where: { $0.id == remembered }) {
+        if let rejection = rejection(of: profile, requirements: requirements, context: context) {
+          rejected[.remembered] = rejection
+        } else {
+          return .success(WorkflowBindingResult(resolution: .resolved(profile, tier: .remembered), rejected: rejected))
+        }
+      } else {
+        rejected[.remembered] = .missing
+      }
+    }
+    let admissible = context.profiles.filter { rejection(of: $0, requirements: requirements, context: context) == nil }
+    if let suggest = requirements.suggest, let match = admissible.first(where: { matches($0, suggestion: suggest) }) {
+      return .success(WorkflowBindingResult(resolution: .resolved(match, tier: .suggestion), rejected: rejected))
+    }
+    if let recommended = AgentProfileRecommendation.recommendedProfile(
+      profiles: admissible,
+      designatedID: context.designatedProfileID,
+      lastLaunchedID: context.lastLaunchedProfileID)
+    {
+      return .success(WorkflowBindingResult(resolution: .resolved(recommended, tier: .recommended), rejected: rejected))
+    }
+    return .success(
+      WorkflowBindingResult(
+        resolution: .ask(candidates: admissible, suggestion: requirements.suggest), rejected: rejected))
+  }
+
+  /// nil when the profile may be bound: exists, enabled, satisfies `agents`, supports a seeded prompt.
+  static func rejection(
+    of profile: AgentProfile,
+    requirements: WorkflowLaunchRequirements,
+    context: WorkflowBindingResolverContext
+  ) -> WorkflowBindingRejection? {
+    guard profile.isEnabled else { return .disabled }
+    let token = profile.runtime.agent.rawValue
+    if let agents = requirements.agents, !agents.contains(token) {
+      return .agentNotAllowed(token)
+    }
+    guard context.supportsSeededPrompt(profile) else { return .promptUnsupported }
+    return nil
+  }
+
+  /// Every field the suggestion names must equal the profile's; absent fields do not constrain.
+  static func matches(_ profile: AgentProfile, suggestion: WorkflowProfileSuggestion) -> Bool {
+    let actual = WorkflowProfileSuggestion(
+      agent: profile.runtime.agent.rawValue,
+      model: profile.model,
+      reasoningEffort: profile.reasoningEffort,
+      executionMode: profile.executionMode.rawValue)
+    for (wanted, value) in [
+      (suggestion.agent, actual.agent), (suggestion.model, actual.model),
+      (suggestion.reasoningEffort, actual.reasoningEffort), (suggestion.executionMode, actual.executionMode),
+    ] where wanted != nil && wanted != value {
+      return false
+    }
+    return true
+  }
+
+  /// Probes the runtime adapter with a seeded prompt; Amp rejects it, the others render it.
+  @Sendable static func adapterSupportsSeededPrompt(_ profile: AgentProfile) -> Bool {
+    let request = AgentStartRequest(
+      runtime: profile.runtime,
+      intent: .prompt("probe"),
+      configuration: AgentLaunchConfiguration(
+        model: profile.model,
+        executionMode: profile.executionMode,
+        reasoningEffort: profile.reasoningEffort,
+        extraArguments: ShellWordSplitter.split(profile.extraArguments)),
+      dedicatedHome: nil)
+    guard let invocation = try? AgentRuntimeAdapterRegistry.makeStartInvocation(request) else { return false }
+    return invocation.arguments.last == "probe"
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+++ b/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
@@ -55,13 +55,63 @@ nonisolated enum WorkflowDeliveryError: Error, Equatable, Sendable {
   }
 }
 
-/// A delivery that passed validation: the body in its persisted form and the accepted verdict.
+/// What a non-strict delivery got wrong (dsl-spec §5): the run keeps the output as provisional
+/// and asks the user instead of bouncing the agent. Under `strict: true` the same findings are
+/// rejections.
+nonisolated enum WorkflowDeliveryIssue: Equatable, Sendable {
+  case missingSections([String])
+  case unparsableJSON
+  case verdictMissing(allowed: [String])
+  case verdictUndeclared(String, allowed: [String])
+  case verdictUnexpected(String)
+
+  var code: String {
+    switch self {
+    case .missingSections: "missing_sections"
+    case .unparsableJSON: "unparsable_json"
+    case .verdictMissing: "verdict_missing"
+    case .verdictUndeclared: "verdict_undeclared"
+    case .verdictUnexpected: "verdict_unexpected"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .missingSections(let sections): "missing section(s) \(sections.joined(separator: ", "))"
+    case .unparsableJSON: "the body is not parseable JSON"
+    case .verdictMissing(let allowed): "no verdict (one of \(allowed.joined(separator: ", ")) is required)"
+    case .verdictUndeclared(let value, let allowed):
+      "verdict '\(value)' is not one of \(allowed.joined(separator: ", "))"
+    case .verdictUnexpected(let value): "verdict '\(value)' was given but this step declares none"
+    }
+  }
+
+  /// The rejection a strict step answers with.
+  var rejection: WorkflowDeliveryError {
+    switch self {
+    case .verdictMissing(let allowed): .verdictRequired(allowed: allowed)
+    default: .outputInvalid(reason: message + ".")
+    }
+  }
+}
+
+/// A delivery that passed validation: the body in its persisted form, the accepted verdict, and
+/// the issues a non-strict step tolerated (empty when the delivery is clean).
 nonisolated struct WorkflowValidatedDelivery: Equatable, Sendable {
   let body: String
   let verdict: String?
+  let issues: [WorkflowDeliveryIssue]
+
+  init(body: String, verdict: String?, issues: [WorkflowDeliveryIssue] = []) {
+    self.body = body
+    self.verdict = verdict
+    self.issues = issues
+  }
 }
 
 nonisolated enum WorkflowDeliveryValidator {
+  /// Size and emptiness always reject; sections, format, and verdict reject only under
+  /// `strict: true` and are otherwise returned as issues on an accepted delivery.
   static func validate(
     body: String,
     verdict: String?,
@@ -72,43 +122,47 @@ nonisolated enum WorkflowDeliveryValidator {
     guard bytes <= limits.maximumBytes else {
       return .failure(.outputTooLarge(bytes: bytes, limit: limits.maximumBytes))
     }
-    switch (expect.verdict, verdict) {
-    case (nil, nil):
-      break
-    case (nil, .some):
-      return .failure(.outputInvalid(reason: "this step declares no verdict."))
-    case (.some(let allowed), nil):
-      return .failure(.verdictRequired(allowed: allowed))
-    case (.some(let allowed), .some(let value)):
-      guard allowed.contains(value) else {
-        return .failure(
-          .outputInvalid(reason: "verdict '\(value)' is not one of \(allowed.joined(separator: ", "))."))
-      }
-    }
     guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return .failure(.outputInvalid(reason: "the body is empty."))
     }
+    var issues: [WorkflowDeliveryIssue] = []
+    var acceptedVerdict: String?
+    switch (expect.verdict, verdict) {
+    case (nil, nil):
+      break
+    case (nil, .some(let value)):
+      issues.append(.verdictUnexpected(value))
+    case (.some(let allowed), nil):
+      issues.append(.verdictMissing(allowed: allowed))
+    case (.some(let allowed), .some(let value)):
+      if allowed.contains(value) {
+        acceptedVerdict = value
+      } else {
+        issues.append(.verdictUndeclared(value, allowed: allowed))
+      }
+    }
+    var persisted = body
     switch expect.format {
     case .markdown:
       let normalized = MarkdownArtifactNormalizer.normalized(body)
       guard !normalized.isEmpty else {
         return .failure(.outputInvalid(reason: "the body is empty."))
       }
-      let missing = expect.sections.filter { !MarkdownArtifactNormalizer.hasSections([$0], in: normalized) }
-      guard missing.isEmpty else {
-        return .failure(
-          .outputInvalid(reason: "missing required section(s): \(missing.joined(separator: ", "))."))
+      let missing = MarkdownArtifactNormalizer.missingSections(expect.sections, in: normalized)
+      if !missing.isEmpty {
+        issues.append(.missingSections(missing))
       }
-      return .success(WorkflowValidatedDelivery(body: normalized + "\n", verdict: verdict))
+      persisted = normalized + "\n"
     case .text:
-      return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
+      break
     case .json:
-      do {
-        _ = try JSONSerialization.jsonObject(with: Data(body.utf8), options: [.fragmentsAllowed])
-      } catch {
-        return .failure(.outputInvalid(reason: "the body is not parseable JSON."))
+      if (try? JSONSerialization.jsonObject(with: Data(body.utf8), options: [.fragmentsAllowed])) == nil {
+        issues.append(.unparsableJSON)
       }
-      return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
     }
+    if expect.strict, let first = issues.first {
+      return .failure(first.rejection)
+    }
+    return .success(WorkflowValidatedDelivery(body: persisted, verdict: acceptedVerdict, issues: issues))
   }
 }

--- a/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+++ b/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
@@ -94,7 +94,11 @@ nonisolated enum WorkflowDeliveryValidator {
       guard !normalized.isEmpty else {
         return .failure(.outputInvalid(reason: "the body is empty."))
       }
-      let missing = expect.sections.filter { !normalized.contains($0) }
+      let headings = Self.headings(outsideFences: normalized)
+      let missing = expect.sections.filter { section in
+        let wanted = section.trimmingCharacters(in: .whitespaces)
+        return !headings.contains { $0 == wanted || $0.hasPrefix(wanted + " ") }
+      }
       guard missing.isEmpty else {
         return .failure(
           .outputInvalid(reason: "missing required section(s): \(missing.joined(separator: ", "))."))
@@ -110,5 +114,27 @@ nonisolated enum WorkflowDeliveryValidator {
       }
       return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
     }
+  }
+
+  /// Heading lines (`#…`) outside fenced code blocks, trimmed; a heading quoted inside a
+  /// fence does not satisfy a required section.
+  static func headings(outsideFences text: String) -> [String] {
+    var headings: [String] = []
+    var fence: String?
+    for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      if let open = fence {
+        if line.hasPrefix(open) { fence = nil }
+        continue
+      }
+      if line.hasPrefix("```") || line.hasPrefix("~~~") {
+        fence = String(line.prefix(3))
+        continue
+      }
+      if line.hasPrefix("#") {
+        headings.append(line)
+      }
+    }
+    return headings
   }
 }

--- a/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+++ b/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
@@ -94,11 +94,7 @@ nonisolated enum WorkflowDeliveryValidator {
       guard !normalized.isEmpty else {
         return .failure(.outputInvalid(reason: "the body is empty."))
       }
-      let headings = Self.headings(outsideFences: normalized)
-      let missing = expect.sections.filter { section in
-        let wanted = section.trimmingCharacters(in: .whitespaces)
-        return !headings.contains { $0 == wanted || $0.hasPrefix(wanted + " ") }
-      }
+      let missing = expect.sections.filter { !MarkdownArtifactNormalizer.hasSections([$0], in: normalized) }
       guard missing.isEmpty else {
         return .failure(
           .outputInvalid(reason: "missing required section(s): \(missing.joined(separator: ", "))."))
@@ -114,27 +110,5 @@ nonisolated enum WorkflowDeliveryValidator {
       }
       return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
     }
-  }
-
-  /// Heading lines (`#…`) outside fenced code blocks, trimmed; a heading quoted inside a
-  /// fence does not satisfy a required section.
-  static func headings(outsideFences text: String) -> [String] {
-    var headings: [String] = []
-    var fence: String?
-    for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
-      let line = rawLine.trimmingCharacters(in: .whitespaces)
-      if let open = fence {
-        if line.hasPrefix(open) { fence = nil }
-        continue
-      }
-      if line.hasPrefix("```") || line.hasPrefix("~~~") {
-        fence = String(line.prefix(3))
-        continue
-      }
-      if line.hasPrefix("#") {
-        headings.append(line)
-      }
-    }
-    return headings
   }
 }

--- a/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+++ b/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
@@ -1,0 +1,114 @@
+// supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+// Validation of a `prowl workflow done` body against the step's `expect` (dsl-spec §5): size
+// caps, format, required sections, and the verdict declaration.
+
+import Foundation
+
+nonisolated struct WorkflowDeliveryLimits: Equatable, Sendable {
+  static let defaultMaximumBytes = 1 << 20
+  static let hardMaximumBytes = 4 << 20
+
+  /// Bytes of UTF-8 a delivered body may have; clamped to `1…hardMaximumBytes`.
+  let maximumBytes: Int
+
+  init(maximumBytes: Int = Self.defaultMaximumBytes) {
+    self.maximumBytes = min(max(1, maximumBytes), Self.hardMaximumBytes)
+  }
+}
+
+nonisolated enum WorkflowDeliveryError: Error, Equatable, Sendable {
+  /// No activation is currently waiting for the caller (or for the addressed step).
+  case stepNotExpecting
+  case tokenRequired
+  case tokenInvalid
+  case outputInvalid(reason: String)
+  case outputTooLarge(bytes: Int, limit: Int)
+  case verdictRequired(allowed: [String])
+
+  var code: String {
+    switch self {
+    case .stepNotExpecting: CLIErrorCode.stepNotExpecting
+    case .tokenRequired: CLIErrorCode.tokenRequired
+    case .tokenInvalid: CLIErrorCode.tokenInvalid
+    case .outputInvalid: CLIErrorCode.outputInvalid
+    case .outputTooLarge: CLIErrorCode.outputTooLarge
+    case .verdictRequired: CLIErrorCode.verdictRequired
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .stepNotExpecting:
+      "No workflow step is waiting for a delivery from this pane."
+    case .tokenRequired:
+      "The delivery token is missing; run the generated completion command "
+        + "(\(WorkflowSchema.tokenEnvironmentKey)=… \(WorkflowCompletionCommand.executable) …)."
+    case .tokenInvalid:
+      "The delivery token does not belong to the step that is waiting; rerun the latest generated completion command."
+    case .outputInvalid(let reason):
+      "The delivered output is invalid: \(reason)"
+    case .outputTooLarge(let bytes, let limit):
+      "The delivered output is \(bytes) bytes; the limit is \(limit) bytes."
+    case .verdictRequired(let allowed):
+      "This step requires a verdict: pass --verdict with one of \(allowed.joined(separator: ", "))."
+    }
+  }
+}
+
+/// A delivery that passed validation: the body in its persisted form and the accepted verdict.
+nonisolated struct WorkflowValidatedDelivery: Equatable, Sendable {
+  let body: String
+  let verdict: String?
+}
+
+nonisolated enum WorkflowDeliveryValidator {
+  static func validate(
+    body: String,
+    verdict: String?,
+    expect: WorkflowExpectation,
+    limits: WorkflowDeliveryLimits
+  ) -> Result<WorkflowValidatedDelivery, WorkflowDeliveryError> {
+    let bytes = body.utf8.count
+    guard bytes <= limits.maximumBytes else {
+      return .failure(.outputTooLarge(bytes: bytes, limit: limits.maximumBytes))
+    }
+    switch (expect.verdict, verdict) {
+    case (nil, nil):
+      break
+    case (nil, .some):
+      return .failure(.outputInvalid(reason: "this step declares no verdict."))
+    case (.some(let allowed), nil):
+      return .failure(.verdictRequired(allowed: allowed))
+    case (.some(let allowed), .some(let value)):
+      guard allowed.contains(value) else {
+        return .failure(
+          .outputInvalid(reason: "verdict '\(value)' is not one of \(allowed.joined(separator: ", "))."))
+      }
+    }
+    guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return .failure(.outputInvalid(reason: "the body is empty."))
+    }
+    switch expect.format {
+    case .markdown:
+      let normalized = MarkdownArtifactNormalizer.normalized(body)
+      guard !normalized.isEmpty else {
+        return .failure(.outputInvalid(reason: "the body is empty."))
+      }
+      let missing = expect.sections.filter { !normalized.contains($0) }
+      guard missing.isEmpty else {
+        return .failure(
+          .outputInvalid(reason: "missing required section(s): \(missing.joined(separator: ", "))."))
+      }
+      return .success(WorkflowValidatedDelivery(body: normalized + "\n", verdict: verdict))
+    case .text:
+      return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
+    case .json:
+      do {
+        _ = try JSONSerialization.jsonObject(with: Data(body.utf8), options: [.fragmentsAllowed])
+      } catch {
+        return .failure(.outputInvalid(reason: "the body is not parseable JSON."))
+      }
+      return .success(WorkflowValidatedDelivery(body: body, verdict: verdict))
+    }
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -100,7 +100,8 @@ nonisolated struct WorkflowCompletionCommand: Equatable, Sendable {
     delivery += "."
     lines.append(delivery)
     if launchCommands.count > 1 {
-      lines.append("When your work for this step is fully complete, make exactly one of these commands your final tool action:")
+      lines.append(
+        "When your work for this step is fully complete, make exactly one of these commands your final tool action:")
     } else {
       lines.append("When your work for this step is fully complete, make this command your final tool action:")
     }
@@ -143,13 +144,16 @@ nonisolated enum WorkflowTypedLine {
   }
 
   /// `instruction` → `[Prowl] Read <absolute path> and follow it[ — finish with: …]`.
-  static func pointer(to path: String, completion: WorkflowCompletionCommand?) throws(WorkflowRenderedTextError) -> String {
+  static func pointer(to path: String, completion: WorkflowCompletionCommand?) throws(WorkflowRenderedTextError)
+    -> String
+  {
     try validated(prefix + "Read \(path) and follow it" + (completion?.typedSuffix ?? ""))
   }
 
   /// The watchdog's one automatic nudge (and the panel's "Nudge again").
   static func nudge(completion: WorkflowCompletionCommand) throws(WorkflowRenderedTextError) -> String {
-    try validated(prefix + nudgeText + completion.messageCommands.joined(separator: WorkflowCompletionCommand.commandSeparator))
+    try validated(
+      prefix + nudgeText + completion.messageCommands.joined(separator: WorkflowCompletionCommand.commandSeparator))
   }
 
   private static func validated(_ line: String) throws(WorkflowRenderedTextError) -> String {

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -82,9 +82,9 @@ nonisolated struct WorkflowCompletionCommand: Equatable, Sendable {
     workflowName: String,
     role: String,
     stepTitle: String?,
-    sections: [String],
-    format: WorkflowOutputFormat
+    expect: WorkflowExpectation
   ) -> String {
+    let (sections, format) = (expect.sections, expect.format)
     var lines = [
       "Prowl workflow completion protocol v\(Self.protocolVersion):",
       "You are the \"\(role)\" role of the Prowl workflow run \(runID) (\(workflowName)).",

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -1,0 +1,189 @@
+// supacode/Domain/Workflow/WorkflowLineRenderer.swift
+// The text a workflow run puts in front of an agent (docs-ai 063, dsl-spec §4/§10): the typed
+// line formats, the single place that spells `prowl workflow done`, the launch protocol block,
+// and the rendered-text boundary every typed line crosses.
+
+import Foundation
+
+/// A rendered line would not survive as one terminal line (`RENDERED_TEXT_INVALID`).
+nonisolated struct WorkflowRenderedTextError: Error, Equatable, Sendable {
+  let line: String
+  var code: String { CLIErrorCode.renderedTextInvalid }
+  var message: String {
+    "The rendered text contains a line terminator or control character and cannot be typed as one line."
+  }
+}
+
+/// The rendered-text boundary: every string that reaches `insertCommittedText` + submit is
+/// validated after template substitution, so a template value can never smuggle a newline
+/// into a TUI. Violations stop the step; nothing is ever typed partially.
+nonisolated enum WorkflowRenderedText {
+  static func isSingleLine(_ text: String) -> Bool {
+    WorkflowValidator.isSingleLine(text)
+  }
+
+  static func validateLine(_ line: String) throws(WorkflowRenderedTextError) {
+    guard isSingleLine(line) else { throw WorkflowRenderedTextError(line: line) }
+  }
+}
+
+/// The completion command of one activation. This is the only place that spells
+/// `prowl workflow done`: the typed hint, the materialized instruction trailer, the launch
+/// protocol block, the watchdog nudge, every re-delivery, and the `WORKFLOW_DELIVERY_REQUIRED`
+/// message all read from it, so no path can show a token-less or verdict-less command.
+nonisolated struct WorkflowCompletionCommand: Equatable, Sendable {
+  static let protocolVersion = 1
+  static let executable = "prowl workflow done"
+  static let commandSeparator = "  or  "
+
+  let token: String
+  /// Declared verdict values; nil when the step has no verdict.
+  let verdicts: [String]?
+
+  init(token: String, verdicts: [String]?) {
+    self.token = token
+    self.verdicts = verdicts
+  }
+
+  /// `PROWL_WORKFLOW_TOKEN=<token> prowl workflow done [--verdict v] -`, one per allowed verdict.
+  var messageCommands: [String] {
+    launchCommands.map { "\(WorkflowSchema.tokenEnvironmentKey)=\(token) \($0)" }
+  }
+
+  /// `prowl workflow done [--verdict v] -`; the token travels in the launched child's environment.
+  var launchCommands: [String] {
+    guard let verdicts, !verdicts.isEmpty else { return ["\(Self.executable) -"] }
+    return verdicts.map { "\(Self.executable) --verdict \($0) -" }
+  }
+
+  /// Appended to a typed `text` or pointer line.
+  var typedSuffix: String {
+    " — finish with: " + messageCommands.joined(separator: Self.commandSeparator)
+  }
+
+  /// The trailer of a materialized instruction file; lists the same commands as the typed line.
+  func instructionTrailer() -> String {
+    var lines = ["", "---", "When this step is fully complete, finish with"]
+    if messageCommands.count > 1 {
+      lines[lines.count - 1] += " exactly one of:"
+    } else {
+      lines[lines.count - 1] += ":"
+    }
+    lines += messageCommands.map { "    \($0)" }
+    lines.append("")
+    return lines.joined(separator: "\n")
+  }
+
+  /// The workflow protocol block appended to a `launch` step's kickoff prompt in place of S2's
+  /// dispatch protocol. The token is not spelled: it is set in the child environment exactly
+  /// like `PROWL_DISPATCH_ID`.
+  func protocolBlock(
+    runID: String,
+    workflowName: String,
+    role: String,
+    stepTitle: String?,
+    sections: [String],
+    format: WorkflowOutputFormat
+  ) -> String {
+    var lines = [
+      "Prowl workflow completion protocol v\(Self.protocolVersion):",
+      "You are the \"\(role)\" role of the Prowl workflow run \(runID) (\(workflowName)).",
+    ]
+    var delivery = "Deliver the output of this step"
+    if let stepTitle, !stepTitle.isEmpty {
+      delivery += " (\(stepTitle))"
+    }
+    delivery += " as \(Self.formatDescription(format)) on stdin"
+    if !sections.isEmpty {
+      delivery += " with the sections: \(sections.joined(separator: ", "))"
+    }
+    delivery += "."
+    lines.append(delivery)
+    if launchCommands.count > 1 {
+      lines.append("When your work for this step is fully complete, make exactly one of these commands your final tool action:")
+    } else {
+      lines.append("When your work for this step is fully complete, make this command your final tool action:")
+    }
+    for (index, command) in launchCommands.enumerated() {
+      if index > 0 { lines.append("or:") }
+      lines.append(command)
+    }
+    if launchCommands.count > 1 {
+      lines.append("Choose exactly one verdict.")
+    }
+    lines.append(
+      "Do not use prowl agents dispatch-complete for this step; Prowl supplies the workflow context automatically.")
+    return lines.joined(separator: "\n") + "\n"
+  }
+
+  /// The `WORKFLOW_DELIVERY_REQUIRED` message for a `dispatch-complete` issued against this activation.
+  func deliveryRequiredMessage(runID: String, stepID: String) -> String {
+    "This pane's pending dispatch is a workflow activation (run \(runID), step \(stepID)); "
+      + "deliver the step's output instead with: " + messageCommands.joined(separator: Self.commandSeparator)
+  }
+
+  private static func formatDescription(_ format: WorkflowOutputFormat) -> String {
+    switch format {
+    case .markdown: "a markdown document"
+    case .text: "plain text"
+    case .json: "a JSON document"
+    }
+  }
+}
+
+/// Typed line formats. Every line Prowl types into a pane starts with `[Prowl] ` so its origin
+/// is visible; every line is validated as one terminal line before it is returned.
+nonisolated enum WorkflowTypedLine {
+  static let prefix = AgentDispatchPrompt.injectedPrefix
+  static let nudgeText = "When your work for this step is fully complete, finish with: "
+
+  /// `text` → `[Prowl] <text>[ — finish with: …]`.
+  static func text(_ text: String, completion: WorkflowCompletionCommand?) throws(WorkflowRenderedTextError) -> String {
+    try validated(prefix + text + (completion?.typedSuffix ?? ""))
+  }
+
+  /// `instruction` → `[Prowl] Read <absolute path> and follow it[ — finish with: …]`.
+  static func pointer(to path: String, completion: WorkflowCompletionCommand?) throws(WorkflowRenderedTextError) -> String {
+    try validated(prefix + "Read \(path) and follow it" + (completion?.typedSuffix ?? ""))
+  }
+
+  /// The watchdog's one automatic nudge (and the panel's "Nudge again").
+  static func nudge(completion: WorkflowCompletionCommand) throws(WorkflowRenderedTextError) -> String {
+    try validated(prefix + nudgeText + completion.messageCommands.joined(separator: WorkflowCompletionCommand.commandSeparator))
+  }
+
+  private static func validated(_ line: String) throws(WorkflowRenderedTextError) -> String {
+    try WorkflowRenderedText.validateLine(line)
+    return line
+  }
+}
+
+nonisolated enum WorkflowLaunchPromptError: Error, Equatable, Sendable {
+  case containsNUL
+  /// `PROMPT_TOO_LARGE`.
+  case tooLarge(bytes: Int)
+
+  var code: String {
+    switch self {
+    case .containsNUL: CLIErrorCode.invalidArgument
+    case .tooLarge: CLIErrorCode.promptTooLarge
+    }
+  }
+}
+
+/// The kickoff prompt of a `launch` step: passed whole through A2's prompt carrier, so it may
+/// span lines, but NUL is rejected and the rendered prompt is capped (dsl-spec §4).
+nonisolated enum WorkflowLaunchPrompt {
+  static let maximumBytes = 32 * 1024
+
+  static func validate(_ prompt: String) throws(WorkflowLaunchPromptError) {
+    guard !prompt.contains("\0") else { throw .containsNUL }
+    let bytes = prompt.utf8.count
+    guard bytes <= maximumBytes else { throw .tooLarge(bytes: bytes) }
+  }
+
+  static func render(userPrompt: String, protocolBlock: String?) -> String {
+    guard let protocolBlock else { return userPrompt }
+    return "\(userPrompt)\n\n---\n\(protocolBlock)"
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -150,6 +150,16 @@ nonisolated enum WorkflowTypedLine {
     try validated(prefix + "Read \(path) and follow it" + (completion?.typedSuffix ?? ""))
   }
 
+  /// The panel's "Ask again" after a provisional delivery: what was missing, and the command.
+  static func askAgain(
+    issues: [WorkflowDeliveryIssue], completion: WorkflowCompletionCommand
+  ) throws(WorkflowRenderedTextError) -> String {
+    let problems = issues.map(\.message).joined(separator: "; ")
+    return try validated(
+      prefix + "Your delivery for this step had \(problems). Deliver it again, complete, with: "
+        + completion.messageCommands.joined(separator: WorkflowCompletionCommand.commandSeparator))
+  }
+
   /// The watchdog's one automatic nudge (and the panel's "Nudge again").
   static func nudge(completion: WorkflowCompletionCommand) throws(WorkflowRenderedTextError) -> String {
     try validated(

--- a/supacode/Domain/Workflow/WorkflowNativeActions.swift
+++ b/supacode/Domain/Workflow/WorkflowNativeActions.swift
@@ -3,6 +3,7 @@
 // `handoff.checkpoint` over the `.prowl/handoff/` coordinator, `git.context` over the same
 // context generator. Typed inputs and outputs follow `WorkflowActionRegistry`.
 
+import Darwin
 import Foundation
 
 nonisolated struct WorkflowActionContext: Sendable {
@@ -175,12 +176,7 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
   ) throws -> HandoffPreparedBriefing {
     guard let path else { return .contextOnly }
     guard let url = try containedPath(path, context: context) else { return .contextOnly }
-    let text: String
-    do {
-      text = try String(contentsOf: url, encoding: .utf8)
-    } catch {
-      throw WorkflowActionError.unreadableBriefing(path: path)
-    }
+    let text = try Self.readRegularFile(url, reportedPath: path)
     do {
       return try coordinator.collectBriefing(.inline(text))
     } catch {
@@ -188,8 +184,9 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
     }
   }
 
-  /// A path input resolved against the worktree root and required to stay inside it
-  /// (canonical comparison, so a symlink cannot point the action elsewhere).
+  /// A path input resolved against the worktree root and required to stay inside it. The
+  /// canonical (symlink-resolved) URL is what the action operates on, so the containment
+  /// that was checked is the containment that is used.
   private func containedPath(_ path: String?, context: WorkflowActionContext) throws -> URL? {
     guard let path, !path.isEmpty else { return nil }
     let url = URL(filePath: path, relativeTo: context.rootURL).standardizedFileURL
@@ -198,6 +195,26 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
     guard canonical == base || AgentProfileLaunchPlanner.isContained(canonical, in: base) else {
       throw WorkflowActionError.unsafePath(path)
     }
-    return url
+    return canonical
+  }
+
+  /// Reads a briefing through an `O_NOFOLLOW` descriptor and requires a regular file, so a
+  /// link planted at the leaf between the containment check and the read is refused.
+  private static func readRegularFile(_ url: URL, reportedPath: String) throws -> String {
+    let descriptor = Darwin.open(url.path(percentEncoded: false), O_RDONLY | O_NOFOLLOW)
+    guard descriptor >= 0 else {
+      if errno == ELOOP { throw WorkflowActionError.unsafePath(reportedPath) }
+      throw WorkflowActionError.unreadableBriefing(path: reportedPath)
+    }
+    let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+    defer { try? handle.close() }
+    var statistics = stat()
+    guard fstat(descriptor, &statistics) == 0, (statistics.st_mode & S_IFMT) == S_IFREG else {
+      throw WorkflowActionError.unreadableBriefing(path: reportedPath)
+    }
+    guard let data = try? handle.readToEnd(), let text = String(data: data, encoding: .utf8) else {
+      throw WorkflowActionError.unreadableBriefing(path: reportedPath)
+    }
+    return text
   }
 }

--- a/supacode/Domain/Workflow/WorkflowNativeActions.swift
+++ b/supacode/Domain/Workflow/WorkflowNativeActions.swift
@@ -150,7 +150,12 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
   /// The handoff context generator: writes `<root>/.prowl/handoff/context.md` and appends one
   /// line to the handoff log; `root` defaults to the worktree and must stay inside it.
   private func gitContext(inputs: [String: String], context: WorkflowActionContext) async throws -> [String: String] {
-    let root = try containedPath(inputs["root"], context: context) ?? context.rootURL
+    let root = try containedPath(inputs["root"], context: context) ?? context.rootURL.resolvingSymlinksInPath()
+    // The handoff store works on paths; re-walk the root without following links right before
+    // it starts so a link planted after the containment check is refused (the residual window
+    // inside the store's own writes stays on the pre-existing handoff trust model).
+    let rootDescriptor = try Self.openContainedDirectory(root, root: context.rootURL.resolvingSymlinksInPath())
+    _ = Darwin.close(rootDescriptor)
     let store = HandoffStore(rootURL: root)
     do {
       let save = try await Task.detached {
@@ -176,7 +181,7 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
   ) throws -> HandoffPreparedBriefing {
     guard let path else { return .contextOnly }
     guard let url = try containedPath(path, context: context) else { return .contextOnly }
-    let text = try Self.readRegularFile(url, reportedPath: path)
+    let text = try Self.readRegularFile(url, root: context.rootURL.resolvingSymlinksInPath(), reportedPath: path)
     do {
       return try coordinator.collectBriefing(.inline(text))
     } catch {
@@ -198,10 +203,35 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
     return canonical
   }
 
-  /// Reads a briefing through an `O_NOFOLLOW` descriptor and requires a regular file, so a
-  /// link planted at the leaf between the containment check and the read is refused.
-  private static func readRegularFile(_ url: URL, reportedPath: String) throws -> String {
-    let descriptor = Darwin.open(url.path(percentEncoded: false), O_RDONLY | O_NOFOLLOW)
+  /// Opens `directory` (a canonical path inside `root`) by walking every component from the
+  /// root with `O_NOFOLLOW | O_DIRECTORY`, so a component swapped for a link after the
+  /// containment check is refused rather than followed. Returns an owned descriptor.
+  private static func openContainedDirectory(_ directory: URL, root: URL) throws -> Int32 {
+    let rootPath = AgentProfileLaunchPlanner.pathString(root)
+    var descriptor = Darwin.open(rootPath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+    guard descriptor >= 0 else { throw WorkflowActionError.unsafePath(rootPath) }
+    let rootComponents = root.standardizedFileURL.pathComponents
+    let components = directory.standardizedFileURL.pathComponents
+    guard components.count >= rootComponents.count, Array(components.prefix(rootComponents.count)) == rootComponents
+    else {
+      _ = Darwin.close(descriptor)
+      throw WorkflowActionError.unsafePath(AgentProfileLaunchPlanner.pathString(directory))
+    }
+    for component in components.dropFirst(rootComponents.count) {
+      let next = openat(descriptor, component, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+      _ = Darwin.close(descriptor)
+      guard next >= 0 else { throw WorkflowActionError.unsafePath(AgentProfileLaunchPlanner.pathString(directory)) }
+      descriptor = next
+    }
+    return descriptor
+  }
+
+  /// Reads a briefing by walking its directory from the worktree root without following links
+  /// and opening the leaf with `O_NOFOLLOW`; requires a regular file.
+  private static func readRegularFile(_ url: URL, root: URL, reportedPath: String) throws -> String {
+    let directoryDescriptor = try openContainedDirectory(url.deletingLastPathComponent(), root: root)
+    let descriptor = openat(directoryDescriptor, url.lastPathComponent, O_RDONLY | O_NOFOLLOW)
+    _ = Darwin.close(directoryDescriptor)
     guard descriptor >= 0 else {
       if errno == ELOOP { throw WorkflowActionError.unsafePath(reportedPath) }
       throw WorkflowActionError.unreadableBriefing(path: reportedPath)

--- a/supacode/Domain/Workflow/WorkflowNativeActions.swift
+++ b/supacode/Domain/Workflow/WorkflowNativeActions.swift
@@ -1,0 +1,203 @@
+// supacode/Domain/Workflow/WorkflowNativeActions.swift
+// Execution of the V1 native actions (dsl-spec §4, decision H12): `handoff.transition` and
+// `handoff.checkpoint` over the `.prowl/handoff/` coordinator, `git.context` over the same
+// context generator. Typed inputs and outputs follow `WorkflowActionRegistry`.
+
+import Foundation
+
+nonisolated struct WorkflowActionContext: Sendable {
+  let runID: UUID
+  /// The source worktree root; every path input must stay inside it.
+  let rootURL: URL
+  /// Role → detected / frozen agent token (nil for a bare shell).
+  let roleAgents: [String: String?]
+  /// The agent token of the `current` role: the outgoing side of a checkpoint or context.
+  let outgoingAgent: String?
+  let sessionContext: HandoffStore.SessionContext?
+  let now: Date
+
+  init(
+    runID: UUID,
+    rootURL: URL,
+    roleAgents: [String: String?],
+    outgoingAgent: String?,
+    sessionContext: HandoffStore.SessionContext? = nil,
+    now: Date
+  ) {
+    self.runID = runID
+    self.rootURL = rootURL.standardizedFileURL
+    self.roleAgents = roleAgents
+    self.outgoingAgent = outgoingAgent
+    self.sessionContext = sessionContext
+    self.now = now
+  }
+}
+
+nonisolated enum WorkflowActionError: Error, Equatable, Sendable {
+  case unknownAction(String)
+  case missingInput(String)
+  case unknownRole(String)
+  case unreadableBriefing(path: String)
+  /// The briefing lacks the required sections; nothing was written.
+  case invalidBriefing(path: String)
+  /// A path input resolves outside the worktree root.
+  case unsafePath(String)
+  case failed(String)
+
+  var message: String {
+    switch self {
+    case .unknownAction(let id): "Unknown action '\(id)'."
+    case .missingInput(let name): "Input '\(name)' is required."
+    case .unknownRole(let role): "Role '\(role)' is not bound in this run."
+    case .unreadableBriefing(let path): "The briefing at \(path) cannot be read."
+    case .invalidBriefing(let path): HandoffCommandHandler.invalidBriefMessage() + " (\(path))"
+    case .unsafePath(let path): "The path \(path) lies outside the worktree."
+    case .failed(let detail): detail
+    }
+  }
+}
+
+/// The boundary the run machine's `.runAction` effect is executed through; B3 passes the
+/// native runner, tests pass fakes.
+protocol WorkflowActionExecuting: Sendable {
+  func execute(actionID: String, inputs: [String: String], context: WorkflowActionContext) async throws -> [String:
+    String]
+}
+
+nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
+  func execute(actionID: String, inputs: [String: String], context: WorkflowActionContext) async throws -> [String:
+    String]
+  {
+    switch actionID {
+    case "handoff.transition":
+      return try await transition(inputs: inputs, context: context)
+    case "handoff.checkpoint":
+      return try await checkpoint(inputs: inputs, context: context)
+    case "git.context":
+      return try await gitContext(inputs: inputs, context: context)
+    default:
+      throw WorkflowActionError.unknownAction(actionID)
+    }
+  }
+
+  // MARK: handoff.transition
+
+  /// Archive-first transition; without `briefing` it is the context-only transition: the
+  /// outgoing `current.md` is archived and removed so a stale briefing never impersonates a
+  /// fresh one, `context.md` is regenerated, and the context-only kickoff prompt is returned.
+  private func transition(inputs: [String: String], context: WorkflowActionContext) async throws -> [String: String] {
+    guard let fromRole = inputs["from"] else { throw WorkflowActionError.missingInput("from") }
+    guard let toRole = inputs["to"] else { throw WorkflowActionError.missingInput("to") }
+    guard let fromAgent = context.roleAgents[fromRole] else { throw WorkflowActionError.unknownRole(fromRole) }
+    guard let toAgent = context.roleAgents[toRole] else { throw WorkflowActionError.unknownRole(toRole) }
+    let store = HandoffStore(rootURL: context.rootURL)
+    let coordinator = HandoffCoordinator(store: store)
+    let briefing = try prepareBriefing(path: inputs["briefing"], coordinator: coordinator, context: context)
+    let artifacts: HandoffCoordinator.TransitionArtifacts
+    do {
+      artifacts = try await coordinator.makeTransitionArtifacts(
+        outgoingAgent: fromAgent,
+        toAgent: toAgent ?? "agent",
+        sessionContext: context.sessionContext,
+        briefing: briefing,
+        now: context.now)
+    } catch {
+      throw WorkflowActionError.failed("Failed to prepare the handoff: \(error)")
+    }
+    await coordinator.logTransition(
+      from: fromAgent ?? "agent",
+      toAgent: toAgent ?? "agent",
+      disposition: .requested,
+      briefing: artifacts.briefing,
+      archivedPath: artifacts.archivedPath,
+      note: inputs["note"],
+      source: "workflow \(context.runID.uuidString)",
+      now: context.now)
+    return [
+      "kickoff_prompt": HandoffCommandHandler.kickoffPrompt(hasBriefing: artifacts.hasBriefing),
+      "artifact_path": artifacts.save.artifactPath,
+      "has_briefing": artifacts.hasBriefing ? "true" : "false",
+    ]
+  }
+
+  // MARK: handoff.checkpoint
+
+  /// Installs a fresh briefing when one is given (archiving the replaced one) and refreshes
+  /// `context.md`; without `briefing` an earlier valid `current.md` stays in place.
+  private func checkpoint(inputs: [String: String], context: WorkflowActionContext) async throws -> [String: String] {
+    let store = HandoffStore(rootURL: context.rootURL)
+    let coordinator = HandoffCoordinator(store: store)
+    let briefing = try prepareBriefing(path: inputs["briefing"], coordinator: coordinator, context: context)
+    do {
+      let (save, outcome) = try await coordinator.makeCheckpoint(
+        outgoingAgent: context.outgoingAgent,
+        sessionContext: context.sessionContext,
+        note: inputs["note"] ?? "workflow \(context.runID.uuidString)",
+        briefing: briefing,
+        now: context.now)
+      return [
+        "artifact_path": save.artifactPath,
+        "has_briefing": outcome.wroteBriefing ? "true" : "false",
+      ]
+    } catch {
+      throw WorkflowActionError.failed("Failed to save the checkpoint: \(error)")
+    }
+  }
+
+  // MARK: git.context
+
+  /// The handoff context generator: writes `<root>/.prowl/handoff/context.md` and appends one
+  /// line to the handoff log; `root` defaults to the worktree and must stay inside it.
+  private func gitContext(inputs: [String: String], context: WorkflowActionContext) async throws -> [String: String] {
+    let root = try containedPath(inputs["root"], context: context) ?? context.rootURL
+    let store = HandoffStore(rootURL: root)
+    do {
+      let save = try await Task.detached {
+        try store.save(
+          outgoingAgent: context.outgoingAgent,
+          sessionContext: nil,
+          note: "workflow \(context.runID.uuidString) git.context",
+          now: context.now)
+      }.value
+      return [
+        "path": store.contextURL.path(percentEncoded: false),
+        "branch": save.repos.first?.branch ?? "",
+      ]
+    } catch {
+      throw WorkflowActionError.failed("Failed to generate the context: \(error)")
+    }
+  }
+
+  // MARK: Helpers
+
+  private func prepareBriefing(
+    path: String?, coordinator: HandoffCoordinator, context: WorkflowActionContext
+  ) throws -> HandoffPreparedBriefing {
+    guard let path else { return .contextOnly }
+    guard let url = try containedPath(path, context: context) else { return .contextOnly }
+    let text: String
+    do {
+      text = try String(contentsOf: url, encoding: .utf8)
+    } catch {
+      throw WorkflowActionError.unreadableBriefing(path: path)
+    }
+    do {
+      return try coordinator.collectBriefing(.inline(text))
+    } catch {
+      throw WorkflowActionError.invalidBriefing(path: path)
+    }
+  }
+
+  /// A path input resolved against the worktree root and required to stay inside it
+  /// (canonical comparison, so a symlink cannot point the action elsewhere).
+  private func containedPath(_ path: String?, context: WorkflowActionContext) throws -> URL? {
+    guard let path, !path.isEmpty else { return nil }
+    let url = URL(filePath: path, relativeTo: context.rootURL).standardizedFileURL
+    let canonical = url.resolvingSymlinksInPath()
+    let base = context.rootURL.resolvingSymlinksInPath()
+    guard canonical == base || AgentProfileLaunchPlanner.isContained(canonical, in: base) else {
+      throw WorkflowActionError.unsafePath(path)
+    }
+    return url
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -1,0 +1,432 @@
+// supacode/Domain/Workflow/WorkflowRun.swift
+// The state of one workflow run (docs-ai 063 B2, dsl-spec §5/§8/§10): frozen context and
+// bindings, the position cursor, invocations and activations, outputs, and the attention
+// vocabulary the panel renders. Transitions live in WorkflowRunMachine.
+
+import Foundation
+
+// MARK: - Identity and bindings
+
+/// A pane a role is bound to; the handle is the short `pN` form templates expose.
+nonisolated struct WorkflowPaneIdentity: Equatable, Sendable, Codable {
+  let surfaceID: UUID
+  let tabID: UUID?
+  let handle: String
+  /// The pane's launch-profile name when Prowl launched it, otherwise the detected agent's
+  /// display name (or `shell` when none).
+  let displayName: String
+  /// The detected agent token; nil for a bare shell.
+  let agent: String?
+
+  enum CodingKeys: String, CodingKey {
+    case surfaceID = "surface_id"
+    case tabID = "tab_id"
+    case handle
+    case displayName = "display_name"
+    case agent
+  }
+}
+
+/// The profile frozen into a `launch` role: identity and agent token only — the launch plan
+/// (with its environment) stays with the wiring layer and never reaches `run.json`.
+nonisolated struct WorkflowProfileBinding: Equatable, Sendable, Codable {
+  let id: UUID
+  let name: String
+  let agent: String
+}
+
+nonisolated enum WorkflowRoleBinding: Equatable, Sendable {
+  case current(WorkflowPaneIdentity)
+  case pick(WorkflowPaneIdentity)
+  case launch(WorkflowProfileBinding, pane: WorkflowPaneIdentity?)
+
+  var source: WorkflowRoleSource {
+    switch self {
+    case .current: .current
+    case .pick: .pick
+    case .launch: .launch
+    }
+  }
+
+  var pane: WorkflowPaneIdentity? {
+    switch self {
+    case .current(let pane), .pick(let pane): pane
+    case .launch(_, let pane): pane
+    }
+  }
+
+  var profile: WorkflowProfileBinding? {
+    if case .launch(let profile, _) = self { return profile }
+    return nil
+  }
+
+  /// `roles.<r>.name` / `roles.<r>.agent` as dsl-spec §6 defines them.
+  var templateRole: WorkflowTemplateContext.Role {
+    switch self {
+    case .current(let pane), .pick(let pane):
+      WorkflowTemplateContext.Role(name: pane.displayName, agent: pane.agent ?? "", pane: pane.handle)
+    case .launch(let profile, let pane):
+      WorkflowTemplateContext.Role(name: profile.name, agent: profile.agent, pane: pane?.handle)
+    }
+  }
+
+  func binding(pane: WorkflowPaneIdentity) -> WorkflowRoleBinding {
+    switch self {
+    case .current: .current(pane)
+    case .pick: .pick(pane)
+    case .launch(let profile, _): .launch(profile, pane: pane)
+    }
+  }
+}
+
+// MARK: - Context
+
+nonisolated enum WorkflowRunScope: Equatable, Sendable, Codable {
+  case bundle
+  case user
+  case repo(repositoryID: String)
+
+  /// The scope key of the binding memory (dsl-spec §3): `bundle`, `user`, or `repo:<repository id>`.
+  var key: String {
+    switch self {
+    case .bundle: "bundle"
+    case .user: "user"
+    case .repo(let repositoryID): "repo:\(repositoryID)"
+    }
+  }
+
+  var workflowScope: WorkflowScope {
+    switch self {
+    case .bundle: .bundle
+    case .user: .user
+    case .repo: .repo
+    }
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let key = try container.decode(String.self)
+    switch key {
+    case "bundle": self = .bundle
+    case "user": self = .user
+    default:
+      guard key.hasPrefix("repo:") else {
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown workflow scope '\(key)'.")
+      }
+      self = .repo(repositoryID: String(key.dropFirst("repo:".count)))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(key)
+  }
+}
+
+nonisolated struct WorkflowRunWorktree: Equatable, Sendable, Codable {
+  let id: String
+  let name: String
+  let branch: String
+  /// The worktree root every run-relative path hangs from.
+  let path: String
+
+  var rootURL: URL { URL(filePath: path, directoryHint: .isDirectory) }
+}
+
+nonisolated struct WorkflowRunContext: Equatable, Sendable {
+  let scope: WorkflowRunScope
+  let definitionPath: String?
+  let worktree: WorkflowRunWorktree
+}
+
+/// Every path under a run directory, derived from validated slugs and the run UUID only.
+nonisolated enum WorkflowRunPaths {
+  static let runsRelativePath = ".prowl/workflow-runs"
+
+  static func runsDirectory(root: URL) -> URL {
+    root.appending(path: runsRelativePath, directoryHint: .isDirectory).standardizedFileURL
+  }
+
+  static func runDirectory(root: URL, runID: UUID) -> URL {
+    runsDirectory(root: root).appending(path: runID.uuidString, directoryHint: .isDirectory)
+  }
+
+  static func instructionURL(runDirectory: URL, stepID: String, ordinal: Int) -> URL {
+    runDirectory.appending(path: "instructions", directoryHint: .isDirectory)
+      .appending(path: "\(stepID).\(ordinal).md", directoryHint: .notDirectory)
+  }
+
+  /// `outputs/<name>.<ordinal>.md`, or the latest view `outputs/<name>.md` without an ordinal.
+  static func outputURL(runDirectory: URL, name: String, ordinal: Int?) -> URL {
+    let file = ordinal.map { "\(name).\($0).md" } ?? "\(name).md"
+    return runDirectory.appending(path: "outputs", directoryHint: .isDirectory)
+      .appending(path: file, directoryHint: .notDirectory)
+  }
+
+  static func skillDirectory(runDirectory: URL, skillID: String) -> URL {
+    runDirectory.appending(path: "skills", directoryHint: .isDirectory)
+      .appending(path: skillID, directoryHint: .isDirectory)
+  }
+
+  static func path(_ url: URL) -> String {
+    AgentProfileLaunchPlanner.pathString(url)
+  }
+}
+
+// MARK: - Invocations and activations
+
+nonisolated enum WorkflowActivationState: String, Equatable, Sendable, Codable {
+  case waiting
+  case delivered
+  case skipped
+  case revoked
+}
+
+/// A waiting invocation (dsl-spec §5): the token correlates a delivery, the dispatch id is
+/// the record in the shared dispatch store once the activation is open.
+nonisolated struct WorkflowActivation: Equatable, Sendable {
+  let ordinal: Int
+  let stepID: String
+  let role: String
+  let token: String
+  let expect: WorkflowExpectation
+  let outputName: String
+  var dispatchID: String?
+  var state: WorkflowActivationState
+
+  var completion: WorkflowCompletionCommand {
+    WorkflowCompletionCommand(token: token, verdicts: expect.verdict)
+  }
+}
+
+nonisolated enum WorkflowInvocationKind: String, Equatable, Sendable, Codable {
+  case message
+  case launch
+}
+
+nonisolated struct WorkflowInvocation: Equatable, Sendable {
+  let ordinal: Int
+  let stepID: String
+  /// 1-based iteration when the step sits inside a `repeat`.
+  let iteration: Int?
+  let role: String
+  let kind: WorkflowInvocationKind
+  let startedAt: Date
+  var instructionPath: String?
+  var activation: WorkflowActivation?
+  var endedAt: Date?
+}
+
+nonisolated struct WorkflowOutputRecord: Equatable, Sendable, Codable {
+  let name: String
+  let ordinal: Int
+  /// `outputs/<name>.<ordinal>.md`.
+  let path: String
+  /// `outputs/<name>.md`, the atomically replaced latest view.
+  let latestPath: String
+  let verdict: String?
+  let deliveredAt: Date
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case ordinal
+    case path
+    case latestPath = "latest_path"
+    case verdict
+    case deliveredAt = "delivered_at"
+  }
+}
+
+// MARK: - Position and step records
+
+nonisolated struct WorkflowRunPosition: Equatable, Sendable {
+  struct Loop: Equatable, Sendable {
+    /// 1-based iteration.
+    var iteration: Int
+    var bodyIndex: Int
+    let max: Int
+  }
+
+  /// Index into the top-level step list.
+  var index: Int
+  var loop: Loop?
+}
+
+nonisolated enum WorkflowStepState: String, Equatable, Sendable, Codable {
+  case active
+  case completed
+  case skipped
+  case failed
+}
+
+nonisolated struct WorkflowStepRecord: Equatable, Sendable {
+  let stepID: String
+  let iteration: Int?
+  var state: WorkflowStepState
+  var ordinal: Int?
+}
+
+// MARK: - Attention and status
+
+nonisolated enum WorkflowAttentionAction: String, Equatable, Sendable, Codable, CaseIterable {
+  case focusPane = "focus_pane"
+  case nudge
+  case keepWaiting = "keep_waiting"
+  case retry
+  case relaunch
+  case skip
+  case cancel
+}
+
+nonisolated enum WorkflowAgentGoneReason: String, Equatable, Sendable, Codable {
+  case sessionEnded = "session_ended"
+  case paneClosed = "pane_closed"
+  case processGone = "process_gone"
+  /// The role has no pane: its launch was skipped or never succeeded.
+  case notLaunched = "not_launched"
+}
+
+/// Why an injection did not deliver the line.
+nonisolated enum WorkflowInjectionFailure: Equatable, Sendable, Codable {
+  /// The role is working or blocked again; the step returns to its idle wait.
+  case roleBusy
+  case roleBlocked
+  case surfaceMissing
+  case insertFailed
+  /// The insert succeeded; the line may sit unsubmitted in the pane's input.
+  case submitFailed
+  case activationUnavailable(String)
+}
+
+nonisolated enum WorkflowAttentionReason: Equatable, Sendable, Codable {
+  case needsInput
+  case idleWithoutDelivery
+  case blocked
+  case agentGone(WorkflowAgentGoneReason)
+  case injectionFailed(WorkflowInjectionFailure)
+  case launchFailed(String)
+  case renderedTextInvalid
+  case actionFailed(String)
+  case timeout
+}
+
+nonisolated struct WorkflowAttention: Equatable, Sendable {
+  let reason: WorkflowAttentionReason
+  let stepID: String
+  let role: String?
+  let ordinal: Int?
+  let actions: [WorkflowAttentionAction]
+  /// Panel copy (decision H7 of docs-ai 063.007); C1 renders it as is.
+  let message: String
+}
+
+nonisolated enum WorkflowRunStatus: Equatable, Sendable {
+  case running
+  case needsAttention(WorkflowAttention)
+  case completed
+  case cancelled
+  case skipped(step: String, dependent: String)
+  case maxRoundsReached
+  case interrupted
+
+  var isTerminal: Bool {
+    switch self {
+    case .running, .needsAttention: false
+    case .completed, .cancelled, .skipped, .maxRoundsReached, .interrupted: true
+    }
+  }
+
+  var attention: WorkflowAttention? {
+    if case .needsAttention(let attention) = self { return attention }
+    return nil
+  }
+}
+
+/// What the run is doing inside the current step.
+nonisolated enum WorkflowRunPhase: Equatable, Sendable {
+  case idle
+  case waitingForRole(role: String, ordinal: Int)
+  case injecting(ordinal: Int)
+  case launching(ordinal: Int)
+  case waitingForDelivery(ordinal: Int)
+  case runningAction(stepID: String)
+}
+
+// MARK: - Run
+
+nonisolated struct WorkflowRun: Equatable, Sendable {
+  let id: UUID
+  let definition: WorkflowDefinition
+  let context: WorkflowRunContext
+  let inputs: [String: String]
+  let startedAt: Date
+  var updatedAt: Date
+  var finishedAt: Date?
+  var bindings: [String: WorkflowRoleBinding]
+  var status: WorkflowRunStatus = .running
+  var phase: WorkflowRunPhase = .idle
+  var position = WorkflowRunPosition(index: 0, loop: nil)
+  var invocations: [WorkflowInvocation] = []
+  /// Latest delivered output per name (latest wins across steps).
+  var outputs: [String: WorkflowOutputRecord] = [:]
+  var actionOutputs: [String: [String: String]] = [:]
+  /// Output name → the step whose skip made it missing.
+  var skippedOutputs: [String: String] = [:]
+  /// Steps skipped at start (`--skip` / the start sheet).
+  let preSkippedSteps: Set<String>
+  /// Iterations completed by the latest `repeat`.
+  var loopCount = 0
+  var stepRecords: [WorkflowStepRecord] = []
+  var nextOrdinal = 1
+  /// Resolved `repeat.max` per repeat step id.
+  let repeatBounds: [String: Int]
+  /// The first step's rendered line when the run was started from the `current` role's own
+  /// pane: returned to the caller instead of being typed (dsl-spec §9).
+  var selfInitiatedLine: String?
+
+  var runDirectory: URL {
+    WorkflowRunPaths.runDirectory(root: context.worktree.rootURL, runID: id)
+  }
+
+  var currentInvocation: WorkflowInvocation? {
+    switch phase {
+    case .waitingForRole(_, let ordinal), .injecting(let ordinal), .launching(let ordinal),
+      .waitingForDelivery(let ordinal):
+      return invocations.first { $0.ordinal == ordinal }
+    case .idle, .runningAction:
+      return nil
+    }
+  }
+
+  /// The activation currently waiting for a delivery, if any.
+  var currentActivation: WorkflowActivation? {
+    guard case .waitingForDelivery(let ordinal) = phase else { return nil }
+    return invocations.first { $0.ordinal == ordinal }?.activation
+  }
+
+  func activation(forDispatchID dispatchID: String) -> WorkflowActivation? {
+    invocations.lazy.compactMap(\.activation).first { $0.dispatchID == dispatchID }
+  }
+
+  /// The step the position cursor points at; nil past the end of the sequence it is in.
+  var currentStep: WorkflowStepDefinition? {
+    guard position.index < definition.steps.count else { return nil }
+    let step = definition.steps[position.index]
+    guard let loop = position.loop else { return step }
+    guard case .repeat(_, _, let body) = step.action, loop.bodyIndex < body.count else { return nil }
+    return body[loop.bodyIndex]
+  }
+
+  var currentIteration: Int? { position.loop?.iteration }
+
+  /// Whether the runner will deliver a `message` to the `current` role (dsl-spec §3).
+  func deliversToCurrentRole() -> Bool {
+    guard let current = definition.roles.first(where: { $0.source == .current }) else { return false }
+    return definition.flattenedSteps.contains { step in
+      if case .message(let role, _, _) = step.action, role == current.name {
+        return !preSkippedSteps.contains(step.id)
+      }
+      return false
+    }
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -179,6 +179,8 @@ nonisolated enum WorkflowActivationState: String, Equatable, Sendable, Codable {
   case waiting
   /// A validated delivery is being written to the run directory; the record completes once it is.
   case persisting
+  /// The delivery is on disk but had issues a non-strict step tolerates; the user decides.
+  case provisional
   case delivered
   case skipped
   case revoked
@@ -281,6 +283,12 @@ nonisolated enum WorkflowAttentionAction: String, Equatable, Sendable, Codable, 
   case keepWaiting = "keep_waiting"
   case retry
   case relaunch
+  /// Keep a provisional delivery as it is.
+  case acceptDelivery = "accept_delivery"
+  /// Keep a provisional delivery and supply the verdict it lacks (one of the declared values).
+  case acceptWithVerdict = "accept_with_verdict"
+  /// Type the step's requirements into the role's pane again and keep waiting.
+  case askAgain = "ask_again"
   case skip
   case cancel
 }
@@ -294,7 +302,7 @@ nonisolated enum WorkflowAgentGoneReason: String, Equatable, Sendable, Codable {
 }
 
 /// Why an injection did not deliver the line.
-nonisolated enum WorkflowInjectionFailure: Equatable, Sendable, Codable {
+nonisolated enum WorkflowInjectionFailure: Equatable, Sendable {
   /// The role is working or blocked again; the step returns to its idle wait.
   case roleBusy
   case roleBlocked
@@ -305,7 +313,7 @@ nonisolated enum WorkflowInjectionFailure: Equatable, Sendable, Codable {
   case activationUnavailable(String)
 }
 
-nonisolated enum WorkflowAttentionReason: Equatable, Sendable, Codable {
+nonisolated enum WorkflowAttentionReason: Equatable, Sendable {
   case needsInput
   case idleWithoutDelivery
   case blocked
@@ -316,6 +324,8 @@ nonisolated enum WorkflowAttentionReason: Equatable, Sendable, Codable {
   case actionFailed(String)
   /// The validated output could not be written to the run directory.
   case persistFailed(String)
+  /// A non-strict delivery is on disk with these issues; the user accepts, asks again, or skips.
+  case deliveryIssues([WorkflowDeliveryIssue])
   case timeout
 }
 

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -177,6 +177,8 @@ nonisolated enum WorkflowRunPaths {
 
 nonisolated enum WorkflowActivationState: String, Equatable, Sendable, Codable {
   case waiting
+  /// A validated delivery is being written to the run directory; the record completes once it is.
+  case persisting
   case delivered
   case skipped
   case revoked
@@ -193,6 +195,11 @@ nonisolated struct WorkflowActivation: Equatable, Sendable {
   let outputName: String
   var dispatchID: String?
   var state: WorkflowActivationState
+  /// `expect.timeout` as an absolute deadline, fixed when the activation opened; a re-armed
+  /// watchdog receives the remaining time, never a fresh cap.
+  var deadline: Date?
+  /// The validated body while the delivery is being persisted (never written to `run.json`).
+  var pendingDelivery: WorkflowValidatedDelivery?
 
   var completion: WorkflowCompletionCommand {
     WorkflowCompletionCommand(token: token, verdicts: expect.verdict)
@@ -307,6 +314,8 @@ nonisolated enum WorkflowAttentionReason: Equatable, Sendable, Codable {
   case launchFailed(String)
   case renderedTextInvalid
   case actionFailed(String)
+  /// The validated output could not be written to the run directory.
+  case persistFailed(String)
   case timeout
 }
 
@@ -402,6 +411,11 @@ nonisolated struct WorkflowRun: Equatable, Sendable {
   var currentActivation: WorkflowActivation? {
     guard case .waitingForDelivery(let ordinal) = phase else { return nil }
     return invocations.first { $0.ordinal == ordinal }?.activation
+  }
+
+  /// The activation of the invocation in flight, whatever its state.
+  var activeActivation: WorkflowActivation? {
+    currentInvocation?.activation
   }
 
   func activation(forDispatchID dispatchID: String) -> WorkflowActivation? {

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -417,7 +417,10 @@ nonisolated struct WorkflowRunMachine {
     }
     run.status = .running
     run.updatedAt = now()
+    // The watchdog supervises a *waiting* delivery: an accepted one is no longer its business,
+    // so it is disarmed before the output is even written and queued verdicts are ignored.
     let effects: [WorkflowRunEffect] = [
+      .disarmWatchdog(ordinal: activation.ordinal),
       .log(
         "Step '\(activation.stepID)': output '\(activation.outputName)' accepted "
           + "(invocation \(activation.ordinal)); persisting."),
@@ -461,7 +464,6 @@ nonisolated struct WorkflowRunMachine {
       $0.state = .delivered
       $0.pendingDelivery = nil
     }
-    effects.append(.disarmWatchdog(ordinal: ordinal))
     if let dispatchID = activation.dispatchID {
       let verdictNote = delivery.verdict.map { " with verdict '\($0)'" } ?? ""
       effects.append(
@@ -497,7 +499,12 @@ nonisolated struct WorkflowRunMachine {
     var loopUntil: WorkflowUntilCondition?
     var loopID: String?
     if fromStart {
-      remaining = steps
+      // Nothing after a `repeat` without `until` can run: it ends the run as `max_rounds_reached`.
+      remaining = []
+      for step in steps {
+        remaining.append(step)
+        if case .repeat(_, nil, _) = step.action { break }
+      }
     } else if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
       // Readers later in this iteration always count; readers earlier in the body only when
       // another iteration can follow; steps after the loop only when an `until` can exit it
@@ -976,7 +983,8 @@ nonisolated struct WorkflowRunMachine {
   private mutating func applyWatchdog(
     ordinal: Int, verdict: WorkflowWatchdogVerdict, effects: inout [WorkflowRunEffect]
   ) {
-    guard let activation = run.currentActivation, activation.ordinal == ordinal else { return }
+    guard let activation = run.currentActivation, activation.ordinal == ordinal, activation.state == .waiting
+    else { return }
     switch verdict {
     case .nudge:
       typeNudge(activation, effects: &effects)
@@ -1025,12 +1033,14 @@ nonisolated struct WorkflowRunMachine {
     case .keepWaiting:
       guard let attention, attention.actions.contains(.keepWaiting), let ordinal = attention.ordinal else { return }
       run.status = .running
+      guard !enforceExpiredDeadline(effects: &effects) else { return }
       effects.append(.log("Step '\(attention.stepID)': keep waiting."))
       armWatchdog(ordinal: ordinal, nudgedAlready: true, effects: &effects)
       effects.append(.persist)
     case .nudge:
       guard let attention, attention.actions.contains(.nudge), let activation = run.currentActivation else { return }
       run.status = .running
+      guard !enforceExpiredDeadline(effects: &effects) else { return }
       typeNudge(activation, effects: &effects)
       effects.append(.log("Step '\(attention.stepID)': nudged again by the user."))
       armWatchdog(ordinal: activation.ordinal, nudgedAlready: true, effects: &effects)
@@ -1050,6 +1060,17 @@ nonisolated struct WorkflowRunMachine {
       guard let attention, attention.actions.contains(.relaunch) else { return }
       relaunchCurrentStep(effects: &effects)
     }
+  }
+
+  /// A hard cap that already passed while the run sat in attention is applied now instead
+  /// of being re-armed for another second; true when the timeout policy ran.
+  private mutating func enforceExpiredDeadline(effects: inout [WorkflowRunEffect]) -> Bool {
+    guard let activation = run.currentActivation, activation.state == .waiting, let deadline = activation.deadline,
+      deadline <= now()
+    else { return false }
+    effects.append(.log("Step '\(activation.stepID)': the timeout already passed; applying its policy."))
+    applyWatchdog(ordinal: activation.ordinal, verdict: .timeout, effects: &effects)
+    return true
   }
 
   private mutating func cancel(effects: inout [WorkflowRunEffect]) {

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -446,7 +446,7 @@ nonisolated struct WorkflowRunMachine {
     var loopID: String?
     if fromStart {
       remaining = steps
-    } else if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
+    } else if run.position.loop != nil, case .repeat(_, let until, let body) = steps[run.position.index].action {
       remaining = body
       loopUntil = until
       loopID = steps[run.position.index].id

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -134,6 +134,40 @@ nonisolated enum WorkflowRunStartError: Error, Equatable, Sendable {
   case missingBinding(role: String)
 }
 
+/// Everything `WorkflowRunMachine.start` needs: the validated definition, the frozen context
+/// and bindings, and the start-sheet / CLI choices.
+nonisolated struct WorkflowRunStartRequest: Sendable {
+  let definition: WorkflowDefinition
+  let runID: UUID
+  let context: WorkflowRunContext
+  let bindings: [String: WorkflowRoleBinding]
+  let inputs: [String: String]
+  let skippedSteps: Set<String>
+  /// The run was started from the pane that is the `current` role (dsl-spec §9).
+  let selfInitiated: Bool
+  let limits: WorkflowDeliveryLimits
+
+  init(
+    definition: WorkflowDefinition,
+    runID: UUID,
+    context: WorkflowRunContext,
+    bindings: [String: WorkflowRoleBinding],
+    inputs: [String: String] = [:],
+    skippedSteps: Set<String> = [],
+    selfInitiated: Bool = false,
+    limits: WorkflowDeliveryLimits = WorkflowDeliveryLimits()
+  ) {
+    self.definition = definition
+    self.runID = runID
+    self.context = context
+    self.bindings = bindings
+    self.inputs = inputs
+    self.skippedSteps = skippedSteps
+    self.selfInitiated = selfInitiated
+    self.limits = limits
+  }
+}
+
 // MARK: - Machine
 
 nonisolated struct WorkflowRunMachine {
@@ -146,20 +180,17 @@ nonisolated struct WorkflowRunMachine {
 
   /// Freezes the run and enters step 1. Throws the start-time validation failures the CLI
   /// maps to `INVALID_ARGUMENT` / `UNSAFE_PATH`.
-  // swiftlint:disable:next function_parameter_count
   static func start(
-    definition: WorkflowDefinition,
-    runID: UUID,
-    context: WorkflowRunContext,
-    bindings: [String: WorkflowRoleBinding],
-    inputs providedInputs: [String: String],
-    skippedSteps: Set<String> = [],
-    selfInitiated: Bool = false,
-    limits: WorkflowDeliveryLimits = WorkflowDeliveryLimits(),
+    _ request: WorkflowRunStartRequest,
     now: @escaping @Sendable () -> Date,
     makeToken: @escaping @Sendable () -> String = { UUID().uuidString }
   ) throws(WorkflowRunStartError) -> (machine: WorkflowRunMachine, effects: [WorkflowRunEffect]) {
-    let inputs = try resolveInputs(definition: definition, provided: providedInputs)
+    let definition = request.definition
+    let context = request.context
+    let bindings = request.bindings
+    let skippedSteps = request.skippedSteps
+    let runID = request.runID
+    let inputs = try resolveInputs(definition: definition, provided: request.inputs)
     guard WorkflowRenderedText.isSingleLine(context.worktree.path) else {
       throw .unsafePath(context.worktree.path)
     }
@@ -188,11 +219,11 @@ nonisolated struct WorkflowRunMachine {
         throw .skipNotAllowed(step: stepID, dependent: dependent)
       }
     }
-    var machine = WorkflowRunMachine(run: run, limits: limits, now: now, makeToken: makeToken)
+    var machine = WorkflowRunMachine(run: run, limits: request.limits, now: now, makeToken: makeToken)
     var effects: [WorkflowRunEffect] = [
       .log("Run \(runID.uuidString) of workflow '\(definition.id)' started."), .persist,
     ]
-    machine.enterCurrentStep(selfInitiated: selfInitiated, effects: &effects)
+    machine.enterCurrentStep(selfInitiated: request.selfInitiated, effects: &effects)
     return (machine, effects)
   }
 
@@ -270,37 +301,17 @@ nonisolated struct WorkflowRunMachine {
       guard case .injecting(ordinal) = run.phase else { return [] }
       openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
     case .injectionFailed(let ordinal, let failure):
-      guard case .injecting(ordinal) = run.phase, let invocation = invocation(ordinal) else { return [] }
-      if failure == .roleBusy {
-        guard let surfaceID = run.bindings[invocation.role]?.pane?.surfaceID else { return [] }
-        run.phase = .waitingForRole(role: invocation.role, ordinal: ordinal)
-        effects.append(.awaitRoleIdle(role: invocation.role, surfaceID: surfaceID, ordinal: ordinal))
-        effects.append(
-          .log("Step '\(invocation.stepID)': role '\(invocation.role)' is busy again; waiting for it to be idle."))
-        return effects
-      }
-      raiseAttention(
-        .injectionFailed(failure), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects
-      )
+      applyInjectionFailed(ordinal: ordinal, failure: failure, effects: &effects)
     case .launched(let ordinal, let pane, let dispatchID):
-      guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal),
-        let binding = run.bindings[invocation.role]
-      else { return [] }
-      run.bindings[invocation.role] = binding.binding(pane: pane)
-      effects.append(.log("Step '\(invocation.stepID)': role '\(invocation.role)' launched in \(pane.handle)."))
-      openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
+      applyLaunched(ordinal: ordinal, pane: pane, dispatchID: dispatchID, effects: &effects)
     case .launchFailed(let ordinal, let reason):
       guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal) else { return [] }
       raiseAttention(
         .launchFailed(reason), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects)
     case .actionCompleted(let stepID, let outputs):
-      guard case .runningAction(stepID) = run.phase, let step = run.currentStep, step.id == stepID else { return [] }
-      run.actionOutputs[stepID] = outputs
-      completeCurrentStep(effects: &effects)
-      effects.append(.log("Step '\(stepID)': action completed."))
-      advance(effects: &effects)
+      applyActionCompleted(stepID: stepID, outputs: outputs, effects: &effects)
     case .actionFailed(let stepID, let reason):
-      guard case .runningAction(stepID) = run.phase, let step = run.currentStep, step.id == stepID else { return [] }
+      guard case .runningAction(stepID) = run.phase, run.currentStep?.id == stepID else { return [] }
       raiseAttention(.actionFailed(reason), stepID: stepID, role: nil, ordinal: nil, effects: &effects)
     case .watchdog(let ordinal, let verdict):
       applyWatchdog(ordinal: ordinal, verdict: verdict, effects: &effects)
@@ -308,6 +319,43 @@ nonisolated struct WorkflowRunMachine {
       applyUser(action, effects: &effects)
     }
     return effects
+  }
+
+  private mutating func applyInjectionFailed(
+    ordinal: Int, failure: WorkflowInjectionFailure, effects: inout [WorkflowRunEffect]
+  ) {
+    guard case .injecting(ordinal) = run.phase, let invocation = invocation(ordinal) else { return }
+    if failure == .roleBusy {
+      guard let surfaceID = run.bindings[invocation.role]?.pane?.surfaceID else { return }
+      run.phase = .waitingForRole(role: invocation.role, ordinal: ordinal)
+      effects.append(.awaitRoleIdle(role: invocation.role, surfaceID: surfaceID, ordinal: ordinal))
+      effects.append(
+        .log("Step '\(invocation.stepID)': role '\(invocation.role)' is busy again; waiting for it to be idle."))
+      return
+    }
+    raiseAttention(
+      .injectionFailed(failure), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects)
+  }
+
+  private mutating func applyLaunched(
+    ordinal: Int, pane: WorkflowPaneIdentity, dispatchID: String?, effects: inout [WorkflowRunEffect]
+  ) {
+    guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal),
+      let binding = run.bindings[invocation.role]
+    else { return }
+    run.bindings[invocation.role] = binding.binding(pane: pane)
+    effects.append(.log("Step '\(invocation.stepID)': role '\(invocation.role)' launched in \(pane.handle)."))
+    openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
+  }
+
+  private mutating func applyActionCompleted(
+    stepID: String, outputs: [String: String], effects: inout [WorkflowRunEffect]
+  ) {
+    guard case .runningAction(stepID) = run.phase, run.currentStep?.id == stepID else { return }
+    run.actionOutputs[stepID] = outputs
+    completeCurrentStep(effects: &effects)
+    effects.append(.log("Step '\(stepID)': action completed."))
+    advance(effects: &effects)
   }
 
   // MARK: Deliveries
@@ -475,65 +523,88 @@ nonisolated struct WorkflowRunMachine {
         return
       }
       if run.preSkippedSteps.contains(step.id) {
-        recordStep(step, state: .skipped, ordinal: nil)
-        if let name = step.outputName {
-          run.skippedOutputs[name] = step.id
-        }
-        effects.append(.log("Step '\(step.id)': skipped at start."))
-        moveNext()
+        skipAtStart(step, effects: &effects)
         continue
       }
       switch step.action {
-      case .message(let role, let content, let expect):
-        enterMessage(
-          step, role: role, content: content, expect: expect, selfInitiated: selfInitiated, effects: &effects)
+      case .message:
+        enterMessage(step, selfInitiated: selfInitiated, effects: &effects)
         return
-      case .launch(let role, let prompt, let skill, let expect):
-        enterLaunch(step, role: role, prompt: prompt, skill: skill, expect: expect, effects: &effects)
+      case .launch:
+        enterLaunch(step, effects: &effects)
         return
       case .action(let id, let inputs):
         enterAction(step, id: id, inputs: inputs, effects: &effects)
         return
       case .notify(let text):
-        guard let rendered = render(text, step: step, effects: &effects) else { return }
-        recordStep(step, state: .completed, ordinal: nil)
-        effects.append(.notify(rendered))
-        effects.append(.log("Step '\(step.id)': notified \"\(rendered)\"."))
-        moveNext()
+        guard enterNotify(step, text: text, effects: &effects) else { return }
       case .close(let role):
-        recordStep(step, state: .completed, ordinal: nil)
-        if let surfaceID = run.bindings[role]?.pane?.surfaceID {
-          effects.append(.close(role: role, surfaceID: surfaceID))
-          effects.append(.log("Step '\(step.id)': close requested for role '\(role)'."))
-        } else {
-          effects.append(.log("Step '\(step.id)': role '\(role)' has no pane to close."))
-        }
-        moveNext()
+        enterClose(step, role: role, effects: &effects)
       case .repeat(_, let until, _):
-        guard run.position.loop == nil else {
-          // Unreachable: a loop position always resolves to a body step or the iteration end.
-          moveNext()
-          continue
-        }
-        run.loopCount = 0
-        switch evaluate(until) {
-        case .satisfied:
-          recordStep(step, state: .skipped, ordinal: nil)
-          effects.append(.log("Step '\(step.id)': 'until' already satisfied; loop skipped."))
-          moveNext()
-        case .notSatisfied:
-          guard let max = run.repeatBounds[step.id] else {
-            finish(.cancelled, effects: &effects)
-            return
-          }
-          run.position.loop = WorkflowRunPosition.Loop(iteration: 1, bodyIndex: 0, max: max)
-          effects.append(.log("Step '\(step.id)': round 1 of at most \(max)."))
-        case .skippedOutput(let skippedStep):
-          finish(.skipped(step: skippedStep, dependent: step.id), effects: &effects)
-          return
-        }
+        guard enterRepeat(step, until: until, effects: &effects) else { return }
       }
     }
+  }
+
+  private mutating func skipAtStart(_ step: WorkflowStepDefinition, effects: inout [WorkflowRunEffect]) {
+    recordStep(step, state: .skipped, ordinal: nil)
+    if let name = step.outputName {
+      run.skippedOutputs[name] = step.id
+    }
+    effects.append(.log("Step '\(step.id)': skipped at start."))
+    moveNext()
+  }
+
+  /// False when rendering ended the run.
+  private mutating func enterNotify(_ step: WorkflowStepDefinition, text: String, effects: inout [WorkflowRunEffect])
+    -> Bool
+  {
+    guard let rendered = render(text, step: step, effects: &effects) else { return false }
+    recordStep(step, state: .completed, ordinal: nil)
+    effects.append(.notify(rendered))
+    effects.append(.log("Step '\(step.id)': notified \"\(rendered)\"."))
+    moveNext()
+    return true
+  }
+
+  private mutating func enterClose(_ step: WorkflowStepDefinition, role: String, effects: inout [WorkflowRunEffect]) {
+    recordStep(step, state: .completed, ordinal: nil)
+    if let surfaceID = run.bindings[role]?.pane?.surfaceID {
+      effects.append(.close(role: role, surfaceID: surfaceID))
+      effects.append(.log("Step '\(step.id)': close requested for role '\(role)'."))
+    } else {
+      effects.append(.log("Step '\(step.id)': role '\(role)' has no pane to close."))
+    }
+    moveNext()
+  }
+
+  /// Evaluates `until` before entry (while-loop semantics); false when the run ended.
+  private mutating func enterRepeat(
+    _ step: WorkflowStepDefinition, until: WorkflowUntilCondition?, effects: inout [WorkflowRunEffect]
+  ) -> Bool {
+    guard run.position.loop == nil else {
+      // Unreachable: a loop position always resolves to a body step or the iteration end.
+      moveNext()
+      return true
+    }
+    run.loopCount = 0
+    switch evaluate(until) {
+    case .satisfied:
+      recordStep(step, state: .skipped, ordinal: nil)
+      effects.append(.log("Step '\(step.id)': 'until' already satisfied; loop skipped."))
+      moveNext()
+    case .notSatisfied:
+      guard let max = run.repeatBounds[step.id] else {
+        finish(.cancelled, effects: &effects)
+        return false
+      }
+      run.position.loop = WorkflowRunPosition.Loop(iteration: 1, bodyIndex: 0, max: max)
+      effects.append(.log("Step '\(step.id)': round 1 of at most \(max)."))
+    case .skippedOutput(let skippedStep):
+      finish(.skipped(step: skippedStep, dependent: step.id), effects: &effects)
+      return false
+    }
+    return true
   }
 
   private mutating func finishIteration(effects: inout [WorkflowRunEffect]) {
@@ -587,13 +658,9 @@ nonisolated struct WorkflowRunMachine {
   // MARK: Step entry
 
   private mutating func enterMessage(
-    _ step: WorkflowStepDefinition,
-    role: String,
-    content: WorkflowMessageContent,
-    expect: WorkflowExpectation?,
-    selfInitiated: Bool,
-    effects: inout [WorkflowRunEffect]
+    _ step: WorkflowStepDefinition, selfInitiated: Bool, effects: inout [WorkflowRunEffect]
   ) {
+    guard case .message(let role, let content, let expect) = step.action else { return }
     let ordinal = mintOrdinal()
     run.invocations.append(
       WorkflowInvocation(
@@ -680,14 +747,8 @@ nonisolated struct WorkflowRunMachine {
     }
   }
 
-  private mutating func enterLaunch(
-    _ step: WorkflowStepDefinition,
-    role: String,
-    prompt: String,
-    skill: String?,
-    expect: WorkflowExpectation?,
-    effects: inout [WorkflowRunEffect]
-  ) {
+  private mutating func enterLaunch(_ step: WorkflowStepDefinition, effects: inout [WorkflowRunEffect]) {
+    guard case .launch(let role, let prompt, let skill, let expect) = step.action else { return }
     let ordinal = mintOrdinal()
     run.invocations.append(
       WorkflowInvocation(
@@ -695,21 +756,25 @@ nonisolated struct WorkflowRunMachine {
     )
     recordStep(step, state: .active, ordinal: ordinal)
     guard let rendered = render(prompt, step: step, effects: &effects) else { return }
-    launch(
-      step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: skill, expect: expect, redelivery: false,
-      effects: &effects)
+    let plan = LaunchPlan(
+      step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: skill, expect: expect, redelivery: false)
+    launch(plan, effects: &effects)
   }
 
-  private mutating func launch(
-    step: WorkflowStepDefinition,
-    ordinal: Int,
-    role: String,
-    userPrompt: String,
-    skill: String?,
-    expect: WorkflowExpectation?,
-    redelivery: Bool,
-    effects: inout [WorkflowRunEffect]
-  ) {
+  private struct LaunchPlan {
+    let step: WorkflowStepDefinition
+    let ordinal: Int
+    let role: String
+    let userPrompt: String
+    let skill: String?
+    let expect: WorkflowExpectation?
+    let redelivery: Bool
+  }
+
+  private mutating func launch(_ plan: LaunchPlan, effects: inout [WorkflowRunEffect]) {
+    let (step, ordinal, role, userPrompt, skill, expect, redelivery) = (
+      plan.step, plan.ordinal, plan.role, plan.userPrompt, plan.skill, plan.expect, plan.redelivery
+    )
     guard let profile = run.bindings[role]?.profile, let requirements = run.definition.role(named: role)?.launch else {
       run.phase = .launching(ordinal: ordinal)
       raiseAttention(
@@ -730,8 +795,7 @@ nonisolated struct WorkflowRunMachine {
       environment[WorkflowSchema.tokenEnvironmentKey] = activation.token
       let title = step.title.flatMap { try? WorkflowTemplate.render($0, context: templateContext()) }
       protocolBlock = activation.completion.protocolBlock(
-        runID: run.id.uuidString, workflowName: run.definition.name, role: role, stepTitle: title,
-        sections: expect.sections, format: expect.format)
+        runID: run.id.uuidString, workflowName: run.definition.name, role: role, stepTitle: title, expect: expect)
     }
     let prompt = WorkflowLaunchPrompt.render(userPrompt: userPrompt, protocolBlock: protocolBlock)
     do {
@@ -965,7 +1029,8 @@ nonisolated struct WorkflowRunMachine {
       recordStep(step, state: .active, ordinal: ordinal)
       guard let rendered = render(content.body, step: step, effects: &effects) else { return }
       launch(
-        step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: nil, expect: expect, redelivery: true,
+        LaunchPlan(
+          step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: nil, expect: expect, redelivery: true),
         effects: &effects)
     default:
       return
@@ -1018,6 +1083,8 @@ nonisolated struct WorkflowRunMachine {
     effects.append(.persist)
   }
 
+  // One case per attention reason: the copy table is deliberately exhaustive (decision H7).
+  // swiftlint:disable:next cyclomatic_complexity
   private func attentionMessage(_ reason: WorkflowAttentionReason, stepID: String, role: String?) -> String {
     let subject: String
     if let role, let binding = run.bindings[role] {

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -1,0 +1,1166 @@
+// supacode/Domain/Workflow/WorkflowRunMachine.swift
+// The pure run state machine (docs-ai 063 B2, decision H2): `apply(event)` and `deliver(...)`
+// mutate a `WorkflowRun` value and return the effects the wiring layer must perform. No I/O
+// happens here; every transport concern is an effect.
+
+import Foundation
+
+// MARK: - Watchdog vocabulary shared with the driver
+
+nonisolated struct WorkflowWatchdogRequest: Equatable, Sendable {
+  let ordinal: Int
+  let stepID: String
+  let role: String
+  let surfaceID: UUID
+  let dispatchID: String?
+  /// `expect.timeout`; nil = no hard cap.
+  let timeoutSeconds: Int?
+  let timeoutPolicy: WorkflowTimeoutPolicy
+  /// Resumed after "Keep waiting" / "Nudge again": the one automatic nudge is spent.
+  let nudgedAlready: Bool
+}
+
+nonisolated enum WorkflowWatchdogAttention: Equatable, Sendable {
+  case needsInput
+  case idleWithoutDelivery
+  case blocked
+  case agentGone(WorkflowAgentGoneReason)
+}
+
+nonisolated enum WorkflowWatchdogVerdict: Equatable, Sendable {
+  case nudge
+  case attention(WorkflowWatchdogAttention)
+  case timeout
+}
+
+// MARK: - Events and effects
+
+nonisolated enum WorkflowUserAction: String, Equatable, Sendable {
+  case retry
+  case relaunch
+  case skip
+  case cancel
+  case nudge
+  case keepWaiting
+}
+
+nonisolated enum WorkflowRunEvent: Equatable, Sendable {
+  case roleIdle(ordinal: Int)
+  case injectionSucceeded(ordinal: Int, dispatchID: String?)
+  case injectionFailed(ordinal: Int, WorkflowInjectionFailure)
+  case launched(ordinal: Int, pane: WorkflowPaneIdentity, dispatchID: String?)
+  case launchFailed(ordinal: Int, reason: String)
+  case actionCompleted(stepID: String, outputs: [String: String])
+  case actionFailed(stepID: String, reason: String)
+  case watchdog(ordinal: Int, WorkflowWatchdogVerdict)
+  case user(WorkflowUserAction)
+}
+
+nonisolated struct WorkflowLaunchRequest: Equatable, Sendable {
+  let role: String
+  let ordinal: Int
+  let profile: WorkflowProfileBinding
+  let prompt: String
+  /// Child-environment values (`PROWL_WORKFLOW_*`); never persisted.
+  let environment: [String: String]
+  let placement: WorkflowPlacement
+  let direction: WorkflowSplitDirection
+  let background: Bool
+  /// The `current` role's pane when the workflow has one; the split anchor.
+  let anchorSurfaceID: UUID?
+  let skill: String?
+  let expectsDelivery: Bool
+  /// A Relaunch re-delivering a `message` step's content as the kickoff prompt.
+  let redelivery: Bool
+}
+
+nonisolated enum WorkflowRunEffect: Equatable, Sendable {
+  /// Wait until the role is idle (dsl-spec §4 injection gate), then send `.roleIdle`.
+  case awaitRoleIdle(role: String, surfaceID: UUID, ordinal: Int)
+  /// The step left its idle wait without injecting (Skip / Cancel / Retry); stop waiting.
+  case cancelRoleWait(ordinal: Int)
+  /// Self-initiated first step: open the activation record without typing anything.
+  case openActivation(role: String, surfaceID: UUID, ordinal: Int)
+  case materializeInstruction(ordinal: Int, stepID: String, text: String)
+  case materializeSkill(id: String)
+  /// Issue + bind the activation (when `opensActivation`) and type the line as one operation.
+  case inject(role: String, surfaceID: UUID, ordinal: Int, line: String, opensActivation: Bool)
+  /// Type a line without opening an activation (the nudge).
+  case typeLine(role: String, surfaceID: UUID, line: String)
+  case launch(WorkflowLaunchRequest)
+  case runAction(stepID: String, actionID: String, inputs: [String: String])
+  case notify(String)
+  case close(role: String, surfaceID: UUID)
+  case abandonActivation(dispatchID: String, reason: String)
+  case completeActivation(dispatchID: String, summary: String)
+  case armWatchdog(WorkflowWatchdogRequest)
+  case disarmWatchdog(ordinal: Int)
+  case persistOutput(name: String, ordinal: Int, body: String)
+  case persist
+  case log(String)
+  case finished(WorkflowRunStatus)
+}
+
+// MARK: - Deliveries and skips
+
+nonisolated enum WorkflowDeliverySelector: Equatable, Sendable {
+  /// From the caller pane's pending dispatch; the token must match the activation.
+  case token(String?)
+  /// `--run --step` without a caller pane: the step's current activation, no token needed.
+  case manual(stepID: String)
+}
+
+nonisolated struct WorkflowDeliveryReceipt: Equatable, Sendable {
+  let ordinal: Int
+  let stepID: String
+  let output: WorkflowOutputRecord
+}
+
+nonisolated enum WorkflowSkipConsequence: Equatable, Sendable {
+  /// The step delivers no output; skipping it affects nothing else.
+  case noOutput
+  /// Only optional action inputs read the output; those actions run without the key.
+  case continues(optionalInputs: [String])
+  /// A template, `until`, or required action input reads the output: the run ends `skipped`.
+  case endsRun(dependent: String)
+}
+
+nonisolated enum WorkflowRunStartError: Error, Equatable, Sendable {
+  case invalidInput(name: String, reason: String)
+  case unsafePath(String)
+  case invalidRepeatBound(step: String)
+  case unknownSkipStep(String)
+  case skipNotAllowed(step: String, dependent: String)
+  case missingBinding(role: String)
+}
+
+// MARK: - Machine
+
+nonisolated struct WorkflowRunMachine {
+  private(set) var run: WorkflowRun
+  let limits: WorkflowDeliveryLimits
+  let now: @Sendable () -> Date
+  let makeToken: @Sendable () -> String
+
+  // MARK: Start
+
+  /// Freezes the run and enters step 1. Throws the start-time validation failures the CLI
+  /// maps to `INVALID_ARGUMENT` / `UNSAFE_PATH`.
+  // swiftlint:disable:next function_parameter_count
+  static func start(
+    definition: WorkflowDefinition,
+    runID: UUID,
+    context: WorkflowRunContext,
+    bindings: [String: WorkflowRoleBinding],
+    inputs providedInputs: [String: String],
+    skippedSteps: Set<String> = [],
+    selfInitiated: Bool = false,
+    limits: WorkflowDeliveryLimits = WorkflowDeliveryLimits(),
+    now: @escaping @Sendable () -> Date,
+    makeToken: @escaping @Sendable () -> String = { UUID().uuidString }
+  ) throws(WorkflowRunStartError) -> (machine: WorkflowRunMachine, effects: [WorkflowRunEffect]) {
+    let inputs = try resolveInputs(definition: definition, provided: providedInputs)
+    guard WorkflowRenderedText.isSingleLine(context.worktree.path) else {
+      throw .unsafePath(context.worktree.path)
+    }
+    let repeatBounds = try resolveRepeatBounds(definition: definition, inputs: inputs)
+    for role in definition.roles where bindings[role.name] == nil {
+      throw .missingBinding(role: role.name)
+    }
+    let startedAt = now()
+    let run = WorkflowRun(
+      id: runID,
+      definition: definition,
+      context: context,
+      inputs: inputs,
+      startedAt: startedAt,
+      updatedAt: startedAt,
+      bindings: bindings,
+      preSkippedSteps: skippedSteps,
+      repeatBounds: repeatBounds
+    )
+    let flattened = definition.flattenedSteps
+    for stepID in skippedSteps.sorted() {
+      guard flattened.contains(where: { $0.id == stepID }) else { throw .unknownSkipStep(stepID) }
+    }
+    for stepID in skippedSteps.sorted() {
+      if case .endsRun(let dependent) = Self.skipConsequence(forStep: stepID, in: run, fromStart: true) {
+        throw .skipNotAllowed(step: stepID, dependent: dependent)
+      }
+    }
+    var machine = WorkflowRunMachine(run: run, limits: limits, now: now, makeToken: makeToken)
+    var effects: [WorkflowRunEffect] = [
+      .log("Run \(runID.uuidString) of workflow '\(definition.id)' started."), .persist,
+    ]
+    machine.enterCurrentStep(selfInitiated: selfInitiated, effects: &effects)
+    return (machine, effects)
+  }
+
+  private static func resolveInputs(
+    definition: WorkflowDefinition, provided: [String: String]
+  ) throws(WorkflowRunStartError) -> [String: String] {
+    for name in provided.keys.sorted() where definition.input(named: name) == nil {
+      throw .invalidInput(name: name, reason: "the workflow declares no input '\(name)'.")
+    }
+    var resolved: [String: String] = [:]
+    for input in definition.inputs {
+      guard let value = provided[input.name] ?? input.defaultValue?.stringValue else {
+        throw .invalidInput(name: input.name, reason: "a value is required.")
+      }
+      switch input.type {
+      case .integer:
+        guard let number = Int(value) else {
+          throw .invalidInput(name: input.name, reason: "'\(value)' is not an integer.")
+        }
+        if let minimum = input.minimum, number < minimum {
+          throw .invalidInput(name: input.name, reason: "\(number) is below the minimum \(minimum).")
+        }
+        if let maximum = input.maximum, number > maximum {
+          throw .invalidInput(name: input.name, reason: "\(number) is above the maximum \(maximum).")
+        }
+        resolved[input.name] = String(number)
+      case .string:
+        guard WorkflowRenderedText.isSingleLine(value) else {
+          throw .invalidInput(name: input.name, reason: "the value must be one line without control characters.")
+        }
+        resolved[input.name] = value
+      case .enum:
+        guard input.values.contains(value) else {
+          throw .invalidInput(
+            name: input.name, reason: "'\(value)' is not one of \(input.values.joined(separator: ", ")).")
+        }
+        resolved[input.name] = value
+      }
+    }
+    return resolved
+  }
+
+  private static func resolveRepeatBounds(
+    definition: WorkflowDefinition, inputs: [String: String]
+  ) throws(WorkflowRunStartError) -> [String: Int] {
+    var bounds: [String: Int] = [:]
+    for step in definition.steps {
+      guard case .repeat(let max, _, _) = step.action else { continue }
+      let value: Int?
+      switch max {
+      case .literal(let literal):
+        value = literal
+      case .template(let text):
+        let reference = (try? WorkflowTemplate.references(in: text))?.first
+        value = reference.flatMap { $0.components.count == 2 ? inputs[$0.components[1]] : nil }.flatMap(Int.init)
+      }
+      guard let value, (1...WorkflowSchema.repeatMaximum).contains(value) else {
+        throw .invalidRepeatBound(step: step.id)
+      }
+      bounds[step.id] = value
+    }
+    return bounds
+  }
+
+  // MARK: Events
+
+  mutating func apply(_ event: WorkflowRunEvent) -> [WorkflowRunEffect] {
+    guard !run.status.isTerminal else { return [] }
+    var effects: [WorkflowRunEffect] = []
+    switch event {
+    case .roleIdle(let ordinal):
+      guard case .waitingForRole(_, ordinal) = run.phase else { return [] }
+      injectCurrentMessage(ordinal: ordinal, effects: &effects)
+    case .injectionSucceeded(let ordinal, let dispatchID):
+      guard case .injecting(ordinal) = run.phase else { return [] }
+      openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
+    case .injectionFailed(let ordinal, let failure):
+      guard case .injecting(ordinal) = run.phase, let invocation = invocation(ordinal) else { return [] }
+      if failure == .roleBusy {
+        guard let surfaceID = run.bindings[invocation.role]?.pane?.surfaceID else { return [] }
+        run.phase = .waitingForRole(role: invocation.role, ordinal: ordinal)
+        effects.append(.awaitRoleIdle(role: invocation.role, surfaceID: surfaceID, ordinal: ordinal))
+        effects.append(
+          .log("Step '\(invocation.stepID)': role '\(invocation.role)' is busy again; waiting for it to be idle."))
+        return effects
+      }
+      raiseAttention(
+        .injectionFailed(failure), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects
+      )
+    case .launched(let ordinal, let pane, let dispatchID):
+      guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal),
+        let binding = run.bindings[invocation.role]
+      else { return [] }
+      run.bindings[invocation.role] = binding.binding(pane: pane)
+      effects.append(.log("Step '\(invocation.stepID)': role '\(invocation.role)' launched in \(pane.handle)."))
+      openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
+    case .launchFailed(let ordinal, let reason):
+      guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal) else { return [] }
+      raiseAttention(
+        .launchFailed(reason), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects)
+    case .actionCompleted(let stepID, let outputs):
+      guard case .runningAction(stepID) = run.phase, let step = run.currentStep, step.id == stepID else { return [] }
+      run.actionOutputs[stepID] = outputs
+      completeCurrentStep(effects: &effects)
+      effects.append(.log("Step '\(stepID)': action completed."))
+      advance(effects: &effects)
+    case .actionFailed(let stepID, let reason):
+      guard case .runningAction(stepID) = run.phase, let step = run.currentStep, step.id == stepID else { return [] }
+      raiseAttention(.actionFailed(reason), stepID: stepID, role: nil, ordinal: nil, effects: &effects)
+    case .watchdog(let ordinal, let verdict):
+      applyWatchdog(ordinal: ordinal, verdict: verdict, effects: &effects)
+    case .user(let action):
+      applyUser(action, effects: &effects)
+    }
+    return effects
+  }
+
+  // MARK: Deliveries
+
+  /// Accepts one delivery for the activation `ordinal` (the caller pane's pending dispatch
+  /// resolved by the wiring layer; nil = the current activation). Errors map to the CLI codes.
+  mutating func deliver(
+    ordinal: Int?,
+    selector: WorkflowDeliverySelector,
+    body: String,
+    verdict: String?
+  ) -> (result: Result<WorkflowDeliveryReceipt, WorkflowDeliveryError>, effects: [WorkflowRunEffect]) {
+    guard !run.status.isTerminal, let activation = run.currentActivation, activation.state == .waiting,
+      ordinal == nil || ordinal == activation.ordinal
+    else {
+      return (.failure(.stepNotExpecting), [])
+    }
+    switch selector {
+    case .token(nil):
+      return (.failure(.tokenRequired), [])
+    case .token(let token?):
+      guard token == activation.token else { return (.failure(.tokenInvalid), []) }
+    case .manual(let stepID):
+      guard stepID == activation.stepID else { return (.failure(.stepNotExpecting), []) }
+    }
+    let validated: WorkflowValidatedDelivery
+    switch WorkflowDeliveryValidator.validate(body: body, verdict: verdict, expect: activation.expect, limits: limits) {
+    case .failure(let error):
+      return (.failure(error), [])
+    case .success(let delivery):
+      validated = delivery
+    }
+    let record = WorkflowOutputRecord(
+      name: activation.outputName,
+      ordinal: activation.ordinal,
+      path: WorkflowRunPaths.path(
+        WorkflowRunPaths.outputURL(
+          runDirectory: run.runDirectory, name: activation.outputName, ordinal: activation.ordinal)),
+      latestPath: WorkflowRunPaths.path(
+        WorkflowRunPaths.outputURL(runDirectory: run.runDirectory, name: activation.outputName, ordinal: nil)),
+      verdict: validated.verdict,
+      deliveredAt: now()
+    )
+    run.outputs[activation.outputName] = record
+    run.skippedOutputs[activation.outputName] = nil
+    updateActivation(ordinal: activation.ordinal) { $0.state = .delivered }
+    var effects: [WorkflowRunEffect] = [
+      .persistOutput(name: activation.outputName, ordinal: activation.ordinal, body: validated.body),
+      .disarmWatchdog(ordinal: activation.ordinal),
+    ]
+    if let dispatchID = activation.dispatchID {
+      let verdictNote = validated.verdict.map { " with verdict '\($0)'" } ?? ""
+      effects.append(
+        .completeActivation(
+          dispatchID: dispatchID,
+          summary: "Delivered output '\(activation.outputName)' for workflow step '\(activation.stepID)'\(verdictNote)."
+        ))
+    }
+    effects.append(
+      .log(
+        "Step '\(activation.stepID)': output '\(activation.outputName)' delivered (invocation \(activation.ordinal))."))
+    run.status = .running
+    completeCurrentStep(effects: &effects)
+    advance(effects: &effects)
+    return (
+      .success(WorkflowDeliveryReceipt(ordinal: activation.ordinal, stepID: activation.stepID, output: record)), effects
+    )
+  }
+
+  // MARK: Skip consequence
+
+  func skipConsequence(forStep stepID: String) -> WorkflowSkipConsequence {
+    Self.skipConsequence(forStep: stepID, in: run, fromStart: false)
+  }
+
+  /// The §5 Skip rule, resolved at the moment of the skip (decision H11): every step that can
+  /// still run — the rest of the current loop body (the next iteration re-reads all of it),
+  /// its `until`, and the top-level steps after it — is scanned for a reader of the output.
+  private static func skipConsequence(forStep stepID: String, in run: WorkflowRun, fromStart: Bool)
+    -> WorkflowSkipConsequence
+  {
+    let steps = run.definition.steps
+    guard let name = run.definition.flattenedSteps.first(where: { $0.id == stepID })?.outputName else {
+      return .noOutput
+    }
+    var remaining: [WorkflowStepDefinition] = []
+    var loopUntil: WorkflowUntilCondition?
+    var loopID: String?
+    if fromStart {
+      remaining = steps
+    } else if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
+      remaining = body
+      loopUntil = until
+      loopID = steps[run.position.index].id
+      remaining += steps[(run.position.index + 1)...]
+    } else {
+      remaining = Array(steps[(run.position.index + 1)...])
+    }
+    var optional: [String] = []
+    if let loopUntil, loopUntil.output == name, let loopID {
+      return .endsRun(dependent: loopID)
+    }
+    for step in remaining where step.id != stepID && !run.preSkippedSteps.contains(step.id) {
+      if let dependent = reader(of: name, in: step, run: run, optional: &optional) {
+        return .endsRun(dependent: dependent)
+      }
+    }
+    return .continues(optionalInputs: optional)
+  }
+
+  /// The id of the step that reads `name` in a way the Skip rule does not tolerate, or nil.
+  private static func reader(
+    of name: String, in step: WorkflowStepDefinition, run: WorkflowRun, optional: inout [String]
+  ) -> String? {
+    if let title = step.title, references(name, in: title) { return step.id }
+    switch step.action {
+    case .message(_, let content, _):
+      if references(name, in: content.body) { return step.id }
+    case .launch(_, let prompt, _, _):
+      if references(name, in: prompt) { return step.id }
+    case .notify(let text):
+      if references(name, in: text) { return step.id }
+    case .close:
+      break
+    case .action(let id, let inputs):
+      let schema = WorkflowActionRegistry.schema(for: id)
+      for (key, value) in inputs.sorted(by: { $0.key < $1.key }) where references(name, in: value) {
+        if schema?.input(named: key)?.required == false {
+          optional.append(step.id)
+        } else {
+          return step.id
+        }
+      }
+    case .repeat(_, let until, let body):
+      if until?.output == name { return step.id }
+      for inner in body where !run.preSkippedSteps.contains(inner.id) {
+        if let dependent = reader(of: name, in: inner, run: run, optional: &optional) { return dependent }
+      }
+    }
+    return nil
+  }
+
+  private static func references(_ name: String, in text: String) -> Bool {
+    guard let references = try? WorkflowTemplate.references(in: text) else { return false }
+    return references.contains { $0.components.count == 3 && $0.components[0] == "outputs" && $0.components[1] == name }
+  }
+
+  // MARK: Advancing
+
+  /// Executes steps from the cursor until one needs the outside world (or the run ends).
+  private mutating func advance(effects: inout [WorkflowRunEffect]) {
+    enterCurrentStep(selfInitiated: false, effects: &effects)
+  }
+
+  private mutating func enterCurrentStep(selfInitiated: Bool, effects: inout [WorkflowRunEffect]) {
+    guard run.status == .running else { return }
+    run.phase = .idle
+    while run.status == .running {
+      guard let step = run.currentStep else {
+        if run.position.loop != nil {
+          finishIteration(effects: &effects)
+          continue
+        }
+        finish(.completed, effects: &effects)
+        return
+      }
+      if run.preSkippedSteps.contains(step.id) {
+        recordStep(step, state: .skipped, ordinal: nil)
+        if let name = step.outputName {
+          run.skippedOutputs[name] = step.id
+        }
+        effects.append(.log("Step '\(step.id)': skipped at start."))
+        moveNext()
+        continue
+      }
+      switch step.action {
+      case .message(let role, let content, let expect):
+        enterMessage(
+          step, role: role, content: content, expect: expect, selfInitiated: selfInitiated, effects: &effects)
+        return
+      case .launch(let role, let prompt, let skill, let expect):
+        enterLaunch(step, role: role, prompt: prompt, skill: skill, expect: expect, effects: &effects)
+        return
+      case .action(let id, let inputs):
+        enterAction(step, id: id, inputs: inputs, effects: &effects)
+        return
+      case .notify(let text):
+        guard let rendered = render(text, step: step, effects: &effects) else { return }
+        recordStep(step, state: .completed, ordinal: nil)
+        effects.append(.notify(rendered))
+        effects.append(.log("Step '\(step.id)': notified \"\(rendered)\"."))
+        moveNext()
+      case .close(let role):
+        recordStep(step, state: .completed, ordinal: nil)
+        if let surfaceID = run.bindings[role]?.pane?.surfaceID {
+          effects.append(.close(role: role, surfaceID: surfaceID))
+          effects.append(.log("Step '\(step.id)': close requested for role '\(role)'."))
+        } else {
+          effects.append(.log("Step '\(step.id)': role '\(role)' has no pane to close."))
+        }
+        moveNext()
+      case .repeat(_, let until, _):
+        guard run.position.loop == nil else {
+          // Unreachable: a loop position always resolves to a body step or the iteration end.
+          moveNext()
+          continue
+        }
+        run.loopCount = 0
+        switch evaluate(until) {
+        case .satisfied:
+          recordStep(step, state: .skipped, ordinal: nil)
+          effects.append(.log("Step '\(step.id)': 'until' already satisfied; loop skipped."))
+          moveNext()
+        case .notSatisfied:
+          guard let max = run.repeatBounds[step.id] else {
+            finish(.cancelled, effects: &effects)
+            return
+          }
+          run.position.loop = WorkflowRunPosition.Loop(iteration: 1, bodyIndex: 0, max: max)
+          effects.append(.log("Step '\(step.id)': round 1 of at most \(max)."))
+        case .skippedOutput(let skippedStep):
+          finish(.skipped(step: skippedStep, dependent: step.id), effects: &effects)
+          return
+        }
+      }
+    }
+  }
+
+  private mutating func finishIteration(effects: inout [WorkflowRunEffect]) {
+    guard var loop = run.position.loop, case .repeat(_, let until, _) = run.definition.steps[run.position.index].action
+    else { return }
+    let step = run.definition.steps[run.position.index]
+    run.loopCount += 1
+    switch evaluate(until) {
+    case .satisfied:
+      run.position.loop = nil
+      recordStep(step, state: .completed, ordinal: nil)
+      effects.append(.log("Step '\(step.id)': 'until' satisfied after \(run.loopCount) round(s)."))
+      moveNext()
+    case .notSatisfied:
+      if loop.iteration >= loop.max {
+        finish(.maxRoundsReached, effects: &effects)
+        return
+      }
+      loop.iteration += 1
+      loop.bodyIndex = 0
+      run.position.loop = loop
+      effects.append(.log("Step '\(step.id)': round \(loop.iteration) of at most \(loop.max)."))
+    case .skippedOutput(let skippedStep):
+      finish(.skipped(step: skippedStep, dependent: step.id), effects: &effects)
+    }
+  }
+
+  private enum UntilResult {
+    case satisfied
+    case notSatisfied
+    case skippedOutput(step: String)
+  }
+
+  private func evaluate(_ until: WorkflowUntilCondition?) -> UntilResult {
+    guard let until else { return .notSatisfied }
+    if let skippedStep = run.skippedOutputs[until.output] {
+      return .skippedOutput(step: skippedStep)
+    }
+    guard let verdict = run.outputs[until.output]?.verdict else { return .notSatisfied }
+    return until.values.contains(verdict) ? .satisfied : .notSatisfied
+  }
+
+  private mutating func moveNext() {
+    if run.position.loop != nil {
+      run.position.loop?.bodyIndex += 1
+    } else {
+      run.position.index += 1
+    }
+  }
+
+  // MARK: Step entry
+
+  private mutating func enterMessage(
+    _ step: WorkflowStepDefinition,
+    role: String,
+    content: WorkflowMessageContent,
+    expect: WorkflowExpectation?,
+    selfInitiated: Bool,
+    effects: inout [WorkflowRunEffect]
+  ) {
+    let ordinal = mintOrdinal()
+    run.invocations.append(
+      WorkflowInvocation(
+        ordinal: ordinal, stepID: step.id, iteration: run.currentIteration, role: role, kind: .message, startedAt: now()
+      ))
+    recordStep(step, state: .active, ordinal: ordinal)
+    guard let pane = run.bindings[role]?.pane else {
+      run.phase = .injecting(ordinal: ordinal)
+      raiseAttention(.agentGone(.notLaunched), stepID: step.id, role: role, ordinal: ordinal, effects: &effects)
+      return
+    }
+    let isCurrentRole = run.definition.role(named: role)?.source == .current
+    if selfInitiated, isCurrentRole {
+      guard
+        let line = renderMessageLine(ordinal: ordinal, step: step, content: content, expect: expect, effects: &effects)
+      else { return }
+      run.selfInitiatedLine = line
+      effects.append(.log("Step '\(step.id)': returned to the caller's own pane instead of being typed."))
+      if expect != nil {
+        run.phase = .injecting(ordinal: ordinal)
+        effects.append(.openActivation(role: role, surfaceID: pane.surfaceID, ordinal: ordinal))
+      } else {
+        completeCurrentStep(effects: &effects)
+        advance(effects: &effects)
+      }
+      return
+    }
+    run.phase = .waitingForRole(role: role, ordinal: ordinal)
+    effects.append(.persist)
+    effects.append(.log("Step '\(step.id)': waiting for role '\(role)' to be idle."))
+    effects.append(.awaitRoleIdle(role: role, surfaceID: pane.surfaceID, ordinal: ordinal))
+  }
+
+  private mutating func injectCurrentMessage(ordinal: Int, effects: inout [WorkflowRunEffect]) {
+    guard let step = run.currentStep, case .message(let role, let content, let expect) = step.action,
+      let pane = run.bindings[role]?.pane
+    else { return }
+    guard
+      let line = renderMessageLine(ordinal: ordinal, step: step, content: content, expect: expect, effects: &effects)
+    else { return }
+    run.phase = .injecting(ordinal: ordinal)
+    effects.append(
+      .inject(role: role, surfaceID: pane.surfaceID, ordinal: ordinal, line: line, opensActivation: expect != nil))
+  }
+
+  /// Renders the typed line (materializing an instruction first) and opens the activation
+  /// token; nil when rendering failed, in which case the run is already in attention or ended.
+  private mutating func renderMessageLine(
+    ordinal: Int,
+    step: WorkflowStepDefinition,
+    content: WorkflowMessageContent,
+    expect: WorkflowExpectation?,
+    effects: inout [WorkflowRunEffect]
+  ) -> String? {
+    guard let invocation = invocation(ordinal) else { return nil }
+    guard let rendered = render(content.body, step: step, effects: &effects) else { return nil }
+    var completion: WorkflowCompletionCommand?
+    if let expect, let outputName = step.outputName {
+      let activation = WorkflowActivation(
+        ordinal: ordinal, stepID: step.id, role: invocation.role, token: makeToken(), expect: expect,
+        outputName: outputName, dispatchID: nil, state: .waiting)
+      updateInvocation(ordinal: ordinal) { $0.activation = activation }
+      completion = activation.completion
+    }
+    do {
+      switch content {
+      case .text:
+        return try WorkflowTypedLine.text(rendered, completion: completion)
+      case .instruction:
+        let url = WorkflowRunPaths.instructionURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
+        let path = WorkflowRunPaths.path(url)
+        var text = rendered
+        if !text.hasSuffix("\n") { text += "\n" }
+        if let completion { text += completion.instructionTrailer() }
+        updateInvocation(ordinal: ordinal) { $0.instructionPath = path }
+        effects.append(.materializeInstruction(ordinal: ordinal, stepID: step.id, text: text))
+        return try WorkflowTypedLine.pointer(to: path, completion: completion)
+      }
+    } catch {
+      run.phase = .injecting(ordinal: ordinal)
+      updateActivation(ordinal: ordinal) { $0.state = .revoked }
+      raiseAttention(.renderedTextInvalid, stepID: step.id, role: invocation.role, ordinal: ordinal, effects: &effects)
+      return nil
+    }
+  }
+
+  private mutating func enterLaunch(
+    _ step: WorkflowStepDefinition,
+    role: String,
+    prompt: String,
+    skill: String?,
+    expect: WorkflowExpectation?,
+    effects: inout [WorkflowRunEffect]
+  ) {
+    let ordinal = mintOrdinal()
+    run.invocations.append(
+      WorkflowInvocation(
+        ordinal: ordinal, stepID: step.id, iteration: run.currentIteration, role: role, kind: .launch, startedAt: now())
+    )
+    recordStep(step, state: .active, ordinal: ordinal)
+    guard let rendered = render(prompt, step: step, effects: &effects) else { return }
+    launch(
+      step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: skill, expect: expect, redelivery: false,
+      effects: &effects)
+  }
+
+  private mutating func launch(
+    step: WorkflowStepDefinition,
+    ordinal: Int,
+    role: String,
+    userPrompt: String,
+    skill: String?,
+    expect: WorkflowExpectation?,
+    redelivery: Bool,
+    effects: inout [WorkflowRunEffect]
+  ) {
+    guard let profile = run.bindings[role]?.profile, let requirements = run.definition.role(named: role)?.launch else {
+      run.phase = .launching(ordinal: ordinal)
+      raiseAttention(
+        .launchFailed("role '\(role)' has no frozen profile"), stepID: step.id, role: role, ordinal: ordinal,
+        effects: &effects)
+      return
+    }
+    var environment = [
+      WorkflowSchema.runEnvironmentKey: run.id.uuidString,
+      WorkflowSchema.roleEnvironmentKey: role,
+    ]
+    var protocolBlock: String?
+    if let expect, let outputName = step.outputName {
+      let activation = WorkflowActivation(
+        ordinal: ordinal, stepID: step.id, role: role, token: makeToken(), expect: expect,
+        outputName: outputName, dispatchID: nil, state: .waiting)
+      updateInvocation(ordinal: ordinal) { $0.activation = activation }
+      environment[WorkflowSchema.tokenEnvironmentKey] = activation.token
+      let title = step.title.flatMap { try? WorkflowTemplate.render($0, context: templateContext()) }
+      protocolBlock = activation.completion.protocolBlock(
+        runID: run.id.uuidString, workflowName: run.definition.name, role: role, stepTitle: title,
+        sections: expect.sections, format: expect.format)
+    }
+    let prompt = WorkflowLaunchPrompt.render(userPrompt: userPrompt, protocolBlock: protocolBlock)
+    do {
+      try WorkflowLaunchPrompt.validate(prompt)
+    } catch {
+      run.phase = .launching(ordinal: ordinal)
+      updateActivation(ordinal: ordinal) { $0.state = .revoked }
+      let reason =
+        switch error {
+        case .containsNUL: "the rendered prompt contains NUL"
+        case .tooLarge(let bytes): "the rendered prompt is \(bytes) bytes, above \(WorkflowLaunchPrompt.maximumBytes)"
+        }
+      raiseAttention(.launchFailed(reason), stepID: step.id, role: role, ordinal: ordinal, effects: &effects)
+      return
+    }
+    if let skill {
+      effects.append(.materializeSkill(id: skill))
+    }
+    let anchor = run.definition.roles.first { $0.source == .current }.flatMap { run.bindings[$0.name]?.pane?.surfaceID }
+    run.phase = .launching(ordinal: ordinal)
+    effects.append(.persist)
+    effects.append(
+      .log(
+        "Step '\(step.id)': launching role '\(role)' with profile '\(profile.name)'\(redelivery ? " (relaunch)" : "").")
+    )
+    effects.append(
+      .launch(
+        WorkflowLaunchRequest(
+          role: role, ordinal: ordinal, profile: profile, prompt: prompt, environment: environment,
+          placement: requirements.placement, direction: requirements.direction, background: requirements.background,
+          anchorSurfaceID: anchor, skill: skill, expectsDelivery: expect != nil, redelivery: redelivery)))
+  }
+
+  private mutating func enterAction(
+    _ step: WorkflowStepDefinition, id: String, inputs: [String: String], effects: inout [WorkflowRunEffect]
+  ) {
+    recordStep(step, state: .active, ordinal: nil)
+    let schema = WorkflowActionRegistry.schema(for: id)
+    var resolved: [String: String] = [:]
+    let context = templateContext()
+    for (key, value) in inputs.sorted(by: { $0.key < $1.key }) {
+      let input = schema?.input(named: key)
+      if input?.kind == .role {
+        resolved[key] = value
+        continue
+      }
+      do {
+        resolved[key] = try WorkflowTemplate.render(value, context: context)
+      } catch WorkflowTemplateError.missingOutput(let name) where input?.required == false {
+        effects.append(.log("Step '\(step.id)': optional input '\(key)' omitted; output '\(name)' was skipped."))
+      } catch WorkflowTemplateError.missingOutput(let name) {
+        finish(.skipped(step: run.skippedOutputs[name] ?? name, dependent: step.id), effects: &effects)
+        return
+      } catch {
+        raiseAttention(
+          .actionFailed("input '\(key)' cannot be rendered: \(error)"), stepID: step.id, role: nil, ordinal: nil,
+          effects: &effects)
+        return
+      }
+    }
+    run.phase = .runningAction(stepID: step.id)
+    effects.append(.persist)
+    effects.append(.log("Step '\(step.id)': running action '\(id)'."))
+    effects.append(.runAction(stepID: step.id, actionID: id, inputs: resolved))
+  }
+
+  // MARK: Waiting and watchdog
+
+  private mutating func openWaiting(ordinal: Int, dispatchID: String?, effects: inout [WorkflowRunEffect]) {
+    guard let invocation = invocation(ordinal) else { return }
+    guard let activation = invocation.activation else {
+      completeCurrentStep(effects: &effects)
+      effects.append(.log("Step '\(invocation.stepID)': delivered to role '\(invocation.role)'."))
+      advance(effects: &effects)
+      return
+    }
+    updateActivation(ordinal: ordinal) { $0.dispatchID = dispatchID }
+    run.phase = .waitingForDelivery(ordinal: ordinal)
+    effects.append(.persist)
+    effects.append(
+      .log("Step '\(invocation.stepID)': waiting for output '\(activation.outputName)' from role '\(invocation.role)'.")
+    )
+    armWatchdog(ordinal: ordinal, nudgedAlready: false, effects: &effects)
+  }
+
+  private mutating func armWatchdog(ordinal: Int, nudgedAlready: Bool, effects: inout [WorkflowRunEffect]) {
+    guard let invocation = invocation(ordinal), let activation = invocation.activation,
+      let surfaceID = run.bindings[invocation.role]?.pane?.surfaceID
+    else { return }
+    effects.append(
+      .armWatchdog(
+        WorkflowWatchdogRequest(
+          ordinal: ordinal, stepID: invocation.stepID, role: invocation.role, surfaceID: surfaceID,
+          dispatchID: activation.dispatchID, timeoutSeconds: activation.expect.timeoutSeconds,
+          timeoutPolicy: activation.expect.onTimeout ?? .attention, nudgedAlready: nudgedAlready)))
+  }
+
+  private mutating func applyWatchdog(
+    ordinal: Int, verdict: WorkflowWatchdogVerdict, effects: inout [WorkflowRunEffect]
+  ) {
+    guard let activation = run.currentActivation, activation.ordinal == ordinal else { return }
+    switch verdict {
+    case .nudge:
+      typeNudge(activation, effects: &effects)
+      effects.append(.log("Step '\(activation.stepID)': nudged role '\(activation.role)'."))
+    case .attention(let reason):
+      let mapped: WorkflowAttentionReason =
+        switch reason {
+        case .needsInput: .needsInput
+        case .idleWithoutDelivery: .idleWithoutDelivery
+        case .blocked: .blocked
+        case .agentGone(let gone): .agentGone(gone)
+        }
+      raiseAttention(mapped, stepID: activation.stepID, role: activation.role, ordinal: ordinal, effects: &effects)
+    case .timeout:
+      switch activation.expect.onTimeout ?? .attention {
+      case .attention:
+        raiseAttention(.timeout, stepID: activation.stepID, role: activation.role, ordinal: ordinal, effects: &effects)
+      case .skip:
+        effects.append(.log("Step '\(activation.stepID)': timeout; skipping as configured."))
+        skipCurrentStep(effects: &effects)
+      case .cancel:
+        effects.append(.log("Step '\(activation.stepID)': timeout; cancelling as configured."))
+        cancel(effects: &effects)
+      }
+    }
+  }
+
+  private mutating func typeNudge(_ activation: WorkflowActivation, effects: inout [WorkflowRunEffect]) {
+    guard let surfaceID = run.bindings[activation.role]?.pane?.surfaceID,
+      let line = try? WorkflowTypedLine.nudge(completion: activation.completion)
+    else { return }
+    effects.append(.typeLine(role: activation.role, surfaceID: surfaceID, line: line))
+  }
+
+  // MARK: User actions
+
+  private mutating func applyUser(_ action: WorkflowUserAction, effects: inout [WorkflowRunEffect]) {
+    let attention = run.status.attention
+    switch action {
+    case .cancel:
+      cancel(effects: &effects)
+    case .skip:
+      guard attention == nil || attention?.actions.contains(.skip) == true else { return }
+      guard run.currentInvocation != nil || attention != nil else { return }
+      skipCurrentStep(effects: &effects)
+    case .keepWaiting:
+      guard let attention, attention.actions.contains(.keepWaiting), let ordinal = attention.ordinal else { return }
+      run.status = .running
+      effects.append(.log("Step '\(attention.stepID)': keep waiting."))
+      armWatchdog(ordinal: ordinal, nudgedAlready: true, effects: &effects)
+      effects.append(.persist)
+    case .nudge:
+      guard let attention, attention.actions.contains(.nudge), let activation = run.currentActivation else { return }
+      run.status = .running
+      typeNudge(activation, effects: &effects)
+      effects.append(.log("Step '\(attention.stepID)': nudged again by the user."))
+      armWatchdog(ordinal: activation.ordinal, nudgedAlready: true, effects: &effects)
+      effects.append(.persist)
+    case .retry:
+      guard let attention, attention.actions.contains(.retry) else { return }
+      retryCurrentStep(effects: &effects)
+    case .relaunch:
+      guard let attention, attention.actions.contains(.relaunch) else { return }
+      relaunchCurrentStep(effects: &effects)
+    }
+  }
+
+  private mutating func cancel(effects: inout [WorkflowRunEffect]) {
+    let stepID = run.currentStep?.id ?? "-"
+    revokeCurrentActivation(
+      reason: "Workflow run \(run.id.uuidString) cancelled at step '\(stepID)'.", effects: &effects)
+    if let record = run.stepRecords.indices.last, run.stepRecords[record].state == .active {
+      run.stepRecords[record].state = .failed
+    }
+    finish(.cancelled, effects: &effects)
+  }
+
+  private mutating func skipCurrentStep(effects: inout [WorkflowRunEffect]) {
+    guard let step = run.currentStep else { return }
+    revokeCurrentActivation(reason: "Workflow run \(run.id.uuidString): step '\(step.id)' skipped.", effects: &effects)
+    updateActivation(ordinal: run.currentInvocation?.ordinal ?? -1) { $0.state = .skipped }
+    if let index = run.stepRecords.indices.last, run.stepRecords[index].state == .active {
+      run.stepRecords[index].state = .skipped
+    }
+    if let name = step.outputName {
+      run.skippedOutputs[name] = step.id
+    }
+    run.status = .running
+    effects.append(.log("Step '\(step.id)': skipped."))
+    switch skipConsequence(forStep: step.id) {
+    case .endsRun(let dependent):
+      finish(.skipped(step: step.id, dependent: dependent), effects: &effects)
+    case .noOutput, .continues:
+      moveNext()
+      advance(effects: &effects)
+    }
+  }
+
+  private mutating func retryCurrentStep(effects: inout [WorkflowRunEffect]) {
+    guard let step = run.currentStep else { return }
+    run.status = .running
+    if let index = run.stepRecords.indices.last, run.stepRecords[index].state == .active {
+      run.stepRecords[index].state = .failed
+    }
+    revokeCurrentActivation(reason: "Workflow run \(run.id.uuidString): step '\(step.id)' retried.", effects: &effects)
+    effects.append(.log("Step '\(step.id)': retry."))
+    advance(effects: &effects)
+  }
+
+  private mutating func relaunchCurrentStep(effects: inout [WorkflowRunEffect]) {
+    guard let step = run.currentStep, let role = step.action.targetRole,
+      case .launch(let profile, _) = run.bindings[role]
+    else { return }
+    run.status = .running
+    if let index = run.stepRecords.indices.last, run.stepRecords[index].state == .active {
+      run.stepRecords[index].state = .failed
+    }
+    revokeCurrentActivation(
+      reason: "Workflow run \(run.id.uuidString): role '\(role)' relaunched at step '\(step.id)'.", effects: &effects)
+    run.bindings[role] = .launch(profile, pane: nil)
+    switch step.action {
+    case .launch:
+      advance(effects: &effects)
+    case .message(_, let content, let expect):
+      let ordinal = mintOrdinal()
+      run.invocations.append(
+        WorkflowInvocation(
+          ordinal: ordinal, stepID: step.id, iteration: run.currentIteration, role: role, kind: .launch,
+          startedAt: now()))
+      recordStep(step, state: .active, ordinal: ordinal)
+      guard let rendered = render(content.body, step: step, effects: &effects) else { return }
+      launch(
+        step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: nil, expect: expect, redelivery: true,
+        effects: &effects)
+    default:
+      return
+    }
+  }
+
+  /// Revokes the current activation's token and abandons its dispatch record.
+  private mutating func revokeCurrentActivation(reason: String, effects: inout [WorkflowRunEffect]) {
+    if case .waitingForRole(_, let ordinal) = run.phase {
+      effects.append(.cancelRoleWait(ordinal: ordinal))
+    }
+    guard let invocation = run.currentInvocation, let activation = invocation.activation else { return }
+    if activation.state == .waiting {
+      updateActivation(ordinal: activation.ordinal) { $0.state = .revoked }
+    }
+    let endedAt = now()
+    updateInvocation(ordinal: activation.ordinal) { $0.endedAt = endedAt }
+    if let dispatchID = activation.dispatchID, activation.state == .waiting {
+      effects.append(.abandonActivation(dispatchID: dispatchID, reason: reason))
+    }
+    if case .waitingForDelivery = run.phase {
+      effects.append(.disarmWatchdog(ordinal: activation.ordinal))
+    }
+  }
+
+  // MARK: Attention and finishing
+
+  private mutating func raiseAttention(
+    _ reason: WorkflowAttentionReason, stepID: String, role: String?, ordinal: Int?, effects: inout [WorkflowRunEffect]
+  ) {
+    let isLaunchRole = role.flatMap { run.bindings[$0]?.source } == .launch
+    let actions: [WorkflowAttentionAction] =
+      switch reason {
+      case .needsInput, .blocked: [.focusPane, .cancel]
+      case .idleWithoutDelivery, .timeout: [.nudge, .keepWaiting, .skip, .cancel]
+      case .agentGone: isLaunchRole ? [.relaunch, .skip, .cancel] : [.skip, .cancel]
+      case .injectionFailed(.surfaceMissing):
+        isLaunchRole ? [.relaunch, .retry, .skip, .cancel] : [.retry, .skip, .cancel]
+      case .injectionFailed(.roleBlocked), .injectionFailed(.submitFailed): [.focusPane, .retry, .skip, .cancel]
+      case .injectionFailed: [.retry, .skip, .cancel]
+      case .launchFailed: [.retry, .skip, .cancel]
+      case .renderedTextInvalid: [.skip, .cancel]
+      case .actionFailed: [.retry, .cancel]
+      }
+    let attention = WorkflowAttention(
+      reason: reason, stepID: stepID, role: role, ordinal: ordinal, actions: actions,
+      message: attentionMessage(reason, stepID: stepID, role: role))
+    run.status = .needsAttention(attention)
+    effects.append(.log("Step '\(stepID)': needs attention — \(attention.message)"))
+    effects.append(.persist)
+  }
+
+  private func attentionMessage(_ reason: WorkflowAttentionReason, stepID: String, role: String?) -> String {
+    let subject: String
+    if let role, let binding = run.bindings[role] {
+      subject = "\(role) (\(binding.templateRole.name))"
+    } else {
+      subject = role ?? "the step"
+    }
+    let outputName = run.currentActivation?.outputName ?? "its output"
+    switch reason {
+    case .needsInput:
+      return "\(subject) is waiting for input in its pane."
+    case .idleWithoutDelivery:
+      return "\(subject) has been idle without delivering \(outputName); Prowl nudged it once."
+    case .blocked:
+      return "\(subject) looks blocked on screen."
+    case .agentGone(.sessionEnded):
+      return "\(subject)'s agent session ended before it delivered \(outputName)."
+    case .agentGone(.paneClosed):
+      return "\(subject)'s pane was closed before it delivered \(outputName)."
+    case .agentGone(.processGone):
+      return "\(subject)'s agent process is gone."
+    case .agentGone(.notLaunched):
+      return "\(subject) has no pane: its launch was skipped or did not succeed."
+    case .injectionFailed(.roleBusy):
+      return "\(subject) is busy."
+    case .injectionFailed(.roleBlocked):
+      return "The line could not be typed: \(subject) is blocked."
+    case .injectionFailed(.surfaceMissing):
+      return "The line could not be typed: \(subject)'s pane is gone."
+    case .injectionFailed(.insertFailed):
+      return "The line could not be typed into \(subject)'s pane."
+    case .injectionFailed(.submitFailed):
+      return "The line was inserted but not submitted; it may still sit unsubmitted in \(subject)'s input. "
+        + "Focus the pane and press Enter, or retry."
+    case .injectionFailed(.activationUnavailable(let detail)):
+      return "The activation for \(subject) could not be opened: \(detail)"
+    case .launchFailed(let detail):
+      return "Launching \(subject) failed: \(detail)"
+    case .renderedTextInvalid:
+      return "The rendered line of step '\(stepID)' is not a single terminal line; nothing was typed."
+    case .actionFailed(let detail):
+      return "Step '\(stepID)' failed: \(detail)"
+    case .timeout:
+      return "Step '\(stepID)' reached its timeout without a delivery from \(subject)."
+    }
+  }
+
+  private mutating func finish(_ status: WorkflowRunStatus, effects: inout [WorkflowRunEffect]) {
+    run.status = status
+    run.phase = .idle
+    run.finishedAt = now()
+    run.updatedAt = run.finishedAt ?? run.updatedAt
+    effects.append(.log("Run finished: \(Self.describe(status))."))
+    effects.append(.persist)
+    effects.append(.finished(status))
+  }
+
+  static func describe(_ status: WorkflowRunStatus) -> String {
+    switch status {
+    case .running: "running"
+    case .needsAttention(let attention): "needs attention (\(attention.message))"
+    case .completed: "completed"
+    case .cancelled: "cancelled"
+    case .skipped(let step, let dependent):
+      "skipped (step '\(step)' was skipped but '\(dependent)' depends on its output)"
+    case .maxRoundsReached: "max rounds reached"
+    case .interrupted: "interrupted"
+    }
+  }
+
+  // MARK: Helpers
+
+  private mutating func completeCurrentStep(effects: inout [WorkflowRunEffect]) {
+    if let ordinal = run.currentInvocation?.ordinal {
+      let endedAt = now()
+      updateInvocation(ordinal: ordinal) { $0.endedAt = endedAt }
+    }
+    if let index = run.stepRecords.indices.last, run.stepRecords[index].state == .active {
+      run.stepRecords[index].state = .completed
+    }
+    run.phase = .idle
+    run.updatedAt = now()
+    moveNext()
+    _ = effects
+  }
+
+  private mutating func recordStep(_ step: WorkflowStepDefinition, state: WorkflowStepState, ordinal: Int?) {
+    run.stepRecords.append(
+      WorkflowStepRecord(stepID: step.id, iteration: run.currentIteration, state: state, ordinal: ordinal))
+    run.updatedAt = now()
+  }
+
+  private mutating func mintOrdinal() -> Int {
+    defer { run.nextOrdinal += 1 }
+    return run.nextOrdinal
+  }
+
+  private func invocation(_ ordinal: Int) -> WorkflowInvocation? {
+    run.invocations.first { $0.ordinal == ordinal }
+  }
+
+  private mutating func updateInvocation(ordinal: Int, _ change: (inout WorkflowInvocation) -> Void) {
+    guard let index = run.invocations.firstIndex(where: { $0.ordinal == ordinal }) else { return }
+    change(&run.invocations[index])
+  }
+
+  private mutating func updateActivation(ordinal: Int, _ change: (inout WorkflowActivation) -> Void) {
+    updateInvocation(ordinal: ordinal) { invocation in
+      guard var activation = invocation.activation else { return }
+      change(&activation)
+      invocation.activation = activation
+    }
+  }
+
+  /// Renders a template; on a missing output the run ends `skipped`, on any other failure the
+  /// step enters attention. Returns nil in both cases.
+  private mutating func render(_ text: String, step: WorkflowStepDefinition, effects: inout [WorkflowRunEffect])
+    -> String?
+  {
+    do {
+      return try WorkflowTemplate.render(text, context: templateContext())
+    } catch WorkflowTemplateError.missingOutput(let name) {
+      finish(.skipped(step: run.skippedOutputs[name] ?? name, dependent: step.id), effects: &effects)
+    } catch {
+      let ordinal = run.currentInvocation?.ordinal
+      raiseAttention(
+        .actionFailed("template cannot be rendered: \(error)"), stepID: step.id, role: step.action.targetRole,
+        ordinal: ordinal, effects: &effects)
+    }
+    return nil
+  }
+
+  func templateContext() -> WorkflowTemplateContext {
+    WorkflowTemplateContext(
+      run: WorkflowTemplateContext.Run(id: run.id.uuidString, directory: WorkflowRunPaths.path(run.runDirectory)),
+      worktree: WorkflowTemplateContext.Worktree(
+        path: run.context.worktree.path, name: run.context.worktree.name, branch: run.context.worktree.branch),
+      roles: run.bindings.mapValues(\.templateRole),
+      outputs: run.outputs.mapValues { WorkflowTemplateContext.Output(path: $0.latestPath, verdict: $0.verdict) },
+      skippedOutputs: Set(run.skippedOutputs.keys),
+      actions: run.actionOutputs,
+      inputs: run.inputs,
+      loop: WorkflowTemplateContext.Loop(index: run.currentIteration, count: run.loopCount)
+    )
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -35,13 +35,17 @@ nonisolated enum WorkflowWatchdogVerdict: Equatable, Sendable {
 
 // MARK: - Events and effects
 
-nonisolated enum WorkflowUserAction: String, Equatable, Sendable {
+nonisolated enum WorkflowUserAction: Equatable, Sendable {
   case retry
   case relaunch
   case skip
   case cancel
   case nudge
   case keepWaiting
+  /// Keep a provisional delivery; `verdict` supplies the declared value it lacked, if any.
+  case acceptDelivery(verdict: String?)
+  /// Type the requirements into the role's pane again and wait for a new delivery.
+  case askAgain
 }
 
 nonisolated enum WorkflowRunEvent: Equatable, Sendable {
@@ -118,6 +122,8 @@ nonisolated struct WorkflowDeliveryReceipt: Equatable, Sendable {
   let ordinal: Int
   let stepID: String
   let output: WorkflowOutputRecord
+  /// Non-empty when the delivery was accepted provisionally; the CLI reports them as warnings.
+  let issues: [WorkflowDeliveryIssue]
 }
 
 nonisolated enum WorkflowSkipConsequence: Equatable, Sendable {
@@ -415,6 +421,8 @@ nonisolated struct WorkflowRunMachine {
       $0.state = .persisting
       $0.pendingDelivery = validated
     }
+    let issueNote =
+      validated.issues.isEmpty ? "" : " with issues: " + validated.issues.map(\.message).joined(separator: "; ")
     run.status = .running
     run.updatedAt = now()
     // The watchdog supervises a *waiting* delivery: an accepted one is no longer its business,
@@ -423,11 +431,14 @@ nonisolated struct WorkflowRunMachine {
       .disarmWatchdog(ordinal: activation.ordinal),
       .log(
         "Step '\(activation.stepID)': output '\(activation.outputName)' accepted "
-          + "(invocation \(activation.ordinal)); persisting."),
+          + "(invocation \(activation.ordinal))\(issueNote); persisting."),
       .persistOutput(name: activation.outputName, ordinal: activation.ordinal, body: validated.body),
     ]
     return (
-      .success(WorkflowDeliveryReceipt(ordinal: activation.ordinal, stepID: activation.stepID, output: record)), effects
+      .success(
+        WorkflowDeliveryReceipt(
+          ordinal: activation.ordinal, stepID: activation.stepID, output: record, issues: validated.issues)),
+      effects
     )
   }
 
@@ -452,12 +463,29 @@ nonisolated struct WorkflowRunMachine {
       .persistFailed(reason), stepID: activation.stepID, role: activation.role, ordinal: ordinal, effects: &effects)
   }
 
-  /// The output is on disk: record it, complete the dispatch record, and advance.
+  /// The output is on disk: a clean delivery completes the dispatch record and advances; one
+  /// with issues stays provisional and asks the user (Accept / Accept with verdict / Ask again).
   private mutating func applyOutputPersisted(ordinal: Int, effects: inout [WorkflowRunEffect]) {
     guard case .waitingForDelivery(ordinal) = run.phase, let activation = run.activeActivation,
       activation.state == .persisting, let delivery = activation.pendingDelivery
     else { return }
-    let record = outputRecord(for: activation, verdict: delivery.verdict)
+    guard delivery.issues.isEmpty else {
+      updateActivation(ordinal: ordinal) { $0.state = .provisional }
+      raiseAttention(
+        .deliveryIssues(delivery.issues), stepID: activation.stepID, role: activation.role, ordinal: ordinal,
+        effects: &effects)
+      return
+    }
+    acceptDelivery(activation: activation, delivery: delivery, verdict: delivery.verdict, effects: &effects)
+  }
+
+  /// Records the delivery, completes the dispatch record, and advances.
+  private mutating func acceptDelivery(
+    activation: WorkflowActivation, delivery: WorkflowValidatedDelivery, verdict: String?,
+    effects: inout [WorkflowRunEffect]
+  ) {
+    let ordinal = activation.ordinal
+    let record = outputRecord(for: activation, verdict: verdict)
     run.outputs[activation.outputName] = record
     run.skippedOutputs[activation.outputName] = nil
     updateActivation(ordinal: ordinal) {
@@ -465,7 +493,7 @@ nonisolated struct WorkflowRunMachine {
       $0.pendingDelivery = nil
     }
     if let dispatchID = activation.dispatchID {
-      let verdictNote = delivery.verdict.map { " with verdict '\($0)'" } ?? ""
+      let verdictNote = verdict.map { " with verdict '\($0)'" } ?? ""
       effects.append(
         .completeActivation(
           dispatchID: dispatchID,
@@ -1031,20 +1059,13 @@ nonisolated struct WorkflowRunMachine {
       guard run.currentInvocation != nil || attention != nil else { return }
       skipCurrentStep(effects: &effects)
     case .keepWaiting:
-      guard let attention, attention.actions.contains(.keepWaiting), let ordinal = attention.ordinal else { return }
-      run.status = .running
-      guard !enforceExpiredDeadline(effects: &effects) else { return }
-      effects.append(.log("Step '\(attention.stepID)': keep waiting."))
-      armWatchdog(ordinal: ordinal, nudgedAlready: true, effects: &effects)
-      effects.append(.persist)
+      keepWaiting(effects: &effects)
     case .nudge:
-      guard let attention, attention.actions.contains(.nudge), let activation = run.currentActivation else { return }
-      run.status = .running
-      guard !enforceExpiredDeadline(effects: &effects) else { return }
-      typeNudge(activation, effects: &effects)
-      effects.append(.log("Step '\(attention.stepID)': nudged again by the user."))
-      armWatchdog(ordinal: activation.ordinal, nudgedAlready: true, effects: &effects)
-      effects.append(.persist)
+      nudgeAgain(effects: &effects)
+    case .acceptDelivery(let verdict):
+      acceptProvisionalDelivery(verdict: verdict, effects: &effects)
+    case .askAgain:
+      askAgain(effects: &effects)
     case .retry:
       guard let attention, attention.actions.contains(.retry) else { return }
       if case .persistFailed = attention.reason, let activation = run.activeActivation,
@@ -1060,6 +1081,74 @@ nonisolated struct WorkflowRunMachine {
       guard let attention, attention.actions.contains(.relaunch) else { return }
       relaunchCurrentStep(effects: &effects)
     }
+  }
+
+  private mutating func keepWaiting(effects: inout [WorkflowRunEffect]) {
+    guard let attention = run.status.attention, attention.actions.contains(.keepWaiting),
+      let ordinal = attention.ordinal
+    else { return }
+    run.status = .running
+    guard !enforceExpiredDeadline(effects: &effects) else { return }
+    effects.append(.log("Step '\(attention.stepID)': keep waiting."))
+    armWatchdog(ordinal: ordinal, nudgedAlready: true, effects: &effects)
+    effects.append(.persist)
+  }
+
+  private mutating func nudgeAgain(effects: inout [WorkflowRunEffect]) {
+    guard let attention = run.status.attention, attention.actions.contains(.nudge),
+      let activation = run.currentActivation
+    else { return }
+    run.status = .running
+    guard !enforceExpiredDeadline(effects: &effects) else { return }
+    typeNudge(activation, effects: &effects)
+    effects.append(.log("Step '\(attention.stepID)': nudged again by the user."))
+    armWatchdog(ordinal: activation.ordinal, nudgedAlready: true, effects: &effects)
+    effects.append(.persist)
+  }
+
+  /// "Accept as delivered" / "Accept with verdict": a declared verdict must be supplied when the
+  /// delivery lacked one, otherwise the accepted output could not drive `until` or templates.
+  private mutating func acceptProvisionalDelivery(verdict: String?, effects: inout [WorkflowRunEffect]) {
+    guard let attention = run.status.attention, let activation = run.activeActivation,
+      activation.state == .provisional, let delivery = activation.pendingDelivery
+    else { return }
+    let accepted: String?
+    if let allowed = activation.expect.verdict {
+      // The delivery's own valid verdict wins; otherwise the user must pick a declared one.
+      if let own = delivery.verdict {
+        accepted = own
+      } else {
+        guard attention.actions.contains(.acceptWithVerdict), let verdict, allowed.contains(verdict) else { return }
+        accepted = verdict
+      }
+    } else {
+      guard attention.actions.contains(.acceptDelivery) else { return }
+      accepted = nil
+    }
+    run.status = .running
+    let note = accepted.map { " with verdict '\($0)'" } ?? ""
+    effects.append(.log("Step '\(activation.stepID)': provisional delivery accepted by the user\(note)."))
+    acceptDelivery(activation: activation, delivery: delivery, verdict: accepted, effects: &effects)
+  }
+
+  /// "Ask again": the same activation (and token) goes back to waiting, the requirements are
+  /// typed into the role's pane, and the watchdog is re-armed with a fresh nudge.
+  private mutating func askAgain(effects: inout [WorkflowRunEffect]) {
+    guard let attention = run.status.attention, attention.actions.contains(.askAgain),
+      let activation = run.activeActivation, activation.state == .provisional,
+      let delivery = activation.pendingDelivery,
+      let surfaceID = run.bindings[activation.role]?.pane?.surfaceID,
+      let line = try? WorkflowTypedLine.askAgain(issues: delivery.issues, completion: activation.completion)
+    else { return }
+    updateActivation(ordinal: activation.ordinal) {
+      $0.state = .waiting
+      $0.pendingDelivery = nil
+    }
+    run.status = .running
+    effects.append(.log("Step '\(activation.stepID)': asked role '\(activation.role)' to deliver again."))
+    effects.append(.typeLine(role: activation.role, surfaceID: surfaceID, line: line))
+    armWatchdog(ordinal: activation.ordinal, nudgedAlready: false, effects: &effects)
+    effects.append(.persist)
   }
 
   /// A hard cap that already passed while the run sat in attention is applied now instead
@@ -1152,7 +1241,7 @@ nonisolated struct WorkflowRunMachine {
       effects.append(.cancelRoleWait(ordinal: ordinal))
     }
     guard let invocation = run.currentInvocation, let activation = invocation.activation else { return }
-    let open = activation.state == .waiting || activation.state == .persisting
+    let open = [.waiting, .persisting, .provisional].contains(activation.state)
     if open {
       updateActivation(ordinal: activation.ordinal) {
         $0.state = .revoked
@@ -1187,6 +1276,10 @@ nonisolated struct WorkflowRunMachine {
       case .launchFailed: [.retry, .skip, .cancel]
       case .renderedTextInvalid: [.skip, .cancel]
       case .actionFailed, .persistFailed: [.retry, .cancel]
+      case .deliveryIssues(let issues):
+        (issues.contains(where: Self.needsVerdict) ? [.acceptWithVerdict] : [.acceptDelivery]) + [
+          .askAgain, .skip, .cancel,
+        ]
       }
     let attention = WorkflowAttention(
       reason: reason, stepID: stepID, role: role, ordinal: ordinal, actions: actions,
@@ -1242,8 +1335,19 @@ nonisolated struct WorkflowRunMachine {
       return "Step '\(stepID)' failed: \(detail)"
     case .persistFailed(let detail):
       return "The delivered output of step '\(stepID)' could not be saved to the run directory: \(detail)"
+    case .deliveryIssues(let issues):
+      return "\(subject) delivered \(outputName), but: \(issues.map(\.message).joined(separator: "; "))."
+        + " Accept it, ask again, or skip."
     case .timeout:
       return "Step '\(stepID)' reached its timeout without a delivery from \(subject)."
+    }
+  }
+
+  /// A provisional delivery without a usable verdict can only be accepted together with one.
+  private static func needsVerdict(_ issue: WorkflowDeliveryIssue) -> Bool {
+    switch issue {
+    case .verdictMissing, .verdictUndeclared: true
+    case .missingSections, .unparsableJSON, .verdictUnexpected: false
     }
   }
 

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -52,6 +52,10 @@ nonisolated enum WorkflowRunEvent: Equatable, Sendable {
   case launchFailed(ordinal: Int, reason: String)
   case actionCompleted(stepID: String, outputs: [String: String])
   case actionFailed(stepID: String, reason: String)
+  /// The `.persistOutput` effect of a delivery succeeded / failed (dsl-spec §5: validate,
+  /// persist, then complete the record).
+  case outputPersisted(ordinal: Int)
+  case outputPersistFailed(ordinal: Int, reason: String)
   case watchdog(ordinal: Int, WorkflowWatchdogVerdict)
   case user(WorkflowUserAction)
 }
@@ -130,6 +134,8 @@ nonisolated enum WorkflowRunStartError: Error, Equatable, Sendable {
   case unsafePath(String)
   case invalidRepeatBound(step: String)
   case unknownSkipStep(String)
+  /// `--skip` names a step without an `expect`; only awaited outputs can be skipped at start.
+  case skipNotExpecting(String)
   case skipNotAllowed(step: String, dependent: String)
   case missingBinding(role: String)
 }
@@ -212,7 +218,8 @@ nonisolated struct WorkflowRunMachine {
     )
     let flattened = definition.flattenedSteps
     for stepID in skippedSteps.sorted() {
-      guard flattened.contains(where: { $0.id == stepID }) else { throw .unknownSkipStep(stepID) }
+      guard let step = flattened.first(where: { $0.id == stepID }) else { throw .unknownSkipStep(stepID) }
+      guard step.action.expect != nil else { throw .skipNotExpecting(stepID) }
     }
     for stepID in skippedSteps.sorted() {
       if case .endsRun(let dependent) = Self.skipConsequence(forStep: stepID, in: run, fromStart: true) {
@@ -260,6 +267,9 @@ nonisolated struct WorkflowRunMachine {
           throw .invalidInput(
             name: input.name, reason: "'\(value)' is not one of \(input.values.joined(separator: ", ")).")
         }
+        guard WorkflowRenderedText.isSingleLine(value) else {
+          throw .invalidInput(name: input.name, reason: "the value must be one line without control characters.")
+        }
         resolved[input.name] = value
       }
     }
@@ -305,14 +315,15 @@ nonisolated struct WorkflowRunMachine {
     case .launched(let ordinal, let pane, let dispatchID):
       applyLaunched(ordinal: ordinal, pane: pane, dispatchID: dispatchID, effects: &effects)
     case .launchFailed(let ordinal, let reason):
-      guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal) else { return [] }
-      raiseAttention(
-        .launchFailed(reason), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects)
+      applyLaunchFailed(ordinal: ordinal, reason: reason, effects: &effects)
     case .actionCompleted(let stepID, let outputs):
       applyActionCompleted(stepID: stepID, outputs: outputs, effects: &effects)
     case .actionFailed(let stepID, let reason):
-      guard case .runningAction(stepID) = run.phase, run.currentStep?.id == stepID else { return [] }
-      raiseAttention(.actionFailed(reason), stepID: stepID, role: nil, ordinal: nil, effects: &effects)
+      applyActionFailed(stepID: stepID, reason: reason, effects: &effects)
+    case .outputPersisted(let ordinal):
+      applyOutputPersisted(ordinal: ordinal, effects: &effects)
+    case .outputPersistFailed(let ordinal, let reason):
+      applyOutputPersistFailed(ordinal: ordinal, reason: reason, effects: &effects)
     case .watchdog(let ordinal, let verdict):
       applyWatchdog(ordinal: ordinal, verdict: verdict, effects: &effects)
     case .user(let action):
@@ -346,6 +357,17 @@ nonisolated struct WorkflowRunMachine {
     run.bindings[invocation.role] = binding.binding(pane: pane)
     effects.append(.log("Step '\(invocation.stepID)': role '\(invocation.role)' launched in \(pane.handle)."))
     openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
+  }
+
+  private mutating func applyLaunchFailed(ordinal: Int, reason: String, effects: inout [WorkflowRunEffect]) {
+    guard case .launching(ordinal) = run.phase, let invocation = invocation(ordinal) else { return }
+    raiseAttention(
+      .launchFailed(reason), stepID: invocation.stepID, role: invocation.role, ordinal: ordinal, effects: &effects)
+  }
+
+  private mutating func applyActionFailed(stepID: String, reason: String, effects: inout [WorkflowRunEffect]) {
+    guard case .runningAction(stepID) = run.phase, run.currentStep?.id == stepID else { return }
+    raiseAttention(.actionFailed(reason), stepID: stepID, role: nil, ordinal: nil, effects: &effects)
   }
 
   private mutating func applyActionCompleted(
@@ -388,7 +410,26 @@ nonisolated struct WorkflowRunMachine {
     case .success(let delivery):
       validated = delivery
     }
-    let record = WorkflowOutputRecord(
+    let record = outputRecord(for: activation, verdict: validated.verdict)
+    updateActivation(ordinal: activation.ordinal) {
+      $0.state = .persisting
+      $0.pendingDelivery = validated
+    }
+    run.status = .running
+    run.updatedAt = now()
+    let effects: [WorkflowRunEffect] = [
+      .log(
+        "Step '\(activation.stepID)': output '\(activation.outputName)' accepted "
+          + "(invocation \(activation.ordinal)); persisting."),
+      .persistOutput(name: activation.outputName, ordinal: activation.ordinal, body: validated.body),
+    ]
+    return (
+      .success(WorkflowDeliveryReceipt(ordinal: activation.ordinal, stepID: activation.stepID, output: record)), effects
+    )
+  }
+
+  private func outputRecord(for activation: WorkflowActivation, verdict: String?) -> WorkflowOutputRecord {
+    WorkflowOutputRecord(
       name: activation.outputName,
       ordinal: activation.ordinal,
       path: WorkflowRunPaths.path(
@@ -396,18 +437,33 @@ nonisolated struct WorkflowRunMachine {
           runDirectory: run.runDirectory, name: activation.outputName, ordinal: activation.ordinal)),
       latestPath: WorkflowRunPaths.path(
         WorkflowRunPaths.outputURL(runDirectory: run.runDirectory, name: activation.outputName, ordinal: nil)),
-      verdict: validated.verdict,
+      verdict: verdict,
       deliveredAt: now()
     )
+  }
+
+  private mutating func applyOutputPersistFailed(ordinal: Int, reason: String, effects: inout [WorkflowRunEffect]) {
+    guard let activation = run.activeActivation, activation.ordinal == ordinal, activation.state == .persisting
+    else { return }
+    raiseAttention(
+      .persistFailed(reason), stepID: activation.stepID, role: activation.role, ordinal: ordinal, effects: &effects)
+  }
+
+  /// The output is on disk: record it, complete the dispatch record, and advance.
+  private mutating func applyOutputPersisted(ordinal: Int, effects: inout [WorkflowRunEffect]) {
+    guard case .waitingForDelivery(ordinal) = run.phase, let activation = run.activeActivation,
+      activation.state == .persisting, let delivery = activation.pendingDelivery
+    else { return }
+    let record = outputRecord(for: activation, verdict: delivery.verdict)
     run.outputs[activation.outputName] = record
     run.skippedOutputs[activation.outputName] = nil
-    updateActivation(ordinal: activation.ordinal) { $0.state = .delivered }
-    var effects: [WorkflowRunEffect] = [
-      .persistOutput(name: activation.outputName, ordinal: activation.ordinal, body: validated.body),
-      .disarmWatchdog(ordinal: activation.ordinal),
-    ]
+    updateActivation(ordinal: ordinal) {
+      $0.state = .delivered
+      $0.pendingDelivery = nil
+    }
+    effects.append(.disarmWatchdog(ordinal: ordinal))
     if let dispatchID = activation.dispatchID {
-      let verdictNote = validated.verdict.map { " with verdict '\($0)'" } ?? ""
+      let verdictNote = delivery.verdict.map { " with verdict '\($0)'" } ?? ""
       effects.append(
         .completeActivation(
           dispatchID: dispatchID,
@@ -415,14 +471,10 @@ nonisolated struct WorkflowRunMachine {
         ))
     }
     effects.append(
-      .log(
-        "Step '\(activation.stepID)': output '\(activation.outputName)' delivered (invocation \(activation.ordinal))."))
+      .log("Step '\(activation.stepID)': output '\(activation.outputName)' delivered (invocation \(ordinal))."))
     run.status = .running
     completeCurrentStep(effects: &effects)
     advance(effects: &effects)
-    return (
-      .success(WorkflowDeliveryReceipt(ordinal: activation.ordinal, stepID: activation.stepID, output: record)), effects
-    )
   }
 
   // MARK: Skip consequence
@@ -446,11 +498,23 @@ nonisolated struct WorkflowRunMachine {
     var loopID: String?
     if fromStart {
       remaining = steps
-    } else if run.position.loop != nil, case .repeat(_, let until, let body) = steps[run.position.index].action {
-      remaining = body
+    } else if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
+      // Readers later in this iteration always count; readers earlier in the body only when
+      // another iteration can follow; steps after the loop only when an `until` can exit it
+      // (without one the loop ends the run as `max_rounds_reached`).
+      if let index = body.firstIndex(where: { $0.id == stepID }) {
+        remaining = Array(body[(index + 1)...])
+        if loop.iteration < loop.max {
+          remaining += body[..<index]
+        }
+      } else {
+        remaining = body
+      }
       loopUntil = until
       loopID = steps[run.position.index].id
-      remaining += steps[(run.position.index + 1)...]
+      if until != nil {
+        remaining += steps[(run.position.index + 1)...]
+      }
     } else {
       remaining = Array(steps[(run.position.index + 1)...])
     }
@@ -719,10 +783,17 @@ nonisolated struct WorkflowRunMachine {
     guard let rendered = render(content.body, step: step, effects: &effects) else { return nil }
     var completion: WorkflowCompletionCommand?
     if let expect, let outputName = step.outputName {
-      let activation = WorkflowActivation(
-        ordinal: ordinal, stepID: step.id, role: invocation.role, token: makeToken(), expect: expect,
-        outputName: outputName, dispatchID: nil, state: .waiting)
-      updateInvocation(ordinal: ordinal) { $0.activation = activation }
+      // A `roleBusy` refusal returns the same invocation to its idle wait: the activation and its
+      // token survive, so the command the run already rendered stays valid (dsl-spec §5).
+      let activation: WorkflowActivation
+      if let existing = invocation.activation, existing.state == .waiting {
+        activation = existing
+      } else {
+        activation = WorkflowActivation(
+          ordinal: ordinal, stepID: step.id, role: invocation.role, token: makeToken(), expect: expect,
+          outputName: outputName, dispatchID: nil, state: .waiting)
+        updateInvocation(ordinal: ordinal) { $0.activation = activation }
+      }
       completion = activation.completion
     }
     do {
@@ -872,7 +943,11 @@ nonisolated struct WorkflowRunMachine {
       advance(effects: &effects)
       return
     }
-    updateActivation(ordinal: ordinal) { $0.dispatchID = dispatchID }
+    let deadline = activation.expect.timeoutSeconds.map { now().addingTimeInterval(TimeInterval($0)) }
+    updateActivation(ordinal: ordinal) {
+      $0.dispatchID = dispatchID
+      if $0.deadline == nil { $0.deadline = deadline }
+    }
     run.phase = .waitingForDelivery(ordinal: ordinal)
     effects.append(.persist)
     effects.append(
@@ -885,11 +960,16 @@ nonisolated struct WorkflowRunMachine {
     guard let invocation = invocation(ordinal), let activation = invocation.activation,
       let surfaceID = run.bindings[invocation.role]?.pane?.surfaceID
     else { return }
+    // The hard cap is an absolute deadline: a re-armed watchdog gets what is left of it.
+    let remaining = activation.deadline.map { max(1, Int($0.timeIntervalSince(now()).rounded(.up))) }
+    if nudgedAlready {
+      effects.append(.disarmWatchdog(ordinal: ordinal))
+    }
     effects.append(
       .armWatchdog(
         WorkflowWatchdogRequest(
           ordinal: ordinal, stepID: invocation.stepID, role: invocation.role, surfaceID: surfaceID,
-          dispatchID: activation.dispatchID, timeoutSeconds: activation.expect.timeoutSeconds,
+          dispatchID: activation.dispatchID, timeoutSeconds: remaining,
           timeoutPolicy: activation.expect.onTimeout ?? .attention, nudgedAlready: nudgedAlready)))
   }
 
@@ -957,6 +1037,14 @@ nonisolated struct WorkflowRunMachine {
       effects.append(.persist)
     case .retry:
       guard let attention, attention.actions.contains(.retry) else { return }
+      if case .persistFailed = attention.reason, let activation = run.activeActivation,
+        let delivery = activation.pendingDelivery
+      {
+        run.status = .running
+        effects.append(.log("Step '\(activation.stepID)': retrying to persist output '\(activation.outputName)'."))
+        effects.append(.persistOutput(name: activation.outputName, ordinal: activation.ordinal, body: delivery.body))
+        return
+      }
       retryCurrentStep(effects: &effects)
     case .relaunch:
       guard let attention, attention.actions.contains(.relaunch) else { return }
@@ -1043,12 +1131,16 @@ nonisolated struct WorkflowRunMachine {
       effects.append(.cancelRoleWait(ordinal: ordinal))
     }
     guard let invocation = run.currentInvocation, let activation = invocation.activation else { return }
-    if activation.state == .waiting {
-      updateActivation(ordinal: activation.ordinal) { $0.state = .revoked }
+    let open = activation.state == .waiting || activation.state == .persisting
+    if open {
+      updateActivation(ordinal: activation.ordinal) {
+        $0.state = .revoked
+        $0.pendingDelivery = nil
+      }
     }
     let endedAt = now()
     updateInvocation(ordinal: activation.ordinal) { $0.endedAt = endedAt }
-    if let dispatchID = activation.dispatchID, activation.state == .waiting {
+    if let dispatchID = activation.dispatchID, open {
       effects.append(.abandonActivation(dispatchID: dispatchID, reason: reason))
     }
     if case .waitingForDelivery = run.phase {
@@ -1073,7 +1165,7 @@ nonisolated struct WorkflowRunMachine {
       case .injectionFailed: [.retry, .skip, .cancel]
       case .launchFailed: [.retry, .skip, .cancel]
       case .renderedTextInvalid: [.skip, .cancel]
-      case .actionFailed: [.retry, .cancel]
+      case .actionFailed, .persistFailed: [.retry, .cancel]
       }
     let attention = WorkflowAttention(
       reason: reason, stepID: stepID, role: role, ordinal: ordinal, actions: actions,
@@ -1127,6 +1219,8 @@ nonisolated struct WorkflowRunMachine {
       return "The rendered line of step '\(stepID)' is not a single terminal line; nothing was typed."
     case .actionFailed(let detail):
       return "Step '\(stepID)' failed: \(detail)"
+    case .persistFailed(let detail):
+      return "The delivered output of step '\(stepID)' could not be saved to the run directory: \(detail)"
     case .timeout:
       return "Step '\(stepID)' reached its timeout without a delivery from \(subject)."
     }

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -310,7 +310,9 @@ nonisolated struct WorkflowRunStore: Sendable {
   /// that the run directory is physically inside the runs directory (no symlink leaf).
   func ensureLayout(runID: UUID) throws {
     let fileManager = FileManager.default
+    try requireOwnedBase()
     try fileManager.createDirectory(at: runsDirectory, withIntermediateDirectories: true)
+    try requireOwnedBase()
     let ignoreURL = runsDirectory.appending(path: Self.ignoreFileName, directoryHint: .notDirectory)
     if !fileManager.fileExists(atPath: ignoreURL.path(percentEncoded: false)) {
       try "*\n".write(to: ignoreURL, atomically: true, encoding: .utf8)
@@ -327,6 +329,7 @@ nonisolated struct WorkflowRunStore: Sendable {
   /// The run directory after the containment gate (`AgentProfileHomeProvisioner` pattern):
   /// lexical containment, no symlink leaf, canonical parent + leaf inside the canonical base.
   func containedRunDirectory(runID: UUID) throws -> URL {
+    try requireOwnedBase()
     let runDirectory = directory(for: runID)
     let path = AgentProfileLaunchPlanner.pathString(runDirectory)
     guard AgentProfileLaunchPlanner.isContained(runDirectory, in: runsDirectory) else {
@@ -353,7 +356,8 @@ nonisolated struct WorkflowRunStore: Sendable {
   }
 
   func readRecord(runID: UUID) throws -> WorkflowRunRecord {
-    let url = directory(for: runID).appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
+    let runDirectory = try containedRunDirectory(runID: runID)
+    let url = runDirectory.appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
     try requireNotSymbolicLink(url)
     return try Self.decodeRecord(at: url)
   }
@@ -494,6 +498,16 @@ nonisolated struct WorkflowRunStore: Sendable {
   }
 
   // MARK: Helpers
+
+  /// `<root>/.prowl` and `<root>/.prowl/workflow-runs` are Prowl-owned directories: a link in
+  /// their place (which a repository can ship) would move every run artifact elsewhere, so
+  /// both are refused when they are symbolic links. Static links are the threat this closes;
+  /// a concurrent local process swapping directories between check and use is outside the
+  /// model (it already runs as the user).
+  private func requireOwnedBase() throws {
+    try requireNotSymbolicLink(rootURL.appending(path: ".prowl", directoryHint: .isDirectory))
+    try requireNotSymbolicLink(runsDirectory)
+  }
 
   private func requireNotSymbolicLink(_ url: URL) throws {
     let path = AgentProfileLaunchPlanner.pathString(url)

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -1,0 +1,492 @@
+// supacode/Domain/Workflow/WorkflowRunStore.swift
+// The run directory (dsl-spec §8): `<root>/.prowl/workflow-runs/<run-id>/` with `run.json`,
+// an append-only `log.md`, materialized instructions and skills, and versioned outputs with an
+// atomically replaced latest view. Every path is built from validated slugs and the run UUID
+// under the same physical containment gate as profile homes.
+
+import Darwin
+import Foundation
+
+// MARK: - run.json
+
+nonisolated struct WorkflowRunRecordInvocation: Codable, Equatable, Sendable {
+  let ordinal: Int
+  let step: String
+  let iteration: Int?
+  let role: String
+  let kind: WorkflowInvocationKind
+  let instructionPath: String?
+  let activation: WorkflowRunRecordActivation?
+  let startedAt: Date
+  let endedAt: Date?
+
+  enum CodingKeys: String, CodingKey {
+    case ordinal
+    case step
+    case iteration
+    case role
+    case kind
+    case instructionPath = "instruction_path"
+    case activation
+    case startedAt = "started_at"
+    case endedAt = "ended_at"
+  }
+}
+
+nonisolated struct WorkflowRunRecordActivation: Codable, Equatable, Sendable {
+  let dispatchID: String?
+  let state: WorkflowActivationState
+  let output: String
+
+  enum CodingKeys: String, CodingKey {
+    case dispatchID = "dispatch_id"
+    case state
+    case output
+  }
+}
+
+nonisolated struct WorkflowRunRecordInfo: Codable, Equatable, Sendable {
+  let id: UUID
+  let workflowID: String
+  let workflowName: String
+  let scope: WorkflowRunScope
+  let definitionPath: String?
+  let status: WorkflowRunRecord.Status
+  let startedAt: Date
+  let updatedAt: Date
+  let finishedAt: Date?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case workflowID = "workflow_id"
+    case workflowName = "workflow_name"
+    case scope
+    case definitionPath = "definition_path"
+    case status
+    case startedAt = "started_at"
+    case updatedAt = "updated_at"
+    case finishedAt = "finished_at"
+  }
+}
+
+/// The persisted snapshot of a run (decision H5 of docs-ai 063.007). Carries profile UUID/name
+/// and agent tokens, pane ids, dispatch ids, and paths — never delivery tokens, environment
+/// values, extra arguments, home paths, or credentials. Readers tolerate unknown keys.
+nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
+  static let currentVersion = 1
+  static let fileName = "run.json"
+
+  struct Attention: Codable, Equatable, Sendable {
+    let reason: String
+    let message: String
+    let actions: [WorkflowAttentionAction]
+    let step: String
+    let role: String?
+    let ordinal: Int?
+  }
+
+  struct Status: Codable, Equatable, Sendable {
+    let state: String
+    let step: String?
+    let dependent: String?
+    let attention: Attention?
+  }
+
+  struct Binding: Codable, Equatable, Sendable {
+    let source: WorkflowRoleSource
+    let profile: WorkflowProfileBinding?
+    let pane: WorkflowPaneIdentity?
+  }
+
+  struct Step: Codable, Equatable, Sendable {
+    let id: String
+    let iteration: Int?
+    let state: WorkflowStepState
+    let ordinal: Int?
+  }
+
+  struct Loop: Codable, Equatable, Sendable {
+    let count: Int
+  }
+
+  let version: Int
+  let run: WorkflowRunRecordInfo
+  let worktree: WorkflowRunWorktree
+  let inputs: [String: String]
+  let bindings: [String: Binding]
+  let invocations: [WorkflowRunRecordInvocation]
+  let outputs: [String: WorkflowOutputRecord]
+  let actions: [String: [String: String]]
+  let skippedOutputs: [String: String]
+  let loop: Loop
+  let steps: [Step]
+
+  enum CodingKeys: String, CodingKey {
+    case version
+    case run
+    case worktree
+    case inputs
+    case bindings
+    case invocations
+    case outputs
+    case actions
+    case skippedOutputs = "skipped_outputs"
+    case loop
+    case steps
+  }
+
+  init(run: WorkflowRun) {
+    version = Self.currentVersion
+    self.run = WorkflowRunRecordInfo(
+      id: run.id,
+      workflowID: run.definition.id,
+      workflowName: run.definition.name,
+      scope: run.context.scope,
+      definitionPath: run.context.definitionPath,
+      status: Status(run.status),
+      startedAt: run.startedAt,
+      updatedAt: run.updatedAt,
+      finishedAt: run.finishedAt
+    )
+    worktree = run.context.worktree
+    inputs = run.inputs
+    bindings = run.bindings.mapValues { Binding(source: $0.source, profile: $0.profile, pane: $0.pane) }
+    invocations = run.invocations.map { invocation in
+      WorkflowRunRecordInvocation(
+        ordinal: invocation.ordinal,
+        step: invocation.stepID,
+        iteration: invocation.iteration,
+        role: invocation.role,
+        kind: invocation.kind,
+        instructionPath: invocation.instructionPath,
+        activation: invocation.activation.map {
+          WorkflowRunRecordActivation(dispatchID: $0.dispatchID, state: $0.state, output: $0.outputName)
+        },
+        startedAt: invocation.startedAt,
+        endedAt: invocation.endedAt
+      )
+    }
+    outputs = run.outputs
+    actions = run.actionOutputs
+    skippedOutputs = run.skippedOutputs
+    loop = Loop(count: run.loopCount)
+    steps = run.stepRecords.map { Step(id: $0.stepID, iteration: $0.iteration, state: $0.state, ordinal: $0.ordinal) }
+  }
+
+  private init(interrupting record: WorkflowRunRecord, at date: Date) {
+    version = record.version
+    run = WorkflowRunRecordInfo(
+      id: record.run.id,
+      workflowID: record.run.workflowID,
+      workflowName: record.run.workflowName,
+      scope: record.run.scope,
+      definitionPath: record.run.definitionPath,
+      status: Status(.interrupted),
+      startedAt: record.run.startedAt,
+      updatedAt: date,
+      finishedAt: date
+    )
+    worktree = record.worktree
+    inputs = record.inputs
+    bindings = record.bindings
+    invocations = record.invocations
+    outputs = record.outputs
+    actions = record.actions
+    skippedOutputs = record.skippedOutputs
+    loop = record.loop
+    steps = record.steps
+  }
+
+  func interrupted(at date: Date) -> WorkflowRunRecord {
+    WorkflowRunRecord(interrupting: self, at: date)
+  }
+
+  static func makeEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    encoder.dateEncodingStrategy = .iso8601
+    return encoder
+  }
+
+  static func makeDecoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }
+}
+
+extension WorkflowRunRecord.Status {
+  nonisolated init(_ status: WorkflowRunStatus) {
+    switch status {
+    case .running:
+      self.init(state: "running", step: nil, dependent: nil, attention: nil)
+    case .needsAttention(let attention):
+      self.init(
+        state: "needs_attention", step: attention.stepID, dependent: nil,
+        attention: WorkflowRunRecord.Attention(
+          reason: attention.reason.code, message: attention.message, actions: attention.actions,
+          step: attention.stepID, role: attention.role, ordinal: attention.ordinal))
+    case .completed:
+      self.init(state: "completed", step: nil, dependent: nil, attention: nil)
+    case .cancelled:
+      self.init(state: "cancelled", step: nil, dependent: nil, attention: nil)
+    case .skipped(let step, let dependent):
+      self.init(state: "skipped", step: step, dependent: dependent, attention: nil)
+    case .maxRoundsReached:
+      self.init(state: "max_rounds_reached", step: nil, dependent: nil, attention: nil)
+    case .interrupted:
+      self.init(state: "interrupted", step: nil, dependent: nil, attention: nil)
+    }
+  }
+
+  nonisolated var isTerminal: Bool {
+    state != "running" && state != "needs_attention"
+  }
+}
+
+extension WorkflowAttentionReason {
+  nonisolated var code: String {
+    switch self {
+    case .needsInput: "needs_input"
+    case .idleWithoutDelivery: "idle_without_delivery"
+    case .blocked: "blocked"
+    case .agentGone(let reason): "agent_gone:\(reason.rawValue)"
+    case .injectionFailed(let failure):
+      switch failure {
+      case .roleBusy: "injection_failed:role_busy"
+      case .roleBlocked: "injection_failed:role_blocked"
+      case .surfaceMissing: "injection_failed:surface_missing"
+      case .insertFailed: "injection_failed:insert_failed"
+      case .submitFailed: "injection_failed:submit_failed"
+      case .activationUnavailable: "injection_failed:activation_unavailable"
+      }
+    case .launchFailed: "launch_failed"
+    case .renderedTextInvalid: "rendered_text_invalid"
+    case .actionFailed: "action_failed"
+    case .timeout: "timeout"
+    }
+  }
+}
+
+// MARK: - Store
+
+nonisolated enum WorkflowRunStoreError: Error, Equatable, Sendable {
+  /// A path component is not a validated slug, or the resolved path leaves the runs directory.
+  case unsafePath(String)
+  /// The run directory or one of its subdirectories is a symbolic link.
+  case symbolicLink(String)
+  case unreadableRecord(String)
+  case skillMissing(String)
+}
+
+/// Result of the launch-time scan for runs a previous app instance left behind.
+nonisolated struct WorkflowInterruptedRuns: Equatable, Sendable {
+  let interrupted: [UUID]
+  /// Run directories whose `run.json` could not be read or decoded; left untouched.
+  let unreadable: [String]
+}
+
+nonisolated struct WorkflowRunStore: Sendable {
+  static let ignoreFileName = ".gitignore"
+  static let logFileName = "log.md"
+
+  let rootURL: URL
+
+  init(rootURL: URL) {
+    self.rootURL = rootURL.standardizedFileURL
+  }
+
+  var runsDirectory: URL { WorkflowRunPaths.runsDirectory(root: rootURL) }
+
+  func directory(for runID: UUID) -> URL {
+    WorkflowRunPaths.runDirectory(root: rootURL, runID: runID)
+  }
+
+  // MARK: Layout
+
+  /// Creates `<runs>/.gitignore` and the run directory with its subdirectories, after proving
+  /// that the run directory is physically inside the runs directory (no symlink leaf).
+  func ensureLayout(runID: UUID) throws {
+    let fileManager = FileManager.default
+    try fileManager.createDirectory(at: runsDirectory, withIntermediateDirectories: true)
+    let ignoreURL = runsDirectory.appending(path: Self.ignoreFileName, directoryHint: .notDirectory)
+    if !fileManager.fileExists(atPath: ignoreURL.path(percentEncoded: false)) {
+      try "*\n".write(to: ignoreURL, atomically: true, encoding: .utf8)
+    }
+    let runDirectory = try containedRunDirectory(runID: runID)
+    try fileManager.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+    for name in ["instructions", "outputs", "skills"] {
+      let subdirectory = runDirectory.appending(path: name, directoryHint: .isDirectory)
+      try requireNotSymbolicLink(subdirectory)
+      try fileManager.createDirectory(at: subdirectory, withIntermediateDirectories: true)
+    }
+  }
+
+  /// The run directory after the containment gate (`AgentProfileHomeProvisioner` pattern):
+  /// lexical containment, no symlink leaf, canonical parent + leaf inside the canonical base.
+  func containedRunDirectory(runID: UUID) throws -> URL {
+    let runDirectory = directory(for: runID)
+    let path = AgentProfileLaunchPlanner.pathString(runDirectory)
+    guard AgentProfileLaunchPlanner.isContained(runDirectory, in: runsDirectory) else {
+      throw WorkflowRunStoreError.unsafePath(path)
+    }
+    do {
+      try AgentProfileHomeProvisioner.validatePhysicalContainment(home: runDirectory, base: runsDirectory)
+    } catch AgentProfileLaunchPlanError.homeIsSymbolicLink {
+      throw WorkflowRunStoreError.symbolicLink(path)
+    } catch {
+      throw WorkflowRunStoreError.unsafePath(path)
+    }
+    return runDirectory
+  }
+
+  // MARK: run.json
+
+  func writeRecord(_ record: WorkflowRunRecord) throws {
+    let runDirectory = try containedRunDirectory(runID: record.run.id)
+    let data = try WorkflowRunRecord.makeEncoder().encode(record)
+    try data.write(
+      to: runDirectory.appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory), options: .atomic)
+  }
+
+  func readRecord(runID: UUID) throws -> WorkflowRunRecord {
+    let url = directory(for: runID).appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
+    return try Self.decodeRecord(at: url)
+  }
+
+  private static func decodeRecord(at url: URL) throws -> WorkflowRunRecord {
+    let data: Data
+    do {
+      data = try Data(contentsOf: url)
+    } catch {
+      throw WorkflowRunStoreError.unreadableRecord(url.path(percentEncoded: false))
+    }
+    do {
+      return try WorkflowRunRecord.makeDecoder().decode(WorkflowRunRecord.self, from: data)
+    } catch {
+      throw WorkflowRunStoreError.unreadableRecord(url.path(percentEncoded: false))
+    }
+  }
+
+  // MARK: log.md
+
+  func appendLog(runID: UUID, line: String, now: Date) throws {
+    let runDirectory = try containedRunDirectory(runID: runID)
+    let logURL = runDirectory.appending(path: Self.logFileName, directoryHint: .notDirectory)
+    let fileManager = FileManager.default
+    if !fileManager.fileExists(atPath: logURL.path(percentEncoded: false)) {
+      try "# Workflow run \(runID.uuidString)\n\n".write(to: logURL, atomically: true, encoding: .utf8)
+    }
+    let entry = "- \(Self.timestamp(now))  \(line.replacing("\n", with: " "))\n"
+    let handle = try FileHandle(forWritingTo: logURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: Data(entry.utf8))
+  }
+
+  // MARK: Instructions and outputs
+
+  @discardableResult
+  func writeInstruction(runID: UUID, stepID: String, ordinal: Int, text: String) throws -> URL {
+    let runDirectory = try containedRunDirectory(runID: runID)
+    guard WorkflowSchema.isSlug(stepID), ordinal > 0 else { throw WorkflowRunStoreError.unsafePath(stepID) }
+    let url = WorkflowRunPaths.instructionURL(runDirectory: runDirectory, stepID: stepID, ordinal: ordinal)
+    try requireNotSymbolicLink(url.deletingLastPathComponent())
+    try text.write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  /// Writes `outputs/<name>.<ordinal>.md` and replaces `outputs/<name>.md` atomically
+  /// (temp file + rename), so a reader never sees a partially written latest view.
+  @discardableResult
+  func writeOutput(runID: UUID, name: String, ordinal: Int, body: String) throws -> (versioned: URL, latest: URL) {
+    let runDirectory = try containedRunDirectory(runID: runID)
+    guard WorkflowSchema.isSlug(name), ordinal > 0 else { throw WorkflowRunStoreError.unsafePath(name) }
+    let versioned = WorkflowRunPaths.outputURL(runDirectory: runDirectory, name: name, ordinal: ordinal)
+    let latest = WorkflowRunPaths.outputURL(runDirectory: runDirectory, name: name, ordinal: nil)
+    try requireNotSymbolicLink(versioned.deletingLastPathComponent())
+    let data = Data(body.utf8)
+    try data.write(to: versioned, options: .atomic)
+    let temporary = latest.deletingLastPathComponent()
+      .appending(path: ".\(name).md.\(UUID().uuidString).tmp", directoryHint: .notDirectory)
+    try data.write(to: temporary)
+    guard rename(temporary.path(percentEncoded: false), latest.path(percentEncoded: false)) == 0 else {
+      let code = errno
+      try? FileManager.default.removeItem(at: temporary)
+      throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+    }
+    return (versioned, latest)
+  }
+
+  // MARK: Skills
+
+  /// Copies a bundled skill directory to `skills/<id>/` so a sandboxed agent can read it from
+  /// the worktree. Only bundled skills are materialized (dsl-spec §4).
+  @discardableResult
+  func materializeSkill(runID: UUID, skill: BundledSkill) throws -> URL {
+    let runDirectory = try containedRunDirectory(runID: runID)
+    guard WorkflowSchema.isWorkflowID(skill.id) else { throw WorkflowRunStoreError.unsafePath(skill.id) }
+    let fileManager = FileManager.default
+    let skillFile = skill.directoryURL.appending(path: "SKILL.md", directoryHint: .notDirectory)
+    guard fileManager.fileExists(atPath: skillFile.path(percentEncoded: false)) else {
+      throw WorkflowRunStoreError.skillMissing(skill.id)
+    }
+    let destination = WorkflowRunPaths.skillDirectory(runDirectory: runDirectory, skillID: skill.id)
+    try requireNotSymbolicLink(destination.deletingLastPathComponent())
+    if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+      try fileManager.removeItem(at: destination)
+    }
+    try fileManager.copyItem(at: skill.directoryURL, to: destination)
+    return destination
+  }
+
+  // MARK: Restart
+
+  /// V1 has no resume: every run left `running` / `needs_attention` on disk becomes
+  /// `interrupted`. Records that cannot be read or decoded are reported and left alone.
+  func markInterruptedRuns(now: Date) throws -> WorkflowInterruptedRuns {
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: runsDirectory.path(percentEncoded: false)) else {
+      return WorkflowInterruptedRuns(interrupted: [], unreadable: [])
+    }
+    let entries = try fileManager.contentsOfDirectory(
+      at: runsDirectory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
+    var interrupted: [UUID] = []
+    var unreadable: [String] = []
+    for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+      guard let runID = UUID(uuidString: entry.lastPathComponent) else { continue }
+      let recordURL = directory(for: runID).appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
+      guard fileManager.fileExists(atPath: recordURL.path(percentEncoded: false)) else { continue }
+      let record: WorkflowRunRecord
+      do {
+        record = try Self.decodeRecord(at: recordURL)
+        _ = try containedRunDirectory(runID: runID)
+      } catch {
+        unreadable.append(recordURL.path(percentEncoded: false))
+        continue
+      }
+      guard record.version == WorkflowRunRecord.currentVersion, !record.run.status.isTerminal else { continue }
+      try writeRecord(record.interrupted(at: now))
+      try appendLog(runID: runID, line: "Run marked interrupted at app launch (no resume in V1).", now: now)
+      interrupted.append(runID)
+    }
+    return WorkflowInterruptedRuns(interrupted: interrupted, unreadable: unreadable)
+  }
+
+  // MARK: Helpers
+
+  private func requireNotSymbolicLink(_ url: URL) throws {
+    let path = AgentProfileLaunchPlanner.pathString(url)
+    if let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+      attributes[.type] as? FileAttributeType == .typeSymbolicLink
+    {
+      throw WorkflowRunStoreError.symbolicLink(path)
+    }
+  }
+
+  private static func timestamp(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.string(from: date)
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -83,6 +83,8 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
     let step: String
     let role: String?
     let ordinal: Int?
+    /// Issue codes of a provisional delivery (`delivery_issues` only).
+    let issues: [String]?
   }
 
   struct Status: Codable, Equatable, Sendable {
@@ -226,7 +228,8 @@ extension WorkflowRunRecord.Status {
         state: "needs_attention", step: attention.stepID, dependent: nil,
         attention: WorkflowRunRecord.Attention(
           reason: attention.reason.code, message: attention.message, actions: attention.actions,
-          step: attention.stepID, role: attention.role, ordinal: attention.ordinal))
+          step: attention.stepID, role: attention.role, ordinal: attention.ordinal,
+          issues: attention.reason.issueCodes))
     case .completed:
       self.init(state: "completed", step: nil, dependent: nil, attention: nil)
     case .cancelled:
@@ -246,6 +249,11 @@ extension WorkflowRunRecord.Status {
 }
 
 extension WorkflowAttentionReason {
+  nonisolated var issueCodes: [String]? {
+    if case .deliveryIssues(let issues) = self { return issues.map(\.code) }
+    return nil
+  }
+
   nonisolated var code: String {
     switch self {
     case .needsInput: "needs_input"
@@ -265,6 +273,7 @@ extension WorkflowAttentionReason {
     case .renderedTextInvalid: "rendered_text_invalid"
     case .actionFailed: "action_failed"
     case .persistFailed: "persist_failed"
+    case .deliveryIssues: "delivery_issues"
     case .timeout: "timeout"
     }
   }

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -270,6 +270,22 @@ extension WorkflowAttentionReason {
   }
 }
 
+/// The restart scan's view of a record: enough to tell version and state, nothing else.
+nonisolated private struct WorkflowRunRecordHeaderStatus: Decodable {
+  let state: String
+}
+
+nonisolated private struct WorkflowRunRecordHeader: Decodable {
+  struct Run: Decodable {
+    let status: WorkflowRunRecordHeaderStatus
+  }
+
+  let version: Int
+  let run: Run
+
+  var isTerminal: Bool { run.status.state != "running" && run.status.state != "needs_attention" }
+}
+
 // MARK: - Store
 
 nonisolated enum WorkflowRunStoreError: Error, Equatable, Sendable {
@@ -467,34 +483,54 @@ nonisolated struct WorkflowRunStore: Sendable {
   // MARK: Restart
 
   /// V1 has no resume: every run left `running` / `needs_attention` on disk becomes
-  /// `interrupted`. Records that cannot be read or decoded are reported and left alone.
+  /// `interrupted`. Only a small header (`version`, `run.status.state`) is read before a run is
+  /// selected, so a record of another version is left alone; a v1 record that cannot be decoded
+  /// or a run directory that fails the containment gate is reported and left untouched.
   func markInterruptedRuns(now: Date) throws -> WorkflowInterruptedRuns {
     let fileManager = FileManager.default
     guard fileManager.fileExists(atPath: runsDirectory.path(percentEncoded: false)) else {
       return WorkflowInterruptedRuns(interrupted: [], unreadable: [])
     }
+    try requireOwnedBase()
     let entries = try fileManager.contentsOfDirectory(
       at: runsDirectory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
     var interrupted: [UUID] = []
     var unreadable: [String] = []
     for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
       guard let runID = UUID(uuidString: entry.lastPathComponent) else { continue }
-      let recordURL = directory(for: runID).appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
+      let runDirectory: URL
+      do {
+        runDirectory = try containedRunDirectory(runID: runID)
+      } catch {
+        unreadable.append(AgentProfileLaunchPlanner.pathString(directory(for: runID)))
+        continue
+      }
+      let recordURL = runDirectory.appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
       guard fileManager.fileExists(atPath: recordURL.path(percentEncoded: false)) else { continue }
+      let recordPath = recordURL.path(percentEncoded: false)
+      guard let header = try? Self.decodeHeader(at: recordURL) else {
+        unreadable.append(recordPath)
+        continue
+      }
+      guard header.version == WorkflowRunRecord.currentVersion, !header.isTerminal else { continue }
       let record: WorkflowRunRecord
       do {
         record = try Self.decodeRecord(at: recordURL)
-        _ = try containedRunDirectory(runID: runID)
       } catch {
-        unreadable.append(recordURL.path(percentEncoded: false))
+        unreadable.append(recordPath)
         continue
       }
-      guard record.version == WorkflowRunRecord.currentVersion, !record.run.status.isTerminal else { continue }
       try writeRecord(record.interrupted(at: now))
       try appendLog(runID: runID, line: "Run marked interrupted at app launch (no resume in V1).", now: now)
       interrupted.append(runID)
     }
     return WorkflowInterruptedRuns(interrupted: interrupted, unreadable: unreadable)
+  }
+
+  private static func decodeHeader(at url: URL) throws -> WorkflowRunRecordHeader {
+    try requireNotSymbolicLinkStatic(url)
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(WorkflowRunRecordHeader.self, from: data)
   }
 
   // MARK: Helpers
@@ -510,6 +546,10 @@ nonisolated struct WorkflowRunStore: Sendable {
   }
 
   private func requireNotSymbolicLink(_ url: URL) throws {
+    try Self.requireNotSymbolicLinkStatic(url)
+  }
+
+  private static func requireNotSymbolicLinkStatic(_ url: URL) throws {
     let path = AgentProfileLaunchPlanner.pathString(url)
     if let attributes = try? FileManager.default.attributesOfItem(atPath: path),
       attributes[.type] as? FileAttributeType == .typeSymbolicLink

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -112,7 +112,8 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
   let version: Int
   let run: WorkflowRunRecordInfo
   let worktree: WorkflowRunWorktree
-  let inputs: [String: String]
+  /// Input names only: values are workflow-defined text and may be anything the user typed.
+  let inputs: [String]
   let bindings: [String: Binding]
   let invocations: [WorkflowRunRecordInvocation]
   let outputs: [String: WorkflowOutputRecord]
@@ -149,7 +150,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
       finishedAt: run.finishedAt
     )
     worktree = run.context.worktree
-    inputs = run.inputs
+    inputs = run.inputs.keys.sorted()
     bindings = run.bindings.mapValues { Binding(source: $0.source, profile: $0.profile, pane: $0.pane) }
     invocations = run.invocations.map { invocation in
       WorkflowRunRecordInvocation(
@@ -263,6 +264,7 @@ extension WorkflowAttentionReason {
     case .launchFailed: "launch_failed"
     case .renderedTextInvalid: "rendered_text_invalid"
     case .actionFailed: "action_failed"
+    case .persistFailed: "persist_failed"
     case .timeout: "timeout"
     }
   }
@@ -345,12 +347,14 @@ nonisolated struct WorkflowRunStore: Sendable {
   func writeRecord(_ record: WorkflowRunRecord) throws {
     let runDirectory = try containedRunDirectory(runID: record.run.id)
     let data = try WorkflowRunRecord.makeEncoder().encode(record)
+    try requireNotSymbolicLink(runDirectory.appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory))
     try data.write(
       to: runDirectory.appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory), options: .atomic)
   }
 
   func readRecord(runID: UUID) throws -> WorkflowRunRecord {
     let url = directory(for: runID).appending(path: WorkflowRunRecord.fileName, directoryHint: .notDirectory)
+    try requireNotSymbolicLink(url)
     return try Self.decodeRecord(at: url)
   }
 
@@ -370,17 +374,30 @@ nonisolated struct WorkflowRunStore: Sendable {
 
   // MARK: log.md
 
+  /// Appends through an `O_NOFOLLOW` descriptor: a `log.md` swapped for a symbolic link is
+  /// refused instead of followed, so the run can never append to a file outside its directory.
   func appendLog(runID: UUID, line: String, now: Date) throws {
     let runDirectory = try containedRunDirectory(runID: runID)
     let logURL = runDirectory.appending(path: Self.logFileName, directoryHint: .notDirectory)
-    let fileManager = FileManager.default
-    if !fileManager.fileExists(atPath: logURL.path(percentEncoded: false)) {
-      try "# Workflow run \(runID.uuidString)\n\n".write(to: logURL, atomically: true, encoding: .utf8)
+    let path = logURL.path(percentEncoded: false)
+    try requireNotSymbolicLink(logURL)
+    let descriptor = Darwin.open(path, O_WRONLY | O_APPEND | O_CREAT | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+    guard descriptor >= 0 else {
+      let code = errno
+      if code == ELOOP { throw WorkflowRunStoreError.symbolicLink(path) }
+      throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
     }
-    let entry = "- \(Self.timestamp(now))  \(line.replacing("\n", with: " "))\n"
-    let handle = try FileHandle(forWritingTo: logURL)
+    let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
     defer { try? handle.close() }
-    try handle.seekToEnd()
+    var statistics = stat()
+    guard fstat(descriptor, &statistics) == 0, (statistics.st_mode & S_IFMT) == S_IFREG else {
+      throw WorkflowRunStoreError.unsafePath(path)
+    }
+    var entry = ""
+    if statistics.st_size == 0 {
+      entry += "# Workflow run \(runID.uuidString)\n\n"
+    }
+    entry += "- \(Self.timestamp(now))  \(line.replacing("\n", with: " "))\n"
     try handle.write(contentsOf: Data(entry.utf8))
   }
 
@@ -392,6 +409,7 @@ nonisolated struct WorkflowRunStore: Sendable {
     guard WorkflowSchema.isSlug(stepID), ordinal > 0 else { throw WorkflowRunStoreError.unsafePath(stepID) }
     let url = WorkflowRunPaths.instructionURL(runDirectory: runDirectory, stepID: stepID, ordinal: ordinal)
     try requireNotSymbolicLink(url.deletingLastPathComponent())
+    try requireNotSymbolicLink(url)
     try text.write(to: url, atomically: true, encoding: .utf8)
     return url
   }
@@ -405,6 +423,8 @@ nonisolated struct WorkflowRunStore: Sendable {
     let versioned = WorkflowRunPaths.outputURL(runDirectory: runDirectory, name: name, ordinal: ordinal)
     let latest = WorkflowRunPaths.outputURL(runDirectory: runDirectory, name: name, ordinal: nil)
     try requireNotSymbolicLink(versioned.deletingLastPathComponent())
+    try requireNotSymbolicLink(versioned)
+    try requireNotSymbolicLink(latest)
     let data = Data(body.utf8)
     try data.write(to: versioned, options: .atomic)
     let temporary = latest.deletingLastPathComponent()

--- a/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
@@ -104,54 +104,69 @@ extension WorkflowTemplate {
     throws(WorkflowTemplateError) -> String
   {
     let parts = reference.components
-    switch (parts.first, parts.count) {
-    case ("run", 2):
-      switch parts[1] {
-      case "id": return context.run.id
-      case "dir": return context.run.directory
-      default: break
+    let value: String? =
+      switch (parts.first, parts.count) {
+      case ("run", 2): runValue(parts[1], context: context)
+      case ("worktree", 2): worktreeValue(parts[1], context: context)
+      case ("inputs", 2): context.inputs[parts[1]]
+      case ("loop", 2): loopValue(parts[1], context: context)
+      case ("roles", 3): try roleValue(parts[1], field: parts[2], context: context)
+      case ("outputs", 3): try outputValue(parts[1], field: parts[2], context: context)
+      case ("actions", 3): context.actions[parts[1]]?[parts[2]]
+      default: nil
       }
-    case ("worktree", 2):
-      switch parts[1] {
-      case "path": return context.worktree.path
-      case "name": return context.worktree.name
-      case "branch": return context.worktree.branch
-      default: break
-      }
-    case ("inputs", 2):
-      if let value = context.inputs[parts[1]] { return value }
-    case ("loop", 2):
-      switch parts[1] {
-      case "index":
-        if let index = context.loop.index { return String(index) }
-      case "count":
-        return String(context.loop.count)
-      default: break
-      }
-    case ("roles", 3):
-      if let role = context.roles[parts[1]] {
-        switch parts[2] {
-        case "name": return role.name
-        case "agent": return role.agent
-        case "pane":
-          guard let pane = role.pane else { throw .paneUnavailable(role: parts[1]) }
-          return pane
-        default: break
-        }
-      }
-    case ("outputs", 3):
-      guard ["path", "verdict"].contains(parts[2]) else { break }
-      guard !context.skippedOutputs.contains(parts[1]), let output = context.outputs[parts[1]] else {
-        throw .missingOutput(name: parts[1])
-      }
-      if parts[2] == "path" { return output.path }
-      guard let verdict = output.verdict else { throw .verdictUnavailable(output: parts[1]) }
-      return verdict
-    case ("actions", 3):
-      if let value = context.actions[parts[1]]?[parts[2]] { return value }
-    default:
-      break
+    guard let value else { throw .unknownVariable(reference.path) }
+    return value
+  }
+
+  private nonisolated static func runValue(_ field: String, context: WorkflowTemplateContext) -> String? {
+    switch field {
+    case "id": context.run.id
+    case "dir": context.run.directory
+    default: nil
     }
-    throw .unknownVariable(reference.path)
+  }
+
+  private nonisolated static func worktreeValue(_ field: String, context: WorkflowTemplateContext) -> String? {
+    switch field {
+    case "path": context.worktree.path
+    case "name": context.worktree.name
+    case "branch": context.worktree.branch
+    default: nil
+    }
+  }
+
+  private nonisolated static func loopValue(_ field: String, context: WorkflowTemplateContext) -> String? {
+    switch field {
+    case "index": context.loop.index.map(String.init)
+    case "count": String(context.loop.count)
+    default: nil
+    }
+  }
+
+  private nonisolated static func roleValue(
+    _ role: String, field: String, context: WorkflowTemplateContext
+  ) throws(WorkflowTemplateError) -> String? {
+    guard let binding = context.roles[role] else { return nil }
+    switch field {
+    case "name": return binding.name
+    case "agent": return binding.agent
+    case "pane":
+      guard let pane = binding.pane else { throw .paneUnavailable(role: role) }
+      return pane
+    default: return nil
+    }
+  }
+
+  private nonisolated static func outputValue(
+    _ name: String, field: String, context: WorkflowTemplateContext
+  ) throws(WorkflowTemplateError) -> String? {
+    guard ["path", "verdict"].contains(field) else { return nil }
+    guard !context.skippedOutputs.contains(name), let output = context.outputs[name] else {
+      throw .missingOutput(name: name)
+    }
+    if field == "path" { return output.path }
+    guard let verdict = output.verdict else { throw .verdictUnavailable(output: name) }
+    return verdict
   }
 }

--- a/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
@@ -76,7 +76,9 @@ nonisolated enum WorkflowTemplateError: Error, Equatable, Sendable {
 }
 
 extension WorkflowTemplate {
-  nonisolated static func render(_ text: String, context: WorkflowTemplateContext) throws(WorkflowTemplateError) -> String {
+  nonisolated static func render(_ text: String, context: WorkflowTemplateContext) throws(WorkflowTemplateError)
+    -> String
+  {
     guard containsReference(text) else { return text }
     let references: [Reference]
     do {
@@ -98,7 +100,9 @@ extension WorkflowTemplate {
     return rendered
   }
 
-  nonisolated static func value(for reference: Reference, context: WorkflowTemplateContext) throws(WorkflowTemplateError) -> String {
+  nonisolated static func value(for reference: Reference, context: WorkflowTemplateContext)
+    throws(WorkflowTemplateError) -> String
+  {
     let parts = reference.components
     switch (parts.first, parts.count) {
     case ("run", 2):

--- a/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
@@ -1,0 +1,153 @@
+// supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
+// Substitution of the dsl-spec §6 whitelist over a typed context. Substituted values are never
+// re-scanned, and a reference to a skipped output is the runtime side of the §5 Skip rule.
+
+import Foundation
+
+nonisolated struct WorkflowTemplateContext: Equatable, Sendable {
+  struct Run: Equatable, Sendable {
+    let id: String
+    let directory: String
+  }
+
+  struct Worktree: Equatable, Sendable {
+    let path: String
+    let name: String
+    let branch: String
+  }
+
+  struct Role: Equatable, Sendable {
+    let name: String
+    let agent: String
+    /// The pane short handle (`p12`); nil until a launch role is launched.
+    let pane: String?
+  }
+
+  struct Output: Equatable, Sendable {
+    let path: String
+    let verdict: String?
+  }
+
+  struct Loop: Equatable, Sendable {
+    /// 1-based iteration; nil outside a `repeat`.
+    let index: Int?
+    /// Iterations completed by the latest loop.
+    let count: Int
+  }
+
+  var run: Run
+  var worktree: Worktree
+  var roles: [String: Role]
+  /// Latest delivered output per name.
+  var outputs: [String: Output]
+  var skippedOutputs: Set<String>
+  var actions: [String: [String: String]]
+  var inputs: [String: String]
+  var loop: Loop
+
+  init(
+    run: Run,
+    worktree: Worktree,
+    roles: [String: Role],
+    outputs: [String: Output],
+    skippedOutputs: Set<String> = [],
+    actions: [String: [String: String]] = [:],
+    inputs: [String: String] = [:],
+    loop: Loop = Loop(index: nil, count: 0)
+  ) {
+    self.run = run
+    self.worktree = worktree
+    self.roles = roles
+    self.outputs = outputs
+    self.skippedOutputs = skippedOutputs
+    self.actions = actions
+    self.inputs = inputs
+    self.loop = loop
+  }
+}
+
+nonisolated enum WorkflowTemplateError: Error, Equatable, Sendable {
+  case malformed(WorkflowTemplate.ScanError)
+  case unknownVariable(String)
+  /// The output was skipped or never delivered: the consumer cannot render (§5 Skip rule).
+  case missingOutput(name: String)
+  case verdictUnavailable(output: String)
+  case paneUnavailable(role: String)
+}
+
+extension WorkflowTemplate {
+  nonisolated static func render(_ text: String, context: WorkflowTemplateContext) throws(WorkflowTemplateError) -> String {
+    guard containsReference(text) else { return text }
+    let references: [Reference]
+    do {
+      references = try Self.references(in: text)
+    } catch {
+      throw .malformed(error)
+    }
+    var rendered = ""
+    var remainder = Substring(text)
+    for reference in references {
+      guard let range = remainder.firstRange(of: "{{"),
+        let close = remainder[range.upperBound...].firstRange(of: "}}")
+      else { break }
+      rendered += remainder[..<range.lowerBound]
+      rendered += try value(for: reference, context: context)
+      remainder = remainder[close.upperBound...]
+    }
+    rendered += remainder
+    return rendered
+  }
+
+  nonisolated static func value(for reference: Reference, context: WorkflowTemplateContext) throws(WorkflowTemplateError) -> String {
+    let parts = reference.components
+    switch (parts.first, parts.count) {
+    case ("run", 2):
+      switch parts[1] {
+      case "id": return context.run.id
+      case "dir": return context.run.directory
+      default: break
+      }
+    case ("worktree", 2):
+      switch parts[1] {
+      case "path": return context.worktree.path
+      case "name": return context.worktree.name
+      case "branch": return context.worktree.branch
+      default: break
+      }
+    case ("inputs", 2):
+      if let value = context.inputs[parts[1]] { return value }
+    case ("loop", 2):
+      switch parts[1] {
+      case "index":
+        if let index = context.loop.index { return String(index) }
+      case "count":
+        return String(context.loop.count)
+      default: break
+      }
+    case ("roles", 3):
+      if let role = context.roles[parts[1]] {
+        switch parts[2] {
+        case "name": return role.name
+        case "agent": return role.agent
+        case "pane":
+          guard let pane = role.pane else { throw .paneUnavailable(role: parts[1]) }
+          return pane
+        default: break
+        }
+      }
+    case ("outputs", 3):
+      guard ["path", "verdict"].contains(parts[2]) else { break }
+      guard !context.skippedOutputs.contains(parts[1]), let output = context.outputs[parts[1]] else {
+        throw .missingOutput(name: parts[1])
+      }
+      if parts[2] == "path" { return output.path }
+      guard let verdict = output.verdict else { throw .verdictUnavailable(output: parts[1]) }
+      return verdict
+    case ("actions", 3):
+      if let value = context.actions[parts[1]]?[parts[2]] { return value }
+    default:
+      break
+    }
+    throw .unknownVariable(reference.path)
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowWatchdog.swift
+++ b/supacode/Domain/Workflow/WorkflowWatchdog.swift
@@ -1,0 +1,428 @@
+// supacode/Domain/Workflow/WorkflowWatchdog.swift
+// The state-driven watchdog of a waiting activation (dsl-spec §10, decision G3 / H6): exact
+// signals first through the activation's epoch-gated dispatch observation, the detector as a
+// fallback, cancellable grace deadlines on an injected clock, and a re-read of the role's
+// state at every expiry so a later event alone never decides anything.
+
+import Foundation
+
+// MARK: - Settings and vocabulary
+
+nonisolated struct WorkflowWatchdogSettings: Equatable, Sendable {
+  /// Below this the detector cannot have settled (2 s stabilization + 3 s working hold) and
+  /// OpenCode can fire `session.idle` twice.
+  static let turnGraceFloor: Duration = .seconds(5)
+
+  let turnGrace: Duration
+  let idleGrace: Duration
+  let blockedGrace: Duration
+
+  init(turnGrace: Duration = .seconds(15), idleGrace: Duration = .seconds(180), blockedGrace: Duration = .seconds(30)) {
+    self.turnGrace = max(turnGrace, Self.turnGraceFloor)
+    self.idleGrace = idleGrace
+    self.blockedGrace = blockedGrace
+  }
+}
+
+nonisolated enum WorkflowWatchdogDeadline: String, Equatable, Sendable {
+  case turnGrace
+  case idleGrace
+  case blockedGrace
+  case timeout
+}
+
+/// What the role's pane looks like right now; re-read at arm time and at every expiry.
+nonisolated struct WorkflowWatchdogSnapshot: Equatable, Sendable {
+  /// Normalized detector state: `working`, `idle`, `done`, `blocked`, `absent`, or `gone`.
+  let state: String
+  let liveChannelCoversTurnEnded: Bool
+  let liveChannelCoversSessionEnd: Bool
+}
+
+nonisolated enum WorkflowWatchdogInput: Equatable, Sendable {
+  case armed(WorkflowWatchdogSnapshot)
+  case detector(state: String)
+  case detectorRemoved
+  case surfaceClosed
+  /// A runtime signal seen on the role's pane (`session-start` / `progress` count as activity).
+  case signal(AgentSignalEvent)
+  /// The activation's dispatch record reports an epoch-gated `needs-input`.
+  case needsInput
+  /// The activation's dispatch record reports the coalesced `turn-ended` without a delivery.
+  case turnEnded
+  case gone(WorkflowAgentGoneReason)
+  /// The dispatch record became terminal for another reason (delivered or abandoned).
+  case activationClosed
+  case deadline(WorkflowWatchdogDeadline, WorkflowWatchdogSnapshot)
+}
+
+typealias WorkflowWatchdogCommands = [WorkflowWatchdogCommand]
+
+nonisolated enum WorkflowWatchdogCommand: Equatable, Sendable {
+  case schedule(WorkflowWatchdogDeadline, Duration)
+  case cancel(WorkflowWatchdogDeadline)
+  case emit(WorkflowWatchdogVerdict)
+  case stop
+}
+
+// MARK: - Policy
+
+/// The pure decision core. Exact mode when a `verified_live` channel covers `turn-ended`,
+/// heuristic mode otherwise; one automatic nudge per activation; `working` never triggers.
+nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
+  enum Mode: Equatable, Sendable {
+    case exact(coversSessionEnd: Bool)
+    case heuristic
+  }
+
+  let settings: WorkflowWatchdogSettings
+  let timeout: Duration?
+  private(set) var mode: Mode?
+  private(set) var nudged: Bool
+  private(set) var stopped = false
+  private var pending: Set<WorkflowWatchdogDeadline> = []
+  /// Activity seen since the last `turn-ended`: a `working` detector state, `session-start`, or `progress`.
+  private var sawActivity = false
+
+  init(settings: WorkflowWatchdogSettings, timeoutSeconds: Int?, nudgedAlready: Bool) {
+    self.settings = settings
+    timeout = timeoutSeconds.map { .seconds($0) }
+    nudged = nudgedAlready
+  }
+
+  mutating func apply(_ input: WorkflowWatchdogInput) -> WorkflowWatchdogCommands {
+    guard !stopped else { return [] }
+    var commands: WorkflowWatchdogCommands = []
+    switch input {
+    case .armed(let snapshot):
+      mode =
+        snapshot.liveChannelCoversTurnEnded
+        ? .exact(coversSessionEnd: snapshot.liveChannelCoversSessionEnd) : .heuristic
+      if let timeout {
+        schedule(.timeout, timeout, &commands)
+      }
+      if mode == .heuristic {
+        applyDetectorLevel(snapshot.state, &commands)
+      }
+    case .detector(let state):
+      if state == "working" {
+        sawActivity = true
+      }
+      if mode == .heuristic {
+        applyDetectorLevel(state, &commands)
+      }
+    case .signal(let event):
+      if event == .sessionStart || event == .progress {
+        sawActivity = true
+      }
+    case .needsInput, .turnEnded, .detectorRemoved, .surfaceClosed, .gone, .activationClosed:
+      applyEvidence(input, &commands)
+    case .deadline(let deadline, let snapshot):
+      pending.remove(deadline)
+      applyExpiry(deadline, snapshot: snapshot, &commands)
+    }
+    return commands
+  }
+
+  /// Dispatch-record and lifecycle evidence: exact facts that either escalate or end the watch.
+  private mutating func applyEvidence(_ input: WorkflowWatchdogInput, _ commands: inout WorkflowWatchdogCommands) {
+    switch input {
+    case .needsInput:
+      cancel(.turnGrace, &commands)
+      cancel(.idleGrace, &commands)
+      commands.append(.emit(.attention(.needsInput)))
+    case .turnEnded:
+      sawActivity = false
+      cancel(.idleGrace, &commands)
+      cancel(.blockedGrace, &commands)
+      schedule(.turnGrace, settings.turnGrace, &commands)
+    case .detectorRemoved:
+      if case .exact(coversSessionEnd: true) = mode {
+        return
+      }
+      finish(with: .attention(.agentGone(.processGone)), &commands)
+    case .surfaceClosed:
+      finish(with: .attention(.agentGone(.paneClosed)), &commands)
+    case .gone(let reason):
+      finish(with: .attention(.agentGone(reason)), &commands)
+    case .activationClosed:
+      stopAll(&commands)
+    case .armed, .detector, .signal, .deadline:
+      break
+    }
+  }
+
+  private mutating func applyDetectorLevel(_ state: String, _ commands: inout WorkflowWatchdogCommands) {
+    switch state {
+    case "working":
+      cancel(.idleGrace, &commands)
+      cancel(.blockedGrace, &commands)
+    case "idle", "done":
+      cancel(.blockedGrace, &commands)
+      if !pending.contains(.idleGrace), !pending.contains(.turnGrace) {
+        sawActivity = false
+        schedule(.idleGrace, settings.idleGrace, &commands)
+      }
+    case "blocked":
+      if !pending.contains(.blockedGrace) {
+        schedule(.blockedGrace, settings.blockedGrace, &commands)
+      }
+    default:
+      break
+    }
+  }
+
+  private mutating func applyExpiry(
+    _ deadline: WorkflowWatchdogDeadline, snapshot: WorkflowWatchdogSnapshot,
+    _ commands: inout WorkflowWatchdogCommands
+  ) {
+    let active = snapshot.state == "working" || sawActivity
+    switch deadline {
+    case .turnGrace:
+      guard !active else {
+        sawActivity = false
+        return
+      }
+      escalate(after: .turnGrace, &commands)
+    case .idleGrace:
+      guard !active else {
+        sawActivity = false
+        if mode == .heuristic, snapshot.state == "idle" || snapshot.state == "done" {
+          schedule(.idleGrace, settings.idleGrace, &commands)
+        }
+        return
+      }
+      escalate(after: .idleGrace, &commands)
+    case .blockedGrace:
+      if snapshot.state == "blocked" {
+        commands.append(.emit(.attention(.blocked)))
+      }
+    case .timeout:
+      finish(with: .timeout, &commands)
+    }
+  }
+
+  /// The one automatic nudge, then `idle_grace`, then attention. Once the nudge is spent
+  /// (or the watchdog resumed after "Keep waiting"), a new turn end still earns `idle_grace`
+  /// before the user is asked; only an `idle_grace` that expires idle escalates.
+  private mutating func escalate(after deadline: WorkflowWatchdogDeadline, _ commands: inout WorkflowWatchdogCommands) {
+    if !nudged {
+      nudged = true
+      commands.append(.emit(.nudge))
+      schedule(.idleGrace, settings.idleGrace, &commands)
+    } else if deadline == .turnGrace {
+      schedule(.idleGrace, settings.idleGrace, &commands)
+    } else {
+      finish(with: .attention(.idleWithoutDelivery), &commands)
+    }
+  }
+
+  private mutating func schedule(
+    _ deadline: WorkflowWatchdogDeadline, _ duration: Duration, _ commands: inout WorkflowWatchdogCommands
+  ) {
+    pending.insert(deadline)
+    commands.append(.schedule(deadline, duration))
+  }
+
+  private mutating func cancel(_ deadline: WorkflowWatchdogDeadline, _ commands: inout WorkflowWatchdogCommands) {
+    guard pending.remove(deadline) != nil else { return }
+    commands.append(.cancel(deadline))
+  }
+
+  private mutating func finish(with verdict: WorkflowWatchdogVerdict, _ commands: inout WorkflowWatchdogCommands) {
+    commands.append(.emit(verdict))
+    stopAll(&commands)
+  }
+
+  private mutating func stopAll(_ commands: inout WorkflowWatchdogCommands) {
+    for deadline in pending.sorted(by: { $0.rawValue < $1.rawValue }) {
+      commands.append(.cancel(deadline))
+    }
+    pending.removeAll()
+    stopped = true
+    commands.append(.stop)
+  }
+}
+
+// MARK: - Driver
+
+/// Runs one activation's policy against the live streams and the injected clock. One driver per
+/// waiting activation; `cancel()` tears everything down (the machine's `disarmWatchdog`).
+@MainActor
+final class WorkflowWatchdog {
+  struct Sources {
+    let observeAgent: @MainActor () -> AgentObservationStream
+    let observeDispatch: @MainActor () -> AgentDispatchObservationStream?
+    let snapshot: @MainActor () -> WorkflowWatchdogSnapshot
+  }
+
+  private let request: WorkflowWatchdogRequest
+  private let sources: Sources
+  private let clock: any Clock<Duration>
+  private var policy: WorkflowWatchdogPolicy
+  private var inputContinuation: AsyncStream<WorkflowWatchdogInput>.Continuation?
+  private var outputContinuation: AsyncStream<WorkflowWatchdogVerdict>.Continuation?
+  private var deadlineTasks: [WorkflowWatchdogDeadline: Task<Void, Never>] = [:]
+  private var readerTasks: [Task<Void, Never>] = []
+  private var processingTask: Task<Void, Never>?
+  private(set) var isRunning = false
+
+  init(
+    request: WorkflowWatchdogRequest,
+    settings: WorkflowWatchdogSettings,
+    sources: Sources,
+    clock: any Clock<Duration> = ContinuousClock()
+  ) {
+    self.request = request
+    self.sources = sources
+    self.clock = clock
+    policy = WorkflowWatchdogPolicy(
+      settings: settings, timeoutSeconds: request.timeoutSeconds, nudgedAlready: request.nudgedAlready)
+  }
+
+  var ordinal: Int { request.ordinal }
+
+  /// Starts observing; the stream finishes when the policy stops or `cancel()` is called.
+  func start() -> AsyncStream<WorkflowWatchdogVerdict> {
+    precondition(!isRunning, "A watchdog runs once")
+    isRunning = true
+    let (output, outputContinuation) = AsyncStream.makeStream(of: WorkflowWatchdogVerdict.self)
+    let (inputs, inputContinuation) = AsyncStream.makeStream(of: WorkflowWatchdogInput.self)
+    self.outputContinuation = outputContinuation
+    self.inputContinuation = inputContinuation
+    startReaders(inputContinuation)
+    processingTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      perform(policy.apply(.armed(sources.snapshot())))
+      for await input in inputs {
+        if policy.stopped { break }
+        perform(policy.apply(input))
+      }
+      finishOutput()
+    }
+    return output
+  }
+
+  func cancel() {
+    guard isRunning else { return }
+    for task in deadlineTasks.values {
+      task.cancel()
+    }
+    deadlineTasks.removeAll()
+    for task in readerTasks {
+      task.cancel()
+    }
+    readerTasks.removeAll()
+    processingTask?.cancel()
+    inputContinuation?.finish()
+    finishOutput()
+  }
+
+  private func finishOutput() {
+    isRunning = false
+    outputContinuation?.finish()
+    outputContinuation = nil
+  }
+
+  private func perform(_ commands: WorkflowWatchdogCommands) {
+    for command in commands {
+      switch command {
+      case .schedule(let deadline, let duration):
+        deadlineTasks[deadline]?.cancel()
+        let clock = clock
+        deadlineTasks[deadline] = Task { @MainActor [weak self] in
+          do {
+            try await clock.sleep(for: duration)
+          } catch {
+            return
+          }
+          guard let self, !Task.isCancelled else { return }
+          inputContinuation?.yield(.deadline(deadline, sources.snapshot()))
+        }
+      case .cancel(let deadline):
+        deadlineTasks.removeValue(forKey: deadline)?.cancel()
+      case .emit(let verdict):
+        outputContinuation?.yield(verdict)
+      case .stop:
+        cancel()
+      }
+    }
+  }
+
+  private func startReaders(_ continuation: AsyncStream<WorkflowWatchdogInput>.Continuation) {
+    let sources = sources
+    readerTasks.append(
+      Task { @MainActor in
+        // A buffer overflow finishes the observer stream with an error; re-subscribe and let the
+        // fresh snapshot re-establish the level, as `agents wait` does.
+        for _ in 0..<3 {
+          var overflowed = false
+          do {
+            for try await state in sources.observeAgent() {
+              continuation.yield(Self.input(for: state))
+            }
+          } catch {
+            overflowed = true
+          }
+          guard overflowed, !Task.isCancelled else { return }
+        }
+      })
+    guard let dispatchStream = sources.observeDispatch() else { return }
+    readerTasks.append(
+      Task { @MainActor in
+        for await observation in dispatchStream {
+          if let input = Self.input(for: observation) {
+            continuation.yield(input)
+          }
+        }
+      })
+  }
+
+  static func input(for state: ObservedAgentState) -> WorkflowWatchdogInput {
+    switch state {
+    case .snapshot(let snapshot):
+      .detector(state: snapshot.agent.map { $0.displayState.rawValue } ?? "absent")
+    case .changed(let entry):
+      .detector(state: entry.displayState.rawValue)
+    case .removed:
+      .detectorRemoved
+    case .signal(let signal):
+      .signal(signal.event)
+    case .surfaceClosed:
+      .surfaceClosed
+    }
+  }
+
+  static func input(for observation: AgentDispatchObservation) -> WorkflowWatchdogInput? {
+    switch observation {
+    case .snapshot(let snapshot), .changed(let snapshot):
+      switch snapshot.record {
+      case .pending: nil
+      case .gone(_, _, _, let reason): .gone(reason == .sessionEnd ? .sessionEnded : .paneClosed)
+      case .completed, .abandoned: .activationClosed
+      }
+    case .needsInput:
+      .needsInput
+    case .incomplete:
+      .turnEnded
+    }
+  }
+
+  /// The arm-time / expiry-time view of the role's pane from the condition evidence the CLI
+  /// waits use, so the watchdog and `agents wait` agree on what "live channel" means.
+  nonisolated static func snapshot(from condition: AgentConditionSnapshot) -> WorkflowWatchdogSnapshot {
+    let state: String =
+      if !condition.isLive {
+        "gone"
+      } else if let agent = condition.agent {
+        agent.displayState.rawValue
+      } else {
+        "absent"
+      }
+    let live = condition.signals.channels.filter { $0.state == .verifiedLive }
+    return WorkflowWatchdogSnapshot(
+      state: state,
+      liveChannelCoversTurnEnded: live.contains { $0.events.contains(.turnEnded) },
+      liveChannelCoversSessionEnd: live.contains { $0.events.contains(.sessionEnd) })
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowWatchdog.swift
+++ b/supacode/Domain/Workflow/WorkflowWatchdog.swift
@@ -16,11 +16,20 @@ nonisolated struct WorkflowWatchdogSettings: Equatable, Sendable {
   let turnGrace: Duration
   let idleGrace: Duration
   let blockedGrace: Duration
+  /// How long a pane without a detected agent at arm time may take to show one (a launch
+  /// that has not settled yet) before it counts as gone — the CLI wait's appearance grace.
+  let appearanceGrace: Duration
 
-  init(turnGrace: Duration = .seconds(15), idleGrace: Duration = .seconds(180), blockedGrace: Duration = .seconds(30)) {
+  init(
+    turnGrace: Duration = .seconds(15),
+    idleGrace: Duration = .seconds(180),
+    blockedGrace: Duration = .seconds(30),
+    appearanceGrace: Duration = .seconds(10)
+  ) {
     self.turnGrace = max(turnGrace, Self.turnGraceFloor)
     self.idleGrace = idleGrace
     self.blockedGrace = blockedGrace
+    self.appearanceGrace = appearanceGrace
   }
 }
 
@@ -28,6 +37,7 @@ nonisolated enum WorkflowWatchdogDeadline: String, Equatable, Sendable {
   case turnGrace
   case idleGrace
   case blockedGrace
+  case appearanceGrace
   case timeout
 }
 
@@ -107,12 +117,19 @@ nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
       if let timeout {
         schedule(.timeout, timeout, &commands)
       }
-      if mode == .heuristic {
+      // No agent on a live surface: either a launch that has not settled or a process that
+      // already exited to the shell. The appearance grace tells them apart at its expiry.
+      if snapshot.state == "absent" {
+        schedule(.appearanceGrace, settings.appearanceGrace, &commands)
+      } else if mode == .heuristic {
         applyDetectorLevel(snapshot.state, &commands)
       }
     case .detector(let state):
       if state == "working" {
         sawActivity = true
+      }
+      if state != "absent" {
+        cancel(.appearanceGrace, &commands)
       }
       if mode == .heuristic {
         applyDetectorLevel(state, &commands)
@@ -203,6 +220,17 @@ nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
       if snapshot.state == "blocked" {
         commands.append(.emit(.attention(.blocked)))
       }
+    case .appearanceGrace:
+      switch snapshot.state {
+      case "absent":
+        finish(with: .attention(.agentGone(.processGone)), &commands)
+      case "gone":
+        finish(with: .attention(.agentGone(.paneClosed)), &commands)
+      default:
+        if mode == .heuristic {
+          applyDetectorLevel(snapshot.state, &commands)
+        }
+      }
     case .timeout:
       finish(with: .timeout, &commands)
     }
@@ -223,7 +251,7 @@ nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
       // `expect.timeout` keeps counting so `on_timeout: skip | cancel` still acts (H13).
       commands.append(.emit(.attention(.idleWithoutDelivery)))
       if pending.contains(.timeout) {
-        for grace in [WorkflowWatchdogDeadline.turnGrace, .idleGrace, .blockedGrace] {
+        for grace in [WorkflowWatchdogDeadline.turnGrace, .idleGrace, .blockedGrace, .appearanceGrace] {
           cancel(grace, &commands)
         }
       } else {
@@ -368,18 +396,18 @@ final class WorkflowWatchdog {
     let sources = sources
     readerTasks.append(
       Task { @MainActor in
-        // A buffer overflow finishes the observer stream with an error; re-subscribe and let the
-        // fresh snapshot re-establish the level, as `agents wait` does.
-        for _ in 0..<3 {
-          var overflowed = false
+        // A buffer overflow finishes the observer stream with an error; re-subscribe for as long
+        // as the watchdog runs and let the fresh snapshot re-establish the level, as `agents
+        // wait` does. A stream that finishes without an error (surface closed) ends the reader.
+        while !Task.isCancelled {
           do {
             for try await state in sources.observeAgent() {
               continuation.yield(Self.input(for: state))
             }
+            return
           } catch {
-            overflowed = true
+            await Task.yield()
           }
-          guard overflowed, !Task.isCancelled else { return }
         }
       })
     guard let dispatchStream = sources.observeDispatch() else { return }

--- a/supacode/Domain/Workflow/WorkflowWatchdog.swift
+++ b/supacode/Domain/Workflow/WorkflowWatchdog.swift
@@ -98,6 +98,12 @@ nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
       mode =
         snapshot.liveChannelCoversTurnEnded
         ? .exact(coversSessionEnd: snapshot.liveChannelCoversSessionEnd) : .heuristic
+      // The arm-time state decides on its own (dsl-spec §10): a pane that is already gone never
+      // produces a later event to wait for.
+      if snapshot.state == "gone" {
+        finish(with: .attention(.agentGone(.paneClosed)), &commands)
+        return commands
+      }
       if let timeout {
         schedule(.timeout, timeout, &commands)
       }

--- a/supacode/Domain/Workflow/WorkflowWatchdog.swift
+++ b/supacode/Domain/Workflow/WorkflowWatchdog.swift
@@ -213,7 +213,16 @@ nonisolated struct WorkflowWatchdogPolicy: Equatable, Sendable {
     } else if deadline == .turnGrace {
       schedule(.idleGrace, settings.idleGrace, &commands)
     } else {
-      finish(with: .attention(.idleWithoutDelivery), &commands)
+      // Attention is a UI state, never a deadline: the grace timers stop, but an explicit
+      // `expect.timeout` keeps counting so `on_timeout: skip | cancel` still acts (H13).
+      commands.append(.emit(.attention(.idleWithoutDelivery)))
+      if pending.contains(.timeout) {
+        for grace in [WorkflowWatchdogDeadline.turnGrace, .idleGrace, .blockedGrace] {
+          cancel(grace, &commands)
+        }
+      } else {
+        stopAll(&commands)
+      }
     }
   }
 

--- a/supacodeTests/WorkflowBindingResolverTests.swift
+++ b/supacodeTests/WorkflowBindingResolverTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowBindingResolverTests {
+  private static let claudeID = UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!
+  private static let codexID = UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!
+  private static let codexHighID = UUID(uuidString: "00000000-0000-0000-0000-00000000000C")!
+  private static let disabledID = UUID(uuidString: "00000000-0000-0000-0000-00000000000D")!
+  private static let ampID = UUID(uuidString: "00000000-0000-0000-0000-00000000000E")!
+
+  private let profiles = [
+    AgentProfile(id: claudeID, name: "Claude Code", runtime: .claude),
+    AgentProfile(id: codexID, name: "Codex", runtime: .codex),
+    AgentProfile(
+      id: codexHighID, name: "Codex xHigh", runtime: .codex, reasoningEffort: "xhigh", executionMode: .standard),
+    AgentProfile(id: disabledID, name: "Disabled Codex", isEnabled: false, runtime: .codex, reasoningEffort: "xhigh"),
+    AgentProfile(id: ampID, name: "Amp", runtime: .amp),
+  ]
+
+  private func role(
+    agents: [String]? = ["codex", "claude"],
+    suggest: WorkflowProfileSuggestion? = nil
+  ) -> WorkflowRoleDefinition {
+    WorkflowRoleDefinition(
+      name: "reviewer", source: .launch,
+      launch: WorkflowLaunchRequirements(agents: agents, suggest: suggest))
+  }
+
+  private func context(
+    designated: UUID? = nil, lastLaunched: UUID? = nil,
+    promptSupport: @escaping @Sendable (AgentProfile) -> Bool = { $0.runtime != .amp }
+  ) -> WorkflowBindingResolverContext {
+    WorkflowBindingResolverContext(
+      profiles: profiles, designatedProfileID: designated, lastLaunchedProfileID: lastLaunched,
+      supportsSeededPrompt: promptSupport)
+  }
+
+  // MARK: - Memory key
+
+  @Test func canonicalRequirementsSortKeysAndAgentsAndOmitAbsentFields() {
+    let role = WorkflowRoleDefinition(
+      name: "reviewer", source: .launch,
+      launch: WorkflowLaunchRequirements(
+        agents: ["codex", "claude"], suggest: WorkflowProfileSuggestion(agent: "codex", reasoningEffort: "xhigh")))
+    #expect(
+      WorkflowBindingResolver.canonicalRequirements(role)
+        == "{\"agents\":[\"claude\",\"codex\"],\"kind\":\"interactive\",\"source\":\"launch\","
+        + "\"suggest\":{\"agent\":\"codex\",\"reasoning_effort\":\"xhigh\"}}")
+    let bare = WorkflowRoleDefinition(name: "r", source: .launch, launch: WorkflowLaunchRequirements())
+    #expect(WorkflowBindingResolver.canonicalRequirements(bare) == "{\"kind\":\"interactive\",\"source\":\"launch\"}")
+    #expect(
+      WorkflowBindingResolver.canonicalRequirements(WorkflowRoleDefinition(name: "a", source: .current))
+        == "{\"source\":\"current\"}")
+  }
+
+  @Test func digestIgnoresAgentOrderAndPresentationButNotRequirements() {
+    let base = role(agents: ["codex", "claude"])
+    let reordered = role(agents: ["claude", "codex"])
+    let placementOnly = WorkflowRoleDefinition(
+      name: "reviewer", source: .launch,
+      launch: WorkflowLaunchRequirements(agents: ["codex", "claude"], bind: .auto, placement: .tab, background: true))
+    let narrowed = role(agents: ["codex"])
+    #expect(WorkflowBindingResolver.requirementsDigest(base) == WorkflowBindingResolver.requirementsDigest(reordered))
+    #expect(
+      WorkflowBindingResolver.requirementsDigest(base) == WorkflowBindingResolver.requirementsDigest(placementOnly))
+    #expect(WorkflowBindingResolver.requirementsDigest(base) != WorkflowBindingResolver.requirementsDigest(narrowed))
+    #expect(WorkflowBindingResolver.requirementsDigest(base).count == 64)
+    let key = WorkflowBindingResolver.memoryKey(
+      scope: .repo(repositoryID: "repo-1"), workflowID: "prowl.adversarial-review", role: base)
+    #expect(key.scope == "repo:repo-1")
+    #expect(key.workflowID == "prowl.adversarial-review")
+    #expect(key.role == "reviewer")
+    #expect(key.digest == WorkflowBindingResolver.requirementsDigest(base))
+  }
+
+  // MARK: - Tiers
+
+  @Test func rememberedBindingWinsWhenStillAdmissible() throws {
+    let result = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: Self.codexID, override: nil, context: context()
+    ).get()
+    #expect(result.resolution == .resolved(profiles[1], tier: .remembered))
+    #expect(result.rejected.isEmpty)
+  }
+
+  @Test func rememberedBindingThatFailsValidationFallsThrough() throws {
+    let disabled = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: Self.disabledID, override: nil, context: context()
+    ).get()
+    #expect(disabled.rejected[.remembered] == .disabled)
+    #expect(disabled.resolution == .resolved(profiles[0], tier: .recommended))
+
+    let missing = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: UUID(), override: nil, context: context()
+    ).get()
+    #expect(missing.rejected[.remembered] == .missing)
+
+    let wrongAgent = try WorkflowBindingResolver.resolve(
+      role: role(agents: ["codex"]), remembered: Self.claudeID, override: nil, context: context()
+    ).get()
+    #expect(wrongAgent.rejected[.remembered] == .agentNotAllowed("claude"))
+    #expect(wrongAgent.resolution == .resolved(profiles[1], tier: .recommended))
+
+    let noPrompt = try WorkflowBindingResolver.resolve(
+      role: role(agents: nil), remembered: Self.ampID, override: nil, context: context()
+    ).get()
+    #expect(noPrompt.rejected[.remembered] == .promptUnsupported)
+  }
+
+  @Test func suggestionMatchesExactlyBeforeTheRecommendation() throws {
+    let suggest = WorkflowProfileSuggestion(agent: "codex", reasoningEffort: "xhigh", executionMode: "standard")
+    let result = try WorkflowBindingResolver.resolve(
+      role: role(suggest: suggest), remembered: nil, override: nil, context: context()
+    ).get()
+    #expect(result.resolution == .resolved(profiles[2], tier: .suggestion))
+
+    let unmatched = WorkflowProfileSuggestion(agent: "codex", model: "gpt-x")
+    let fallback = try WorkflowBindingResolver.resolve(
+      role: role(suggest: unmatched), remembered: nil, override: nil, context: context(designated: Self.codexID)
+    ).get()
+    #expect(fallback.resolution == .resolved(profiles[1], tier: .recommended))
+  }
+
+  @Test func recommendationFollowsThe053TiersOverTheFilteredSet() throws {
+    let designated = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: nil,
+      context: context(designated: Self.codexHighID, lastLaunched: Self.codexID)
+    ).get()
+    #expect(designated.resolution == .resolved(profiles[2], tier: .recommended))
+    let lastLaunched = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: nil,
+      context: context(designated: Self.disabledID, lastLaunched: Self.codexID)
+    ).get()
+    #expect(lastLaunched.resolution == .resolved(profiles[1], tier: .recommended))
+    let filtered = try WorkflowBindingResolver.resolve(
+      role: role(agents: ["codex"]), remembered: nil, override: nil, context: context(designated: Self.claudeID)
+    ).get()
+    #expect(filtered.resolution == .resolved(profiles[1], tier: .recommended))
+  }
+
+  @Test func nothingAdmissibleAsksWithTheSuggestion() throws {
+    let suggest = WorkflowProfileSuggestion(agent: "gemini")
+    let result = try WorkflowBindingResolver.resolve(
+      role: role(agents: ["gemini"], suggest: suggest), remembered: nil, override: nil, context: context()
+    ).get()
+    #expect(result.resolution == .ask(candidates: [], suggestion: suggest))
+    let noPromptSupport = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: nil, context: context(promptSupport: { _ in false })
+    ).get()
+    #expect(noPromptSupport.resolution == .ask(candidates: [], suggestion: nil))
+  }
+
+  @Test func overridesResolveByIDOrUniqueNameAndFallThroughWhenInadmissible() throws {
+    let byID = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: .profileID(Self.codexID), context: context()
+    ).get()
+    #expect(byID.resolution == .resolved(profiles[1], tier: .override))
+    let byName = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: .profileName("Codex xHigh"), context: context()
+    ).get()
+    #expect(byName.resolution == .resolved(profiles[2], tier: .override))
+    let auto = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: Self.codexID, override: .auto, context: context()
+    ).get()
+    #expect(auto.resolution == .resolved(profiles[1], tier: .remembered))
+
+    #expect(
+      WorkflowBindingResolver.resolve(role: role(), remembered: nil, override: .profileName("Nope"), context: context())
+        == .failure(.profileNotFound("Nope")))
+    #expect(
+      WorkflowBindingResolver.resolve(role: role(), remembered: nil, override: .profileID(UUID()), context: context())
+        .failureCode == "PROFILE_NOT_FOUND")
+    var duplicated = profiles
+    duplicated.append(AgentProfile(id: UUID(), name: "Codex", runtime: .codex))
+    let duplicateContext = WorkflowBindingResolverContext(profiles: duplicated, supportsSeededPrompt: { _ in true })
+    #expect(
+      WorkflowBindingResolver.resolve(
+        role: role(), remembered: nil, override: .profileName("Codex"), context: duplicateContext)
+        == .failure(.profileNotUnique("Codex")))
+
+    let inadmissible = try WorkflowBindingResolver.resolve(
+      role: role(), remembered: nil, override: .profileID(Self.disabledID), context: context()
+    ).get()
+    #expect(inadmissible.rejected[.override] == .disabled)
+    #expect(inadmissible.resolution == .resolved(profiles[0], tier: .recommended))
+  }
+
+  @Test func nonLaunchRolesCannotBeResolved() {
+    let current = WorkflowRoleDefinition(name: "author", source: .current)
+    #expect(
+      WorkflowBindingResolver.resolve(role: current, remembered: nil, override: nil, context: context())
+        == .failure(.roleNotLaunchable("author")))
+  }
+
+  @Test func adapterProbeRejectsAmpAndAcceptsSeededPromptRuntimes() {
+    #expect(WorkflowBindingResolver.adapterSupportsSeededPrompt(profiles[0]))
+    #expect(WorkflowBindingResolver.adapterSupportsSeededPrompt(profiles[1]))
+    #expect(!WorkflowBindingResolver.adapterSupportsSeededPrompt(profiles[4]))
+  }
+}
+
+extension Result where Success == WorkflowBindingResult, Failure == WorkflowBindingError {
+  fileprivate var failureCode: String? {
+    if case .failure(let error) = self { return error.code }
+    return nil
+  }
+}

--- a/supacodeTests/WorkflowDeliveryValidatorTests.swift
+++ b/supacodeTests/WorkflowDeliveryValidatorTests.swift
@@ -51,6 +51,12 @@ struct WorkflowDeliveryValidatorTests {
     #expect(throws: Never.self) { try validate(tilde, expect: expect).get() }
   }
 
+  @Test func tildeWrappedRepliesPersistWithoutTheWrapper() throws {
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let delivery = try validate("~~~markdown\n## Findings\nx\n## Verdict\ny\n~~~\nchat trailer", expect: expect).get()
+    #expect(delivery.body == "## Findings\nx\n## Verdict\ny\n")
+  }
+
   @Test func missingSectionIsOutputInvalid() {
     let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
     guard case .failure(let error) = validate("## Findings\nnothing", expect: expect) else {

--- a/supacodeTests/WorkflowDeliveryValidatorTests.swift
+++ b/supacodeTests/WorkflowDeliveryValidatorTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowDeliveryValidatorTests {
+  private let limits = WorkflowDeliveryLimits()
+
+  private func validate(
+    _ body: String,
+    verdict: String? = nil,
+    expect: WorkflowExpectation = WorkflowExpectation(),
+    limits: WorkflowDeliveryLimits? = nil
+  ) -> Result<WorkflowValidatedDelivery, WorkflowDeliveryError> {
+    WorkflowDeliveryValidator.validate(body: body, verdict: verdict, expect: expect, limits: limits ?? self.limits)
+  }
+
+  @Test func markdownDeliveryIsNormalizedAndSectionsChecked() throws {
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let body = """
+      Sure, here is my review:
+      ```markdown
+      # Review
+      ## Findings
+      - none
+      ## Verdict
+      clean
+      ```
+      Let me know if you need more.
+      """
+    let delivery = try validate(body, expect: expect).get()
+    #expect(delivery.body == "# Review\n## Findings\n- none\n## Verdict\nclean\n")
+    #expect(delivery.verdict == nil)
+  }
+
+  @Test func missingSectionIsOutputInvalid() {
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    guard case .failure(let error) = validate("## Findings\nnothing", expect: expect) else {
+      Issue.record("expected failure")
+      return
+    }
+    #expect(error.code == "OUTPUT_INVALID")
+    #expect(error.message.contains("## Verdict"))
+  }
+
+  @Test func emptyBodyIsOutputInvalidForEveryFormat() {
+    for format in [WorkflowOutputFormat.markdown, .text, .json] {
+      guard case .failure(let error) = validate("  \n\n", expect: WorkflowExpectation(format: format)) else {
+        Issue.record("expected failure for \(format)")
+        continue
+      }
+      #expect(error.code == "OUTPUT_INVALID")
+    }
+  }
+
+  @Test func textIsKeptVerbatimAndJSONMustParse() throws {
+    let text = try validate("  raw text\nwith lines  ", expect: WorkflowExpectation(format: .text)).get()
+    #expect(text.body == "  raw text\nwith lines  ")
+
+    let json = try validate("{\"ok\": true}\n", expect: WorkflowExpectation(format: .json)).get()
+    #expect(json.body == "{\"ok\": true}\n")
+    guard case .failure(let error) = validate("{not json", expect: WorkflowExpectation(format: .json)) else {
+      Issue.record("expected failure")
+      return
+    }
+    #expect(error.code == "OUTPUT_INVALID")
+  }
+
+  @Test func verdictRulesFollowTheDeclaration() throws {
+    let declared = WorkflowExpectation(verdict: ["clean", "issues"])
+    guard case .failure(let required) = validate("# ok\n", expect: declared) else {
+      Issue.record("expected VERDICT_REQUIRED")
+      return
+    }
+    #expect(required == .verdictRequired(allowed: ["clean", "issues"]))
+    #expect(required.code == "VERDICT_REQUIRED")
+
+    guard case .failure(let undeclared) = validate("# ok\n", verdict: "maybe", expect: declared) else {
+      Issue.record("expected OUTPUT_INVALID")
+      return
+    }
+    #expect(undeclared.code == "OUTPUT_INVALID")
+
+    let accepted = try validate("# ok\n", verdict: "issues", expect: declared).get()
+    #expect(accepted.verdict == "issues")
+
+    guard case .failure(let unexpected) = validate("# ok\n", verdict: "clean", expect: WorkflowExpectation()) else {
+      Issue.record("expected OUTPUT_INVALID for an undeclared verdict")
+      return
+    }
+    #expect(unexpected.code == "OUTPUT_INVALID")
+  }
+
+  @Test func sizeCapsUseTheDefaultAndClampToTheHardMaximum() {
+    #expect(WorkflowDeliveryLimits.defaultMaximumBytes == 1 << 20)
+    #expect(WorkflowDeliveryLimits.hardMaximumBytes == 4 << 20)
+    #expect(WorkflowDeliveryLimits(maximumBytes: 10 << 20).maximumBytes == 4 << 20)
+    #expect(WorkflowDeliveryLimits(maximumBytes: 0).maximumBytes == 1)
+
+    let tooBig = "# a\n" + String(repeating: "x", count: 1 << 20)
+    guard case .failure(let error) = validate(tooBig) else {
+      Issue.record("expected OUTPUT_TOO_LARGE")
+      return
+    }
+    #expect(error.code == "OUTPUT_TOO_LARGE")
+    #expect(error == .outputTooLarge(bytes: tooBig.utf8.count, limit: 1 << 20))
+
+    let raised = WorkflowDeliveryLimits(maximumBytes: 2 << 20)
+    #expect(throws: Never.self) { try validate(tooBig, limits: raised).get() }
+  }
+
+  @Test func sizeIsMeasuredOnTheRawBodyBeforeNormalization() {
+    let expect = WorkflowExpectation(format: .markdown)
+    let preamble = String(repeating: "p", count: (1 << 20) - 5)
+    let body = preamble + "\n# ok\n"
+    guard case .failure(let error) = validate(body, expect: expect) else {
+      Issue.record("expected OUTPUT_TOO_LARGE")
+      return
+    }
+    #expect(error.code == "OUTPUT_TOO_LARGE")
+  }
+}

--- a/supacodeTests/WorkflowDeliveryValidatorTests.swift
+++ b/supacodeTests/WorkflowDeliveryValidatorTests.swift
@@ -33,6 +33,24 @@ struct WorkflowDeliveryValidatorTests {
     #expect(delivery.verdict == nil)
   }
 
+  @Test func sectionsMustBeHeadingsOutsideCodeFences() throws {
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let fenced = "# Review\n```text\n## Findings\n```\n## Verdict\nclean"
+    guard case .failure(let error) = validate(fenced, expect: expect) else {
+      Issue.record("a heading inside a fence must not count")
+      return
+    }
+    #expect(error.message.contains("## Findings"))
+    #expect(!error.message.contains("## Verdict"))
+    let prose = "# Review\nsee ## Findings below\n## Verdict\nclean"
+    #expect(validate(prose, expect: expect).failureCode == "OUTPUT_INVALID")
+    let suffixed = "# Review\n## Findings (2)\n- a\n## Verdict\nclean"
+    #expect(throws: Never.self) { try validate(suffixed, expect: expect).get() }
+    #expect(validate("# Review\n## Findingsx\n## Verdict", expect: expect).failureCode == "OUTPUT_INVALID")
+    let tilde = "# Review\n~~~\n## Findings\n~~~\n## Findings\n## Verdict\nok"
+    #expect(throws: Never.self) { try validate(tilde, expect: expect).get() }
+  }
+
   @Test func missingSectionIsOutputInvalid() {
     let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
     guard case .failure(let error) = validate("## Findings\nnothing", expect: expect) else {

--- a/supacodeTests/WorkflowDeliveryValidatorTests.swift
+++ b/supacodeTests/WorkflowDeliveryValidatorTests.swift
@@ -34,7 +34,7 @@ struct WorkflowDeliveryValidatorTests {
   }
 
   @Test func sectionsMustBeHeadingsOutsideCodeFences() throws {
-    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"], strict: true)
     let fenced = "# Review\n```text\n## Findings\n```\n## Verdict\nclean"
     guard case .failure(let error) = validate(fenced, expect: expect) else {
       Issue.record("a heading inside a fence must not count")
@@ -57,14 +57,52 @@ struct WorkflowDeliveryValidatorTests {
     #expect(delivery.body == "## Findings\nx\n## Verdict\ny\n")
   }
 
-  @Test func missingSectionIsOutputInvalid() {
-    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
-    guard case .failure(let error) = validate("## Findings\nnothing", expect: expect) else {
+  @Test func missingSectionIsAnIssueByDefaultAndARejectionUnderStrict() throws {
+    let lenient = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let delivery = try validate("## Findings\nnothing", expect: lenient).get()
+    #expect(delivery.issues == [.missingSections(["## Verdict"])])
+    #expect(delivery.body == "## Findings\nnothing\n")
+
+    let strict = WorkflowExpectation(sections: ["## Findings", "## Verdict"], strict: true)
+    guard case .failure(let error) = validate("## Findings\nnothing", expect: strict) else {
       Issue.record("expected failure")
       return
     }
     #expect(error.code == "OUTPUT_INVALID")
     #expect(error.message.contains("## Verdict"))
+  }
+
+  @Test func sectionMatchingForgivesLevelAndCase() throws {
+    let expect = WorkflowExpectation(sections: ["## Findings", "## Verdict"])
+    let delivery = try validate("# Review\n### findings\n- a\n## VERDICT (draft)\nclean", expect: expect).get()
+    #expect(delivery.issues.isEmpty)
+  }
+
+  @Test func softIssuesCoverFormatAndVerdict() throws {
+    let json = try validate("{not json", expect: WorkflowExpectation(format: .json)).get()
+    #expect(json.issues == [.unparsableJSON])
+    #expect(json.body == "{not json")
+    guard
+      case .failure(let strictJSON) = validate("{not json", expect: WorkflowExpectation(format: .json, strict: true))
+    else {
+      Issue.record("expected failure")
+      return
+    }
+    #expect(strictJSON.code == "OUTPUT_INVALID")
+
+    let declared = WorkflowExpectation(verdict: ["clean", "issues"])
+    let missing = try validate("# ok\n", expect: declared).get()
+    #expect(missing.issues == [.verdictMissing(allowed: ["clean", "issues"])])
+    #expect(missing.verdict == nil)
+    let undeclared = try validate("# ok\n", verdict: "maybe", expect: declared).get()
+    #expect(undeclared.issues == [.verdictUndeclared("maybe", allowed: ["clean", "issues"])])
+    #expect(undeclared.verdict == nil)
+    let unexpected = try validate("# ok\n", verdict: "clean", expect: WorkflowExpectation()).get()
+    #expect(unexpected.issues == [.verdictUnexpected("clean")])
+    #expect(unexpected.verdict == nil)
+    let clean = try validate("# ok\n", verdict: "issues", expect: declared).get()
+    #expect(clean.issues.isEmpty)
+    #expect(clean.verdict == "issues")
   }
 
   @Test func emptyBodyIsOutputInvalidForEveryFormat() {
@@ -83,15 +121,16 @@ struct WorkflowDeliveryValidatorTests {
 
     let json = try validate("{\"ok\": true}\n", expect: WorkflowExpectation(format: .json)).get()
     #expect(json.body == "{\"ok\": true}\n")
-    guard case .failure(let error) = validate("{not json", expect: WorkflowExpectation(format: .json)) else {
+    guard case .failure(let error) = validate("{not json", expect: WorkflowExpectation(format: .json, strict: true))
+    else {
       Issue.record("expected failure")
       return
     }
     #expect(error.code == "OUTPUT_INVALID")
   }
 
-  @Test func verdictRulesFollowTheDeclaration() throws {
-    let declared = WorkflowExpectation(verdict: ["clean", "issues"])
+  @Test func verdictRulesFollowTheDeclarationUnderStrict() throws {
+    let declared = WorkflowExpectation(verdict: ["clean", "issues"], strict: true)
     guard case .failure(let required) = validate("# ok\n", expect: declared) else {
       Issue.record("expected VERDICT_REQUIRED")
       return
@@ -108,7 +147,9 @@ struct WorkflowDeliveryValidatorTests {
     let accepted = try validate("# ok\n", verdict: "issues", expect: declared).get()
     #expect(accepted.verdict == "issues")
 
-    guard case .failure(let unexpected) = validate("# ok\n", verdict: "clean", expect: WorkflowExpectation()) else {
+    guard
+      case .failure(let unexpected) = validate("# ok\n", verdict: "clean", expect: WorkflowExpectation(strict: true))
+    else {
       Issue.record("expected OUTPUT_INVALID for an undeclared verdict")
       return
     }

--- a/supacodeTests/WorkflowLineRendererTests.swift
+++ b/supacodeTests/WorkflowLineRendererTests.swift
@@ -42,7 +42,7 @@ struct WorkflowLineRendererTests {
     let command = WorkflowCompletionCommand(token: token, verdicts: ["clean", "issues"])
     let block = command.protocolBlock(
       runID: "RUN-1", workflowName: "Adversarial Review", role: "reviewer", stepTitle: "Reviewer starting round 1",
-      sections: ["## Findings", "## Verdict"], format: .markdown)
+      expect: WorkflowExpectation(sections: ["## Findings", "## Verdict"]))
     #expect(block.contains("Prowl workflow completion protocol v1"))
     #expect(block.contains("RUN-1"))
     #expect(block.contains("Adversarial Review"))
@@ -109,7 +109,7 @@ struct WorkflowLineRendererTests {
   @Test func launchPromptAppendsProtocolBlockAfterASeparator() {
     let command = WorkflowCompletionCommand(token: token, verdicts: nil)
     let block = command.protocolBlock(
-      runID: "R", workflowName: "W", role: "reviewer", stepTitle: nil, sections: [], format: .markdown)
+      runID: "R", workflowName: "W", role: "reviewer", stepTitle: nil, expect: WorkflowExpectation())
     let prompt = WorkflowLaunchPrompt.render(userPrompt: "Review it.", protocolBlock: block)
     #expect(prompt.hasPrefix("Review it.\n\n---\n"))
     #expect(prompt.hasSuffix(block))

--- a/supacodeTests/WorkflowLineRendererTests.swift
+++ b/supacodeTests/WorkflowLineRendererTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowLineRendererTests {
+  private let token = "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+
+  // MARK: - Completion command
+
+  @Test func messageCommandCarriesTokenPrefixAndOneCommandPerVerdict() {
+    let plain = WorkflowCompletionCommand(token: token, verdicts: nil)
+    #expect(plain.messageCommands == ["PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -"])
+    #expect(plain.typedSuffix == " — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -")
+
+    let verdicts = WorkflowCompletionCommand(token: token, verdicts: ["clean", "issues"])
+    #expect(
+      verdicts.messageCommands == [
+        "PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict clean -",
+        "PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict issues -",
+      ])
+    #expect(
+      verdicts.typedSuffix
+        == " — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict clean -"
+        + "  or  PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict issues -")
+    #expect(verdicts.launchCommands == ["prowl workflow done --verdict clean -", "prowl workflow done --verdict issues -"])
+  }
+
+  @Test func nudgeLineUsesThePrefixAndTheSameCommands() throws {
+    let command = WorkflowCompletionCommand(token: token, verdicts: ["clean", "issues"])
+    let line = try WorkflowTypedLine.nudge(completion: command)
+    #expect(line.hasPrefix(AgentDispatchPrompt.injectedPrefix))
+    #expect(
+      line
+        == "[Prowl] When your work for this step is fully complete, finish with: "
+        + "PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict clean -"
+        + "  or  PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict issues -")
+  }
+
+  @Test func protocolBlockNamesRunRoleSectionsAndEveryCommandWithoutPrefix() {
+    let command = WorkflowCompletionCommand(token: token, verdicts: ["clean", "issues"])
+    let block = command.protocolBlock(
+      runID: "RUN-1", workflowName: "Adversarial Review", role: "reviewer", stepTitle: "Reviewer starting round 1",
+      sections: ["## Findings", "## Verdict"], format: .markdown)
+    #expect(block.contains("Prowl workflow completion protocol v1"))
+    #expect(block.contains("RUN-1"))
+    #expect(block.contains("Adversarial Review"))
+    #expect(block.contains("\"reviewer\""))
+    #expect(block.contains("## Findings, ## Verdict"))
+    #expect(block.contains("\nprowl workflow done --verdict clean -\n"))
+    #expect(block.contains("\nprowl workflow done --verdict issues -\n"))
+    #expect(!block.contains("PROWL_WORKFLOW_TOKEN"))
+    #expect(block.contains("dispatch-complete"))
+  }
+
+  @Test func instructionTrailerAndDeliveryRequiredMessageListTheMessageCommands() {
+    let command = WorkflowCompletionCommand(token: token, verdicts: nil)
+    let trailer = command.instructionTrailer()
+    #expect(trailer.contains("PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -"))
+    let message = command.deliveryRequiredMessage(runID: "RUN-1", stepID: "brief")
+    #expect(message.contains("RUN-1"))
+    #expect(message.contains("brief"))
+    #expect(message.contains("PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -"))
+  }
+
+  // MARK: - Typed lines
+
+  @Test func textLineIsPrefixedAndSuffixed() throws {
+    let command = WorkflowCompletionCommand(token: token, verdicts: nil)
+    #expect(try WorkflowTypedLine.text("Findings: /r/outputs/findings.md", completion: nil) == "[Prowl] Findings: /r/outputs/findings.md")
+    #expect(
+      try WorkflowTypedLine.text("Fix each item.", completion: command)
+        == "[Prowl] Fix each item. — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -")
+  }
+
+  @Test func pointerLineNamesTheAbsolutePath() throws {
+    let line = try WorkflowTypedLine.pointer(to: "/repo/.prowl/workflow-runs/R/instructions/brief.1.md", completion: nil)
+    #expect(line == "[Prowl] Read /repo/.prowl/workflow-runs/R/instructions/brief.1.md and follow it")
+  }
+
+  @Test func renderedTextBoundaryRejectsTerminatorsAndControls() {
+    for bad in ["a\nb", "a\rb", "a\u{2028}b", "a\u{2029}b", "a\tb", "a\u{1B}[0m", "a\u{85}b", "a\u{9F}b"] {
+      #expect(throws: WorkflowRenderedTextError.self) { try WorkflowRenderedText.validateLine(bad) }
+    }
+    #expect(throws: Never.self) { try WorkflowRenderedText.validateLine("plain ascii — with dash and emoji 🐱") }
+  }
+
+  @Test func typedLineWithInjectedTerminatorFailsWithoutPartialOutput() {
+    #expect(throws: WorkflowRenderedTextError.self) {
+      try WorkflowTypedLine.text("first\nsecond", completion: nil)
+    }
+  }
+
+  // MARK: - Launch prompt
+
+  @Test func launchPromptRejectsNULAndOversize() {
+    #expect(throws: WorkflowLaunchPromptError.containsNUL) { try WorkflowLaunchPrompt.validate("a\0b") }
+    let big = String(repeating: "x", count: WorkflowLaunchPrompt.maximumBytes + 1)
+    #expect(throws: WorkflowLaunchPromptError.tooLarge(bytes: WorkflowLaunchPrompt.maximumBytes + 1)) {
+      try WorkflowLaunchPrompt.validate(big)
+    }
+    #expect(throws: Never.self) { try WorkflowLaunchPrompt.validate("multi\nline\nprompt") }
+  }
+
+  @Test func launchPromptAppendsProtocolBlockAfterASeparator() {
+    let command = WorkflowCompletionCommand(token: token, verdicts: nil)
+    let block = command.protocolBlock(
+      runID: "R", workflowName: "W", role: "reviewer", stepTitle: nil, sections: [], format: .markdown)
+    let prompt = WorkflowLaunchPrompt.render(userPrompt: "Review it.", protocolBlock: block)
+    #expect(prompt.hasPrefix("Review it.\n\n---\n"))
+    #expect(prompt.hasSuffix(block))
+    #expect(WorkflowLaunchPrompt.render(userPrompt: "Plain", protocolBlock: nil) == "Plain")
+  }
+}

--- a/supacodeTests/WorkflowLineRendererTests.swift
+++ b/supacodeTests/WorkflowLineRendererTests.swift
@@ -23,7 +23,8 @@ struct WorkflowLineRendererTests {
       verdicts.typedSuffix
         == " — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict clean -"
         + "  or  PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done --verdict issues -")
-    #expect(verdicts.launchCommands == ["prowl workflow done --verdict clean -", "prowl workflow done --verdict issues -"])
+    #expect(
+      verdicts.launchCommands == ["prowl workflow done --verdict clean -", "prowl workflow done --verdict issues -"])
   }
 
   @Test func nudgeLineUsesThePrefixAndTheSameCommands() throws {
@@ -67,14 +68,17 @@ struct WorkflowLineRendererTests {
 
   @Test func textLineIsPrefixedAndSuffixed() throws {
     let command = WorkflowCompletionCommand(token: token, verdicts: nil)
-    #expect(try WorkflowTypedLine.text("Findings: /r/outputs/findings.md", completion: nil) == "[Prowl] Findings: /r/outputs/findings.md")
+    #expect(
+      try WorkflowTypedLine.text("Findings: /r/outputs/findings.md", completion: nil)
+        == "[Prowl] Findings: /r/outputs/findings.md")
     #expect(
       try WorkflowTypedLine.text("Fix each item.", completion: command)
         == "[Prowl] Fix each item. — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow done -")
   }
 
   @Test func pointerLineNamesTheAbsolutePath() throws {
-    let line = try WorkflowTypedLine.pointer(to: "/repo/.prowl/workflow-runs/R/instructions/brief.1.md", completion: nil)
+    let line = try WorkflowTypedLine.pointer(
+      to: "/repo/.prowl/workflow-runs/R/instructions/brief.1.md", completion: nil)
     #expect(line == "[Prowl] Read /repo/.prowl/workflow-runs/R/instructions/brief.1.md and follow it")
   }
 

--- a/supacodeTests/WorkflowNativeActionsTests.swift
+++ b/supacodeTests/WorkflowNativeActionsTests.swift
@@ -168,6 +168,21 @@ struct WorkflowNativeActionsTests {
     }
   }
 
+  @Test func briefingSectionsInsideFencesAreNotAccepted() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let fencedURL = root.appending(path: "fenced.md")
+    try "# Handoff\n```text\n## Objective\n## Current State\n## Next Steps\n```\n".write(
+      to: fencedURL, atomically: true, encoding: .utf8)
+    #expect(HandoffStore.validatedBriefing(from: try String(contentsOf: fencedURL, encoding: .utf8)) == nil)
+    await #expect(throws: WorkflowActionError.invalidBriefing(path: fencedURL.path(percentEncoded: false))) {
+      try await WorkflowNativeActionRunner().execute(
+        actionID: "handoff.checkpoint", inputs: ["briefing": fencedURL.path(percentEncoded: false)],
+        context: context(root: root))
+    }
+    #expect(!HandoffStore(rootURL: root).hasCurrentArtifact)
+  }
+
   @Test func checkpointKeepsAnEarlierBriefingWithoutANewOne() async throws {
     let root = try makeRepo()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowNativeActionsTests.swift
+++ b/supacodeTests/WorkflowNativeActionsTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowNativeActionsTests {
+  nonisolated private static let now = Date(timeIntervalSince1970: 1_760_000_000)
+
+  private func makeRepo() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appending(path: "workflow-actions-tests", directoryHint: .isDirectory)
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    for arguments in [
+      ["init", "-q", "-b", "main"], ["config", "user.email", "t@example.com"], ["config", "user.name", "T"],
+    ] {
+      try runGit(arguments, in: url)
+    }
+    try "hello\n".write(to: url.appending(path: "README.md"), atomically: true, encoding: .utf8)
+    try runGit(["add", "."], in: url)
+    try runGit(["commit", "-q", "-m", "init"], in: url)
+    return url
+  }
+
+  private func runGit(_ arguments: [String], in directory: URL) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = ["-C", directory.path(percentEncoded: false)] + arguments
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+      throw NSError(domain: "WorkflowNativeActionsTests.Git", code: Int(process.terminationStatus))
+    }
+  }
+
+  private func context(root: URL) -> WorkflowActionContext {
+    WorkflowActionContext(
+      runID: UUID(uuidString: "0BADCAFE-0000-4000-8000-000000000042")!,
+      rootURL: root,
+      roleAgents: ["source": "claude", "receiver": "codex", "shell": nil],
+      outgoingAgent: "claude",
+      now: Self.now)
+  }
+
+  private let briefing = """
+    # Handoff
+    ## Objective
+    Ship.
+    ## Current State
+    Green.
+    ## Next Steps
+    1. Review.
+    """
+
+  @Test func transitionWithBriefingArchivesFirstAndReturnsTheBriefingKickoff() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = HandoffStore(rootURL: root)
+    try store.writeBriefing(
+      "# Handoff\n## Objective\nold\n## Current State\nx\n## Next Steps\ny\n", archivingPrevious: false, now: Self.now)
+    let briefingURL = root.appending(path: "brief.md")
+    try briefing.write(to: briefingURL, atomically: true, encoding: .utf8)
+
+    let outputs = try await WorkflowNativeActionRunner().execute(
+      actionID: "handoff.transition",
+      inputs: [
+        "briefing": briefingURL.path(percentEncoded: false), "from": "source", "to": "receiver", "note": "round 1",
+      ],
+      context: context(root: root))
+
+    #expect(outputs["has_briefing"] == "true")
+    #expect(outputs["artifact_path"] == store.currentURL.path(percentEncoded: false))
+    #expect(outputs["kickoff_prompt"] == HandoffCommandHandler.kickoffPrompt(hasBriefing: true))
+    #expect(try String(contentsOf: store.currentURL, encoding: .utf8) == briefing + "\n")
+    let archive = try FileManager.default.contentsOfDirectory(
+      atPath: store.archiveDirectory.path(percentEncoded: false))
+    #expect(archive.count == 1)
+    #expect(archive.first?.contains("-claude-to-codex") == true)
+    #expect(FileManager.default.fileExists(atPath: store.contextURL.path(percentEncoded: false)))
+    let log = try String(contentsOf: store.logURL, encoding: .utf8)
+    #expect(log.contains("claude → codex  launch=requested  briefing=inline"))
+    #expect(log.contains("source=workflow 0BADCAFE-0000-4000-8000-000000000042"))
+    #expect(log.contains("note=\"round 1\""))
+  }
+
+  @Test func transitionWithoutBriefingRemovesTheStaleArtifact() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = HandoffStore(rootURL: root)
+    try store.writeBriefing(
+      "# Handoff\n## Objective\nold\n## Current State\nx\n## Next Steps\ny\n", archivingPrevious: false, now: Self.now)
+
+    let outputs = try await WorkflowNativeActionRunner().execute(
+      actionID: "handoff.transition", inputs: ["from": "source", "to": "receiver"], context: context(root: root))
+
+    #expect(outputs["has_briefing"] == "false")
+    #expect(outputs["kickoff_prompt"] == HandoffCommandHandler.kickoffPrompt(hasBriefing: false))
+    #expect(!store.hasCurrentArtifact)
+    #expect(FileManager.default.fileExists(atPath: store.contextURL.path(percentEncoded: false)))
+    let archive = try FileManager.default.contentsOfDirectory(
+      atPath: store.archiveDirectory.path(percentEncoded: false))
+    #expect(archive.count == 1)
+  }
+
+  @Test func transitionValidatesRolesAndBriefing() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let runner = WorkflowNativeActionRunner()
+    await #expect(throws: WorkflowActionError.missingInput("to")) {
+      try await runner.execute(actionID: "handoff.transition", inputs: ["from": "source"], context: context(root: root))
+    }
+    await #expect(throws: WorkflowActionError.unknownRole("ghost")) {
+      try await runner.execute(
+        actionID: "handoff.transition", inputs: ["from": "source", "to": "ghost"], context: context(root: root))
+    }
+    let invalidURL = root.appending(path: "invalid.md")
+    try "just prose".write(to: invalidURL, atomically: true, encoding: .utf8)
+    await #expect(throws: WorkflowActionError.invalidBriefing(path: invalidURL.path(percentEncoded: false))) {
+      try await runner.execute(
+        actionID: "handoff.transition",
+        inputs: ["briefing": invalidURL.path(percentEncoded: false), "from": "source", "to": "receiver"],
+        context: context(root: root))
+    }
+    #expect(!HandoffStore(rootURL: root).hasCurrentArtifact)
+    let missing = root.appending(path: "missing.md").path(percentEncoded: false)
+    await #expect(throws: WorkflowActionError.unreadableBriefing(path: missing)) {
+      try await runner.execute(
+        actionID: "handoff.transition", inputs: ["briefing": missing, "from": "source", "to": "receiver"],
+        context: context(root: root))
+    }
+    await #expect(throws: WorkflowActionError.unsafePath("/etc/passwd")) {
+      try await runner.execute(
+        actionID: "handoff.transition", inputs: ["briefing": "/etc/passwd", "from": "source", "to": "receiver"],
+        context: context(root: root))
+    }
+    await #expect(throws: WorkflowActionError.unknownAction("nope")) {
+      try await runner.execute(actionID: "nope", inputs: [:], context: context(root: root))
+    }
+  }
+
+  @Test func checkpointKeepsAnEarlierBriefingWithoutANewOne() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = HandoffStore(rootURL: root)
+    let earlier = "# Handoff\n## Objective\nold\n## Current State\nx\n## Next Steps\ny\n"
+    try store.writeBriefing(earlier, archivingPrevious: false, now: Self.now)
+
+    let contextOnly = try await WorkflowNativeActionRunner().execute(
+      actionID: "handoff.checkpoint", inputs: [:], context: context(root: root))
+    #expect(contextOnly["has_briefing"] == "false")
+    #expect(try String(contentsOf: store.currentURL, encoding: .utf8) == earlier)
+
+    let briefingURL = root.appending(path: "brief.md")
+    try briefing.write(to: briefingURL, atomically: true, encoding: .utf8)
+    let withBriefing = try await WorkflowNativeActionRunner().execute(
+      actionID: "handoff.checkpoint", inputs: ["briefing": briefingURL.path(percentEncoded: false)],
+      context: context(root: root))
+    #expect(withBriefing["has_briefing"] == "true")
+    #expect(withBriefing["artifact_path"] == store.currentURL.path(percentEncoded: false))
+    #expect(try String(contentsOf: store.currentURL, encoding: .utf8) == briefing + "\n")
+    let archive = try FileManager.default.contentsOfDirectory(
+      atPath: store.archiveDirectory.path(percentEncoded: false))
+    #expect(archive.contains { $0.contains("replaced-current") })
+  }
+
+  @Test func gitContextWritesTheHandoffContextAndReportsTheBranch() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let outputs = try await WorkflowNativeActionRunner().execute(
+      actionID: "git.context", inputs: ["root": root.path(percentEncoded: false)], context: context(root: root))
+    let store = HandoffStore(rootURL: root)
+    #expect(outputs["path"] == store.contextURL.path(percentEncoded: false))
+    #expect(outputs["branch"] == "main")
+    let contextText = try String(contentsOf: store.contextURL, encoding: .utf8)
+    #expect(contextText.hasPrefix("# Handoff Context (generated)"))
+    #expect(contextText.contains("Outgoing agent (detected): claude"))
+    let defaulted = try await WorkflowNativeActionRunner().execute(
+      actionID: "git.context", inputs: [:], context: context(root: root))
+    #expect(defaulted["branch"] == "main")
+    await #expect(throws: WorkflowActionError.unsafePath("/tmp")) {
+      try await WorkflowNativeActionRunner().execute(
+        actionID: "git.context", inputs: ["root": "/tmp"], context: context(root: root))
+    }
+  }
+}

--- a/supacodeTests/WorkflowNativeActionsTests.swift
+++ b/supacodeTests/WorkflowNativeActionsTests.swift
@@ -140,6 +140,34 @@ struct WorkflowNativeActionsTests {
     }
   }
 
+  @Test func briefingLinksAreResolvedAndMustStayInsideTheWorktree() async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let briefingURL = root.appending(path: "brief.md")
+    try briefing.write(to: briefingURL, atomically: true, encoding: .utf8)
+    let inside = root.appending(path: "link-inside.md")
+    try FileManager.default.createSymbolicLink(at: inside, withDestinationURL: briefingURL)
+    let outputs = try await WorkflowNativeActionRunner().execute(
+      actionID: "handoff.checkpoint", inputs: ["briefing": inside.path(percentEncoded: false)],
+      context: context(root: root))
+    #expect(outputs["has_briefing"] == "true")
+
+    let outside = root.appending(path: "link-outside.md")
+    try FileManager.default.createSymbolicLink(at: outside, withDestinationURL: URL(filePath: "/etc/hosts"))
+    await #expect(throws: WorkflowActionError.unsafePath(outside.path(percentEncoded: false))) {
+      try await WorkflowNativeActionRunner().execute(
+        actionID: "handoff.checkpoint", inputs: ["briefing": outside.path(percentEncoded: false)],
+        context: context(root: root))
+    }
+    let directory = root.appending(path: "dir", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    await #expect(throws: WorkflowActionError.unreadableBriefing(path: directory.path(percentEncoded: false))) {
+      try await WorkflowNativeActionRunner().execute(
+        actionID: "handoff.checkpoint", inputs: ["briefing": directory.path(percentEncoded: false)],
+        context: context(root: root))
+    }
+  }
+
   @Test func checkpointKeepsAnEarlierBriefingWithoutANewOne() async throws {
     let root = try makeRepo()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -1,0 +1,377 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// Interprets the machine's effects against the run store, a fake activation bridge, a fake
+/// launch boundary, and the native action runner — the executable specification of how B3's
+/// wiring must perform each effect (docs-ai 063.007, decision H2).
+@MainActor
+final class WorkflowRunHarness {
+  final class FakeActivationBridge: WorkflowActivationBridge {
+    private(set) var opened: [(surfaceID: UUID, dispatchID: String)] = []
+    private(set) var cancelled: [String] = []
+    private(set) var abandoned: [(dispatchID: String, reason: String)] = []
+    private(set) var completed: [(dispatchID: String, summary: String)] = []
+    var busyOnce = false
+    private var counter = 0
+
+    func openMessageActivation(surfaceID: UUID) -> Result<String, WorkflowActivationOpenFailure> {
+      if busyOnce {
+        busyOnce = false
+        return .failure(.roleBusy)
+      }
+      return .success(issue(surfaceID: surfaceID))
+    }
+
+    func openLaunchActivation(surfaceID: UUID) -> String {
+      issue(surfaceID: surfaceID)
+    }
+
+    private func issue(surfaceID: UUID) -> String {
+      counter += 1
+      let id = "dispatch-\(counter)"
+      opened.append((surfaceID, id))
+      return id
+    }
+
+    func cancelActivation(dispatchID: String) { cancelled.append(dispatchID) }
+    func abandonActivation(dispatchID: String, reason: String) { abandoned.append((dispatchID, reason)) }
+    func completeActivation(dispatchID: String, summary: String) { completed.append((dispatchID, summary)) }
+    func observeActivation(dispatchID: String) -> AgentDispatchObservationStream? { nil }
+  }
+
+  private(set) var machine: WorkflowRunMachine
+  let store: WorkflowRunStore
+  let bridge = FakeActivationBridge()
+  let actions: any WorkflowActionExecuting
+  let skillsDirectory: URL
+  let now: Date
+  private(set) var typedLines: [(surfaceID: UUID, line: String)] = []
+  private(set) var launches: [WorkflowLaunchRequest] = []
+  private(set) var watchdogs: [WorkflowWatchdogRequest] = []
+  private(set) var disarmed: [Int] = []
+  private(set) var notifications: [String] = []
+  private(set) var closed: [String] = []
+  private(set) var finished: WorkflowRunStatus?
+  private var paneCounter = 10
+
+  init(
+    machine: WorkflowRunMachine,
+    effects: [WorkflowRunEffect],
+    store: WorkflowRunStore,
+    actions: any WorkflowActionExecuting,
+    skillsDirectory: URL,
+    now: Date
+  ) async throws {
+    self.machine = machine
+    self.store = store
+    self.actions = actions
+    self.skillsDirectory = skillsDirectory
+    self.now = now
+    try store.ensureLayout(runID: machine.run.id)
+    try await perform(effects)
+  }
+
+  var run: WorkflowRun { machine.run }
+
+  func deliver(token: String, body: String, verdict: String? = nil) async throws -> Result<
+    WorkflowDeliveryReceipt, WorkflowDeliveryError
+  > {
+    let (result, effects) = machine.deliver(ordinal: nil, selector: .token(token), body: body, verdict: verdict)
+    try await perform(effects)
+    return result
+  }
+
+  func user(_ action: WorkflowUserAction) async throws {
+    try await perform(machine.apply(.user(action)))
+  }
+
+  func watchdog(_ verdict: WorkflowWatchdogVerdict) async throws {
+    guard let ordinal = machine.run.currentActivation?.ordinal else { return }
+    try await perform(machine.apply(.watchdog(ordinal: ordinal, verdict)))
+  }
+
+  private func apply(_ event: WorkflowRunEvent) async throws {
+    try await perform(machine.apply(event))
+  }
+
+  // swiftlint:disable:next cyclomatic_complexity
+  private func perform(_ effects: [WorkflowRunEffect]) async throws {
+    let runID = machine.run.id
+    for effect in effects {
+      switch effect {
+      case .awaitRoleIdle(_, _, let ordinal):
+        try await apply(.roleIdle(ordinal: ordinal))
+      case .cancelRoleWait:
+        break
+      case .openActivation(_, let surfaceID, let ordinal):
+        let dispatchID = bridge.openLaunchActivation(surfaceID: surfaceID)
+        try await apply(.injectionSucceeded(ordinal: ordinal, dispatchID: dispatchID))
+      case .materializeInstruction(let ordinal, let stepID, let text):
+        try store.writeInstruction(runID: runID, stepID: stepID, ordinal: ordinal, text: text)
+      case .materializeSkill(let id):
+        let skill = BundledSkill(
+          id: id, name: id, description: "d", audience: .workflow,
+          directoryURL: skillsDirectory.appending(path: id, directoryHint: .isDirectory))
+        try store.materializeSkill(runID: runID, skill: skill)
+      case .inject(_, let surfaceID, let ordinal, let line, let opensActivation):
+        var dispatchID: String?
+        if opensActivation {
+          switch bridge.openMessageActivation(surfaceID: surfaceID) {
+          case .failure(let failure):
+            try await apply(.injectionFailed(ordinal: ordinal, failure.injectionFailure))
+            continue
+          case .success(let id):
+            dispatchID = id
+          }
+        }
+        typedLines.append((surfaceID, line))
+        try await apply(.injectionSucceeded(ordinal: ordinal, dispatchID: dispatchID))
+      case .typeLine(_, let surfaceID, let line):
+        typedLines.append((surfaceID, line))
+      case .launch(let request):
+        launches.append(request)
+        paneCounter += 1
+        let pane = WorkflowPaneIdentity(
+          surfaceID: UUID(), tabID: UUID(), handle: "p\(paneCounter)", displayName: request.profile.name,
+          agent: request.profile.agent)
+        let dispatchID = request.expectsDelivery ? bridge.openLaunchActivation(surfaceID: pane.surfaceID) : nil
+        try await apply(.launched(ordinal: request.ordinal, pane: pane, dispatchID: dispatchID))
+      case .runAction(let stepID, let actionID, let inputs):
+        let context = WorkflowActionContext(
+          runID: runID, rootURL: machine.run.context.worktree.rootURL,
+          roleAgents: machine.run.bindings.mapValues { $0.templateRole.agent.isEmpty ? nil : $0.templateRole.agent },
+          outgoingAgent: machine.run.bindings.values.first { $0.source == .current }?.pane?.agent, now: now)
+        do {
+          let outputs = try await actions.execute(actionID: actionID, inputs: inputs, context: context)
+          try await apply(.actionCompleted(stepID: stepID, outputs: outputs))
+        } catch {
+          try await apply(.actionFailed(stepID: stepID, reason: "\(error)"))
+        }
+      case .notify(let text):
+        notifications.append(text)
+      case .close(let role, _):
+        closed.append(role)
+      case .abandonActivation(let dispatchID, let reason):
+        bridge.abandonActivation(dispatchID: dispatchID, reason: reason)
+      case .completeActivation(let dispatchID, let summary):
+        bridge.completeActivation(dispatchID: dispatchID, summary: summary)
+      case .armWatchdog(let request):
+        watchdogs.append(request)
+      case .disarmWatchdog(let ordinal):
+        disarmed.append(ordinal)
+      case .persistOutput(let name, let ordinal, let body):
+        try store.writeOutput(runID: runID, name: name, ordinal: ordinal, body: body)
+      case .persist:
+        try store.writeRecord(WorkflowRunRecord(run: machine.run))
+      case .log(let line):
+        try store.appendLog(runID: runID, line: line, now: now)
+      case .finished(let status):
+        finished = status
+      }
+    }
+  }
+}
+
+@MainActor
+struct WorkflowRunHarnessTests {
+  nonisolated private static let now = Date(timeIntervalSince1970: 1_760_000_000)
+
+  private struct FakeActions: WorkflowActionExecuting {
+    func execute(
+      actionID: String, inputs: [String: String], context: WorkflowActionContext
+    ) throws -> [String: String] {
+      switch actionID {
+      case "git.context": ["path": "\(inputs["root"] ?? "")/.prowl/handoff/context.md", "branch": "feat/x"]
+      default: ["kickoff_prompt": "Take over.", "artifact_path": "/a", "has_briefing": "false"]
+      }
+    }
+  }
+
+  private func makeRoot() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appending(path: "workflow-harness-tests", directoryHint: .isDirectory)
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    let skills = url.appending(path: "skills/prowl.adversarial-reviewer", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: skills, withIntermediateDirectories: true)
+    try "---\nname: r\ndescription: d\n---\n# Reviewer\n".write(
+      to: skills.appending(path: "SKILL.md"), atomically: true, encoding: .utf8)
+    return url
+  }
+
+  private func makeHarness(
+    _ yaml: String = WorkflowRunMachineTests.adversarialReview,
+    root: URL,
+    inputs: [String: String] = [:],
+    skipped: Set<String> = [],
+    actions: any WorkflowActionExecuting = FakeActions()
+  ) async throws -> WorkflowRunHarness {
+    let definition = try #require(WorkflowDocumentParser.parse(yaml).definition)
+    let counter = WorkflowRunMachineTests.TokenCounter()
+    let started = try WorkflowRunMachine.start(
+      WorkflowRunStartRequest(
+        definition: definition,
+        runID: UUID(),
+        context: WorkflowRunContext(
+          scope: .user, definitionPath: nil,
+          worktree: WorkflowRunWorktree(
+            id: "wt", name: "feature", branch: "feat/x", path: root.path(percentEncoded: false))),
+        bindings: [
+          definition.roles[0].name: .current(WorkflowRunMachineTests.authorPane),
+          definition.roles[1].name: .launch(WorkflowRunMachineTests.reviewerProfile, pane: nil),
+        ],
+        inputs: inputs,
+        skippedSteps: skipped),
+      now: { Self.now },
+      makeToken: { counter.next() })
+    return try await WorkflowRunHarness(
+      machine: started.machine, effects: started.effects, store: WorkflowRunStore(rootURL: root),
+      actions: actions, skillsDirectory: root.appending(path: "skills", directoryHint: .isDirectory), now: Self.now)
+  }
+
+  @Test func adversarialReviewRunsEndToEndAgainstFakeBoundaries() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root, inputs: ["max_rounds": "3", "focus": "the parser"])
+    let runDirectory = harness.store.directory(for: harness.run.id)
+
+    // brief: the pointer line was typed with the token after the activation opened.
+    #expect(harness.typedLines.count == 1)
+    #expect(
+      harness.typedLines[0].line.hasPrefix(
+        "[Prowl] Read \(runDirectory.path(percentEncoded: false))instructions/brief.1.md and follow it"))
+    #expect(harness.typedLines[0].line.contains("PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow done -"))
+    #expect(harness.bridge.opened.map(\.dispatchID) == ["dispatch-1"])
+    #expect(harness.run.phase == .waitingForDelivery(ordinal: 1))
+    let instruction = try String(contentsOf: runDirectory.appending(path: "instructions/brief.1.md"), encoding: .utf8)
+    #expect(
+      instruction.hasPrefix(
+        "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n\n---\n"))
+    #expect(instruction.contains("PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow done -"))
+
+    _ = try await harness.deliver(token: "TOKEN-1", body: "# Brief\n## Scope\nx\n## Claims\ny")
+    #expect(harness.bridge.completed.map(\.dispatchID) == ["dispatch-1"])
+    #expect(harness.disarmed == [1])
+    #expect(harness.launches.count == 1)
+    #expect(
+      harness.launches[0].prompt.hasPrefix(
+        "Read \(runDirectory.path(percentEncoded: false))outputs/brief.md and review (strict)."))
+    #expect(harness.launches[0].environment["PROWL_WORKFLOW_TOKEN"] == "TOKEN-2")
+    #expect(
+      FileManager.default.fileExists(
+        atPath: runDirectory.appending(path: "skills/prowl.adversarial-reviewer/SKILL.md").path(percentEncoded: false)))
+    #expect(harness.run.bindings["reviewer"]?.pane?.handle == "p11")
+    #expect(harness.run.phase == .waitingForDelivery(ordinal: 2))
+
+    _ = try await harness.deliver(token: "TOKEN-2", body: "## Findings\n- a\n## Verdict\nissues", verdict: "issues")
+    #expect(harness.typedLines.count == 2)
+    #expect(
+      harness.typedLines[1].line
+        == "[Prowl] Findings: \(runDirectory.path(percentEncoded: false))outputs/findings.md. Fix or rebut each item."
+        + " — finish with: PROWL_WORKFLOW_TOKEN=TOKEN-3 prowl workflow done -")
+    _ = try await harness.deliver(token: "TOKEN-3", body: "# Done")
+    #expect(harness.typedLines[2].surfaceID == harness.run.bindings["reviewer"]?.pane?.surfaceID)
+    _ = try await harness.deliver(token: "TOKEN-4", body: "# Findings\nnone", verdict: "clean")
+
+    #expect(harness.finished == .completed)
+    #expect(harness.notifications == ["Adversarial review: clean after 1 round(s)"])
+    #expect(harness.closed == ["reviewer"])
+    #expect(harness.bridge.opened.map(\.dispatchID) == ["dispatch-1", "dispatch-2", "dispatch-3", "dispatch-4"])
+    #expect(harness.bridge.completed.map(\.dispatchID) == ["dispatch-1", "dispatch-2", "dispatch-3", "dispatch-4"])
+    #expect(harness.bridge.abandoned.isEmpty)
+    #expect(harness.watchdogs.map(\.ordinal) == [1, 2, 3, 4])
+
+    let outputs = try FileManager.default.contentsOfDirectory(
+      atPath: runDirectory.appending(path: "outputs").path(percentEncoded: false)
+    ).sorted()
+    #expect(
+      outputs == [
+        "brief.1.md", "brief.md", "disposition.3.md", "disposition.md", "findings.2.md", "findings.4.md", "findings.md",
+      ])
+    #expect(
+      try String(contentsOf: runDirectory.appending(path: "outputs/findings.md"), encoding: .utf8)
+        == "# Findings\nnone\n")
+    let record = try harness.store.readRecord(runID: harness.run.id)
+    #expect(record.run.status.state == "completed")
+    #expect(record.invocations.map(\.ordinal) == [1, 2, 3, 4])
+    #expect(
+      record.invocations.compactMap(\.activation?.dispatchID) == [
+        "dispatch-1", "dispatch-2", "dispatch-3", "dispatch-4",
+      ])
+    #expect(record.loop.count == 1)
+    let log = try String(contentsOf: runDirectory.appending(path: "log.md"), encoding: .utf8)
+    #expect(log.contains("Run finished: completed."))
+    #expect(!log.contains("TOKEN-"))
+    #expect(try String(contentsOf: harness.store.runsDirectory.appending(path: ".gitignore"), encoding: .utf8) == "*\n")
+  }
+
+  @Test func cancelAbandonsThePendingActivationAndKeepsDeliveredOutputs() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root)
+    _ = try await harness.deliver(token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
+    try await harness.user(.cancel)
+    #expect(harness.finished == .cancelled)
+    #expect(harness.bridge.abandoned.map(\.dispatchID) == ["dispatch-2"])
+    #expect(
+      harness.bridge.abandoned[0].reason == "Workflow run \(harness.run.id.uuidString) cancelled at step 'launch'.")
+    #expect(try harness.store.readRecord(runID: harness.run.id).run.status.state == "cancelled")
+    #expect(
+      FileManager.default.fileExists(
+        atPath: harness.store.directory(for: harness.run.id).appending(path: "outputs/brief.md").path(
+          percentEncoded: false)))
+    #expect(harness.closed.isEmpty)
+  }
+
+  @Test func aBusyRoleIsWaitedForAgainBeforeAnythingIsTyped() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root)
+    _ = try await harness.deliver(token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
+    harness.bridge.busyOnce = true
+    _ = try await harness.deliver(token: "TOKEN-2", body: "## Findings\n## Verdict", verdict: "issues")
+    #expect(harness.run.phase == .waitingForDelivery(ordinal: 3))
+    #expect(harness.typedLines.count == 2)
+    #expect(harness.run.invocations.count == 3)
+    #expect(harness.bridge.opened.map(\.dispatchID) == ["dispatch-1", "dispatch-2", "dispatch-3"])
+  }
+
+  @Test func nudgeAndAttentionFlowThroughTheWatchdogVerdicts() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root)
+    try await harness.watchdog(.nudge)
+    #expect(
+      harness.typedLines.last?.line.hasPrefix(
+        "[Prowl] When your work for this step is fully complete, finish with: PROWL_WORKFLOW_TOKEN=TOKEN-1") == true)
+    try await harness.watchdog(.attention(.idleWithoutDelivery))
+    #expect(try harness.store.readRecord(runID: harness.run.id).run.status.state == "needs_attention")
+    try await harness.user(.keepWaiting)
+    #expect(harness.watchdogs.last?.nudgedAlready == true)
+    _ = try await harness.deliver(token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
+    #expect(harness.run.status == .running)
+  }
+
+  @Test func handoffWithSkippedBriefRunsTheContextOnlyTransition() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(
+      WorkflowRunMachineTests.handoff, root: root, skipped: ["brief"], actions: WorkflowNativeActionRunner())
+    #expect(harness.finished == .completed)
+    #expect(harness.typedLines.isEmpty)
+    #expect(harness.launches.count == 1)
+    #expect(harness.launches[0].prompt == HandoffCommandHandler.kickoffPrompt(hasBriefing: false))
+    #expect(!harness.launches[0].expectsDelivery)
+    #expect(harness.notifications == ["Handed off to Pi Reviewer"])
+    #expect(
+      FileManager.default.fileExists(
+        atPath: root.appending(path: ".prowl/handoff/context.md").path(percentEncoded: false)))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: root.appending(path: ".prowl/handoff/current.md").path(percentEncoded: false)))
+    let record = try harness.store.readRecord(runID: harness.run.id)
+    #expect(record.skippedOutputs == ["brief": "brief"])
+    #expect(record.actions["transition"]?["has_briefing"] == "false")
+  }
+}

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -162,7 +162,13 @@ final class WorkflowRunHarness {
       case .disarmWatchdog(let ordinal):
         disarmed.append(ordinal)
       case .persistOutput(let name, let ordinal, let body):
-        try store.writeOutput(runID: runID, name: name, ordinal: ordinal, body: body)
+        do {
+          try store.writeOutput(runID: runID, name: name, ordinal: ordinal, body: body)
+        } catch {
+          try await apply(.outputPersistFailed(ordinal: ordinal, reason: "\(error)"))
+          continue
+        }
+        try await apply(.outputPersisted(ordinal: ordinal))
       case .persist:
         try store.writeRecord(WorkflowRunRecord(run: machine.run))
       case .log(let line):
@@ -306,6 +312,29 @@ struct WorkflowRunHarnessTests {
     #expect(try String(contentsOf: harness.store.runsDirectory.appending(path: ".gitignore"), encoding: .utf8) == "*\n")
   }
 
+  @Test func aFailingStoreLeavesTheDeliveryInAttentionUntilRetried() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root)
+    let outputs = harness.store.directory(for: harness.run.id).appending(path: "outputs", directoryHint: .isDirectory)
+    try FileManager.default.removeItem(at: outputs)
+    let elsewhere = root.appending(path: "elsewhere", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(at: outputs, withDestinationURL: elsewhere)
+    let result = try await harness.deliver(token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
+    #expect((try? result.get()) != nil)
+    #expect(harness.run.status.attention?.reason.code == "persist_failed")
+    #expect(harness.bridge.completed.isEmpty)
+    #expect(harness.launches.isEmpty)
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
+    try FileManager.default.removeItem(at: outputs)
+    try FileManager.default.createDirectory(at: outputs, withIntermediateDirectories: true)
+    try await harness.user(.retry)
+    #expect(harness.bridge.completed.map(\.dispatchID) == ["dispatch-1"])
+    #expect(harness.launches.count == 1)
+    #expect(try harness.store.readRecord(runID: harness.run.id).outputs["brief"]?.ordinal == 1)
+  }
+
   @Test func cancelAbandonsThePendingActivationAndKeepsDeliveredOutputs() async throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }
@@ -335,6 +364,10 @@ struct WorkflowRunHarnessTests {
     #expect(harness.typedLines.count == 2)
     #expect(harness.run.invocations.count == 3)
     #expect(harness.bridge.opened.map(\.dispatchID) == ["dispatch-1", "dispatch-2", "dispatch-3"])
+    #expect(harness.run.invocations[2].activation?.token == "TOKEN-3")
+    let delivered = try await harness.deliver(token: "TOKEN-3", body: "# Done")
+    #expect(try delivered.get().ordinal == 3)
+    #expect(harness.run.phase == .waitingForDelivery(ordinal: 4))
   }
 
   @Test func nudgeAndAttentionFlowThroughTheWatchdogVerdicts() async throws {

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -335,6 +335,24 @@ struct WorkflowRunHarnessTests {
     #expect(try harness.store.readRecord(runID: harness.run.id).outputs["brief"]?.ordinal == 1)
   }
 
+  @Test func aProvisionalDeliveryIsKeptOnDiskUntilTheUserAcceptsIt() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let harness = try await makeHarness(root: root)
+    let result = try await harness.deliver(token: "TOKEN-1", body: "## Scope\nonly")
+    #expect(try result.get().issues == [.missingSections(["## Claims"])])
+    #expect(harness.run.status.attention?.reason.code == "delivery_issues")
+    #expect(harness.bridge.completed.isEmpty)
+    #expect(harness.launches.isEmpty)
+    let brief = harness.store.directory(for: harness.run.id).appending(path: "outputs/brief.md")
+    #expect(try String(contentsOf: brief, encoding: .utf8) == "## Scope\nonly\n")
+    #expect(try harness.store.readRecord(runID: harness.run.id).run.status.attention?.issues == ["missing_sections"])
+    try await harness.user(.acceptDelivery(verdict: nil))
+    #expect(harness.bridge.completed.map(\.dispatchID) == ["dispatch-1"])
+    #expect(harness.launches.count == 1)
+    #expect(try harness.store.readRecord(runID: harness.run.id).outputs["brief"]?.ordinal == 1)
+  }
+
   @Test func cancelAbandonsThePendingActivationAndKeepsDeliveredOutputs() async throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -130,16 +130,17 @@ struct WorkflowRunMachineTests {
         "reviewer": .launch(Self.reviewerProfile, pane: nil),
       ]
     let started = try WorkflowRunMachine.start(
-      definition: definition(yaml),
-      runID: Self.runID,
-      context: WorkflowRunContext(
-        scope: .repo(repositoryID: "repo-1"),
-        definitionPath: "/repo/.prowl/workflows/review.yaml",
-        worktree: WorkflowRunWorktree(id: "wt", name: "feature", branch: "feat/x", path: "/repo")),
-      bindings: bindings,
-      inputs: inputs,
-      skippedSteps: skipped,
-      selfInitiated: selfInitiated,
+      WorkflowRunStartRequest(
+        definition: definition(yaml),
+        runID: Self.runID,
+        context: WorkflowRunContext(
+          scope: .repo(repositoryID: "repo-1"),
+          definitionPath: "/repo/.prowl/workflows/review.yaml",
+          worktree: WorkflowRunWorktree(id: "wt", name: "feature", branch: "feat/x", path: "/repo")),
+        bindings: bindings,
+        inputs: inputs,
+        skippedSteps: skipped,
+        selfInitiated: selfInitiated),
       now: { Self.start },
       makeToken: { counter.next() }
     )
@@ -421,13 +422,13 @@ struct WorkflowRunMachineTests {
   @Test func startRejectsAWorktreePathThatIsNotOneLine() throws {
     #expect(throws: WorkflowRunStartError.unsafePath("/re\npo")) {
       try WorkflowRunMachine.start(
-        definition: definition(Self.handoff),
-        runID: Self.runID,
-        context: WorkflowRunContext(
-          scope: .user, definitionPath: nil,
-          worktree: WorkflowRunWorktree(id: "wt", name: "w", branch: "b", path: "/re\npo")),
-        bindings: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)],
-        inputs: [:],
+        WorkflowRunStartRequest(
+          definition: definition(Self.handoff),
+          runID: Self.runID,
+          context: WorkflowRunContext(
+            scope: .user, definitionPath: nil,
+            worktree: WorkflowRunWorktree(id: "wt", name: "w", branch: "b", path: "/re\npo")),
+          bindings: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)]),
         now: { Self.start })
     }
   }

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -1,0 +1,821 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+// swiftlint:disable file_length type_body_length
+struct WorkflowRunMachineTests {
+  // MARK: - Fixtures
+
+  nonisolated static let adversarialReview = """
+    schema: prowl.workflow/v1
+    id: prowl.adversarial-review
+    name: Adversarial Review
+    inputs:
+      max_rounds: { type: integer, default: 5, min: 1, max: 30 }
+      focus:      { type: string,  default: "" }
+      mode:       { type: enum, values: [strict, lenient], default: strict }
+    roles:
+      author:
+        source: current
+      reviewer:
+        source: launch
+        agents: [pi, codex]
+        placement: split
+        direction: right
+    steps:
+      - id: brief
+        title: "Author writing the brief"
+        message: author
+        instruction: |
+          Write a short brief for an adversarial reviewer: ## Scope, ## Claims.
+          Focus: {{ inputs.focus }}
+        expect: { output: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
+      - id: launch
+        title: "Reviewer starting round 1"
+        launch: reviewer
+        prompt: "Read {{ outputs.brief.path }} and review ({{ inputs.mode }})."
+        skill: prowl.adversarial-reviewer
+        expect: { output: findings, sections: ["## Findings", "## Verdict"], verdict: [clean, issues] }
+      - id: rounds
+        repeat:
+          max: "{{ inputs.max_rounds }}"
+          until: outputs.findings.verdict == clean
+        steps:
+          - id: fix
+            title: "Round {{ loop.index }}: author addressing findings"
+            message: author
+            text: "Findings: {{ outputs.findings.path }}. Fix or rebut each item."
+            expect: { output: disposition }
+          - id: rereview
+            title: "Round {{ loop.index }}: reviewer re-checking"
+            message: reviewer
+            text: "Disposition: {{ outputs.disposition.path }}. Re-review."
+            expect: { output: findings, verdict: [clean, issues] }
+      - id: context
+        action: git.context
+        with: { root: "{{ worktree.path }}" }
+      - id: done
+        notify: "Adversarial review: {{ outputs.findings.verdict }} after {{ loop.count }} round(s)"
+      - id: cleanup
+        close: reviewer
+    """
+
+  nonisolated static let handoff = """
+    schema: prowl.workflow/v1
+    id: prowl.handoff
+    name: Hand Off
+    roles:
+      source:
+        source: current
+      receiver:
+        source: launch
+        placement: tab
+        background: true
+    steps:
+      - id: brief
+        message: source
+        instruction: |
+          Write the handoff briefing.
+        expect: { output: brief, sections: ["## Objective"] }
+      - id: transition
+        action: handoff.transition
+        with: { briefing: "{{ outputs.brief.path }}", from: source, to: receiver }
+      - id: launch
+        launch: receiver
+        prompt: "{{ actions.transition.kickoff_prompt }}"
+      - id: done
+        notify: "Handed off to {{ roles.receiver.name }}"
+    """
+
+  nonisolated static let authorPane = WorkflowPaneIdentity(
+    surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+    tabID: UUID(uuidString: "00000000-0000-0000-0000-000000000011")!,
+    handle: "p1", displayName: "Claude Code", agent: "claude")
+  nonisolated static let reviewerProfile = WorkflowProfileBinding(
+    id: UUID(uuidString: "00000000-0000-0000-0000-000000000009")!, name: "Pi Reviewer", agent: "pi")
+  nonisolated static let reviewerPane = WorkflowPaneIdentity(
+    surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+    tabID: UUID(uuidString: "00000000-0000-0000-0000-000000000011")!,
+    handle: "p2", displayName: "Pi Reviewer", agent: "pi")
+  nonisolated static let runID = UUID(uuidString: "0BADCAFE-0000-4000-8000-000000000042")!
+  nonisolated static let start = Date(timeIntervalSince1970: 1_760_000_000)
+
+  nonisolated final class TokenCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func next() -> String {
+      lock.lock()
+      defer { lock.unlock() }
+      count += 1
+      return "TOKEN-\(count)"
+    }
+  }
+
+  private func definition(_ yaml: String) throws -> WorkflowDefinition {
+    try #require(WorkflowDocumentParser.parse(yaml).definition)
+  }
+
+  private func makeMachine(
+    _ yaml: String = adversarialReview,
+    roles: [String: WorkflowRoleBinding]? = nil,
+    inputs: [String: String] = [:],
+    skipped: Set<String> = [],
+    selfInitiated: Bool = false
+  ) throws -> (WorkflowRunMachine, [WorkflowRunEffect]) {
+    let counter = TokenCounter()
+    let bindings =
+      roles ?? [
+        "author": .current(Self.authorPane),
+        "reviewer": .launch(Self.reviewerProfile, pane: nil),
+      ]
+    let started = try WorkflowRunMachine.start(
+      definition: definition(yaml),
+      runID: Self.runID,
+      context: WorkflowRunContext(
+        scope: .repo(repositoryID: "repo-1"),
+        definitionPath: "/repo/.prowl/workflows/review.yaml",
+        worktree: WorkflowRunWorktree(id: "wt", name: "feature", branch: "feat/x", path: "/repo")),
+      bindings: bindings,
+      inputs: inputs,
+      skippedSteps: skipped,
+      selfInitiated: selfInitiated,
+      now: { Self.start },
+      makeToken: { counter.next() }
+    )
+    return (started.machine, started.effects)
+  }
+
+  private var runDir: String { "/repo/.prowl/workflow-runs/\(Self.runID.uuidString)" }
+
+  /// Drives the fixture through `brief` → `launch` → findings delivery and returns the machine.
+  private func machineAfterFindings(verdict: String, inputs: [String: String] = [:]) throws -> WorkflowRunMachine {
+    var (machine, _) = try makeMachine(inputs: inputs)
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let brief = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
+    _ = try brief.result.get()
+    _ = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
+    let findings = machine.deliver(
+      ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n- a\n## Verdict\n\(verdict)", verdict: verdict)
+    _ = try findings.result.get()
+    return machine
+  }
+
+  // MARK: - Linear flow
+
+  @Test func startEntersTheFirstMessageStepByWaitingForTheRole() throws {
+    let (machine, effects) = try makeMachine()
+    #expect(machine.run.status == .running)
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 1))
+    #expect(effects.contains(.awaitRoleIdle(role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 1)))
+    #expect(effects.first == .log("Run \(Self.runID.uuidString) of workflow 'prowl.adversarial-review' started."))
+    #expect(machine.run.invocations.map(\.ordinal) == [1])
+    #expect(
+      machine.run.stepRecords == [WorkflowStepRecord(stepID: "brief", iteration: nil, state: .active, ordinal: 1)])
+    #expect(machine.run.inputs == ["max_rounds": "5", "focus": "", "mode": "strict"])
+  }
+
+  @Test func roleIdleMaterializesTheInstructionAndInjectsThePointerLineWithTheToken() throws {
+    var (machine, _) = try makeMachine(inputs: ["focus": "the parser"])
+    let effects = machine.apply(.roleIdle(ordinal: 1))
+    let path = "\(runDir)/instructions/brief.1.md"
+    let command = WorkflowCompletionCommand(token: "TOKEN-1", verdicts: nil)
+    #expect(
+      effects.contains(
+        .materializeInstruction(
+          ordinal: 1, stepID: "brief",
+          text: "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n"
+            + command.instructionTrailer())))
+    #expect(
+      effects.contains(
+        .inject(
+          role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 1,
+          line: "[Prowl] Read \(path) and follow it — finish with: PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow done -",
+          opensActivation: true)))
+    #expect(machine.run.phase == .injecting(ordinal: 1))
+    #expect(machine.run.invocations[0].activation?.token == "TOKEN-1")
+    #expect(machine.run.invocations[0].instructionPath == path)
+  }
+
+  @Test func injectionSuccessOpensTheActivationAndArmsTheWatchdog() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    let effects = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
+    #expect(machine.run.activation(forDispatchID: "d1")?.ordinal == 1)
+    #expect(machine.run.currentActivation?.state == .waiting)
+    #expect(
+      effects.contains(
+        .armWatchdog(
+          WorkflowWatchdogRequest(
+            ordinal: 1, stepID: "brief", role: "author", surfaceID: Self.authorPane.surfaceID, dispatchID: "d1",
+            timeoutSeconds: 600, timeoutPolicy: .attention, nudgedAlready: false))))
+  }
+
+  @Test func deliveryChecksTheTokenValidatesTheBodyAndAdvancesToTheLaunch() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token(nil), body: "x", verdict: nil).result == .failure(.tokenRequired))
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token("nope"), body: "x", verdict: nil).result == .failure(.tokenInvalid))
+    #expect(
+      machine.deliver(ordinal: 2, selector: .token("TOKEN-1"), body: "x", verdict: nil).result
+        == .failure(.stepNotExpecting))
+    let invalid = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope only", verdict: nil)
+    #expect(invalid.result.failureCode == "OUTPUT_INVALID")
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
+
+    let (result, effects) = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "```md\n# Brief\n## Scope\nx\n## Claims\ny\n```", verdict: nil)
+    let receipt = try result.get()
+    #expect(receipt.output.name == "brief")
+    #expect(receipt.output.path == "\(runDir)/outputs/brief.1.md")
+    #expect(receipt.output.latestPath == "\(runDir)/outputs/brief.md")
+    #expect(effects.contains(.persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n")))
+    #expect(effects.contains(.disarmWatchdog(ordinal: 1)))
+    #expect(
+      effects.contains(
+        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+    #expect(effects.contains(.materializeSkill(id: "prowl.adversarial-reviewer")))
+    guard
+      case .launch(let request)? = effects.first(where: { if case .launch = $0 { return true } else { return false } })
+    else {
+      Issue.record("expected a launch effect")
+      return
+    }
+    #expect(request.role == "reviewer")
+    #expect(request.ordinal == 2)
+    #expect(request.profile == Self.reviewerProfile)
+    #expect(
+      request.prompt.hasPrefix(
+        "Read \(runDir)/outputs/brief.md and review (strict).\n\n---\nProwl workflow completion protocol v1:"))
+    #expect(
+      request.prompt.contains("\nprowl workflow done --verdict clean -\nor:\nprowl workflow done --verdict issues -\n"))
+    #expect(request.prompt.contains("Reviewer starting round 1"))
+    #expect(
+      request.environment == [
+        "PROWL_WORKFLOW_TOKEN": "TOKEN-2", "PROWL_WORKFLOW_RUN": Self.runID.uuidString,
+        "PROWL_WORKFLOW_ROLE": "reviewer",
+      ])
+    #expect(request.placement == .split)
+    #expect(request.direction == .right)
+    #expect(request.anchorSurfaceID == Self.authorPane.surfaceID)
+    #expect(request.expectsDelivery)
+    #expect(!request.redelivery)
+    #expect(machine.run.phase == .launching(ordinal: 2))
+    #expect(machine.run.invocations[0].activation?.state == .delivered)
+    #expect(machine.run.outputs["brief"]?.ordinal == 1)
+  }
+
+  @Test func launchedBindsThePaneAndWaitsForTheFindings() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    let effects = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
+    #expect(machine.run.bindings["reviewer"]?.pane == Self.reviewerPane)
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 2))
+    #expect(machine.run.activation(forDispatchID: "d2")?.token == "TOKEN-2")
+    #expect(
+      effects.contains {
+        if case .armWatchdog(let request) = $0 {
+          return request.ordinal == 2 && request.dispatchID == "d2"
+        } else {
+          return false
+        }
+      })
+    #expect(machine.templateContext().roles["reviewer"]?.pane == "p2")
+  }
+
+  @Test func verdictRequiredAndUndeclaredVerdictAreRejected() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    _ = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
+    #expect(
+      machine.deliver(ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n## Verdict", verdict: nil).result
+        == .failure(.verdictRequired(allowed: ["clean", "issues"])))
+    #expect(
+      machine.deliver(ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n## Verdict", verdict: "maybe").result
+        .failureCode == "OUTPUT_INVALID")
+  }
+
+  @Test func cleanVerdictBeforeTheLoopSkipsItAndFinishesTheRun() throws {
+    var machine = try machineAfterFindings(verdict: "clean")
+    #expect(machine.run.loopCount == 0)
+    #expect(machine.run.phase == .runningAction(stepID: "context"))
+    #expect(
+      machine.run.stepRecords.contains(
+        WorkflowStepRecord(stepID: "rounds", iteration: nil, state: .skipped, ordinal: nil)))
+    let effects = machine.apply(
+      .actionCompleted(stepID: "context", outputs: ["path": "/repo/.prowl/handoff/context.md", "branch": "feat/x"]))
+    #expect(effects.contains(.notify("Adversarial review: clean after 0 round(s)")))
+    #expect(effects.contains(.close(role: "reviewer", surfaceID: Self.reviewerPane.surfaceID)))
+    #expect(effects.last == .finished(.completed))
+    #expect(machine.run.status == .completed)
+    #expect(machine.run.finishedAt == Self.start)
+    #expect(machine.run.actionOutputs["context"]?["branch"] == "feat/x")
+  }
+
+  @Test func issuesVerdictRunsRoundsUntilCleanWithLatestWinsOutputs() throws {
+    var machine = try machineAfterFindings(verdict: "issues", inputs: ["max_rounds": "3"])
+    #expect(machine.run.position.loop == WorkflowRunPosition.Loop(iteration: 1, bodyIndex: 0, max: 3))
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 3))
+    #expect(machine.run.stepRecords.last == WorkflowStepRecord(stepID: "fix", iteration: 1, state: .active, ordinal: 3))
+
+    let inject = machine.apply(.roleIdle(ordinal: 3))
+    #expect(
+      inject.contains(
+        .inject(
+          role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 3,
+          line: "[Prowl] Findings: \(runDir)/outputs/findings.md. Fix or rebut each item. — finish with: "
+            + "PROWL_WORKFLOW_TOKEN=TOKEN-3 prowl workflow done -",
+          opensActivation: true)))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done\nfixed", verdict: nil).result.get()
+
+    #expect(machine.run.phase == .waitingForRole(role: "reviewer", ordinal: 4))
+    _ = machine.apply(.roleIdle(ordinal: 4))
+    _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
+    let round1 = machine.deliver(ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings\nstill", verdict: "issues")
+    let receipt = try round1.result.get()
+    #expect(receipt.output.path == "\(runDir)/outputs/findings.4.md")
+    #expect(round1.effects.contains(.persistOutput(name: "findings", ordinal: 4, body: "# Findings\nstill\n")))
+    #expect(machine.run.outputs["findings"]?.ordinal == 4)
+    #expect(machine.run.loopCount == 1)
+    #expect(machine.run.position.loop == WorkflowRunPosition.Loop(iteration: 2, bodyIndex: 0, max: 3))
+    #expect(machine.templateContext().loop == WorkflowTemplateContext.Loop(index: 2, count: 1))
+
+    _ = machine.apply(.roleIdle(ordinal: 5))
+    _ = machine.apply(.injectionSucceeded(ordinal: 5, dispatchID: "d5"))
+    _ = try machine.deliver(ordinal: 5, selector: .token("TOKEN-5"), body: "# Done\nfixed again", verdict: nil).result
+      .get()
+    _ = machine.apply(.roleIdle(ordinal: 6))
+    _ = machine.apply(.injectionSucceeded(ordinal: 6, dispatchID: "d6"))
+    _ = try machine.deliver(ordinal: 6, selector: .token("TOKEN-6"), body: "# Findings\nnone", verdict: "clean").result
+      .get()
+    #expect(machine.run.loopCount == 2)
+    #expect(machine.run.position.loop == nil)
+    #expect(machine.run.phase == .runningAction(stepID: "context"))
+    let effects = machine.apply(.actionCompleted(stepID: "context", outputs: [:]))
+    #expect(effects.contains(.notify("Adversarial review: clean after 2 round(s)")))
+    #expect(machine.run.status == .completed)
+  }
+
+  @Test func reachingMaxWithIssuesEndsAsMaxRoundsReached() throws {
+    var machine = try machineAfterFindings(verdict: "issues", inputs: ["max_rounds": "1"])
+    _ = machine.apply(.roleIdle(ordinal: 3))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    _ = machine.apply(.roleIdle(ordinal: 4))
+    _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
+    let (result, effects) = machine.deliver(
+      ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings", verdict: "issues")
+    _ = try result.get()
+    #expect(machine.run.status == .maxRoundsReached)
+    #expect(effects.last == .finished(.maxRoundsReached))
+    #expect(machine.run.loopCount == 1)
+  }
+
+  // MARK: - Start validation
+
+  @Test func startValidatesInputsRepeatBoundsPathAndBindings() throws {
+    #expect(throws: WorkflowRunStartError.invalidRepeatBound(step: "rounds")) {
+      try makeMachine(inputs: ["max_rounds": "25"])
+    }
+    #expect(throws: WorkflowRunStartError.invalidInput(name: "max_rounds", reason: "40 is above the maximum 30.")) {
+      try makeMachine(inputs: ["max_rounds": "40"])
+    }
+    #expect(
+      throws: WorkflowRunStartError.invalidInput(
+        name: "focus", reason: "the value must be one line without control characters.")
+    ) {
+      try makeMachine(inputs: ["focus": "a\nb"])
+    }
+    #expect(throws: WorkflowRunStartError.invalidInput(name: "mode", reason: "'loose' is not one of strict, lenient."))
+    {
+      try makeMachine(inputs: ["mode": "loose"])
+    }
+    #expect(
+      throws: WorkflowRunStartError.invalidInput(name: "other", reason: "the workflow declares no input 'other'.")
+    ) {
+      try makeMachine(inputs: ["other": "1"])
+    }
+    #expect(throws: WorkflowRunStartError.missingBinding(role: "reviewer")) {
+      try makeMachine(roles: ["author": .current(Self.authorPane)])
+    }
+    #expect(throws: WorkflowRunStartError.unknownSkipStep("nope")) {
+      try makeMachine(skipped: ["nope"])
+    }
+    #expect(throws: WorkflowRunStartError.skipNotAllowed(step: "brief", dependent: "launch")) {
+      try makeMachine(skipped: ["brief"])
+    }
+  }
+
+  @Test func startRejectsAWorktreePathThatIsNotOneLine() throws {
+    #expect(throws: WorkflowRunStartError.unsafePath("/re\npo")) {
+      try WorkflowRunMachine.start(
+        definition: definition(Self.handoff),
+        runID: Self.runID,
+        context: WorkflowRunContext(
+          scope: .user, definitionPath: nil,
+          worktree: WorkflowRunWorktree(id: "wt", name: "w", branch: "b", path: "/re\npo")),
+        bindings: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)],
+        inputs: [:],
+        now: { Self.start })
+    }
+  }
+
+  // MARK: - Skip rule
+
+  @Test func skipWithANonOptionalConsumerEndsTheRunAndAbandonsTheActivation() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    #expect(machine.skipConsequence(forStep: "brief") == .endsRun(dependent: "launch"))
+    let effects = machine.apply(.user(.skip))
+    #expect(machine.run.status == .skipped(step: "brief", dependent: "launch"))
+    #expect(
+      effects.contains(
+        .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString): step 'brief' skipped.")))
+    #expect(effects.contains(.disarmWatchdog(ordinal: 1)))
+    #expect(effects.last == .finished(.skipped(step: "brief", dependent: "launch")))
+    #expect(machine.run.invocations[0].activation?.state == .skipped)
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "x", verdict: nil).result
+        == .failure(.stepNotExpecting))
+  }
+
+  @Test func skipInsideTheLoopEndsTheRunBecauseUntilReadsTheOutput() throws {
+    var machine = try machineAfterFindings(verdict: "issues")
+    _ = machine.apply(.roleIdle(ordinal: 3))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    #expect(machine.skipConsequence(forStep: "rereview") == .endsRun(dependent: "rounds"))
+    #expect(machine.skipConsequence(forStep: "fix") == .endsRun(dependent: "rereview"))
+    _ = machine.apply(.roleIdle(ordinal: 4))
+    _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
+    _ = machine.apply(.user(.skip))
+    #expect(machine.run.status == .skipped(step: "rereview", dependent: "rounds"))
+  }
+
+  @Test func skipOfAnOptionalActionInputContinuesWithoutTheKey() throws {
+    var (machine, _) = try makeMachine(
+      Self.handoff,
+      roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)])
+    #expect(machine.skipConsequence(forStep: "brief") == .continues(optionalInputs: ["transition"]))
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let effects = machine.apply(.user(.skip))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.skippedOutputs == ["brief": "brief"])
+    #expect(
+      effects.contains(
+        .runAction(stepID: "transition", actionID: "handoff.transition", inputs: ["from": "source", "to": "receiver"])))
+    #expect(machine.run.phase == .runningAction(stepID: "transition"))
+    let launch = machine.apply(
+      .actionCompleted(
+        stepID: "transition", outputs: ["kickoff_prompt": "Take over.", "artifact_path": "/x", "has_briefing": "false"])
+    )
+    guard
+      case .launch(let request)? = launch.first(where: { if case .launch = $0 { return true } else { return false } })
+    else {
+      Issue.record("expected a launch effect")
+      return
+    }
+    #expect(request.prompt == "Take over.")
+    #expect(!request.expectsDelivery)
+    #expect(request.environment == ["PROWL_WORKFLOW_RUN": Self.runID.uuidString, "PROWL_WORKFLOW_ROLE": "receiver"])
+    #expect(request.placement == .tab)
+    #expect(request.background)
+    let done = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: nil))
+    #expect(done.contains(.notify("Handed off to Pi Reviewer")))
+    #expect(machine.run.status == .completed)
+  }
+
+  @Test func preSkippedStepsAreRecordedSkippedAndNeverEntered() throws {
+    let (machine, effects) = try makeMachine(
+      Self.handoff,
+      roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)],
+      skipped: ["brief"])
+    #expect(
+      machine.run.stepRecords.first
+        == WorkflowStepRecord(stepID: "brief", iteration: nil, state: .skipped, ordinal: nil))
+    #expect(machine.run.invocations.isEmpty)
+    #expect(
+      effects.contains(
+        .runAction(stepID: "transition", actionID: "handoff.transition", inputs: ["from": "source", "to": "receiver"])))
+    #expect(!machine.run.deliversToCurrentRole())
+    let (unskipped, _) = try makeMachine(
+      Self.handoff, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)])
+    #expect(unskipped.run.deliversToCurrentRole())
+  }
+
+  // MARK: - Attention, retry, relaunch, cancel
+
+  @Test func injectionFailureRaisesAttentionAndRetryMintsANewInvocation() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionFailed(ordinal: 1, .submitFailed))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .injectionFailed(.submitFailed))
+    #expect(attention.actions == [.focusPane, .retry, .skip, .cancel])
+    #expect(attention.message.contains("unsubmitted"))
+    #expect(attention.message.contains("author (Claude Code)"))
+    #expect(machine.run.activation(forDispatchID: "d1") == nil)
+
+    let effects = machine.apply(.user(.retry))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 2))
+    #expect(effects.contains(.awaitRoleIdle(role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 2)))
+    #expect(machine.run.invocations[0].activation?.state == .revoked)
+    #expect(machine.run.stepRecords.map(\.state) == [.failed, .active])
+    _ = machine.apply(.roleIdle(ordinal: 2))
+    #expect(machine.run.invocations[1].activation?.token == "TOKEN-2")
+  }
+
+  @Test func roleBusyReturnsTheStepToItsIdleWait() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    let effects = machine.apply(.injectionFailed(ordinal: 1, .roleBusy))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 1))
+    #expect(effects.contains(.awaitRoleIdle(role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 1)))
+  }
+
+  @Test func skipDuringTheIdleWaitCancelsTheWait() throws {
+    var (machine, _) = try makeMachine(
+      Self.handoff,
+      roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)])
+    let effects = machine.apply(.user(.skip))
+    #expect(effects.contains(.cancelRoleWait(ordinal: 1)))
+    #expect(machine.run.phase == .runningAction(stepID: "transition"))
+  }
+
+  @Test func watchdogNudgeTypesTheNudgeAndAttentionOffersTheIdleActions() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let nudge = machine.apply(.watchdog(ordinal: 1, .nudge))
+    let command = WorkflowCompletionCommand(token: "TOKEN-1", verdicts: nil)
+    #expect(
+      nudge.contains(
+        .typeLine(
+          role: "author", surfaceID: Self.authorPane.surfaceID, line: try WorkflowTypedLine.nudge(completion: command)))
+    )
+    #expect(machine.run.status == .running)
+
+    #expect(machine.apply(.watchdog(ordinal: 7, .attention(.idleWithoutDelivery))).isEmpty)
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .idleWithoutDelivery)
+    #expect(attention.actions == [.nudge, .keepWaiting, .skip, .cancel])
+    #expect(attention.message == "author (Claude Code) has been idle without delivering brief; Prowl nudged it once.")
+
+    let resumed = machine.apply(.user(.keepWaiting))
+    #expect(machine.run.status == .running)
+    #expect(
+      resumed.contains(
+        .armWatchdog(
+          WorkflowWatchdogRequest(
+            ordinal: 1, stepID: "brief", role: "author", surfaceID: Self.authorPane.surfaceID, dispatchID: "d1",
+            timeoutSeconds: 600, timeoutPolicy: .attention, nudgedAlready: true))))
+
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.needsInput)))
+    #expect(machine.run.status.attention?.actions == [.focusPane, .cancel])
+    let late = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    #expect((try? late.result.get()) != nil)
+    #expect(machine.run.status == .running)
+    #expect(machine.run.phase == .launching(ordinal: 2))
+  }
+
+  @Test func userNudgeTypesAgainAndReArmsWithTheNudgeSpent() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    let effects = machine.apply(.user(.nudge))
+    #expect(effects.contains { if case .typeLine = $0 { return true } else { return false } })
+    #expect(
+      effects.contains { if case .armWatchdog(let request) = $0 { return request.nudgedAlready } else { return false } }
+    )
+    #expect(machine.run.status == .running)
+  }
+
+  @Test func timeoutPoliciesAttentionSkipAndCancel() throws {
+    var attention = try makeMachine().0
+    _ = attention.apply(.roleIdle(ordinal: 1))
+    _ = attention.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = attention.apply(.watchdog(ordinal: 1, .timeout))
+    #expect(attention.run.status.attention?.reason == .timeout)
+    #expect(attention.run.status.attention?.actions == [.nudge, .keepWaiting, .skip, .cancel])
+
+    let skipYAML = Self.handoff.replacing(
+      "expect: { output: brief, sections: [\"## Objective\"] }",
+      with: "expect: { output: brief, timeout: 1m, on_timeout: skip }")
+    var skipping = try makeMachine(
+      skipYAML, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)]
+    ).0
+    _ = skipping.apply(.roleIdle(ordinal: 1))
+    _ = skipping.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let skipped = skipping.apply(.watchdog(ordinal: 1, .timeout))
+    #expect(
+      skipped.contains(
+        .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString): step 'brief' skipped.")))
+    #expect(skipping.run.phase == .runningAction(stepID: "transition"))
+
+    let cancelYAML = Self.handoff.replacing(
+      "expect: { output: brief, sections: [\"## Objective\"] }",
+      with: "expect: { output: brief, timeout: 1m, on_timeout: cancel }")
+    var cancelling = try makeMachine(
+      cancelYAML, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)]
+    ).0
+    _ = cancelling.apply(.roleIdle(ordinal: 1))
+    _ = cancelling.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = cancelling.apply(.watchdog(ordinal: 1, .timeout))
+    #expect(cancelling.run.status == .cancelled)
+  }
+
+  @Test func cancelAbandonsTheActivationNamingRunAndStepAndKeepsOutputs() throws {
+    var machine = try machineAfterFindings(verdict: "issues")
+    _ = machine.apply(.roleIdle(ordinal: 3))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    let effects = machine.apply(.user(.cancel))
+    #expect(machine.run.status == .cancelled)
+    #expect(
+      effects.contains(
+        .abandonActivation(dispatchID: "d3", reason: "Workflow run \(Self.runID.uuidString) cancelled at step 'fix'.")))
+    #expect(effects.contains(.disarmWatchdog(ordinal: 3)))
+    #expect(effects.last == .finished(.cancelled))
+    #expect(machine.run.outputs.keys.sorted() == ["brief", "findings"])
+    #expect(!effects.contains { if case .close = $0 { return true } else { return false } })
+    #expect(machine.apply(.user(.retry)).isEmpty)
+  }
+
+  @Test func relaunchRedeliversTheCurrentStepAsALaunchPromptAndRebindsThePane() throws {
+    var machine = try machineAfterFindings(verdict: "issues")
+    _ = machine.apply(.roleIdle(ordinal: 3))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    _ = machine.apply(.roleIdle(ordinal: 4))
+    _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
+    _ = machine.apply(.watchdog(ordinal: 4, .attention(.agentGone(.sessionEnded))))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.actions == [.relaunch, .skip, .cancel])
+    #expect(attention.message == "reviewer (Pi Reviewer)'s agent session ended before it delivered findings.")
+
+    let effects = machine.apply(.user(.relaunch))
+    #expect(
+      effects.contains(
+        .abandonActivation(
+          dispatchID: "d4",
+          reason: "Workflow run \(Self.runID.uuidString): role 'reviewer' relaunched at step 'rereview'.")))
+    guard
+      case .launch(let request)? = effects.first(where: { if case .launch = $0 { return true } else { return false } })
+    else {
+      Issue.record("expected a launch effect")
+      return
+    }
+    #expect(request.redelivery)
+    #expect(request.ordinal == 5)
+    #expect(
+      request.prompt.hasPrefix(
+        "Disposition: \(runDir)/outputs/disposition.md. Re-review.\n\n---\nProwl workflow completion protocol v1:"))
+    #expect(request.environment["PROWL_WORKFLOW_TOKEN"] == "TOKEN-5")
+    #expect(machine.run.bindings["reviewer"]?.pane == nil)
+    #expect(machine.run.invocations[3].activation?.state == .revoked)
+
+    let newPane = WorkflowPaneIdentity(
+      surfaceID: UUID(), tabID: nil, handle: "p5", displayName: "Pi Reviewer", agent: "pi")
+    _ = machine.apply(.launched(ordinal: 5, pane: newPane, dispatchID: "d5"))
+    #expect(machine.run.bindings["reviewer"]?.pane == newPane)
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 5))
+    #expect(
+      machine.deliver(ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings", verdict: "clean").result
+        == .failure(.stepNotExpecting))
+    _ = try machine.deliver(ordinal: 5, selector: .token("TOKEN-5"), body: "# Findings", verdict: "clean").result.get()
+    #expect(machine.run.position.loop == nil)
+  }
+
+  @Test func aGoneCurrentRoleOffersNoRelaunch() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.agentGone(.paneClosed))))
+    #expect(machine.run.status.attention?.actions == [.skip, .cancel])
+    #expect(machine.apply(.user(.relaunch)).isEmpty)
+  }
+
+  @Test func launchFailureThenSkipLeavesTheRoleWithoutAPane() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = try machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+      .result.get()
+    _ = machine.apply(.launchFailed(ordinal: 2, reason: "home provisioning failed"))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .launchFailed("home provisioning failed"))
+    #expect(attention.actions == [.retry, .skip, .cancel])
+    let retry = machine.apply(.user(.retry))
+    #expect(
+      retry.contains {
+        if case .launch(let request) = $0 {
+          return request.ordinal == 3 && request.environment["PROWL_WORKFLOW_TOKEN"] == "TOKEN-3"
+        } else {
+          return false
+        }
+      })
+    _ = machine.apply(.launchFailed(ordinal: 3, reason: "again"))
+    #expect(machine.skipConsequence(forStep: "launch") == .endsRun(dependent: "rounds"))
+    _ = machine.apply(.user(.skip))
+    #expect(machine.run.status == .skipped(step: "launch", dependent: "rounds"))
+  }
+
+  @Test func actionFailureOffersRetryAndCancelOnly() throws {
+    var machine = try machineAfterFindings(verdict: "clean")
+    _ = machine.apply(.actionFailed(stepID: "context", reason: "git is unavailable"))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .actionFailed("git is unavailable"))
+    #expect(attention.actions == [.retry, .cancel])
+    #expect(machine.apply(.user(.skip)).isEmpty)
+    let retry = machine.apply(.user(.retry))
+    #expect(retry.contains(.runAction(stepID: "context", actionID: "git.context", inputs: ["root": "/repo"])))
+    #expect(machine.run.status == .running)
+  }
+
+  @Test func manualDeliveryTargetsTheStepsCurrentActivation() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    #expect(
+      machine.deliver(ordinal: nil, selector: .manual(stepID: "launch"), body: "x", verdict: nil).result
+        == .failure(.stepNotExpecting))
+    let (result, _) = machine.deliver(
+      ordinal: nil, selector: .manual(stepID: "brief"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    #expect(try result.get().stepID == "brief")
+  }
+
+  @Test func selfInitiatedRunReturnsTheFirstLineInsteadOfTyping() throws {
+    let (machine, effects) = try makeMachine(selfInitiated: true)
+    #expect(effects.contains(.openActivation(role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 1)))
+    #expect(!effects.contains { if case .inject = $0 { return true } else { return false } })
+    #expect(!effects.contains { if case .awaitRoleIdle = $0 { return true } else { return false } })
+    let line = try #require(machine.run.selfInitiatedLine)
+    #expect(
+      line.hasPrefix(
+        "[Prowl] Read \(runDir)/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=TOKEN-1"))
+    #expect(machine.run.phase == .injecting(ordinal: 1))
+    var continued = machine
+    _ = continued.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    #expect(continued.run.phase == .waitingForDelivery(ordinal: 1))
+  }
+
+  @Test func messageToARoleWithoutAPaneRaisesAttention() throws {
+    let yaml = """
+      schema: prowl.workflow/v1
+      id: ping
+      name: Ping
+      roles:
+        author:
+          source: current
+        reviewer:
+          source: launch
+      steps:
+        - id: launch
+          launch: reviewer
+          prompt: "Review."
+        - id: ping
+          message: reviewer
+          text: "hello"
+          expect: { output: pong }
+      """
+    var (machine, _) = try makeMachine(yaml, skipped: ["launch"])
+    #expect(machine.run.phase == .injecting(ordinal: 1))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .agentGone(.notLaunched))
+    #expect(attention.actions == [.relaunch, .skip, .cancel])
+    let effects = machine.apply(.user(.relaunch))
+    #expect(
+      effects.contains {
+        if case .launch(let request) = $0 {
+          return request.redelivery && request.prompt.hasPrefix("hello\n\n---\n")
+        } else {
+          return false
+        }
+      })
+  }
+}
+// swiftlint:enable file_length type_body_length
+
+extension Result where Failure == WorkflowDeliveryError {
+  var failureCode: String? {
+    if case .failure(let error) = self { return error.code }
+    return nil
+  }
+}

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -264,6 +264,7 @@ struct WorkflowRunMachineTests {
     #expect(receipt.output.latestPath == "\(runDir)/outputs/brief.md")
     #expect(
       effects == [
+        .disarmWatchdog(ordinal: 1),
         .log("Step 'brief': output 'brief' accepted (invocation 1); persisting."),
         .persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n"),
       ])
@@ -284,7 +285,7 @@ struct WorkflowRunMachineTests {
       ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
     #expect(machine.apply(.outputPersisted(ordinal: 7)).isEmpty)
     let effects = machine.apply(.outputPersisted(ordinal: 1))
-    #expect(effects.contains(.disarmWatchdog(ordinal: 1)))
+    #expect(!effects.contains(.disarmWatchdog(ordinal: 1)))
     #expect(
       effects.contains(
         .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
@@ -318,6 +319,31 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.invocations[0].activation?.state == .delivered)
     #expect(machine.run.invocations[0].activation?.pendingDelivery == nil)
     #expect(machine.run.outputs["brief"]?.ordinal == 1)
+  }
+
+  @Test func watchdogVerdictsAreIgnoredOnceADeliveryWasAccepted() throws {
+    let skipYAML = Self.handoff.replacing(
+      "expect: { output: brief, sections: [\"## Objective\"] }",
+      with: "expect: { output: brief, timeout: 1m, on_timeout: skip }")
+    var (machine, _) = try makeMachine(
+      skipYAML, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)])
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let (result, effects) = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Objective\nx", verdict: nil)
+    _ = try result.get()
+    #expect(effects.first == .disarmWatchdog(ordinal: 1))
+    #expect(machine.apply(.watchdog(ordinal: 1, .timeout)).isEmpty)
+    #expect(machine.apply(.watchdog(ordinal: 1, .attention(.agentGone(.sessionEnded)))).isEmpty)
+    #expect(machine.apply(.watchdog(ordinal: 1, .nudge)).isEmpty)
+    #expect(machine.run.status == .running)
+    #expect(machine.run.invocations[0].activation?.state == .persisting)
+    let persisted = machine.apply(.outputPersisted(ordinal: 1))
+    #expect(
+      persisted.contains(
+        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+    #expect(!persisted.contains(.disarmWatchdog(ordinal: 1)))
+    #expect(machine.run.phase == .runningAction(stepID: "transition"))
   }
 
   @Test func persistFailureRaisesAttentionAndRetryRePersists() throws {
@@ -601,6 +627,42 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.status == .maxRoundsReached)
   }
 
+  @Test func startTimeSkipIgnoresReadersAfterALoopWithoutUntil() throws {
+    let yaml = """
+      schema: prowl.workflow/v1
+      id: seed-rounds
+      name: Seed rounds
+      roles:
+        author:
+          source: current
+      steps:
+        - id: seed
+          message: author
+          text: "seed"
+          expect: { output: x }
+        - id: rounds
+          repeat:
+            max: 1
+          steps:
+            - id: work
+              message: author
+              text: "work"
+        - id: after
+          notify: "after {{ outputs.x.path }}"
+      """
+    let (machine, _) = try makeMachine(yaml, roles: ["author": .current(Self.authorPane)], skipped: ["seed"])
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 1))
+    let reading = yaml.replacing("text: \"work\"", with: "text: \"work {{ outputs.x.path }}\"")
+    #expect(throws: WorkflowRunStartError.skipNotAllowed(step: "seed", dependent: "work")) {
+      try makeMachine(reading, roles: ["author": .current(Self.authorPane)], skipped: ["seed"])
+    }
+    let exiting = yaml.replacing("      max: 1\n", with: "      max: 1\n      until: outputs.x.verdict == ok\n")
+      .replacing("expect: { output: x }", with: "expect: { output: x, verdict: [ok, bad] }")
+    #expect(throws: WorkflowRunStartError.skipNotAllowed(step: "seed", dependent: "rounds")) {
+      try makeMachine(exiting, roles: ["author": .current(Self.authorPane)], skipped: ["seed"])
+    }
+  }
+
   @Test func skipOfAnOptionalActionInputContinuesWithoutTheKey() throws {
     var (machine, _) = try makeMachine(
       Self.handoff,
@@ -763,12 +825,35 @@ struct WorkflowRunMachineTests {
       })
     now.advance(seconds: 400)
     _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    // The deadline (start + 630 s) has passed: Nudge applies the timeout policy instead of
+    // buying another window.
     let nudged = machine.apply(.user(.nudge))
+    #expect(!nudged.contains { if case .armWatchdog = $0 { return true } else { return false } })
+    #expect(!nudged.contains { if case .typeLine = $0 { return true } else { return false } })
+    #expect(machine.run.status.attention?.reason == .timeout)
+  }
+
+  @Test func anExpiredDeadlineOnKeepWaitingAppliesTheTimeoutPolicy() throws {
+    let skipYAML = Self.handoff.replacing(
+      "expect: { output: brief, sections: [\"## Objective\"] }",
+      with: "expect: { output: brief, timeout: 1m, on_timeout: skip }")
+    let now = NowBox(Self.start)
+    var (machine, _) = try makeMachine(
+      skipYAML, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)],
+      now: now)
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    now.advance(seconds: 61)
+    let effects = machine.apply(.user(.keepWaiting))
     #expect(
-      nudged.contains {
-        if case .armWatchdog(let request) = $0 { return request.timeoutSeconds == 1 }
-        return false
-      })
+      effects.contains(
+        .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString): step 'brief' skipped.")))
+    #expect(!effects.contains { if case .armWatchdog = $0 { return true } else { return false } })
+    #expect(machine.run.phase == .runningAction(stepID: "transition"))
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "# B\n## Objective", verdict: nil).result
+        == .failure(.stepNotExpecting))
   }
 
   @Test func userNudgeTypesAgainAndReArmsWithTheNudgeSpent() throws {

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -252,8 +252,6 @@ struct WorkflowRunMachineTests {
     #expect(
       machine.deliver(ordinal: 2, selector: .token("TOKEN-1"), body: "x", verdict: nil).result
         == .failure(.stepNotExpecting))
-    let invalid = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope only", verdict: nil)
-    #expect(invalid.result.failureCode == "OUTPUT_INVALID")
     #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
 
     let (result, effects) = machine.deliver(
@@ -386,8 +384,20 @@ struct WorkflowRunMachineTests {
     #expect(machine.templateContext().roles["reviewer"]?.pane == "p2")
   }
 
-  @Test func verdictRequiredAndUndeclaredVerdictAreRejected() throws {
-    var (machine, _) = try makeMachine()
+  @Test func strictStepsRejectMissingSectionsAndVerdicts() throws {
+    let yaml = Self.adversarialReview
+      .replacing("timeout: 10m }", with: "timeout: 10m, strict: true }")
+      .replacing(
+        "verdict: [clean, issues] }\n  - id: rounds",
+        with: "verdict: [clean, issues], strict: true }\n  - id: rounds")
+    var (machine, _) = try makeMachine(yaml)
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let invalid = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope only", verdict: nil)
+    #expect(invalid.result.failureCode == "OUTPUT_INVALID")
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
+    #expect(machine.run.invocations[0].activation?.state == .waiting)
+
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
     try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
@@ -398,6 +408,104 @@ struct WorkflowRunMachineTests {
     #expect(
       machine.deliver(ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n## Verdict", verdict: "maybe").result
         .failureCode == "OUTPUT_INVALID")
+  }
+
+  @Test func provisionalDeliveryAsksTheUserAndAcceptContinues() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let (result, _) = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx", verdict: nil)
+    let receipt = try result.get()
+    #expect(receipt.issues == [.missingSections(["## Claims"])])
+    let persisted = machine.apply(.outputPersisted(ordinal: 1))
+    #expect(!persisted.contains { if case .completeActivation = $0 { return true } else { return false } })
+    #expect(machine.run.invocations[0].activation?.state == .provisional)
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .deliveryIssues([.missingSections(["## Claims"])]))
+    #expect(attention.actions == [.acceptDelivery, .askAgain, .skip, .cancel])
+    #expect(
+      attention.message
+        == "author (Claude Code) delivered brief, but: missing section(s) ## Claims. Accept it, ask again, or skip.")
+    #expect(machine.run.outputs.isEmpty)
+    #expect(machine.apply(.watchdog(ordinal: 1, .nudge)).isEmpty)
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "x", verdict: nil).result
+        == .failure(.stepNotExpecting))
+
+    let accepted = machine.apply(.user(.acceptDelivery(verdict: nil)))
+    #expect(
+      accepted.contains(
+        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.outputs["brief"]?.ordinal == 1)
+    #expect(machine.run.invocations[0].activation?.state == .delivered)
+    #expect(machine.run.phase == .launching(ordinal: 2))
+  }
+
+  @Test func provisionalDeliveryWithoutAVerdictNeedsOneToBeAccepted() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
+    _ = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
+    try deliverPersisted(&machine, ordinal: 2, token: "TOKEN-2", body: "## Findings\n- a\n## Verdict\nlooks clean")
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .deliveryIssues([.verdictMissing(allowed: ["clean", "issues"])]))
+    #expect(attention.actions == [.acceptWithVerdict, .askAgain, .skip, .cancel])
+    #expect(machine.apply(.user(.acceptDelivery(verdict: nil))).isEmpty)
+    #expect(machine.apply(.user(.acceptDelivery(verdict: "maybe"))).isEmpty)
+    #expect(machine.run.status.attention != nil)
+    _ = machine.apply(.user(.acceptDelivery(verdict: "clean")))
+    #expect(machine.run.outputs["findings"]?.verdict == "clean")
+    #expect(machine.run.loopCount == 0)
+    #expect(machine.run.phase == .runningAction(stepID: "context"))
+  }
+
+  @Test func askAgainReturnsTheActivationToWaitingWithTheSameToken() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "# Brief\n## Scope\nx")
+    let effects = machine.apply(.user(.askAgain))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.invocations[0].activation?.state == .waiting)
+    #expect(machine.run.invocations[0].activation?.pendingDelivery == nil)
+    #expect(
+      effects.contains(
+        .typeLine(
+          role: "author", surfaceID: Self.authorPane.surfaceID,
+          line:
+            "[Prowl] Your delivery for this step had missing section(s) ## Claims. Deliver it again, complete, with: "
+            + "PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow done -")))
+    #expect(
+      effects.contains {
+        if case .armWatchdog(let request) = $0 {
+          return request.ordinal == 1 && !request.nudgedAlready
+        } else {
+          return false
+        }
+      })
+    #expect(machine.apply(.user(.askAgain)).isEmpty)
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "# Brief\n## Scope\nx\n## Claims\ny")
+    #expect(machine.run.phase == .launching(ordinal: 2))
+    #expect(machine.run.invocations.count == 2)
+  }
+
+  @Test func skipOfAProvisionalDeliveryAbandonsItsRecord() throws {
+    var (machine, _) = try makeMachine(
+      Self.handoff, roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)])
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "# Brief without the objective")
+    #expect(machine.run.status.attention?.actions == [.acceptDelivery, .askAgain, .skip, .cancel])
+    let effects = machine.apply(.user(.skip))
+    #expect(
+      effects.contains(
+        .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString): step 'brief' skipped.")))
+    #expect(machine.run.invocations[0].activation?.state == .skipped)
+    #expect(machine.run.skippedOutputs == ["brief": "brief"])
+    #expect(machine.run.phase == .runningAction(stepID: "transition"))
   }
 
   @Test func cleanVerdictBeforeTheLoopSkipsItAndFinishesTheRun() throws {

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -112,6 +112,22 @@ struct WorkflowRunMachineTests {
     }
   }
 
+  nonisolated final class NowBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ value: Date) { self.value = value }
+    var now: Date {
+      lock.lock()
+      defer { lock.unlock() }
+      return value
+    }
+    func advance(seconds: TimeInterval) {
+      lock.lock()
+      defer { lock.unlock() }
+      value = value.addingTimeInterval(seconds)
+    }
+  }
+
   private func definition(_ yaml: String) throws -> WorkflowDefinition {
     try #require(WorkflowDocumentParser.parse(yaml).definition)
   }
@@ -121,7 +137,8 @@ struct WorkflowRunMachineTests {
     roles: [String: WorkflowRoleBinding]? = nil,
     inputs: [String: String] = [:],
     skipped: Set<String> = [],
-    selfInitiated: Bool = false
+    selfInitiated: Bool = false,
+    now: NowBox = NowBox(start)
   ) throws -> (WorkflowRunMachine, [WorkflowRunEffect]) {
     let counter = TokenCounter()
     let bindings =
@@ -141,7 +158,7 @@ struct WorkflowRunMachineTests {
         inputs: inputs,
         skippedSteps: skipped,
         selfInitiated: selfInitiated),
-      now: { Self.start },
+      now: { now.now },
       makeToken: { counter.next() }
     )
     return (started.machine, started.effects)
@@ -149,18 +166,25 @@ struct WorkflowRunMachineTests {
 
   private var runDir: String { "/repo/.prowl/workflow-runs/\(Self.runID.uuidString)" }
 
+  /// A successful delivery followed by its persistence: the effects of both phases.
+  @discardableResult
+  private func deliverPersisted(
+    _ machine: inout WorkflowRunMachine, ordinal: Int, token: String, body: String, verdict: String? = nil
+  ) throws -> [WorkflowRunEffect] {
+    let (result, effects) = machine.deliver(ordinal: ordinal, selector: .token(token), body: body, verdict: verdict)
+    _ = try result.get()
+    return effects + machine.apply(.outputPersisted(ordinal: ordinal))
+  }
+
   /// Drives the fixture through `brief` → `launch` → findings delivery and returns the machine.
   private func machineAfterFindings(verdict: String, inputs: [String: String] = [:]) throws -> WorkflowRunMachine {
     var (machine, _) = try makeMachine(inputs: inputs)
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
-    let brief = machine.deliver(
-      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
-    _ = try brief.result.get()
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "# Brief\n## Scope\nx\n## Claims\ny")
     _ = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
-    let findings = machine.deliver(
-      ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n- a\n## Verdict\n\(verdict)", verdict: verdict)
-    _ = try findings.result.get()
+    try deliverPersisted(
+      &machine, ordinal: 2, token: "TOKEN-2", body: "## Findings\n- a\n## Verdict\n\(verdict)", verdict: verdict)
     return machine
   }
 
@@ -207,6 +231,7 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
     #expect(machine.run.activation(forDispatchID: "d1")?.ordinal == 1)
     #expect(machine.run.currentActivation?.state == .waiting)
+    #expect(machine.run.currentActivation?.deadline == Self.start.addingTimeInterval(600))
     #expect(
       effects.contains(
         .armWatchdog(
@@ -215,7 +240,7 @@ struct WorkflowRunMachineTests {
             timeoutSeconds: 600, timeoutPolicy: .attention, nudgedAlready: false))))
   }
 
-  @Test func deliveryChecksTheTokenValidatesTheBodyAndAdvancesToTheLaunch() throws {
+  @Test func deliveryChecksTheTokenAndValidatesTheBodyBeforePersisting() throws {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
@@ -237,7 +262,28 @@ struct WorkflowRunMachineTests {
     #expect(receipt.output.name == "brief")
     #expect(receipt.output.path == "\(runDir)/outputs/brief.1.md")
     #expect(receipt.output.latestPath == "\(runDir)/outputs/brief.md")
-    #expect(effects.contains(.persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n")))
+    #expect(
+      effects == [
+        .log("Step 'brief': output 'brief' accepted (invocation 1); persisting."),
+        .persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n"),
+      ])
+    // Nothing advances until the output is on disk (dsl-spec §5: validate, persist, complete).
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
+    #expect(machine.run.invocations[0].activation?.state == .persisting)
+    #expect(machine.run.outputs.isEmpty)
+    #expect(
+      machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "again", verdict: nil).result
+        == .failure(.stepNotExpecting))
+  }
+
+  @Test func persistedOutputCompletesTheActivationAndAdvancesToTheLaunch() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
+    #expect(machine.apply(.outputPersisted(ordinal: 7)).isEmpty)
+    let effects = machine.apply(.outputPersisted(ordinal: 1))
     #expect(effects.contains(.disarmWatchdog(ordinal: 1)))
     #expect(
       effects.contains(
@@ -270,25 +316,46 @@ struct WorkflowRunMachineTests {
     #expect(!request.redelivery)
     #expect(machine.run.phase == .launching(ordinal: 2))
     #expect(machine.run.invocations[0].activation?.state == .delivered)
+    #expect(machine.run.invocations[0].activation?.pendingDelivery == nil)
     #expect(machine.run.outputs["brief"]?.ordinal == 1)
+  }
+
+  @Test func persistFailureRaisesAttentionAndRetryRePersists() throws {
+    var (machine, _) = try makeMachine()
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    _ = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
+    _ = machine.apply(.outputPersistFailed(ordinal: 1, reason: "disk full"))
+    let attention = try #require(machine.run.status.attention)
+    #expect(attention.reason == .persistFailed("disk full"))
+    #expect(attention.actions == [.retry, .cancel])
+    #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
+    let retry = machine.apply(.user(.retry))
+    #expect(retry.contains(.persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n")))
+    #expect(machine.run.status == .running)
+    #expect(machine.run.invocations[0].activation?.state == .persisting)
+    let cancel = machine.apply(.user(.cancel))
+    #expect(
+      cancel.contains(
+        .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString) cancelled at step 'brief'.")
+      ))
+    #expect(machine.run.status == .cancelled)
   }
 
   @Test func launchedBindsThePaneAndWaitsForTheFindings() throws {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
-    _ = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
     let effects = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
     #expect(machine.run.bindings["reviewer"]?.pane == Self.reviewerPane)
     #expect(machine.run.phase == .waitingForDelivery(ordinal: 2))
     #expect(machine.run.activation(forDispatchID: "d2")?.token == "TOKEN-2")
     #expect(
       effects.contains {
-        if case .armWatchdog(let request) = $0 {
-          return request.ordinal == 2 && request.dispatchID == "d2"
-        } else {
-          return false
-        }
+        if case .armWatchdog(let request) = $0 { return request.ordinal == 2 && request.dispatchID == "d2" }
+        return false
       })
     #expect(machine.templateContext().roles["reviewer"]?.pane == "p2")
   }
@@ -297,7 +364,7 @@ struct WorkflowRunMachineTests {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
-    _ = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
     _ = machine.apply(.launched(ordinal: 2, pane: Self.reviewerPane, dispatchID: "d2"))
     #expect(
       machine.deliver(ordinal: 2, selector: .token("TOKEN-2"), body: "## Findings\n## Verdict", verdict: nil).result
@@ -339,28 +406,26 @@ struct WorkflowRunMachineTests {
             + "PROWL_WORKFLOW_TOKEN=TOKEN-3 prowl workflow done -",
           opensActivation: true)))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
-    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done\nfixed", verdict: nil).result.get()
+    try deliverPersisted(&machine, ordinal: 3, token: "TOKEN-3", body: "# Done\nfixed")
 
     #expect(machine.run.phase == .waitingForRole(role: "reviewer", ordinal: 4))
     _ = machine.apply(.roleIdle(ordinal: 4))
     _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
-    let round1 = machine.deliver(ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings\nstill", verdict: "issues")
-    let receipt = try round1.result.get()
-    #expect(receipt.output.path == "\(runDir)/outputs/findings.4.md")
-    #expect(round1.effects.contains(.persistOutput(name: "findings", ordinal: 4, body: "# Findings\nstill\n")))
+    let round1 = try deliverPersisted(
+      &machine, ordinal: 4, token: "TOKEN-4", body: "# Findings\nstill", verdict: "issues")
+    #expect(round1.contains(.persistOutput(name: "findings", ordinal: 4, body: "# Findings\nstill\n")))
     #expect(machine.run.outputs["findings"]?.ordinal == 4)
+    #expect(machine.run.outputs["findings"]?.path == "\(runDir)/outputs/findings.4.md")
     #expect(machine.run.loopCount == 1)
     #expect(machine.run.position.loop == WorkflowRunPosition.Loop(iteration: 2, bodyIndex: 0, max: 3))
     #expect(machine.templateContext().loop == WorkflowTemplateContext.Loop(index: 2, count: 1))
 
     _ = machine.apply(.roleIdle(ordinal: 5))
     _ = machine.apply(.injectionSucceeded(ordinal: 5, dispatchID: "d5"))
-    _ = try machine.deliver(ordinal: 5, selector: .token("TOKEN-5"), body: "# Done\nfixed again", verdict: nil).result
-      .get()
+    try deliverPersisted(&machine, ordinal: 5, token: "TOKEN-5", body: "# Done\nfixed again")
     _ = machine.apply(.roleIdle(ordinal: 6))
     _ = machine.apply(.injectionSucceeded(ordinal: 6, dispatchID: "d6"))
-    _ = try machine.deliver(ordinal: 6, selector: .token("TOKEN-6"), body: "# Findings\nnone", verdict: "clean").result
-      .get()
+    try deliverPersisted(&machine, ordinal: 6, token: "TOKEN-6", body: "# Findings\nnone", verdict: "clean")
     #expect(machine.run.loopCount == 2)
     #expect(machine.run.position.loop == nil)
     #expect(machine.run.phase == .runningAction(stepID: "context"))
@@ -373,12 +438,10 @@ struct WorkflowRunMachineTests {
     var machine = try machineAfterFindings(verdict: "issues", inputs: ["max_rounds": "1"])
     _ = machine.apply(.roleIdle(ordinal: 3))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
-    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    try deliverPersisted(&machine, ordinal: 3, token: "TOKEN-3", body: "# Done")
     _ = machine.apply(.roleIdle(ordinal: 4))
     _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
-    let (result, effects) = machine.deliver(
-      ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings", verdict: "issues")
-    _ = try result.get()
+    let effects = try deliverPersisted(&machine, ordinal: 4, token: "TOKEN-4", body: "# Findings", verdict: "issues")
     #expect(machine.run.status == .maxRoundsReached)
     #expect(effects.last == .finished(.maxRoundsReached))
     #expect(machine.run.loopCount == 1)
@@ -416,6 +479,27 @@ struct WorkflowRunMachineTests {
     }
     #expect(throws: WorkflowRunStartError.skipNotAllowed(step: "brief", dependent: "launch")) {
       try makeMachine(skipped: ["brief"])
+    }
+  }
+
+  @Test func startRejectsSkipsOfStepsWithoutAnExpect() throws {
+    for step in ["transition", "launch", "done"] {
+      #expect(throws: WorkflowRunStartError.skipNotExpecting(step)) {
+        try makeMachine(
+          Self.handoff,
+          roles: ["source": .current(Self.authorPane), "receiver": .launch(Self.reviewerProfile, pane: nil)],
+          skipped: [step])
+      }
+    }
+  }
+
+  @Test func startRejectsEnumValuesThatAreNotOneLine() throws {
+    let yaml = Self.adversarialReview.replacing("values: [strict, lenient]", with: "values: [strict, \"two\\nlines\"]")
+    #expect(
+      throws: WorkflowRunStartError.invalidInput(
+        name: "mode", reason: "the value must be one line without control characters.")
+    ) {
+      try makeMachine(yaml, inputs: ["mode": "two\nlines"])
     }
   }
 
@@ -457,13 +541,64 @@ struct WorkflowRunMachineTests {
     var machine = try machineAfterFindings(verdict: "issues")
     _ = machine.apply(.roleIdle(ordinal: 3))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
-    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    try deliverPersisted(&machine, ordinal: 3, token: "TOKEN-3", body: "# Done")
     #expect(machine.skipConsequence(forStep: "rereview") == .endsRun(dependent: "rounds"))
     #expect(machine.skipConsequence(forStep: "fix") == .endsRun(dependent: "rereview"))
     _ = machine.apply(.roleIdle(ordinal: 4))
     _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
     _ = machine.apply(.user(.skip))
     #expect(machine.run.status == .skipped(step: "rereview", dependent: "rounds"))
+  }
+
+  @Test func skipInTheFinalIterationWithoutUntilIgnoresReadersThatCannotRunAgain() throws {
+    let yaml = """
+      schema: prowl.workflow/v1
+      id: rounds-only
+      name: Rounds
+      roles:
+        author:
+          source: current
+      steps:
+        - id: seed
+          message: author
+          text: "seed"
+          expect: { output: x }
+        - id: rounds
+          repeat:
+            max: 2
+          steps:
+            - id: read
+              message: author
+              text: "read {{ outputs.x.path }}"
+            - id: produce
+              message: author
+              text: "produce"
+              expect: { output: x }
+        - id: after
+          notify: "after {{ outputs.x.path }}"
+      """
+    var (machine, _) = try makeMachine(yaml, roles: ["author": .current(Self.authorPane)])
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "# x")
+    // iteration 1: `read` (no expect) then `produce`
+    _ = machine.apply(.roleIdle(ordinal: 2))
+    _ = machine.apply(.injectionSucceeded(ordinal: 2, dispatchID: nil))
+    #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 3))
+    // Another iteration can follow: the earlier body reader still counts.
+    #expect(machine.skipConsequence(forStep: "produce") == .endsRun(dependent: "read"))
+    _ = machine.apply(.roleIdle(ordinal: 3))
+    _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
+    try deliverPersisted(&machine, ordinal: 3, token: "TOKEN-2", body: "# x2")
+    // iteration 2 (the last, no `until`): `read` ran, `produce` is current.
+    _ = machine.apply(.roleIdle(ordinal: 4))
+    _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: nil))
+    #expect(machine.run.position.loop == WorkflowRunPosition.Loop(iteration: 2, bodyIndex: 1, max: 2))
+    #expect(machine.skipConsequence(forStep: "produce") == .continues(optionalInputs: []))
+    _ = machine.apply(.roleIdle(ordinal: 5))
+    _ = machine.apply(.injectionSucceeded(ordinal: 5, dispatchID: "d5"))
+    _ = machine.apply(.user(.skip))
+    #expect(machine.run.status == .maxRoundsReached)
   }
 
   @Test func skipOfAnOptionalActionInputContinuesWithoutTheKey() throws {
@@ -541,13 +676,25 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.invocations[1].activation?.token == "TOKEN-2")
   }
 
-  @Test func roleBusyReturnsTheStepToItsIdleWait() throws {
+  @Test func roleBusyReturnsTheStepToItsIdleWaitAndKeepsItsToken() throws {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     let effects = machine.apply(.injectionFailed(ordinal: 1, .roleBusy))
     #expect(machine.run.status == .running)
     #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 1))
     #expect(effects.contains(.awaitRoleIdle(role: "author", surfaceID: Self.authorPane.surfaceID, ordinal: 1)))
+    let again = machine.apply(.roleIdle(ordinal: 1))
+    #expect(machine.run.invocations.count == 1)
+    #expect(machine.run.invocations[0].activation?.token == "TOKEN-1")
+    #expect(
+      again.contains {
+        if case .inject(_, _, 1, let line, true) = $0 { return line.contains("PROWL_WORKFLOW_TOKEN=TOKEN-1 ") }
+        return false
+      })
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    let (result, _) = machine.deliver(
+      ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
+    #expect((try? result.get()) != nil)
   }
 
   @Test func skipDuringTheIdleWaitCancelsTheWait() throws {
@@ -568,8 +715,8 @@ struct WorkflowRunMachineTests {
     #expect(
       nudge.contains(
         .typeLine(
-          role: "author", surfaceID: Self.authorPane.surfaceID, line: try WorkflowTypedLine.nudge(completion: command)))
-    )
+          role: "author", surfaceID: Self.authorPane.surfaceID, line: try WorkflowTypedLine.nudge(completion: command))
+      ))
     #expect(machine.run.status == .running)
 
     #expect(machine.apply(.watchdog(ordinal: 7, .attention(.idleWithoutDelivery))).isEmpty)
@@ -581,6 +728,7 @@ struct WorkflowRunMachineTests {
 
     let resumed = machine.apply(.user(.keepWaiting))
     #expect(machine.run.status == .running)
+    #expect(resumed.contains(.disarmWatchdog(ordinal: 1)))
     #expect(
       resumed.contains(
         .armWatchdog(
@@ -593,7 +741,34 @@ struct WorkflowRunMachineTests {
     let late = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
     #expect((try? late.result.get()) != nil)
     #expect(machine.run.status == .running)
+    _ = machine.apply(.outputPersisted(ordinal: 1))
     #expect(machine.run.phase == .launching(ordinal: 2))
+  }
+
+  @Test func reArmedWatchdogsCarryTheRemainingHardTimeout() throws {
+    let now = NowBox(Self.start)
+    var (machine, _) = try makeMachine(now: now)
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    now.advance(seconds: 30)
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
+    #expect(machine.run.currentActivation?.deadline == Self.start.addingTimeInterval(630))
+    now.advance(seconds: 200)
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    now.advance(seconds: 100)
+    let resumed = machine.apply(.user(.keepWaiting))
+    #expect(
+      resumed.contains {
+        if case .armWatchdog(let request) = $0 { return request.timeoutSeconds == 300 && request.nudgedAlready }
+        return false
+      })
+    now.advance(seconds: 400)
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    let nudged = machine.apply(.user(.nudge))
+    #expect(
+      nudged.contains {
+        if case .armWatchdog(let request) = $0 { return request.timeoutSeconds == 1 }
+        return false
+      })
   }
 
   @Test func userNudgeTypesAgainAndReArmsWithTheNudgeSpent() throws {
@@ -663,7 +838,7 @@ struct WorkflowRunMachineTests {
     var machine = try machineAfterFindings(verdict: "issues")
     _ = machine.apply(.roleIdle(ordinal: 3))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
-    _ = try machine.deliver(ordinal: 3, selector: .token("TOKEN-3"), body: "# Done", verdict: nil).result.get()
+    try deliverPersisted(&machine, ordinal: 3, token: "TOKEN-3", body: "# Done")
     _ = machine.apply(.roleIdle(ordinal: 4))
     _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
     _ = machine.apply(.watchdog(ordinal: 4, .attention(.agentGone(.sessionEnded))))
@@ -700,7 +875,7 @@ struct WorkflowRunMachineTests {
     #expect(
       machine.deliver(ordinal: 4, selector: .token("TOKEN-4"), body: "# Findings", verdict: "clean").result
         == .failure(.stepNotExpecting))
-    _ = try machine.deliver(ordinal: 5, selector: .token("TOKEN-5"), body: "# Findings", verdict: "clean").result.get()
+    try deliverPersisted(&machine, ordinal: 5, token: "TOKEN-5", body: "# Findings", verdict: "clean")
     #expect(machine.run.position.loop == nil)
   }
 
@@ -717,8 +892,7 @@ struct WorkflowRunMachineTests {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
-    _ = try machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
-      .result.get()
+    try deliverPersisted(&machine, ordinal: 1, token: "TOKEN-1", body: "## Scope\nx\n## Claims\ny")
     _ = machine.apply(.launchFailed(ordinal: 2, reason: "home provisioning failed"))
     let attention = try #require(machine.run.status.attention)
     #expect(attention.reason == .launchFailed("home provisioning failed"))
@@ -728,9 +902,8 @@ struct WorkflowRunMachineTests {
       retry.contains {
         if case .launch(let request) = $0 {
           return request.ordinal == 3 && request.environment["PROWL_WORKFLOW_TOKEN"] == "TOKEN-3"
-        } else {
-          return false
         }
+        return false
       })
     _ = machine.apply(.launchFailed(ordinal: 3, reason: "again"))
     #expect(machine.skipConsequence(forStep: "launch") == .endsRun(dependent: "rounds"))
@@ -791,6 +964,7 @@ struct WorkflowRunMachineTests {
         - id: launch
           launch: reviewer
           prompt: "Review."
+          expect: { output: ready }
         - id: ping
           message: reviewer
           text: "hello"
@@ -804,11 +978,8 @@ struct WorkflowRunMachineTests {
     let effects = machine.apply(.user(.relaunch))
     #expect(
       effects.contains {
-        if case .launch(let request) = $0 {
-          return request.redelivery && request.prompt.hasPrefix("hello\n\n---\n")
-        } else {
-          return false
-        }
+        if case .launch(let request) = $0 { return request.redelivery && request.prompt.hasPrefix("hello\n\n---\n") }
+        return false
       })
   }
 }

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -88,6 +88,25 @@ struct WorkflowRunStoreTests {
     #expect(decoded.bindings["source"]?.pane == WorkflowRunMachineTests.authorPane)
     #expect(decoded.invocations.first?.activation?.output == "brief")
     #expect(decoded.run.status.attention?.actions == [.nudge, .keepWaiting, .skip, .cancel])
+    #expect(decoded.run.status.attention?.issues == nil)
+  }
+
+  @Test func recordCarriesTheIssueCodesOfAProvisionalDelivery() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var run = try makeRun(root: root)
+    let attention = WorkflowAttention(
+      reason: .deliveryIssues([.missingSections(["## Objective"]), .verdictMissing(allowed: ["a", "b"])]),
+      stepID: "brief", role: "source", ordinal: 1, actions: [.acceptWithVerdict, .askAgain, .skip, .cancel],
+      message: "m")
+    run.status = .needsAttention(attention)
+    let record = WorkflowRunRecord(run: run)
+    #expect(record.run.status.attention?.reason == "delivery_issues")
+    #expect(record.run.status.attention?.issues == ["missing_sections", "verdict_missing"])
+    let store = WorkflowRunStore(rootURL: root)
+    try store.ensureLayout(runID: run.id)
+    try store.writeRecord(record)
+    #expect(try store.readRecord(runID: run.id) == record)
   }
 
   @Test func recordKeepsInputNamesButNeverInputValues() throws {

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowRunStoreTests {
+  nonisolated private static let now = Date(timeIntervalSince1970: 1_760_000_000)
+
+  private func makeRoot() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appending(path: "workflow-run-store-tests", directoryHint: .isDirectory)
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func makeRun(root: URL, status: WorkflowRunStatus = .running) throws -> WorkflowRun {
+    let definition = try #require(WorkflowDocumentParser.parse(WorkflowRunMachineTests.handoff).definition)
+    let started = try WorkflowRunMachine.start(
+      WorkflowRunStartRequest(
+        definition: definition,
+        runID: UUID(),
+        context: WorkflowRunContext(
+          scope: .repo(repositoryID: "repo-1"), definitionPath: "/x/review.yaml",
+          worktree: WorkflowRunWorktree(
+            id: "wt", name: "feature", branch: "feat/x", path: root.path(percentEncoded: false))),
+        bindings: [
+          "source": .current(WorkflowRunMachineTests.authorPane),
+          "receiver": .launch(WorkflowRunMachineTests.reviewerProfile, pane: nil),
+        ]),
+      now: { Self.now },
+      makeToken: { "SECRET-TOKEN" })
+    var machine = started.machine
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "dispatch-1"))
+    if case .needsAttention = status {
+      _ = machine.apply(.watchdog(ordinal: 1, .attention(.idleWithoutDelivery)))
+    }
+    if status == .cancelled {
+      _ = machine.apply(.user(.cancel))
+    }
+    return machine.run
+  }
+
+  @Test func layoutCreatesTheSelfIgnoringRunsDirectoryAndSubdirectories() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let runs = root.appending(path: ".prowl/workflow-runs", directoryHint: .isDirectory)
+    #expect(try String(contentsOf: runs.appending(path: ".gitignore"), encoding: .utf8) == "*\n")
+    for name in ["instructions", "outputs", "skills"] {
+      var isDirectory: ObjCBool = false
+      let path = runs.appending(path: runID.uuidString).appending(path: name).path(percentEncoded: false)
+      #expect(FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue)
+    }
+  }
+
+  @Test func recordRoundTripsWithoutTokensOrEnvironment() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let run = try makeRun(
+      root: root,
+      status: .needsAttention(
+        WorkflowAttention(
+          reason: .idleWithoutDelivery, stepID: "brief", role: "source", ordinal: 1, actions: [], message: "")))
+    try store.ensureLayout(runID: run.id)
+    let record = WorkflowRunRecord(run: run)
+    try store.writeRecord(record)
+
+    let url = store.directory(for: run.id).appending(path: "run.json")
+    let json = try String(contentsOf: url, encoding: .utf8)
+    #expect(!json.contains("SECRET-TOKEN"))
+    #expect(json.contains("\"dispatch_id\" : \"dispatch-1\""))
+    #expect(json.contains("\"version\" : 1"))
+    #expect(json.contains("\"scope\" : \"repo:repo-1\""))
+    #expect(json.contains("\"state\" : \"needs_attention\""))
+    #expect(json.contains("\"reason\" : \"idle_without_delivery\""))
+    #expect(json.contains("\"agent\" : \"pi\""))
+    #expect(!json.contains("PROWL_"))
+
+    let decoded = try store.readRecord(runID: run.id)
+    #expect(decoded == record)
+    #expect(decoded.bindings["receiver"]?.profile == WorkflowRunMachineTests.reviewerProfile)
+    #expect(decoded.bindings["source"]?.pane == WorkflowRunMachineTests.authorPane)
+    #expect(decoded.invocations.first?.activation?.output == "brief")
+    #expect(decoded.run.status.attention?.actions == [.nudge, .keepWaiting, .skip, .cancel])
+  }
+
+  @Test func recordDecodingToleratesUnknownKeys() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let run = try makeRun(root: root)
+    try store.ensureLayout(runID: run.id)
+    try store.writeRecord(WorkflowRunRecord(run: run))
+    let url = store.directory(for: run.id).appending(path: "run.json")
+    var json = try String(contentsOf: url, encoding: .utf8)
+    json = json.replacing("\"version\" : 1", with: "\"version\" : 1,\n  \"future_key\" : { \"nested\" : true }")
+    try json.write(to: url, atomically: true, encoding: .utf8)
+    #expect(try store.readRecord(runID: run.id).run.id == run.id)
+  }
+
+  @Test func outputsAreVersionedAndTheLatestViewIsReplacedAtomically() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let first = try store.writeOutput(runID: runID, name: "findings", ordinal: 2, body: "round 1\n")
+    let second = try store.writeOutput(runID: runID, name: "findings", ordinal: 4, body: "round 2\n")
+    #expect(first.versioned.lastPathComponent == "findings.2.md")
+    #expect(second.versioned.lastPathComponent == "findings.4.md")
+    #expect(first.latest == second.latest)
+    #expect(try String(contentsOf: first.versioned, encoding: .utf8) == "round 1\n")
+    #expect(try String(contentsOf: second.latest, encoding: .utf8) == "round 2\n")
+    let leftovers = try FileManager.default.contentsOfDirectory(
+      atPath: second.latest.deletingLastPathComponent().path(percentEncoded: false))
+    #expect(leftovers.sorted() == ["findings.2.md", "findings.4.md", "findings.md"])
+  }
+
+  @Test func instructionsAndLogAreWrittenUnderTheRun() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let instruction = try store.writeInstruction(runID: runID, stepID: "brief", ordinal: 1, text: "Do it.\n")
+    #expect(instruction.lastPathComponent == "brief.1.md")
+    #expect(try String(contentsOf: instruction, encoding: .utf8) == "Do it.\n")
+    try store.appendLog(runID: runID, line: "started", now: Self.now)
+    try store.appendLog(runID: runID, line: "two\nlines", now: Self.now)
+    let log = try String(contentsOf: store.directory(for: runID).appending(path: "log.md"), encoding: .utf8)
+    #expect(
+      log
+        == "# Workflow run \(runID.uuidString)\n\n- 2025-10-09T08:53:20Z  started\n- 2025-10-09T08:53:20Z  two lines\n")
+  }
+
+  @Test func unsafeSlugsAreRejectedBeforeTouchingTheDisk() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    #expect(throws: WorkflowRunStoreError.unsafePath("../escape")) {
+      try store.writeInstruction(runID: runID, stepID: "../escape", ordinal: 1, text: "x")
+    }
+    #expect(throws: WorkflowRunStoreError.unsafePath("Bad Name")) {
+      try store.writeOutput(runID: runID, name: "Bad Name", ordinal: 1, body: "x")
+    }
+    #expect(throws: WorkflowRunStoreError.unsafePath("brief")) {
+      try store.writeInstruction(runID: runID, stepID: "brief", ordinal: 0, text: "x")
+    }
+  }
+
+  @Test func symlinkedRunDirectoryLeafIsRejected() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try FileManager.default.createDirectory(at: store.runsDirectory, withIntermediateDirectories: true)
+    let elsewhere = root.appending(path: "elsewhere", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(at: store.directory(for: runID), withDestinationURL: elsewhere)
+    #expect(
+      throws: WorkflowRunStoreError.symbolicLink(
+        store.directory(for: runID).path(percentEncoded: false).trimmingSuffix("/"))
+    ) {
+      try store.ensureLayout(runID: runID)
+    }
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
+  }
+
+  @Test func symlinkedOutputsDirectoryIsRejected() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let outputs = store.directory(for: runID).appending(path: "outputs", directoryHint: .isDirectory)
+    try FileManager.default.removeItem(at: outputs)
+    let elsewhere = root.appending(path: "elsewhere", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(at: outputs, withDestinationURL: elsewhere)
+    #expect(throws: WorkflowRunStoreError.self) {
+      try store.writeOutput(runID: runID, name: "findings", ordinal: 1, body: "x")
+    }
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
+  }
+
+  @Test func skillIsMaterializedFromTheBundleDirectory() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let bundle = root.appending(path: "bundle/skills/prowl.adversarial-reviewer", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+    try "---\nname: reviewer\ndescription: Review.\n---\n# Review\n".write(
+      to: bundle.appending(path: "SKILL.md"), atomically: true, encoding: .utf8)
+    try "checklist".write(to: bundle.appending(path: "checklist.md"), atomically: true, encoding: .utf8)
+    let skill = BundledSkill(
+      id: "prowl.adversarial-reviewer", name: "reviewer", description: "Review.", audience: .workflow,
+      directoryURL: bundle)
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let destination = try store.materializeSkill(runID: runID, skill: skill)
+    #expect(
+      destination
+        == store.directory(for: runID).appending(path: "skills/prowl.adversarial-reviewer", directoryHint: .isDirectory)
+    )
+    #expect(try String(contentsOf: destination.appending(path: "SKILL.md"), encoding: .utf8).hasSuffix("# Review\n"))
+    #expect(
+      FileManager.default.fileExists(atPath: destination.appending(path: "checklist.md").path(percentEncoded: false)))
+    _ = try store.materializeSkill(runID: runID, skill: skill)
+    let missing = BundledSkill(
+      id: "prowl.nope", name: "n", description: "d", audience: .workflow, directoryURL: root.appending(path: "nope"))
+    #expect(throws: WorkflowRunStoreError.skillMissing("prowl.nope")) {
+      try store.materializeSkill(runID: runID, skill: missing)
+    }
+  }
+
+  @Test func interruptedScanFlipsOnlyNonTerminalRunsAndReportsUnreadableOnes() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    #expect(try store.markInterruptedRuns(now: Self.now) == WorkflowInterruptedRuns(interrupted: [], unreadable: []))
+
+    let running = try makeRun(root: root)
+    let attention = try makeRun(
+      root: root,
+      status: .needsAttention(
+        WorkflowAttention(reason: .blocked, stepID: "brief", role: nil, ordinal: nil, actions: [], message: "")))
+    let cancelled = try makeRun(root: root, status: .cancelled)
+    for run in [running, attention, cancelled] {
+      try store.ensureLayout(runID: run.id)
+      try store.writeRecord(WorkflowRunRecord(run: run))
+    }
+    let brokenID = UUID()
+    try store.ensureLayout(runID: brokenID)
+    try "{ not json".write(
+      to: store.directory(for: brokenID).appending(path: "run.json"), atomically: true, encoding: .utf8)
+    let later = Self.now.addingTimeInterval(60)
+    let result = try store.markInterruptedRuns(now: later)
+    #expect(Set(result.interrupted) == [running.id, attention.id])
+    #expect(
+      result.unreadable == [store.directory(for: brokenID).appending(path: "run.json").path(percentEncoded: false)])
+    let flipped = try store.readRecord(runID: running.id)
+    #expect(flipped.run.status.state == "interrupted")
+    #expect(flipped.run.finishedAt == later)
+    #expect(flipped.invocations.count == 1)
+    #expect(try store.readRecord(runID: cancelled.id).run.status.state == "cancelled")
+    let log = try String(contentsOf: store.directory(for: running.id).appending(path: "log.md"), encoding: .utf8)
+    #expect(log.contains("marked interrupted"))
+    #expect(try store.markInterruptedRuns(now: later).interrupted.isEmpty)
+  }
+}
+
+extension String {
+  fileprivate func trimmingSuffix(_ suffix: String) -> String {
+    hasSuffix(suffix) ? String(dropLast(suffix.count)) : self
+  }
+}

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -83,10 +83,60 @@ struct WorkflowRunStoreTests {
 
     let decoded = try store.readRecord(runID: run.id)
     #expect(decoded == record)
+    #expect(decoded.inputs == [])
     #expect(decoded.bindings["receiver"]?.profile == WorkflowRunMachineTests.reviewerProfile)
     #expect(decoded.bindings["source"]?.pane == WorkflowRunMachineTests.authorPane)
     #expect(decoded.invocations.first?.activation?.output == "brief")
     #expect(decoded.run.status.attention?.actions == [.nudge, .keepWaiting, .skip, .cancel])
+  }
+
+  @Test func recordKeepsInputNamesButNeverInputValues() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let definition = try #require(WorkflowDocumentParser.parse(WorkflowRunMachineTests.adversarialReview).definition)
+    let started = try WorkflowRunMachine.start(
+      WorkflowRunStartRequest(
+        definition: definition,
+        runID: UUID(),
+        context: WorkflowRunContext(
+          scope: .user, definitionPath: nil,
+          worktree: WorkflowRunWorktree(id: "wt", name: "w", branch: "b", path: root.path(percentEncoded: false))),
+        bindings: [
+          "author": .current(WorkflowRunMachineTests.authorPane),
+          "reviewer": .launch(WorkflowRunMachineTests.reviewerProfile, pane: nil),
+        ],
+        inputs: ["focus": "hunter2-secret"]),
+      now: { Self.now })
+    let store = WorkflowRunStore(rootURL: root)
+    try store.ensureLayout(runID: started.machine.run.id)
+    try store.writeRecord(WorkflowRunRecord(run: started.machine.run))
+    let json = try String(
+      contentsOf: store.directory(for: started.machine.run.id).appending(path: "run.json"), encoding: .utf8)
+    #expect(!json.contains("hunter2-secret"))
+    #expect(try store.readRecord(runID: started.machine.run.id).inputs == ["focus", "max_rounds", "mode"])
+  }
+
+  @Test func symlinkedLogAndRecordLeavesAreRefused() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let runID = UUID()
+    try store.ensureLayout(runID: runID)
+    let victim = root.appending(path: "victim.txt")
+    try "original\n".write(to: victim, atomically: true, encoding: .utf8)
+    let log = store.directory(for: runID).appending(path: "log.md")
+    try FileManager.default.createSymbolicLink(at: log, withDestinationURL: victim)
+    #expect(throws: WorkflowRunStoreError.self) { try store.appendLog(runID: runID, line: "hi", now: Self.now) }
+    #expect(try String(contentsOf: victim, encoding: .utf8) == "original\n")
+    let record = store.directory(for: runID).appending(path: "run.json")
+    try FileManager.default.createSymbolicLink(at: record, withDestinationURL: victim)
+    #expect(throws: WorkflowRunStoreError.self) { try store.readRecord(runID: runID) }
+    let run = try makeRun(root: root)
+    try store.ensureLayout(runID: run.id)
+    try FileManager.default.createSymbolicLink(
+      at: store.directory(for: run.id).appending(path: "run.json"), withDestinationURL: victim)
+    #expect(throws: WorkflowRunStoreError.self) { try store.writeRecord(WorkflowRunRecord(run: run)) }
+    #expect(try String(contentsOf: victim, encoding: .utf8) == "original\n")
   }
 
   @Test func recordDecodingToleratesUnknownKeys() throws {

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -246,6 +246,38 @@ struct WorkflowRunStoreTests {
     #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
   }
 
+  @Test func restartScanRefusesALinkedBaseAndSkipsForeignVersionsWithoutDecodingThem() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let elsewhere = root.appending(path: "elsewhere/workflow-runs", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: root.appending(path: ".prowl", directoryHint: .isDirectory),
+      withDestinationURL: root.appending(path: "elsewhere", directoryHint: .isDirectory))
+    #expect(throws: WorkflowRunStoreError.self) {
+      try WorkflowRunStore(rootURL: root).markInterruptedRuns(now: Self.now)
+    }
+
+    let clean = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: clean) }
+    let store = WorkflowRunStore(rootURL: clean)
+    let foreignID = UUID()
+    try store.ensureLayout(runID: foreignID)
+    try "{\"version\": 2, \"run\": {\"status\": {\"state\": \"running\"}}, \"future\": true}".write(
+      to: store.directory(for: foreignID).appending(path: "run.json"), atomically: true, encoding: .utf8)
+    let headerlessID = UUID()
+    try store.ensureLayout(runID: headerlessID)
+    try "{\"version\": 1}".write(
+      to: store.directory(for: headerlessID).appending(path: "run.json"), atomically: true, encoding: .utf8)
+    let result = try store.markInterruptedRuns(now: Self.now)
+    #expect(result.interrupted.isEmpty)
+    #expect(
+      result.unreadable == [store.directory(for: headerlessID).appending(path: "run.json").path(percentEncoded: false)])
+    #expect(
+      try String(contentsOf: store.directory(for: foreignID).appending(path: "run.json"), encoding: .utf8).contains(
+        "\"future\": true"))
+  }
+
   @Test func aLinkedRunDirectoryIsNeverReadEither() throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -223,6 +223,46 @@ struct WorkflowRunStoreTests {
     #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
   }
 
+  @Test func aLinkedProwlDirectoryOrRunsDirectoryIsRefused() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let elsewhere = root.appending(path: "elsewhere", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: root.appending(path: ".prowl", directoryHint: .isDirectory), withDestinationURL: elsewhere)
+    let store = WorkflowRunStore(rootURL: root)
+    #expect(throws: WorkflowRunStoreError.self) { try store.ensureLayout(runID: UUID()) }
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
+
+    let second = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: second) }
+    try FileManager.default.createDirectory(
+      at: second.appending(path: ".prowl", directoryHint: .isDirectory), withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: second.appending(path: ".prowl/workflow-runs", directoryHint: .isDirectory), withDestinationURL: elsewhere)
+    let secondStore = WorkflowRunStore(rootURL: second)
+    #expect(throws: WorkflowRunStoreError.self) { try secondStore.ensureLayout(runID: UUID()) }
+    #expect(throws: WorkflowRunStoreError.self) { try secondStore.appendLog(runID: UUID(), line: "x", now: Self.now) }
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
+  }
+
+  @Test func aLinkedRunDirectoryIsNeverReadEither() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = WorkflowRunStore(rootURL: root)
+    let genuine = try makeRun(root: root)
+    try store.ensureLayout(runID: genuine.id)
+    try store.writeRecord(WorkflowRunRecord(run: genuine))
+    let external = root.appending(path: "external", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+    try FileManager.default.copyItem(
+      at: store.directory(for: genuine.id).appending(path: "run.json"), to: external.appending(path: "run.json"))
+    let linkedID = UUID()
+    try FileManager.default.createSymbolicLink(at: store.directory(for: linkedID), withDestinationURL: external)
+    #expect(throws: WorkflowRunStoreError.self) { try store.readRecord(runID: linkedID) }
+    #expect(try store.markInterruptedRuns(now: Self.now).unreadable.count == 1)
+  }
+
   @Test func symlinkedOutputsDirectoryIsRejected() throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowTemplateRendererTests.swift
+++ b/supacodeTests/WorkflowTemplateRendererTests.swift
@@ -78,7 +78,7 @@ struct WorkflowTemplateRendererTests {
     #expect(throws: WorkflowTemplateError.unknownVariable("loop.index")) {
       var context = makeContext()
       context.loop = WorkflowTemplateContext.Loop(index: nil, count: 0)
-      try WorkflowTemplate.render("{{ loop.index }}", context: context)
+      _ = try WorkflowTemplate.render("{{ loop.index }}", context: context)
     }
     #expect(throws: WorkflowTemplateError.malformed(.unbalanced)) {
       try WorkflowTemplate.render("{{ run.id", context: makeContext())

--- a/supacodeTests/WorkflowTemplateRendererTests.swift
+++ b/supacodeTests/WorkflowTemplateRendererTests.swift
@@ -13,8 +13,10 @@ struct WorkflowTemplateRendererTests {
         "reviewer": WorkflowTemplateContext.Role(name: "Pi Reviewer", agent: "pi", pane: nil),
       ],
       outputs: [
-        "findings": WorkflowTemplateContext.Output(path: "/repo/.prowl/workflow-runs/RUN-1/outputs/findings.md", verdict: "issues"),
-        "brief": WorkflowTemplateContext.Output(path: "/repo/.prowl/workflow-runs/RUN-1/outputs/brief.md", verdict: nil),
+        "findings": WorkflowTemplateContext.Output(
+          path: "/repo/.prowl/workflow-runs/RUN-1/outputs/findings.md", verdict: "issues"),
+        "brief": WorkflowTemplateContext.Output(
+          path: "/repo/.prowl/workflow-runs/RUN-1/outputs/brief.md", verdict: nil),
       ],
       skippedOutputs: ["disposition"],
       actions: ["transition": ["kickoff_prompt": "Take over.", "has_briefing": "true"]],

--- a/supacodeTests/WorkflowTemplateRendererTests.swift
+++ b/supacodeTests/WorkflowTemplateRendererTests.swift
@@ -25,7 +25,7 @@ struct WorkflowTemplateRendererTests {
     )
   }
 
-  @Test func rendersEveryWhitelistedVariable() throws {
+  @Test func rendersEveryAllowedVariable() throws {
     let context = makeContext()
     let text = """
       {{ run.id }}|{{ run.dir }}|{{ worktree.path }}|{{ worktree.name }}|{{ worktree.branch }}|\

--- a/supacodeTests/WorkflowTemplateRendererTests.swift
+++ b/supacodeTests/WorkflowTemplateRendererTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowTemplateRendererTests {
+  private func makeContext() -> WorkflowTemplateContext {
+    WorkflowTemplateContext(
+      run: WorkflowTemplateContext.Run(id: "RUN-1", directory: "/repo/.prowl/workflow-runs/RUN-1"),
+      worktree: WorkflowTemplateContext.Worktree(path: "/repo", name: "feature", branch: "feat/x"),
+      roles: [
+        "author": WorkflowTemplateContext.Role(name: "Claude Code", agent: "claude", pane: "p3"),
+        "reviewer": WorkflowTemplateContext.Role(name: "Pi Reviewer", agent: "pi", pane: nil),
+      ],
+      outputs: [
+        "findings": WorkflowTemplateContext.Output(path: "/repo/.prowl/workflow-runs/RUN-1/outputs/findings.md", verdict: "issues"),
+        "brief": WorkflowTemplateContext.Output(path: "/repo/.prowl/workflow-runs/RUN-1/outputs/brief.md", verdict: nil),
+      ],
+      skippedOutputs: ["disposition"],
+      actions: ["transition": ["kickoff_prompt": "Take over.", "has_briefing": "true"]],
+      inputs: ["max_rounds": "5", "focus": "the parser"],
+      loop: WorkflowTemplateContext.Loop(index: 2, count: 1)
+    )
+  }
+
+  @Test func rendersEveryWhitelistedVariable() throws {
+    let context = makeContext()
+    let text = """
+      {{ run.id }}|{{ run.dir }}|{{ worktree.path }}|{{ worktree.name }}|{{ worktree.branch }}|\
+      {{ roles.author.name }}|{{ roles.author.agent }}|{{ roles.author.pane }}|{{ roles.reviewer.name }}|\
+      {{ outputs.findings.path }}|{{ outputs.findings.verdict }}|{{ actions.transition.kickoff_prompt }}|\
+      {{ inputs.max_rounds }}|{{ inputs.focus }}|{{ loop.index }}|{{ loop.count }}
+      """
+    let rendered = try WorkflowTemplate.render(text, context: context)
+    #expect(
+      rendered
+        == "RUN-1|/repo/.prowl/workflow-runs/RUN-1|/repo|feature|feat/x|Claude Code|claude|p3|Pi Reviewer|"
+        + "/repo/.prowl/workflow-runs/RUN-1/outputs/findings.md|issues|Take over.|5|the parser|2|1")
+  }
+
+  @Test func textWithoutReferencesIsReturnedVerbatim() throws {
+    #expect(try WorkflowTemplate.render("no placeholders here", context: makeContext()) == "no placeholders here")
+  }
+
+  @Test func skippedOutputIsTheSkipRuleSignal() {
+    #expect(throws: WorkflowTemplateError.missingOutput(name: "disposition")) {
+      try WorkflowTemplate.render("Read {{ outputs.disposition.path }}", context: makeContext())
+    }
+  }
+
+  @Test func neverProducedOutputIsAlsoMissing() {
+    #expect(throws: WorkflowTemplateError.missingOutput(name: "nothing")) {
+      try WorkflowTemplate.render("{{ outputs.nothing.path }}", context: makeContext())
+    }
+  }
+
+  @Test func verdictOfAnOutputWithoutVerdictIsUnavailable() {
+    #expect(throws: WorkflowTemplateError.verdictUnavailable(output: "brief")) {
+      try WorkflowTemplate.render("{{ outputs.brief.verdict }}", context: makeContext())
+    }
+  }
+
+  @Test func paneOfAnUnlaunchedRoleIsUnavailable() {
+    #expect(throws: WorkflowTemplateError.paneUnavailable(role: "reviewer")) {
+      try WorkflowTemplate.render("{{ roles.reviewer.pane }}", context: makeContext())
+    }
+  }
+
+  @Test func unknownVariablesAndMalformedPlaceholdersThrow() {
+    #expect(throws: WorkflowTemplateError.unknownVariable("run.nope")) {
+      try WorkflowTemplate.render("{{ run.nope }}", context: makeContext())
+    }
+    #expect(throws: WorkflowTemplateError.unknownVariable("inputs.other")) {
+      try WorkflowTemplate.render("{{ inputs.other }}", context: makeContext())
+    }
+    #expect(throws: WorkflowTemplateError.unknownVariable("loop.index")) {
+      var context = makeContext()
+      context.loop = WorkflowTemplateContext.Loop(index: nil, count: 0)
+      try WorkflowTemplate.render("{{ loop.index }}", context: context)
+    }
+    #expect(throws: WorkflowTemplateError.malformed(.unbalanced)) {
+      try WorkflowTemplate.render("{{ run.id", context: makeContext())
+    }
+  }
+
+  @Test func substitutedValuesAreNotReScanned() throws {
+    var context = makeContext()
+    context.inputs["focus"] = "{{ run.id }}"
+    #expect(try WorkflowTemplate.render("[{{ inputs.focus }}]", context: context) == "[{{ run.id }}]")
+  }
+}

--- a/supacodeTests/WorkflowWatchdogTests.swift
+++ b/supacodeTests/WorkflowWatchdogTests.swift
@@ -175,6 +175,14 @@ struct WorkflowWatchdogPolicyTests {
     #expect(untimed.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery)), .stop])
   }
 
+  @Test func armingOnAGonePaneRaisesAttentionAtOnce() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: false)
+    let gone = WorkflowWatchdogSnapshot(
+      state: "gone", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false)
+    #expect(policy.apply(.armed(gone)) == [.emit(.attention(.agentGone(.paneClosed))), .stop])
+    #expect(policy.stopped)
+  }
+
   @Test func hardTimeoutFiresRegardlessOfMode() {
     var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: false)
     #expect(policy.apply(.armed(exact)) == [.schedule(.timeout, .seconds(600))])

--- a/supacodeTests/WorkflowWatchdogTests.swift
+++ b/supacodeTests/WorkflowWatchdogTests.swift
@@ -1,0 +1,385 @@
+import Clocks
+import Foundation
+import Testing
+
+@testable import supacode
+
+// MARK: - Policy (pure)
+
+struct WorkflowWatchdogPolicyTests {
+  private let settings = WorkflowWatchdogSettings()
+  private let exact = WorkflowWatchdogSnapshot(
+    state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true)
+  private let codexLike = WorkflowWatchdogSnapshot(
+    state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: false)
+  private let heuristic = WorkflowWatchdogSnapshot(
+    state: "working", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false)
+
+  private func idle(_ live: Bool = true) -> WorkflowWatchdogSnapshot {
+    WorkflowWatchdogSnapshot(state: "idle", liveChannelCoversTurnEnded: live, liveChannelCoversSessionEnd: live)
+  }
+
+  private func working(_ live: Bool = true) -> WorkflowWatchdogSnapshot {
+    WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: live, liveChannelCoversSessionEnd: live)
+  }
+
+  @Test func settingsClampTurnGraceToTheFloor() {
+    #expect(WorkflowWatchdogSettings(turnGrace: .seconds(2)).turnGrace == .seconds(5))
+    #expect(WorkflowWatchdogSettings().turnGrace == .seconds(15))
+    #expect(WorkflowWatchdogSettings().idleGrace == .seconds(180))
+    #expect(WorkflowWatchdogSettings().blockedGrace == .seconds(30))
+  }
+
+  @Test func exactModeNeedsInputIsImmediateAndKeepsWatching() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    #expect(policy.apply(.armed(exact)) == [])
+    #expect(policy.mode == .exact(coversSessionEnd: true))
+    #expect(policy.apply(.needsInput) == [.emit(.attention(.needsInput))])
+    #expect(!policy.stopped)
+    #expect(policy.apply(.turnEnded) == [.schedule(.turnGrace, .seconds(15))])
+  }
+
+  @Test func exactModeTurnEndedNudgesOnceThenEscalates() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = policy.apply(.armed(exact))
+    #expect(policy.apply(.turnEnded) == [.schedule(.turnGrace, .seconds(15))])
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [.emit(.nudge), .schedule(.idleGrace, .seconds(180))])
+    #expect(policy.nudged)
+    #expect(policy.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery)), .stop])
+    #expect(policy.stopped)
+    #expect(policy.apply(.turnEnded) == [])
+  }
+
+  @Test func turnGraceReArmsWhenTheRoleIsWorkingOrReportedActivity() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = policy.apply(.armed(exact))
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.deadline(.turnGrace, working())) == [])
+    #expect(!policy.nudged)
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.signal(.progress)) == [])
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [])
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.signal(.sessionStart)) == [])
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [])
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.detector(state: "working")) == [])
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [])
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [.emit(.nudge), .schedule(.idleGrace, .seconds(180))])
+  }
+
+  @Test func idleGraceReArmsWhileTheNudgedRoleWorksAndNeverNudgesTwice() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = policy.apply(.armed(exact))
+    _ = policy.apply(.turnEnded)
+    _ = policy.apply(.deadline(.turnGrace, idle()))
+    #expect(policy.apply(.deadline(.idleGrace, working())) == [])
+    #expect(policy.apply(.turnEnded) == [.schedule(.turnGrace, .seconds(15))])
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery)), .stop])
+  }
+
+  @Test func resumedWatchdogSkipsTheAutomaticNudge() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: true)
+    _ = policy.apply(.armed(exact))
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery)), .stop])
+  }
+
+  @Test func goneEvidenceEndsTheWatchdog() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = policy.apply(.armed(exact))
+    _ = policy.apply(.turnEnded)
+    #expect(
+      policy.apply(.gone(.sessionEnded)) == [.emit(.attention(.agentGone(.sessionEnded))), .cancel(.turnGrace), .stop])
+
+    var closed = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = closed.apply(.armed(exact))
+    #expect(closed.apply(.surfaceClosed) == [.emit(.attention(.agentGone(.paneClosed))), .stop])
+
+    var delivered = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = delivered.apply(.armed(exact))
+    #expect(delivered.apply(.activationClosed) == [.stop])
+  }
+
+  @Test func detectorRemovalIsDiagnosticOnlyWhenAChannelCoversSessionEnd() {
+    var covered = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = covered.apply(.armed(exact))
+    #expect(covered.apply(.detectorRemoved) == [])
+    #expect(!covered.stopped)
+
+    var uncovered = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = uncovered.apply(.armed(codexLike))
+    #expect(uncovered.apply(.detectorRemoved) == [.emit(.attention(.agentGone(.processGone))), .stop])
+
+    var heuristicPolicy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = heuristicPolicy.apply(.armed(heuristic))
+    #expect(heuristicPolicy.apply(.detectorRemoved) == [.emit(.attention(.agentGone(.processGone))), .stop])
+  }
+
+  @Test func heuristicModeUsesDetectorLevelsWithGrace() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    #expect(policy.apply(.armed(heuristic)) == [])
+    #expect(policy.mode == .heuristic)
+    #expect(policy.apply(.detector(state: "blocked")) == [.schedule(.blockedGrace, .seconds(30))])
+    #expect(policy.apply(.detector(state: "blocked")) == [])
+    #expect(
+      policy.apply(
+        .deadline(
+          .blockedGrace,
+          WorkflowWatchdogSnapshot(
+            state: "blocked", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false))) == [
+          .emit(.attention(.blocked))
+        ])
+    #expect(!policy.stopped)
+    #expect(policy.apply(.detector(state: "working")) == [])
+    #expect(policy.apply(.detector(state: "idle")) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.detector(state: "done")) == [])
+    #expect(policy.apply(.detector(state: "working")) == [.cancel(.idleGrace)])
+    #expect(policy.apply(.detector(state: "idle")) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle(false))) == [.emit(.nudge), .schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, working(false))) == [])
+    #expect(policy.apply(.detector(state: "idle")) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle(false))) == [.emit(.attention(.idleWithoutDelivery)), .stop])
+  }
+
+  @Test func heuristicModeArmedOnAnIdleLevelStartsTheGraceAtOnce() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    #expect(policy.apply(.armed(idle(false))) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle(false))) == [.emit(.nudge), .schedule(.idleGrace, .seconds(180))])
+  }
+
+  @Test func exactModeIgnoresDetectorLevels() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = policy.apply(.armed(idle()))
+    #expect(policy.apply(.detector(state: "idle")) == [])
+    #expect(policy.apply(.detector(state: "blocked")) == [])
+    #expect(policy.apply(.deadline(.blockedGrace, idle())) == [])
+  }
+
+  @Test func hardTimeoutFiresRegardlessOfMode() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: false)
+    #expect(policy.apply(.armed(exact)) == [.schedule(.timeout, .seconds(600))])
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.deadline(.timeout, working())) == [.emit(.timeout), .cancel(.turnGrace), .stop])
+  }
+
+  @Test func snapshotMapsConditionEvidence() {
+    let live = AgentSignalChannelPayload(
+      source: "hook_claude", state: .verifiedLive, confidence: "exact", events: [.turnEnded, .sessionStart],
+      lastSeenAt: "t")
+    let observed = AgentSignalChannelPayload(
+      source: "cooperative_cli", state: .observed, confidence: "exact", events: [.sessionEnd], lastSeenAt: "t")
+    let signals = AgentSignalsPayload(channels: [live, observed], last: nil, lastBinding: nil)
+    let condition = AgentConditionSnapshot(agent: nil, signal: nil, revision: 3, isLive: true, signals: signals)
+    #expect(
+      WorkflowWatchdog.snapshot(from: condition)
+        == WorkflowWatchdogSnapshot(
+          state: "absent", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: false))
+    let gone = AgentConditionSnapshot(agent: nil, signal: nil, revision: 3, isLive: false, signals: .empty)
+    #expect(WorkflowWatchdog.snapshot(from: gone).state == "gone")
+  }
+}
+
+// MARK: - Driver (streams + TestClock)
+
+@MainActor
+@Suite(.serialized)
+struct WorkflowWatchdogDriverTests {
+  @MainActor
+  final class SnapshotBox {
+    var snapshot: WorkflowWatchdogSnapshot
+    init(_ snapshot: WorkflowWatchdogSnapshot) { self.snapshot = snapshot }
+  }
+
+  private static let request = WorkflowWatchdogRequest(
+    ordinal: 1, stepID: "brief", role: "author", surfaceID: UUID(), dispatchID: "d1",
+    timeoutSeconds: nil, timeoutPolicy: .attention, nudgedAlready: false)
+
+  private static let pending = AgentDispatchSnapshot(
+    record: .pending(id: "d1", createdAt: Date(timeIntervalSince1970: 0)), binding: nil)
+
+  private func settle() async {
+    for _ in 0..<25 { await Task.yield() }
+  }
+
+  struct Rig {
+    let watchdog: WorkflowWatchdog
+    let agent: AgentObservationStream.Continuation
+    let dispatch: AgentDispatchObservationStream.Continuation
+  }
+
+  private func makeWatchdog(
+    request: WorkflowWatchdogRequest = request,
+    snapshot: SnapshotBox,
+    clock: TestClock<Duration>
+  ) -> Rig {
+    let (agentStream, agentContinuation) = AgentObservationStream.makeStream()
+    let (dispatchStream, dispatchContinuation) = AgentDispatchObservationStream.makeStream()
+    let watchdog = WorkflowWatchdog(
+      request: request,
+      settings: WorkflowWatchdogSettings(),
+      sources: WorkflowWatchdog.Sources(
+        observeAgent: { agentStream },
+        observeDispatch: { dispatchStream },
+        snapshot: { snapshot.snapshot }),
+      clock: clock)
+    return Rig(watchdog: watchdog, agent: agentContinuation, dispatch: dispatchContinuation)
+  }
+
+  @Test func exactModeNudgesAfterTurnGraceAndEscalatesAfterIdleGrace() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true))
+    let rig = makeWatchdog(snapshot: box, clock: clock)
+    let (watchdog, dispatch) = (rig.watchdog, rig.dispatch)
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    dispatch.yield(.incomplete(Self.pending))
+    await settle()
+    box.snapshot = WorkflowWatchdogSnapshot(
+      state: "idle", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true)
+    await settle()
+    await clock.advance(by: .seconds(14))
+    await settle()
+    await clock.advance(by: .seconds(1))
+    #expect(await verdicts.next() == .nudge)
+    await settle()
+    await clock.advance(by: .seconds(180))
+    #expect(await verdicts.next() == .attention(.idleWithoutDelivery))
+    #expect(await verdicts.next() == nil)
+    #expect(!watchdog.isRunning)
+  }
+
+  @Test func turnGraceReReadsTheStateAndReArmsOnWorking() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true))
+    let rig = makeWatchdog(snapshot: box, clock: clock)
+    let (watchdog, dispatch) = (rig.watchdog, rig.dispatch)
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    dispatch.yield(.incomplete(Self.pending))
+    await settle()
+    await clock.advance(by: .seconds(15))
+    await settle()
+    dispatch.yield(.incomplete(Self.pending))
+    await settle()
+    box.snapshot = WorkflowWatchdogSnapshot(
+      state: "idle", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true)
+    await settle()
+    await clock.advance(by: .seconds(15))
+    #expect(await verdicts.next() == .nudge)
+    watchdog.cancel()
+    #expect(await verdicts.next() == nil)
+  }
+
+  @Test func needsInputAndGoneArriveThroughTheDispatchStream() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true))
+    let rig = makeWatchdog(snapshot: box, clock: clock)
+    let (watchdog, dispatch) = (rig.watchdog, rig.dispatch)
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    dispatch.yield(.needsInput(Self.pending))
+    #expect(await verdicts.next() == .attention(.needsInput))
+    let gone = AgentDispatchSnapshot(
+      record: .gone(
+        id: "d1", createdAt: Date(timeIntervalSince1970: 0), goneAt: Date(timeIntervalSince1970: 1), reason: .sessionEnd
+      ),
+      binding: nil)
+    dispatch.yield(.changed(gone))
+    #expect(await verdicts.next() == .attention(.agentGone(.sessionEnded)))
+    #expect(await verdicts.next() == nil)
+    _ = watchdog
+  }
+
+  @Test func surfaceClosedOnTheAgentStreamEndsTheWatchdog() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false))
+    let rig = makeWatchdog(snapshot: box, clock: clock)
+    let (watchdog, agent) = (rig.watchdog, rig.agent)
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    agent.yield(.surfaceClosed)
+    #expect(await verdicts.next() == .attention(.agentGone(.paneClosed)))
+    #expect(await verdicts.next() == nil)
+    _ = watchdog
+  }
+
+  @Test func heuristicModeIdleLevelNudgesAfterIdleGrace() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "idle", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false))
+    let watchdog = makeWatchdog(snapshot: box, clock: clock).watchdog
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    await clock.advance(by: .seconds(180))
+    #expect(await verdicts.next() == .nudge)
+    await settle()
+    await clock.advance(by: .seconds(180))
+    #expect(await verdicts.next() == .attention(.idleWithoutDelivery))
+    #expect(await verdicts.next() == nil)
+    _ = watchdog
+  }
+
+  @Test func hardTimeoutFiresOnTheClock() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "working", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true))
+    let request = WorkflowWatchdogRequest(
+      ordinal: 1, stepID: "brief", role: "author", surfaceID: UUID(), dispatchID: "d1",
+      timeoutSeconds: 60, timeoutPolicy: .skip, nudgedAlready: false)
+    let watchdog = makeWatchdog(request: request, snapshot: box, clock: clock).watchdog
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    await clock.advance(by: .seconds(60))
+    #expect(await verdicts.next() == .timeout)
+    #expect(await verdicts.next() == nil)
+    _ = watchdog
+  }
+
+  @Test func cancelStopsEverythingWithoutAVerdict() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "idle", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false))
+    let watchdog = makeWatchdog(snapshot: box, clock: clock).watchdog
+    var verdicts = watchdog.start().makeAsyncIterator()
+    await settle()
+    watchdog.cancel()
+    #expect(await verdicts.next() == nil)
+    await settle()
+    await clock.advance(by: .seconds(400))
+    #expect(!watchdog.isRunning)
+  }
+
+  @Test func inputMappingCoversEveryObservation() {
+    let entry = ActiveAgentEntry(
+      id: UUID(), worktreeID: "wt", worktreeName: "wt", workingDirectory: nil, tabID: TerminalTabID(),
+      paneTitle: "t", surfaceID: UUID(), paneIndex: 1, iconLookupToken: "claude", agent: .claude,
+      rawState: .idle, displayState: .done, lastChangedAt: Date())
+    #expect(WorkflowWatchdog.input(for: .changed(entry)) == .detector(state: "done"))
+    #expect(
+      WorkflowWatchdog.input(for: .snapshot(AgentObservationSnapshot(agent: nil, latestSignal: nil, revision: 0)))
+        == .detector(state: "absent"))
+    #expect(WorkflowWatchdog.input(for: .removed) == .detectorRemoved)
+    #expect(WorkflowWatchdog.input(for: .surfaceClosed) == .surfaceClosed)
+    let signal = AgentSignal(
+      kind: .progress(nil), source: .cooperativeCLI, confidence: .exact, timestamp: Date(), sessionID: nil, detail: nil,
+      claimedOrigin: nil)
+    #expect(WorkflowWatchdog.input(for: .signal(signal)) == .signal(.progress))
+    #expect(WorkflowWatchdog.input(for: .snapshot(Self.pending)) == nil)
+    #expect(WorkflowWatchdog.input(for: .incomplete(Self.pending)) == .turnEnded)
+    #expect(WorkflowWatchdog.input(for: .needsInput(Self.pending)) == .needsInput)
+    let abandoned = AgentDispatchSnapshot(
+      record: .abandoned(id: "d1", createdAt: Date(), abandonedAt: Date(), reason: "r"), binding: nil)
+    #expect(WorkflowWatchdog.input(for: .changed(abandoned)) == .activationClosed)
+    let closed = AgentDispatchSnapshot(
+      record: .gone(id: "d1", createdAt: Date(), goneAt: Date(), reason: .surfaceClosed), binding: nil)
+    #expect(WorkflowWatchdog.input(for: .changed(closed)) == .gone(.paneClosed))
+  }
+}

--- a/supacodeTests/WorkflowWatchdogTests.swift
+++ b/supacodeTests/WorkflowWatchdogTests.swift
@@ -183,6 +183,29 @@ struct WorkflowWatchdogPolicyTests {
     #expect(policy.stopped)
   }
 
+  @Test func armingWithoutADetectedAgentWaitsTheAppearanceGraceThenReportsItGone() {
+    let absent = WorkflowWatchdogSnapshot(
+      state: "absent", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false)
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    #expect(policy.apply(.armed(absent)) == [.schedule(.appearanceGrace, .seconds(10))])
+    #expect(policy.apply(.deadline(.appearanceGrace, absent)) == [.emit(.attention(.agentGone(.processGone))), .stop])
+
+    var appearing = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = appearing.apply(.armed(absent))
+    #expect(appearing.apply(.detector(state: "working")) == [.cancel(.appearanceGrace)])
+    #expect(!appearing.stopped)
+
+    var settled = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = settled.apply(.armed(absent))
+    #expect(settled.apply(.deadline(.appearanceGrace, idle(false))) == [.schedule(.idleGrace, .seconds(180))])
+
+    var exact = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: false)
+    _ = exact.apply(
+      .armed(
+        WorkflowWatchdogSnapshot(state: "absent", liveChannelCoversTurnEnded: true, liveChannelCoversSessionEnd: true)))
+    #expect(exact.apply(.deadline(.appearanceGrace, working())) == [])
+  }
+
   @Test func hardTimeoutFiresRegardlessOfMode() {
     var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: false)
     #expect(policy.apply(.armed(exact)) == [.schedule(.timeout, .seconds(600))])
@@ -379,6 +402,41 @@ struct WorkflowWatchdogDriverTests {
     await settle()
     await clock.advance(by: .seconds(400))
     #expect(!watchdog.isRunning)
+  }
+
+  @Test func observerOverflowsAreRetriedUntilTheStreamDelivers() async throws {
+    let clock = TestClock()
+    let box = SnapshotBox(
+      WorkflowWatchdogSnapshot(state: "idle", liveChannelCoversTurnEnded: false, liveChannelCoversSessionEnd: false))
+    let (dispatchStream, _) = AgentDispatchObservationStream.makeStream()
+    let attempts = Counter()
+    let watchdog = WorkflowWatchdog(
+      request: Self.request,
+      settings: WorkflowWatchdogSettings(),
+      sources: WorkflowWatchdog.Sources(
+        observeAgent: {
+          attempts.increment()
+          if attempts.value <= 4 {
+            return AgentObservationStream { $0.finish(throwing: AgentObservationError.bufferOverflow) }
+          }
+          return AgentObservationStream { continuation in
+            continuation.yield(.removed)
+            continuation.finish()
+          }
+        },
+        observeDispatch: { dispatchStream },
+        snapshot: { box.snapshot }),
+      clock: clock)
+    var verdicts = watchdog.start().makeAsyncIterator()
+    #expect(await verdicts.next() == .attention(.agentGone(.processGone)))
+    #expect(await verdicts.next() == nil)
+    #expect(attempts.value == 5)
+  }
+
+  @MainActor
+  final class Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
   }
 
   @Test func inputMappingCoversEveryObservation() {

--- a/supacodeTests/WorkflowWatchdogTests.swift
+++ b/supacodeTests/WorkflowWatchdogTests.swift
@@ -159,6 +159,22 @@ struct WorkflowWatchdogPolicyTests {
     #expect(policy.apply(.deadline(.blockedGrace, idle())) == [])
   }
 
+  @Test func idleAttentionKeepsTheHardTimeoutAlive() {
+    var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: true)
+    #expect(policy.apply(.armed(exact)) == [.schedule(.timeout, .seconds(600))])
+    _ = policy.apply(.turnEnded)
+    #expect(policy.apply(.deadline(.turnGrace, idle())) == [.schedule(.idleGrace, .seconds(180))])
+    #expect(policy.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery))])
+    #expect(!policy.stopped)
+    #expect(policy.apply(.deadline(.timeout, idle())) == [.emit(.timeout), .stop])
+
+    var untimed = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: nil, nudgedAlready: true)
+    _ = untimed.apply(.armed(exact))
+    _ = untimed.apply(.turnEnded)
+    _ = untimed.apply(.deadline(.turnGrace, idle()))
+    #expect(untimed.apply(.deadline(.idleGrace, idle())) == [.emit(.attention(.idleWithoutDelivery)), .stop])
+  }
+
   @Test func hardTimeoutFiresRegardlessOfMode() {
     var policy = WorkflowWatchdogPolicy(settings: settings, timeoutSeconds: 600, nudgedAlready: false)
     #expect(policy.apply(.armed(exact)) == [.schedule(.timeout, .seconds(600))])


### PR DESCRIPTION
## Summary

Slice **B2** of Agent Workflows (docs-ai 063): the pure runner core that turns a validated `WorkflowDefinition` into a run. No user-facing surface — it stays dormant on `main` until B3 wires it into TCA and the CLI (`prowl workflow run/status/done/cancel`).

- `WorkflowRunMachine` — reducer-style state machine over `WorkflowRun` (`apply(event) -> [effects]`, `deliver(...)`): `repeat … until` with while-loop semantics, run-global invocation ordinals, per-activation delivery tokens checked in the machine, the immediate Skip consequence, Retry / Relaunch / Skip / Cancel / Keep waiting / Nudge, two-phase delivery (validate → persist → complete the dispatch record), the self-initiated first step.
- Renderers — one completion-command renderer (`prowl workflow done` is spelled nowhere else), `[Prowl] ` typed lines behind the rendered-text boundary, the launch protocol block, the §6 template renderer.
- `WorkflowDeliveryValidator` — a review gate, not a wall (H14): token, empty body, and the 1 MiB default / 4 MiB hard cap always reject; missing sections (heading level and case forgiven, fences excluded), unparsable `json`, and a missing / undeclared verdict are *issues* — the body is kept as provisional, the CLI answers `ok` + `warnings`, and the run asks the user (Accept as delivered / Accept with verdict / Ask again / Skip / Cancel). `expect.strict: true` restores the hard rejection.
- `WorkflowRunStore` — `<root>/.prowl/workflow-runs/<run-id>/` with `run.json` v1 (dispatch ids, never tokens, env, or input values), append-only `log.md`, materialized instructions and bundled skills, versioned outputs with an atomically replaced latest view, symlink-refusing leaves and the `AgentProfileHomeProvisioner` containment gate, the launch-time `interrupted` scan.
- `WorkflowWatchdog` — exact-signal-first policy (`needs-input` → attention; `turn-ended` → 15 s grace with re-read → one nudge → 3 min → attention; heuristic `blocked` 30 s / `idle` 3 min without a live channel; explicit `expect.timeout` survives attention) plus the driver over the activation's dispatch observation, the surface observer, and an injected clock.
- `WorkflowNativeActionRunner` — `handoff.transition` / `handoff.checkpoint` / `git.context` over the handoff coordinator with contained, canonical path inputs.
- `WorkflowBindingResolver` — the §3 tiers with the SHA-256 requirement digest and per-candidate re-validation.
- `WorkflowActivationBridge` — the dispatch-store seam B3 implements.
- Shared: `MarkdownArtifactNormalizer` (moved out of `HandoffStore`, now also handles chatter before the opening fence), the `PROWL_WORKFLOW_*` environment keys, the §9 error codes, `enum_value_multiline` in the validator.

Record: `docs-ai/063-agent-workflows/007-b2-runner-core.md`; the DSL spec, the 063 plan, and the release plan are updated in the same PR.

## Design decisions

Grilled with onevcat before code (H1–H13 in the record), plus H14 decided on the open PR (validation as a review gate with `expect.strict` opt-in): pure reducer + effects interpreted by B3 (the test harness is the executable spec for each effect); token check in the machine, the dispatch store untouched; per-activation watchdog streams (`observeAgentDispatch` + `observeAgentState`) on an injected clock; `run.json` v1 without tokens; Relaunch for `launch` roles only (re-delivers the current step as the kickoff prompt); Skip resolves its §5 consequence at once; pure binding resolver, memory/sheet stay with B3/C2; `git.context` reuses the handoff context generator; action failure offers Retry / Cancel.

## Validation

- `make check` — clean (swift-format + SwiftLint strict).
- `xcodebuild test` on the eleven workflow suites + `HandoffStoreTests`: 144 tests, 0 failures.
- `make build-cli`, `make test-cli-unit` (227), `make test-cli-smoke`, `make test-cli-integration` (109) — all green.
- `make build-app` — 0 warnings in the changed files.
- Full `make test` — 2827 tests, 0 failures (run after H14; 2796 / 2808 / 2816 / 2819 on the earlier states of the branch).
- Four adversarial review rounds with a read-only reviewer Profile: round 1 raised 1 P0 / 6 P1 / 3 P2 (symlink leaves in the run directory, two-phase delivery, token reuse on `roleBusy`, `--skip` only for awaited outputs, timeout surviving attention, canonical action paths, no input values in `run.json`, fence-aware sections, enum inputs at the boundary, position-aware Skip consequence); round 2 raised 1 P0 / 3 P1 / 4 P2 (linked `.prowl` base, watchdog verdicts during persistence, descriptor-walked action paths, arm-time gone, expired deadline, start-time skip scan, heading-aware handoff sections, tilde fences); round 3 raised 0 P0 / 2 P1 / 3 P2 (restart-scan gate and header, appearance grace, CommonMark fence closers, unbounded overflow retry); round 4 verified everything and left 2 P2 in the normalizer (ATX headings, trailer code blocks), also fixed. Every finding was fixed with a regression test; nothing at P0–P2 remains. Details in the record.

B2 has no user-facing surface, so the end-to-end pass is replaced by the fake-boundary harness plus the list in the record of what B3 verifies live (idle wait + re-dispatch on real panes, the typed line reaching the composer, `done` resolving through caller ancestry, `agents wait --dispatch` on an activation, the protocol block and `PROWL_WORKFLOW_TOKEN` in the child environment, watchdog timings on hooked / unhooked runtimes, `WORKFLOW_DELIVERY_REQUIRED`).

## Not changed

No CLI command, socket handler, TCA feature, UI, bundled definition, or skill — those are B3 / C1 / D1 / D2. `AgentDispatchStore` and the 064 observation code are untouched; `HandoffStore` only delegates its briefing normalization to the shared normalizer.

