### PR TITLE
Create Ghostty surfaces while the display is asleep

### DIFF
--- a/docs-ai/007-ghostty-embedding-integration/ghostty-fork-sync.md
+++ b/docs-ai/007-ghostty-embedding-integration/ghostty-fork-sync.md
@@ -34,6 +34,15 @@ upstream tag, cherry-pick all of them.
    - Keeps the public `ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*)`
      API shape and fixes the Zig export to accept the unused surface parameter.
    - Drop this patch when upgrading to an upstream tag that contains `4803d58`.
+5. `a0671ce9bf8a8e5ac8079021385adf2047462cc6` — `Backport Ghostty lazy display link creation`
+   - Backports upstream `ghostty-org/ghostty#13639` (`a177ba90af`, merged 2026-08-05) before an
+     upstream tag that includes it exists.
+   - Makes CoreVideo display link creation lazy and non-fatal in `src/renderer/generic.zig`
+     (`syncDisplayLink`), so `ghostty_surface_new` succeeds with zero active displays (display
+     asleep, locked session) and falls back to change-driven rendering until a display-id update
+     recreates the link. `pkg/macos/video/display_link.zig` reports `CreationFailed` instead of
+     `OutOfMemory`. Background: `docs-ai/063-agent-workflows/009-display-sleep-surface-spike.md`.
+   - Drop this patch when upgrading to an upstream tag that contains `a177ba90af`.
    - This is the commit the submodule currently points at.
 
 ## Upgrade To A New Ghostty Tag
@@ -107,8 +116,15 @@ Build GhosttyKit with Xcode 26.3:
 DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make sync-ghostty
 ```
 
-Build Prowl itself with the current Xcode, typically Xcode 26.4:
+Xcode 26.3 is a hard requirement for the Zig side, not a preference: from Xcode 26.4 on, the
+macOS SDK's `libSystem.tbd` lists `arm64e-macos` instead of `arm64-macos`, and zig 0.15.2's
+Mach-O linker cannot match its `aarch64-macos` target to it, so `zig build` fails while linking
+its own build runner with a wall of undefined libc symbols (`_waitpid`, `_sigaction`, …;
+ziglang/zig#31658, fixed on the 0.16 line but never released for 0.15). Xcode 26.3 ships SDK
+26.2, the last one with the old target list. Revisit when the fork moves to a Ghostty release
+that requires zig 0.16. A freshly installed Xcode 26.x may also lack the Metal toolchain that
+`Ghostty.metallib` needs; `xcodebuild -downloadComponent MetalToolchain` fixes
+`cannot execute tool 'metal'`.
 
-```bash
-DEVELOPER_DIR=/Applications/Xcode-26.4.1.app/Contents/Developer make build-app
-```
+Build Prowl itself with the current Xcode (26.6 at the time of writing); no `DEVELOPER_DIR` is
+needed for `make build-app`.

--- a/docs-ai/017-upstream-sync-process/upstream-ledger.md
+++ b/docs-ai/017-upstream-sync-process/upstream-ledger.md
@@ -15,6 +15,18 @@ Future upstream checks should only inspect commits **after** this baseline.
 
 ---
 
+## 2026-08-30 — Ghostty fork patch: lazy display link
+
+- Added `a0671ce9` `Backport Ghostty lazy display link creation` to `onevcat/ghostty`
+  `release/v1.3.1-patched` (backport of upstream `ghostty-org/ghostty#13639`, not yet in a tagged
+  Ghostty release). New Ghostty surfaces no longer fail with `CREATE_FAILED` while the display is
+  asleep; see `docs-ai/063-agent-workflows/009-display-sleep-surface-spike.md`.
+- Prowl submodule bumped to that commit; prebuilt artifacts published as
+  `xcframework-a0671ce9bf8a8e5ac8079021385adf2047462cc6-prowl-v1` and pinned in
+  `scripts/ghosttykit-checksums.txt`. Drop the patch when upgrading past `a177ba90af`.
+
+---
+
 ## 2026-07-12 — Ledger corrections (docs-ai backfill audit)
 
 Verifying this ledger against GitHub during the docs-ai backfill (PR #558) surfaced four

--- a/scripts/ghosttykit-checksums.txt
+++ b/scripts/ghosttykit-checksums.txt
@@ -2,3 +2,4 @@
 # Release tags use: xcframework-<ghostty_sha>-prowl-v1
 # Format: <ghostty_sha> <GhosttyKit.xcframework.tar.gz sha256> <GhosttyKit-resources.tar.gz sha256>
 48365577c1ae8e422c0dd90489921f07b9f79171 69c2c06ed0f90c1e1fd86c607641f31239b374ea57d6cb59c61f543ac4528cd5 bfd2645d742670aa42e6bfab97f62d99f73a51fb8d922a091e51ba38ef5bd4d2
+a0671ce9bf8a8e5ac8079021385adf2047462cc6 20247b8007f1429f3bab79d0a8bac96a551ece1c5e77b767c6c6fa493c4fca83 bd89a194e6920116b65066200b08b713fa249345fa3e6144ebf9039285ed4584


### PR DESCRIPTION
## Summary

- bump `ThirdParty/ghostty` to `a0671ce9` on `onevcat/ghostty` `release/v1.3.1-patched`, which backports upstream [ghostty-org/ghostty#13639](https://github.com/ghostty-org/ghostty/pull/13639): CoreVideo display link creation is now lazy and non-fatal, so `ghostty_surface_new` no longer aborts with `error.OutOfMemory` when `CGGetActiveDisplayList` reports zero displays
- new tabs, splits, and Agent Profile launches therefore work while the display is asleep (previously `CREATE_FAILED` for Profiles and silent dead shells for tabs/splits — see `docs-ai/063-agent-workflows/009-display-sleep-surface-spike.md` on #745); the display link is recreated on the next display-id update after wake
- publish and pin the prebuilt artifacts (`xcframework-a0671ce9…-prowl-v1` on `onevcat/ghostty`, `scripts/ghosttykit-checksums.txt`)
- record the fork patch in the ghostty fork-sync runbook and the upstream ledger, and document why GhosttyKit must be built with Xcode 26.3 (SDK 26.4+ drops `arm64-macos` from `libSystem.tbd`, which zig 0.15.2 cannot link — ziglang/zig#31658)

## Verification

- GhosttyKit built with `DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make -B build-ghostty-xcframework` (universal), packaged with `scripts/package-ghosttykit-artifacts.sh`, uploaded, then round-tripped from a clean artifact state with `make ensure-ghostty` (checksums validated)
- live check against an isolated Debug instance with a CoreGraphics probe confirming `active=0` for the whole `pmset displaysleepnow` interval: `prowl create tab`, `prowl create pane`, and a Profile launch all succeeded while dark and answered `prowl send --capture` from inside the interval; the unified log shows `error creating display link; using fallback rendering err=error.CreationFailed` per dark surface, then `created display link` / `updating display link display id=2` after wake; all panes kept working and rendered after wake
- `make check`, `make build-app`; full `make test` in progress (result posted below)
