### PR TITLE
Constrain --agent to the detector's own vocabulary

### DIFF
--- a/scripts/make-detection-fixture.py
+++ b/scripts/make-detection-fixture.py
@@ -71,6 +71,30 @@ def canonical_tail(content: str, limit: int = DETECTOR_TAIL_LIMIT) -> str:
     return "\n".join(lines[start:])
 
 
+# The runtime names `DetectedAgent` carries, which are also the `<runtime>` path
+# component of a fixture. Two of them are not the case name (`cursor-agent`,
+# `qodercli`), so an unconstrained flag is easy to get wrong — and every wrong
+# value would take the bounded-tail branch below without saying so.
+# `test_agent_vocabulary_matches_the_swift_enum` fails when this list drifts.
+DETECTED_AGENTS = (
+    "pi",
+    "omp",
+    "claude",
+    "codex",
+    "gemini",
+    "cursor-agent",
+    "cline",
+    "opencode",
+    "copilot",
+    "kimi",
+    "droid",
+    "amp",
+    "qodercli",
+    "qwen",
+    "grok",
+)
+
+
 def detection_screen_text(text: str, agent: str) -> str:
     """Port of `DetectedAgent.detectionScreenText(from:)`.
 
@@ -234,10 +258,11 @@ def main() -> int:
     parser.add_argument(
         "--agent",
         required=True,
+        choices=DETECTED_AGENTS,
         metavar="AGENT",
         help="detector the fixture targets (the <runtime> path component, e.g. claude "
         "or codex); claude keeps the full screen, every other agent takes the "
-        "bounded 24-line tail",
+        "bounded 24-line tail. One of: " + ", ".join(DETECTED_AGENTS),
     )
     parser.add_argument(
         "--redact",

--- a/scripts/make-detection-fixture.py
+++ b/scripts/make-detection-fixture.py
@@ -8,10 +8,10 @@ detector reads for the given agent, and applies redactions without changing
 the visible width of any line.
 
 The reduction mirrors `DetectedAgent.detectionScreenText(from:)`: `claude`
-consumes the full active screen and is passed through untrimmed, while every
-other agent consumes the bounded 24-line tail. `--agent` selects between the
-two, and is required because the capture does not record which detector will
-consume it.
+consumes the full active screen and is passed through untrimmed, `pi` consumes a
+32-line tail, and every other agent consumes a 24-line tail. `--agent` selects
+among the three, and is required because the capture does not record which
+detector will consume it.
 
 Width matters. A fixture exists to pin how the classifier reads a real screen,
 and the agent CLIs wrap, shorten, and truncate their rows to the terminal width.
@@ -48,7 +48,11 @@ import re
 import sys
 import unicodedata
 
+# Ports of `agentDetectionRecentLineLimit` and `piAgentDetectionRecentLineLimit`
+# in `supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift`.
+# `test_tail_limits_match_the_swift_constants` fails when either one drifts.
 DETECTOR_TAIL_LIMIT = 24
+PI_DETECTOR_TAIL_LIMIT = 32
 
 
 def canonical_tail(content: str, limit: int = DETECTOR_TAIL_LIMIT) -> str:
@@ -98,11 +102,17 @@ DETECTED_AGENTS = (
 def detection_screen_text(text: str, agent: str) -> str:
     """Port of `DetectedAgent.detectionScreenText(from:)`.
 
-    `claude` consumes the full active screen; every other agent consumes the
-    bounded tail. The special case is deliberate on the Swift side: trimming a
-    Claude capture can delete the very row that reproduces a bug.
+    `claude` consumes the full active screen, `pi` a 32-line tail, and every
+    other agent a 24-line tail. Claude's case is deliberate on the Swift side:
+    trimming a Claude capture can delete the very row that reproduces a bug. Pi
+    keeps the wider tail so the pi-subagents widget holds its header and its live
+    job row in one slice.
     """
-    return text if agent == "claude" else canonical_tail(text)
+    if agent == "claude":
+        return text
+    if agent == "pi":
+        return canonical_tail(text, limit=PI_DETECTOR_TAIL_LIMIT)
+    return canonical_tail(text)
 
 
 class FixtureError(Exception):
@@ -261,8 +271,9 @@ def main() -> int:
         choices=DETECTED_AGENTS,
         metavar="AGENT",
         help="detector the fixture targets (the <runtime> path component, e.g. claude "
-        "or codex); claude keeps the full screen, every other agent takes the "
-        "bounded 24-line tail. One of: " + ", ".join(DETECTED_AGENTS),
+        "or codex); claude keeps the full screen, pi takes the bounded 32-line "
+        "tail, every other agent the bounded 24-line tail. One of: "
+        + ", ".join(DETECTED_AGENTS),
     )
     parser.add_argument(
         "--redact",

--- a/scripts/test_make_detection_fixture.py
+++ b/scripts/test_make_detection_fixture.py
@@ -25,6 +25,29 @@ SCRIPT = pathlib.Path(__file__).resolve().parent / "make-detection-fixture.py"
 DETECTED_AGENT_SWIFT = (
     SCRIPT.parent.parent / "supacode/Domain/AgentDetection/DetectedAgent.swift"
 )
+SCREEN_HEURISTICS_SWIFT = (
+    SCRIPT.parent.parent / "supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift"
+)
+
+
+def swift_declaration_body(source: str, header: str) -> str:
+    """The braced body of the declaration `header` opens, brace-matched.
+
+    Splitting on a later member instead would stop the scan early, and a case
+    declared after that member would go unread.
+    """
+    start = source.index(header)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated declaration: {header}")
+
 
 _spec = importlib.util.spec_from_file_location("make_detection_fixture", SCRIPT)
 fixture = importlib.util.module_from_spec(_spec)
@@ -126,10 +149,40 @@ class AgentVocabulary(unittest.TestCase):
         # The generator mirrors the detector's dispatch, so its agent names have
         # to be the detector's. A hand-copied list drifts silently; this fails.
         source = DETECTED_AGENT_SWIFT.read_text(encoding="utf-8")
-        body = source.split("enum DetectedAgent", 1)[1].split("var id:", 1)[0]
-        cases = re.findall(r'^\s*case (\w+)(?:\s*=\s*"([^"]+)")?\s*$', body, re.M)
+        body = swift_declaration_body(source, "enum DetectedAgent")
+        # Two leading spaces pins a member of the enum itself. A `case .claude:`
+        # inside one of its switch statements sits deeper and ends in a colon,
+        # so it matches neither the indent nor the end-of-line anchor.
+        cases = re.findall(r'^  case (\w+)(?:\s*=\s*"([^"]+)")?\s*$', body, re.M)
         self.assertTrue(cases, "no cases parsed from DetectedAgent.swift")
         self.assertEqual(list(fixture.DETECTED_AGENTS), [raw or name for name, raw in cases])
+
+    def test_body_scan_reads_past_a_member_declared_before_a_case(self):
+        # The scan used to stop at `var id:`. Swift permits a case after a
+        # computed property, and that case has to be read.
+        source = "enum Sample: String {\n  case first\n  var id: String { rawValue }\n  case last\n}\n"
+        body = swift_declaration_body(source, "enum Sample")
+        cases = re.findall(r'^  case (\w+)(?:\s*=\s*"([^"]+)")?\s*$', body, re.M)
+        self.assertEqual([name for name, _ in cases], ["first", "last"])
+
+
+class TailLimits(unittest.TestCase):
+    def test_tail_limits_match_the_swift_constants(self):
+        # The generator ports the detector's line budgets. A budget changed on
+        # the Swift side and not here produces a fixture the detector never
+        # reads, and the corpus round trip cannot see it: applying a wider tail
+        # to an already narrower fixture leaves the fixture unchanged.
+        source = SCREEN_HEURISTICS_SWIFT.read_text(encoding="utf-8")
+        limits = dict(
+            re.findall(r"^nonisolated let (\w*[Ll]ineLimit) = (\d+)$", source, re.M)
+        )
+        self.assertEqual(
+            limits,
+            {
+                "agentDetectionRecentLineLimit": str(fixture.DETECTOR_TAIL_LIMIT),
+                "piAgentDetectionRecentLineLimit": str(fixture.PI_DETECTOR_TAIL_LIMIT),
+            },
+        )
 
 
 class Reduction(unittest.TestCase):
@@ -139,10 +192,25 @@ class Reduction(unittest.TestCase):
         text = "\n".join(f"line {index}" for index in range(40))
         self.assertEqual(fixture.detection_screen_text(text, "claude"), text)
 
+    def test_pi_takes_the_wider_bounded_tail(self):
+        # Mirrors the `.pi` branch: 32 non-blank lines, not the default 24.
+        text = "\n".join(f"line {index}" for index in range(40))
+        reduced = fixture.detection_screen_text(text, "pi")
+        self.assertEqual(reduced.split("\n"), [f"line {index}" for index in range(8, 40)])
+
     def test_other_agents_take_the_bounded_tail(self):
         text = "\n".join(f"line {index}" for index in range(40))
         reduced = fixture.detection_screen_text(text, "codex")
         self.assertEqual(reduced.split("\n"), [f"line {index}" for index in range(16, 40)])
+
+    def test_each_agent_takes_its_own_slice_of_one_screen(self):
+        # The three reduction categories, read off the same capture.
+        text = "\n".join(f"line {index}" for index in range(40))
+        widths = {
+            agent: len(fixture.detection_screen_text(text, agent).split("\n"))
+            for agent in ("claude", "pi", "codex")
+        }
+        self.assertEqual(widths, {"claude": 40, "pi": 32, "codex": 24})
 
     def test_blank_lines_do_not_count_toward_the_tail_budget(self):
         rows = [f"line {index}" for index in range(30)]

--- a/scripts/test_make_detection_fixture.py
+++ b/scripts/test_make_detection_fixture.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+import re
 import subprocess
 import sys
 import tempfile
 import unittest
 
 SCRIPT = pathlib.Path(__file__).resolve().parent / "make-detection-fixture.py"
+DETECTED_AGENT_SWIFT = (
+    SCRIPT.parent.parent / "supacode/Domain/AgentDetection/DetectedAgent.swift"
+)
 
 _spec = importlib.util.spec_from_file_location("make_detection_fixture", SCRIPT)
 fixture = importlib.util.module_from_spec(_spec)
@@ -116,6 +120,18 @@ class MoneyMasking(unittest.TestCase):
         self.assertEqual(len(applied), 2)
 
 
+
+class AgentVocabulary(unittest.TestCase):
+    def test_agent_vocabulary_matches_the_swift_enum(self):
+        # The generator mirrors the detector's dispatch, so its agent names have
+        # to be the detector's. A hand-copied list drifts silently; this fails.
+        source = DETECTED_AGENT_SWIFT.read_text(encoding="utf-8")
+        body = source.split("enum DetectedAgent", 1)[1].split("var id:", 1)[0]
+        cases = re.findall(r'^\s*case (\w+)(?:\s*=\s*"([^"]+)")?\s*$', body, re.M)
+        self.assertTrue(cases, "no cases parsed from DetectedAgent.swift")
+        self.assertEqual(list(fixture.DETECTED_AGENTS), [raw or name for name, raw in cases])
+
+
 class Reduction(unittest.TestCase):
     def test_claude_keeps_the_full_screen(self):
         # Mirrors `DetectedAgent.detectionScreenText(from:)`: trimming a Claude
@@ -174,6 +190,13 @@ class EndToEnd(unittest.TestCase):
         self.assertNotIn("realname", result.stderr)
         self.assertIn("/Users/usr", result.stderr)
         self.assertIn("1 line", result.stderr)
+
+    def test_unknown_agent_is_rejected(self):
+        # Before the flag was constrained, "Claude" was not "claude" and so took
+        # the bounded-tail branch, silently dropping rows from a Claude capture.
+        result = self.run_script("row", agent="Claude")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid choice", result.stderr)
 
     def test_undecidable_replacement_fails_the_run(self):
         result = self.run_script("│ owner name │", "--redact", "owner=❤️")

--- a/supacodeTests/Fixtures/AgentScreenDetection/README.md
+++ b/supacodeTests/Fixtures/AgentScreenDetection/README.md
@@ -37,10 +37,14 @@ derived from `idle + unseen` and is never a fixture state.
    - `claude` consumes the full active screen. Commit the capture as read, without
      trimming; it must not exceed the terminal rows recorded in metadata. Trimming a
      Claude capture can delete the very row above the window that reproduces a bug.
-   - Every other agent consumes the bounded tail produced by the production
-     `agentDetectionRecentText` helper: start at the 24th non-empty line from the
-     bottom when at least 24 exist; otherwise retain the whole screen. Keep blank
-     lines and trailing screen rows inside that window.
+   - `pi` consumes a 32-line tail, so the pi-subagents widget keeps its header and
+     its live job row in one slice.
+   - Every other agent consumes the 24-line tail produced by the production
+     `agentDetectionRecentText` helper.
+
+   A tail starts at the budget-th non-empty line from the bottom when that many
+   exist; otherwise it retains the whole screen. Keep blank lines and trailing
+   screen rows inside that window.
 7. Redact paths, repositories, account identifiers, all real-session prompts/model output,
    and the counters a custom status line reports for the session — cost, token totals,
    quota percentages, elapsed time — without changing runtime chrome, line ordering,
@@ -63,9 +67,11 @@ scripts/make-detection-fixture.py .local/agent-screen-captures/capture.json \
 ```
 
 `--agent` is required and selects the step 6 reduction: `claude` keeps the full active
-screen, and every other agent value takes the bounded 24-line tail. The flag mirrors
-`DetectedAgent.detectionScreenText(from:)` rather than reading the agent from the
-capture, because the capture does not record which detector will consume it.
+screen, `pi` takes the bounded 32-line tail, and every other agent value takes the bounded
+24-line tail. The flag mirrors `DetectedAgent.detectionScreenText(from:)` rather than
+reading the agent from the capture, because the capture does not record which detector will
+consume it. A capture reduced under the wrong budget cannot be caught later: applying a
+wider tail to an already narrower fixture leaves the fixture unchanged.
 
 Each replacement is padded or trimmed in the spaces immediately following it, so every
 later column on the row — a closing box border, a second column of chrome — keeps its


### PR DESCRIPTION
Follow-up to the review comment on #702. `--agent` is required but unvalidated, so every value that is not exactly `claude` takes the bounded-tail branch:

```python
return text if agent == "claude" else canonical_tail(text)
```

`--agent Claude` therefore reduces a Claude capture to 24 lines and says nothing. That is the loss the flag was added to prevent, and a trimmed screen is a plausible screen, so no later step can catch it. Two of the runtime names are also not the case name, `cursor-agent` and `qodercli`, so a wrong value is not only a typo risk.

`choices=DETECTED_AGENTS` turns it into an argparse error and puts the accepted names in `--help`.

The list is a hand copy of `DetectedAgent`, which is the part that rots. A test parses the enum out of `DetectedAgent.swift` and compares, so the copy fails the build rather than drifting, in the same shape as `AgentScreenRuleCoverageTests`. A second test pins the rejection end to end.

`make check` passes, 78 script tests.
