### PR TITLE
Add the workflow start sheet and GUI entry points

### DIFF
--- a/docs-ai/063-agent-workflows/011-c2-start-sheet.md
+++ b/docs-ai/063-agent-workflows/011-c2-start-sheet.md
@@ -9,8 +9,18 @@ R2b slice ([release plan](release-plan.md)), on B3 (#744) and C1 (#747), impleme
 the PR (findings and dispositions in its comments): six findings fixed, one rejected with
 rationale, one coverage gap closed; the closing round reports no open P0/P1. A CLI
 regression smoke pass (isolated Debug instance, `workflow run` from a live Claude pane to a
-completed run record) is green; the GUI entry-point E2E and 061 visual verification remain
-before merge.
+completed run record) is green. The live GUI E2E pass is complete: an `ask` run started
+from the palette (sheet with source picker, defaulted + required inputs, skip choice,
+Run gating) ran to a completed record with both input values rendered into the typed
+instruction; the `auto` run started from the palette with no sheet; the Agents popover
+lists runnable rows with the "Run with Options…" escape hatch (verified to force the sheet)
+and names the validation-failing file as an inert diagnostic row; the Active Agents menu's
+`Run Workflow ▸` submenu starts with the row's pane pinned (read-only source row); the
+`in <workflow> · <role>` subtitle appears the moment a run starts; Esc dismisses via the
+key anchor; 061 visuals verified in Normal, Shelf, and Canvas plus a constrained-width
+window. The pass also caught a real integration bug — view-scope `@Dependency` readers
+(popover, context menu) resolved the empty `liveValue` stub instead of the assembled
+client — fixed by publishing the live client through `WorkflowStartClientRegistry`.
 
 ## Product contract
 

--- a/docs-ai/063-agent-workflows/011-c2-start-sheet.md
+++ b/docs-ai/063-agent-workflows/011-c2-start-sheet.md
@@ -4,7 +4,13 @@
 
 Drafted 2026-08-31; decisions frozen in the grill session of 2026-09-01. C2 is the first
 R2b slice ([release plan](release-plan.md)), on B3 (#744) and C1 (#747), implemented on
-`feat/workflow-start-sheet-c2`.
+`feat/workflow-start-sheet-c2` and opened as
+[#752](https://github.com/onevcat/Prowl/pull/752). Four adversarial review rounds ran over
+the PR (findings and dispositions in its comments): six findings fixed, one rejected with
+rationale, one coverage gap closed; the closing round reports no open P0/P1. A CLI
+regression smoke pass (isolated Debug instance, `workflow run` from a live Claude pane to a
+completed run record) is green; the GUI entry-point E2E and 061 visual verification remain
+before merge.
 
 ## Product contract
 

--- a/docs-ai/063-agent-workflows/011-c2-start-sheet.md
+++ b/docs-ai/063-agent-workflows/011-c2-start-sheet.md
@@ -1,0 +1,93 @@
+# 063.011 — Workflow Start Sheet and Entry Points (C2)
+
+## Status
+
+Drafted 2026-08-31; decisions frozen in the grill session of 2026-09-01. C2 is the first
+R2b slice ([release plan](release-plan.md)), on B3 (#744) and C1 (#747), implemented on
+`feat/workflow-start-sheet-c2`.
+
+## Product contract
+
+R2a left exactly one way to start a workflow: `prowl workflow run` from a terminal. C2 gives
+GUI users the same power without changing what a run *is*: every start still goes through the
+same admission, binding resolution, and validation the CLI path uses, and the status center
+(C1) takes over the moment the run exists.
+
+Three entry points, per [000-plan](000-plan.md):
+
+- the Agents capsule popover gains a **Workflows** section (`Hand Off…` stays its first row);
+- the Command Palette gains `Run Workflow: <name>` commands;
+- Active Agents rows gain a `Run Workflow ▸` context menu, and rows that belong to a run show
+  an `in <workflow> · <role>` subtitle.
+
+The **start sheet** (`WorkflowStartOverlay`, the handoff HUD's centered keyboard-capturing
+card pattern — not window-modal) collects what the run needs before it exists:
+
+- title/description; a "You" source row for the `current` role (a picker — see decision 2);
+- one profile picker per `launch` role — filtered by `agents`, pre-selected from binding
+  resolution (dsl-spec §3), unavailable rows dimmed with the reason, and
+  "Create profile from suggestion…" when nothing matches;
+- one pane picker per `pick` role — detected agents in the source worktree, excluding panes
+  already in a run and the current pane;
+- inputs (defaults pre-filled), a "Skip <step title>" choice for steps skippable at start
+  (§9 `--skip` rule), and a "Don't ask again for this workflow" toggle when `bind: ask`;
+- a CLI-not-installed banner with an inline Install action that disables Run;
+- Cancel / Run.
+
+`bind: auto` with unambiguous resolution and fully defaulted inputs skips the sheet entirely.
+
+## Decisions frozen before implementation (grilled 2026-09-01)
+
+1. **One start path.** The GUI never grows its own run-creation logic: the sheet gathers the
+   same overrides/inputs/skips `workflow run` accepts and submits through the same
+   coordinator entry; admission errors surface with the CLI's error semantics.
+2. **The sheet's "You" row is a source picker** — the GUI equivalent of the CLI's `[source]`
+   positional. It pre-selects the selected worktree's focused pane (capsule popover, palette)
+   or the clicked row's pane (Active Agents menu, fixed there), and lets the user re-pick
+   among the source worktree's detected agent panes when the pre-selection is unqualified or
+   wrong. A workflow without a `current` role runs against the selected worktree. Run is
+   disabled inside the sheet only when the whole worktree holds no qualified source.
+3. **Entry-point visibility differs by surface.** Workflows disabled in Settings
+   (`disabledWorkflowIDs`) appear nowhere; validation-failing ones appear only in the capsule
+   popover, dimmed with the reason (the popover is the diagnostic surface); enabled + valid
+   ones appear in all three entry points.
+4. **"Create profile from suggestion…" is an inline confirm block** inside the picker: it
+   shows the profile about to be created (editable name defaulting from the role/agent, the
+   `suggest` fields as a read-only summary), and Create persists a normal profile and selects
+   it. No silent one-click creation, no round-trip to the Settings editor.
+5. **Bind-mode override is tri-state** (`nil` = follow the YAML `bind` / force `ask` / force
+   `auto`), keyed like `disabledWorkflowIDs` and stored beside the binding memory in
+   `UserGlobalSettings`; the sheet's "Don't ask again" writes `auto`, and D1's Settings page
+   drives the same value. The capsule popover row carries a secondary **"Run with Options…"**
+   action that forces the sheet — the GUI escape hatch matching an explicit CLI `--role`
+   (the only place it is offered).
+6. **Auto-skip needs no extra feedback and never skips required inputs.** When the sheet is
+   skipped, C1's toolbar status item is the start feedback; a workflow with a required,
+   defaultless input still presents the sheet to collect it.
+7. **C2 does not touch handoff.** The HUD keeps its choose stage until D3; "replaces" in the
+   000-plan is the end state, not this slice.
+8. **One atomic PR**, C1-style, with the 061 toolbar rules and Normal/Shelf/Canvas visual
+   verification for every entry-point surface.
+
+## Implementation shape
+
+- A pure start-sheet presentation model derived from the workflow definition, binding
+  resolution output, detected agents, and CLI install status; `WorkflowStartFeature` (TCA)
+  owns selection state and submits typed intents.
+- Binding resolution reuses B3's pure resolver; the sheet is only the `ask` tier's UI and
+  never re-derives eligibility.
+- Entry-point wiring: palette commands from the discovery list (enabled + valid definitions
+  visible to the worktree), capsule popover section, Active Agents context menu + subtitle.
+- Reducer tests for every sheet transition (resolution tiers, unavailable pickers, skip
+  consequences, banner gating, auto-skip path); no `Task.sleep`, `TestClock` only.
+
+## Verification
+
+`make check`, `make test`, `make build-app`; isolated-Debug E2E: an `ask` run started from
+each entry point end to end, an `auto` run that skips the sheet, the CLI-missing banner; 061
+visual verification in Normal, Shelf, and Canvas at normal and constrained widths.
+
+## Out of scope
+
+Settings › Workflows page and authoring skill (D1), built-in workflows (D2), handoff
+migration (D3), headless roles and the GUI editor (V2).

--- a/docs-ai/063-agent-workflows/011-c2-start-sheet.md
+++ b/docs-ai/063-agent-workflows/011-c2-start-sheet.md
@@ -87,6 +87,44 @@ card pattern — not window-modal) collects what the run needs before it exists:
 each entry point end to end, an `auto` run that skips the sheet, the CLI-missing banner; 061
 visual verification in Normal, Shelf, and Canvas at normal and constrained widths.
 
+## Implementation notes (decisions taken while building, recorded per the working agreement)
+
+- **The presentation model folded into `WorkflowStartFeature.State`.** The plan sketched a
+  separate pure model (C1's shape); the sheet's derived values (`canRun`, skip-aware source
+  requirement, per-step skip consequence) read naturally as State computed properties and are
+  tested through the reducer, so a parallel model type would only add indirection. The raw
+  material stays a separate pure layer (`WorkflowStartContext`, assembled by the live client).
+- **Start-time `endsRun` skips are never armed.** §9 refuses them at admission; the sheet
+  disables the toggle and shows the reason instead of letting Run fail. The consequence is
+  recomputed against the other chosen skips, so ordering effects (skipping a reader frees its
+  producer) present correctly. `WorkflowRunMachine.startSkipConsequence` exposes the existing
+  rule; the in-run Skip path is untouched.
+- **A pick-role workflow always presents the sheet**, mirroring the CLI, where `pick` bindings
+  are always explicit (`--role r=pN`).
+- **Popover rows for validation-failing files are inert** (dimmed, named, with the error
+  count); the "dimmed but clickable" rule stays specific to launcher availability warnings,
+  which are heuristic — a failing validation is not.
+- **The palette lists workflows from a state snapshot refreshed on palette open** — the
+  assembler runs on every body evaluation and must not scan the filesystem. In Canvas the
+  snapshot uses the reducer-side action target, which matches the palette's own target in
+  every case except a Canvas card focused between opening the palette and activating a row.
+- **The Active Agents subtitle is replaced, not appended**, while a pane is bound to an active
+  run (`in <workflow> · <role>`), synced from `WorkflowRunsFeature` state on every
+  `workflowRuns` action; the branch/title subtitle returns when the run ends.
+- **The CLI banner's Install acts inline** via the same `CLIInstallClient.install` path
+  Settings uses, and a success flips the sheet's own `cliInstalled` gate without reopening.
+- **`cliInstalled` treats `installedDifferentSource` as installed** — the slot holds a live
+  `prowl`; distinguishing foreign installs is Settings' business, not the sheet's.
+- **Keyboard**: the sheet relies on `keyboardShortcut(.cancelAction/.defaultAction)` and
+  focusable controls rather than the handoff HUD's swallow-everything key capture, because the
+  sheet hosts text fields. Verified live; if keys ever leak to the terminal below, a
+  conditional capture view is the follow-up.
+- **A dedicated `docs/components/workflows.md` page remains D1's deliverable**; C2 documents
+  the entry points in `command-palette.md`, `active-agents.md`, and `agent-profiles.md`.
+- **Toolchain note**: reducer bodies in this codebase must spell `some Reducer<State, Action>`
+  — `some ReducerOf<Self>` fails to satisfy the `Reducer` conformance under Swift 6.2's
+  default-MainActor isolation with no useful diagnostic.
+
 ## Out of scope
 
 Settings › Workflows page and authoring skill (D1), built-in workflows (D2), handoff

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -47,6 +47,8 @@ Command Palette → "Toggle Active Agents Panel".
 
 Rows appear in the order agents are first detected. (See
 [agent-detection](agent-detection.md) for how these states are determined.)
+A row whose pane is bound to an active workflow run replaces its subtitle with
+`in <workflow> · <role>` for the life of the run.
 
 ## Interactions
 
@@ -57,6 +59,10 @@ Rows appear in the order agents are first detected. (See
     (selecting and focusing it first), regardless of which pane currently has
     focus. Same flow as the toolbar Agents capsule; see
     [handoff](handoff.md).
+  - **Run Workflow ▸** — one entry per runnable workflow visible to the
+    agent's worktree; starts it with this pane fixed as the `current` role's
+    source (opening the start sheet when something needs a decision). Shown
+    only when at least one runnable workflow exists.
   - **Mark as Read** — clears the pane's unread notifications without
     switching to it.
   - **Copy Path** / **Reveal in Finder** — the agent's working directory (or

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -27,8 +27,12 @@ respawn.
 ## Launching
 
 - **Toolbar Agents capsule** — always opens a popover. With a detected agent it
-  leads with Hand Off; launch rows follow under a "New agent in this worktree"
-  section header, the current worktree's **Recommended** profile first. Each
+  leads with Hand Off; a "Run a workflow" section follows when the worktree can
+  see workflows (each row starts the workflow, its trailing `ellipsis.circle`
+  control — "Run with Options…" — forces the start sheet, and files that fail
+  validation are listed dimmed with their reason); launch rows follow under a
+  "New agent in this worktree" section header, the current worktree's
+  **Recommended** profile first. Each
   row shows the profile name with the runtime name trailing. Rows for runtimes
   that look unavailable are dimmed with a warning but stay clickable —
   availability signals can be wrong, so they never block a launch. "Manage

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -55,6 +55,12 @@ selected worktree has a pull request).
   **Launch Agent: <name>** row per enabled profile, the current worktree's
   Recommended profile first — the same launch action as the toolbar Agents
   menu. See [agent-profiles](agent-profiles.md).
+- **Workflows** (when a terminal worktree is selected): a
+  **Run Workflow: <name>** row per runnable workflow visible to the
+  action-target worktree (refreshed when the palette opens). Activation goes
+  through the workflow start sheet — or starts immediately when the workflow's
+  bindings resolve without a decision. Validation-failing files are not listed
+  here; the toolbar Agents popover names them with their reason.
 - **Debug** (Debug builds only): toast/update/dock simulations.
 
 ## Behavior notes

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -176,6 +176,11 @@ struct ContentView: View {
         HandoffHudOverlayView(store: handoffHudStore)
       }
     }
+    .overlay {
+      if let workflowStartStore = store.scope(state: \.workflowStart, action: \.workflowStart.presented) {
+        WorkflowStartOverlayView(store: workflowStartStore)
+      }
+    }
     .background(WindowTabbingDisabler())
   }
 

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -166,7 +166,8 @@ struct ContentView: View {
           actionTargetWorktreeID: store.repositories.isShowingCanvas
             ? terminalManager.canvasFocusedWorktreeID
             : nil,
-          ghosttyCommands: ghosttyShortcuts.commandPaletteEntries
+          ghosttyCommands: ghosttyShortcuts.commandPaletteEntries,
+          workflowItems: store.workflowPaletteItems
         ),
         resolvedKeybindings: store.resolvedKeybindings
       )

--- a/supacode/App/WorkflowRuntimeComposition.swift
+++ b/supacode/App/WorkflowRuntimeComposition.swift
@@ -52,6 +52,7 @@ struct WorkflowRuntimeInstallation {
   let watchdog: WorkflowWatchdogClient
   let queue: WorkflowEffectQueueClient
   let responder: WorkflowCLIResponderClient
+  let start: WorkflowStartClient
 
   func install(into values: inout DependencyValues) {
     values.workflowActivationClient = activation
@@ -59,6 +60,7 @@ struct WorkflowRuntimeInstallation {
     values.workflowWatchdogClient = watchdog
     values.workflowEffectQueue = queue
     values.workflowCLIResponder = responder
+    values.workflowStartClient = start
   }
 }
 
@@ -84,7 +86,10 @@ extension SupacodeApp {
       queue: WorkflowEffectQueue().client,
       responder: WorkflowCLIResponderClient(respond: { requestID, resolution in
         coordinatorBox.coordinator?.resolve(requestID, resolution)
-      })
+      }),
+      start: makeWorkflowStartClient(
+        terminalManager: terminalManager, storeBox: storeBox,
+        coordinatorBox: coordinatorBox, reservations: reservations)
     )
   }
 

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -14,7 +14,7 @@ extension SupacodeApp {
     coordinatorBox: WorkflowCoordinatorBox,
     reservations: WorkflowPaneReservations
   ) -> WorkflowStartClient {
-    WorkflowStartClient(
+    let client = WorkflowStartClient(
       catalog: { worktreeID in
         guard let appStore = storeBox.store else { return [] }
         let snapshot = makeWorkflowRuntimeSnapshot(appStore: appStore, terminalManager: terminalManager)
@@ -59,6 +59,10 @@ extension SupacodeApp {
           message: response.error?.message ?? "The workflow could not be started.")
       }
     )
+    // Views outside the store scope (popover, context menu) resolve the global default,
+    // so the assembled client must be published there too.
+    WorkflowStartClientRegistry.shared.client = client
+    return client
   }
 
   // MARK: - Catalog

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -177,10 +177,14 @@ extension SupacodeApp {
       var candidates = agentCandidates
       let preferred = preferredSourceSurfaceID ?? focusedSurfaceID(of: worktree)
       if let preferred, !candidates.contains(where: { $0.surfaceID == preferred }),
-        !busySurfaceIDs.contains(preferred), let bare = candidate(surfaceID: preferred)
+        preferredSourceSurfaceID != nil || !busySurfaceIDs.contains(preferred),
+        let extra = candidate(surfaceID: preferred)
       {
-        // The focused pane may be a bare shell: a valid source while no delivery survives.
-        candidates.insert(bare, at: 0)
+        // The focused pane may be a bare shell (a valid source while no delivery survives),
+        // and an explicitly pinned Active Agents pane stays the fixed source even while it
+        // is bound to a run — admission answers with the CLI's own PANE_BUSY instead of the
+        // sheet pre-judging it (011 decision 1).
+        candidates.insert(extra, at: 0)
       }
       let preselected = candidates.contains { $0.surfaceID == preferred } ? preferred : nil
       source = WorkflowStartSource(

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -28,8 +28,9 @@ extension SupacodeApp {
         let snapshot = makeWorkflowRuntimeSnapshot(appStore: appStore, terminalManager: terminalManager)
         return makeWorkflowStartContext(
           workflowKey: workflowKey, worktreeID: worktreeID, preferredSourceSurfaceID: preferredSource,
-          snapshot: snapshot, appStore: appStore, terminalManager: terminalManager,
-          reservations: reservations)
+          assembly: WorkflowStartAssembly(
+            snapshot: snapshot, appStore: appStore, terminalManager: terminalManager,
+            reservations: reservations))
       },
       run: { request in
         guard let appStore = storeBox.store, let coordinator = coordinatorBox.coordinator else {
@@ -111,16 +112,25 @@ extension SupacodeApp {
 
   // MARK: - Context
 
+  /// The app-side facts one start-context assembly reads.
+  struct WorkflowStartAssembly {
+    let snapshot: WorkflowRuntimeSnapshot
+    let appStore: StoreOf<AppFeature>
+    let terminalManager: WorktreeTerminalManager
+    let reservations: WorkflowPaneReservations
+  }
+
   @MainActor
   private static func makeWorkflowStartContext(
     workflowKey: String,
     worktreeID: String,
     preferredSourceSurfaceID: UUID?,
-    snapshot: WorkflowRuntimeSnapshot,
-    appStore: StoreOf<AppFeature>,
-    terminalManager: WorktreeTerminalManager,
-    reservations: WorkflowPaneReservations
+    assembly: WorkflowStartAssembly
   ) -> WorkflowStartContext? {
+    let snapshot = assembly.snapshot
+    let appStore = assembly.appStore
+    let terminalManager = assembly.terminalManager
+    let reservations = assembly.reservations
     guard
       let entries = try? workflowCatalogEntries(worktreeID: worktreeID, snapshot: snapshot),
       let entry = entries.first(where: { candidate in
@@ -146,7 +156,7 @@ extension SupacodeApp {
       $0.worktreeID == worktreeID
     }
     let panesByID: [UUID: TargetResolutionSnapshot.Pane] = Dictionary(
-      uniqueKeysWithValues: worktree.tabs.flatMap(\.panes).map { ($0.id, $0) })
+      worktree.tabs.flatMap(\.panes).map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
     func candidate(surfaceID: UUID) -> WorkflowStartPaneCandidate? {
       guard let pane = panesByID[surfaceID] else { return nil }
@@ -172,25 +182,61 @@ extension SupacodeApp {
         // The focused pane may be a bare shell: a valid source while no delivery survives.
         candidates.insert(bare, at: 0)
       }
+      let preselected = candidates.contains { $0.surfaceID == preferred } ? preferred : nil
       source = WorkflowStartSource(
         roleName: currentRole.name,
         candidates: candidates,
-        preselectedSurfaceID: candidates.contains { $0.surfaceID == preferred } ? preferred : nil)
+        preselectedSurfaceID: preselected,
+        isPreselectionFixed: preferredSourceSurfaceID != nil && preselected != nil)
     }
 
     let bindOverride = settings.workflowBindMode(for: workflowKey)
     let runScope = WorkflowRunAdmission.runScope(entry.file.scope, worktree: domainWorktree)
-    let repositoryRootURL = URL(filePath: worktree.rootPath, directoryHint: .isDirectory)
+    let launchRoles = makeStartLaunchRoles(
+      definition: definition, scope: runScope, bindOverride: bindOverride,
+      repositoryRootURL: URL(filePath: worktree.rootPath, directoryHint: .isDirectory),
+      settings: settings)
+
+    let pickRoles: [WorkflowStartPickRole] = definition.roles.compactMap { role in
+      guard role.source == .pick else { return nil }
+      return WorkflowStartPickRole(name: role.name, candidates: agentCandidates)
+    }
+
+    let cliStatus = CLIInstallClient.liveValue.installationStatus(cliDefaultInstallPath)
+    let cliInstalled = cliStatus != .notInstalled
+
+    return WorkflowStartContext(
+      item: item,
+      definition: definition,
+      worktreeID: worktreeID,
+      worktreeName: worktree.name,
+      source: source,
+      launchRoles: launchRoles,
+      pickRoles: pickRoles,
+      cliInstalled: cliInstalled,
+      bindModeOverride: bindOverride)
+  }
+
+  /// dsl-spec §3 binding resolution, presented: the resolver's pre-selection per launch role,
+  /// every enabled profile as a picker candidate with its rejection reason, and the suggestion
+  /// the inline create block starts from.
+  @MainActor
+  private static func makeStartLaunchRoles(
+    definition: WorkflowDefinition,
+    scope: WorkflowRunScope,
+    bindOverride: WorkflowBindModeOverride.Mode?,
+    repositoryRootURL: URL,
+    settings: UserGlobalSettings
+  ) -> [WorkflowStartLaunchRole] {
     @Shared(.userRepositorySettings(repositoryRootURL)) var repositorySettings
     let resolverContext = WorkflowBindingResolverContext(
       profiles: settings.agentProfiles,
       designatedProfileID: repositorySettings.defaultAgentProfileID,
       lastLaunchedProfileID: repositorySettings.lastLaunchedAgentProfileID)
-
-    let launchRoles: [WorkflowStartLaunchRole] = definition.roles.compactMap { role in
+    return definition.roles.compactMap { role in
       guard role.source == .launch, let requirements = role.launch else { return nil }
       let memoryKey = WorkflowBindingResolver.memoryKey(
-        scope: runScope, workflowID: definition.id, role: role)
+        scope: scope, workflowID: definition.id, role: role)
       let remembered = settings.rememberedWorkflowBinding(for: memoryKey)
       let result = WorkflowBindingResolver.resolve(
         role: role, remembered: remembered, override: nil, context: resolverContext)
@@ -223,25 +269,6 @@ extension SupacodeApp {
         suggestion: suggestion ?? requirements.suggest,
         rejectedNote: rejectedNote)
     }
-
-    let pickRoles: [WorkflowStartPickRole] = definition.roles.compactMap { role in
-      guard role.source == .pick else { return nil }
-      return WorkflowStartPickRole(name: role.name, candidates: agentCandidates)
-    }
-
-    let cliStatus = CLIInstallClient.liveValue.installationStatus(cliDefaultInstallPath)
-    let cliInstalled = cliStatus != .notInstalled
-
-    return WorkflowStartContext(
-      item: item,
-      definition: definition,
-      worktreeID: worktreeID,
-      worktreeName: worktree.name,
-      source: source,
-      launchRoles: launchRoles,
-      pickRoles: pickRoles,
-      cliInstalled: cliInstalled,
-      bindModeOverride: bindOverride)
   }
 
   private static func focusedSurfaceID(of worktree: TargetResolutionSnapshot.Worktree) -> UUID? {

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -1,0 +1,267 @@
+// supacode/App/WorkflowStartComposition.swift
+// Live assembly of WorkflowStartClient (docs-ai 063 C2). The GUI start path reads the same
+// catalog, resolver, and settings the CLI path reads, and submits through
+// WorkflowRuntimeCoordinator.run — admission stays the single authority (011 decision 1).
+
+import ComposableArchitecture
+import Foundation
+
+extension SupacodeApp {
+  @MainActor
+  static func makeWorkflowStartClient(
+    terminalManager: WorktreeTerminalManager,
+    storeBox: SupacodeAppStoreBox,
+    coordinatorBox: WorkflowCoordinatorBox,
+    reservations: WorkflowPaneReservations
+  ) -> WorkflowStartClient {
+    WorkflowStartClient(
+      catalog: { worktreeID in
+        guard let appStore = storeBox.store else { return [] }
+        let snapshot = makeWorkflowRuntimeSnapshot(appStore: appStore, terminalManager: terminalManager)
+        guard let entries = try? workflowCatalogEntries(worktreeID: worktreeID, snapshot: snapshot) else {
+          return []
+        }
+        return entries.compactMap { startCatalogItem($0, snapshot: snapshot) }
+      },
+      context: { workflowKey, worktreeID, preferredSource in
+        guard let appStore = storeBox.store else { return nil }
+        let snapshot = makeWorkflowRuntimeSnapshot(appStore: appStore, terminalManager: terminalManager)
+        return makeWorkflowStartContext(
+          workflowKey: workflowKey, worktreeID: worktreeID, preferredSourceSurfaceID: preferredSource,
+          snapshot: snapshot, appStore: appStore, terminalManager: terminalManager,
+          reservations: reservations)
+      },
+      run: { request in
+        guard let appStore = storeBox.store, let coordinator = coordinatorBox.coordinator else {
+          return .failed(
+            code: CLIErrorCode.transportFailed, message: "Workflow runtime is not available.")
+        }
+        let snapshot = makeWorkflowRuntimeSnapshot(appStore: appStore, terminalManager: terminalManager)
+        guard let worktree = snapshot.resolution.worktrees.first(where: { $0.id == request.worktreeID })
+        else {
+          return .failed(
+            code: CLIErrorCode.targetNotFound, message: "The source worktree is no longer available.")
+        }
+        let source = WorkflowRunSource(
+          worktree: worktree, paneID: request.sourceSurfaceID, paneIsCaller: false)
+        let input = WorkflowInput(
+          action: .run,
+          target: request.sourceSurfaceID.map { .pane($0.uuidString) } ?? .worktree(request.worktreeID),
+          workflow: request.workflowID,
+          roleBindings: request.roleBindings,
+          inputValues: request.inputValues,
+          skippedSteps: request.skippedSteps)
+        let response = await coordinator.run(input, source: source, snapshot: snapshot)
+        if response.ok { return .started }
+        return .failed(
+          code: response.error?.code ?? CLIErrorCode.transportFailed,
+          message: response.error?.message ?? "The workflow could not be started.")
+      }
+    )
+  }
+
+  // MARK: - Catalog
+
+  @MainActor
+  private static func workflowCatalogEntries(
+    worktreeID: String, snapshot: WorkflowRuntimeSnapshot
+  ) throws -> [WorkflowCatalogEntry] {
+    let worktree = snapshot.resolution.worktrees.first { $0.id == worktreeID }
+    let repoURL = worktree.map {
+      WorkflowSources.repoDirectory(root: URL(filePath: $0.rootPath, directoryHint: .isDirectory))
+    }
+    let sources = WorkflowSources(
+      bundle: snapshot.bundleWorkflowsURL, user: snapshot.userWorkflowsURL, repo: repoURL)
+    return try WorkflowDiscovery.catalog(sources: sources) { scope in
+      WorkflowValidationContext(
+        scope: scope,
+        bundledSkillIDs: snapshot.bundledSkillIDs,
+        knownAgents: snapshot.knownAgents,
+        installedAgents: snapshot.installedAgents,
+        enabledProfiles: snapshot.enabledProfiles
+      )
+    }
+  }
+
+  /// nil hides the entry everywhere: shadowed duplicates and definitions disabled in Settings
+  /// (011 decision 3). A file that fails validation stays listed (the popover dims it); one
+  /// that does not even parse keeps a file-based key so the popover can still name it.
+  @MainActor
+  private static func startCatalogItem(
+    _ entry: WorkflowCatalogEntry, snapshot: WorkflowRuntimeSnapshot
+  ) -> WorkflowStartCatalogItem? {
+    guard !entry.shadowed else { return nil }
+    let file = entry.file
+    guard let id = file.id else {
+      let filename = file.url.lastPathComponent
+      return WorkflowStartCatalogItem(
+        key: "\(file.scope.rawValue)/file:\(filename)", workflowID: filename, name: filename,
+        workflowDescription: nil, validationFailure: "Cannot parse the file.")
+    }
+    let key = WorkflowCommandHandler.disabledKey(scope: file.scope, id: id)
+    guard !snapshot.disabledWorkflowIDs.contains(key) else { return nil }
+    let errors = file.diagnostics.errorCount
+    return WorkflowStartCatalogItem(
+      key: key,
+      workflowID: id,
+      name: file.definition?.name ?? id,
+      workflowDescription: file.definition?.description,
+      validationFailure: file.isValid ? nil : "\(errors) validation error\(errors == 1 ? "" : "s")")
+  }
+
+  // MARK: - Context
+
+  @MainActor
+  private static func makeWorkflowStartContext(
+    workflowKey: String,
+    worktreeID: String,
+    preferredSourceSurfaceID: UUID?,
+    snapshot: WorkflowRuntimeSnapshot,
+    appStore: StoreOf<AppFeature>,
+    terminalManager: WorktreeTerminalManager,
+    reservations: WorkflowPaneReservations
+  ) -> WorkflowStartContext? {
+    guard
+      let entries = try? workflowCatalogEntries(worktreeID: worktreeID, snapshot: snapshot),
+      let entry = entries.first(where: { candidate in
+        startCatalogItem(candidate, snapshot: snapshot)?.key == workflowKey
+      }),
+      let item = startCatalogItem(entry, snapshot: snapshot),
+      let definition = entry.file.definition,
+      let worktree = snapshot.resolution.worktrees.first(where: { $0.id == worktreeID }),
+      let domainWorktree = resolveCLITerminalWorktree(
+        id: worktreeID, repositories: Array(appStore.state.repositories.repositories))
+    else { return nil }
+
+    @Shared(.userGlobalSettings) var settings
+
+    let workflowRuns = appStore.state.workflowRuns
+    let busySurfaceIDs = Set(
+      workflowRuns.paneOwners.compactMap { surfaceID, runID in
+        workflowRuns.sessions[runID]?.run.status.isTerminal == false ? surfaceID : nil
+      }
+    ).union(reservations.pending(for: workflowRuns, isLive: { terminalManager.isSurfaceLive($0) }))
+
+    let agentEntries = appStore.state.repositories.activeAgents.entries.filter {
+      $0.worktreeID == worktreeID
+    }
+    let panesByID: [UUID: TargetResolutionSnapshot.Pane] = Dictionary(
+      uniqueKeysWithValues: worktree.tabs.flatMap(\.panes).map { ($0.id, $0) })
+
+    func candidate(surfaceID: UUID) -> WorkflowStartPaneCandidate? {
+      guard let pane = panesByID[surfaceID] else { return nil }
+      let agent = agentEntries.first { $0.surfaceID == surfaceID }
+      return WorkflowStartPaneCandidate(
+        surfaceID: surfaceID,
+        handle: pane.handle.map { "p\($0)" },
+        agentToken: agent?.agent.rawValue,
+        agentDisplayName: agent?.agent.displayName,
+        paneTitle: pane.title)
+    }
+
+    let agentCandidates = agentEntries.compactMap { candidate(surfaceID: $0.surfaceID) }
+      .filter { !busySurfaceIDs.contains($0.surfaceID) }
+
+    var source: WorkflowStartSource?
+    if let currentRole = definition.roles.first(where: { $0.source == .current }) {
+      var candidates = agentCandidates
+      let preferred = preferredSourceSurfaceID ?? focusedSurfaceID(of: worktree)
+      if let preferred, !candidates.contains(where: { $0.surfaceID == preferred }),
+        !busySurfaceIDs.contains(preferred), let bare = candidate(surfaceID: preferred)
+      {
+        // The focused pane may be a bare shell: a valid source while no delivery survives.
+        candidates.insert(bare, at: 0)
+      }
+      source = WorkflowStartSource(
+        roleName: currentRole.name,
+        candidates: candidates,
+        preselectedSurfaceID: candidates.contains { $0.surfaceID == preferred } ? preferred : nil)
+    }
+
+    let bindOverride = settings.workflowBindMode(for: workflowKey)
+    let runScope = WorkflowRunAdmission.runScope(entry.file.scope, worktree: domainWorktree)
+    let repositoryRootURL = URL(filePath: worktree.rootPath, directoryHint: .isDirectory)
+    @Shared(.userRepositorySettings(repositoryRootURL)) var repositorySettings
+    let resolverContext = WorkflowBindingResolverContext(
+      profiles: settings.agentProfiles,
+      designatedProfileID: repositorySettings.defaultAgentProfileID,
+      lastLaunchedProfileID: repositorySettings.lastLaunchedAgentProfileID)
+
+    let launchRoles: [WorkflowStartLaunchRole] = definition.roles.compactMap { role in
+      guard role.source == .launch, let requirements = role.launch else { return nil }
+      let memoryKey = WorkflowBindingResolver.memoryKey(
+        scope: runScope, workflowID: definition.id, role: role)
+      let remembered = settings.rememberedWorkflowBinding(for: memoryKey)
+      let result = WorkflowBindingResolver.resolve(
+        role: role, remembered: remembered, override: nil, context: resolverContext)
+      var resolvedProfileID: UUID?
+      var suggestion: WorkflowProfileSuggestion?
+      if case .success(let binding) = result {
+        switch binding.resolution {
+        case .resolved(let profile, _): resolvedProfileID = profile.id
+        case .ask(_, let suggested): suggestion = suggested
+        }
+      }
+      let rejectedNote: String? =
+        if case .success(let binding) = result, binding.rejected[.remembered] != nil {
+          "The previously used profile no longer qualifies."
+        } else { nil }
+      let candidates = settings.agentProfiles.filter(\.isEnabled).map { profile in
+        WorkflowStartLaunchRole.Candidate(
+          profileID: profile.id,
+          name: profile.name,
+          agentToken: profile.runtime.agent.rawValue,
+          unavailableReason: WorkflowBindingResolver.rejection(
+            of: profile, requirements: requirements, context: resolverContext
+          ).map { rejectionText($0, requirements: requirements) })
+      }
+      return WorkflowStartLaunchRole(
+        name: role.name,
+        effectiveBind: bindOverride.map { $0 == .auto ? WorkflowBindMode.auto : .ask } ?? requirements.bind,
+        resolvedProfileID: resolvedProfileID,
+        candidates: candidates,
+        suggestion: suggestion ?? requirements.suggest,
+        rejectedNote: rejectedNote)
+    }
+
+    let pickRoles: [WorkflowStartPickRole] = definition.roles.compactMap { role in
+      guard role.source == .pick else { return nil }
+      return WorkflowStartPickRole(name: role.name, candidates: agentCandidates)
+    }
+
+    let cliStatus = CLIInstallClient.liveValue.installationStatus(cliDefaultInstallPath)
+    let cliInstalled = cliStatus != .notInstalled
+
+    return WorkflowStartContext(
+      item: item,
+      definition: definition,
+      worktreeID: worktreeID,
+      worktreeName: worktree.name,
+      source: source,
+      launchRoles: launchRoles,
+      pickRoles: pickRoles,
+      cliInstalled: cliInstalled,
+      bindModeOverride: bindOverride)
+  }
+
+  private static func focusedSurfaceID(of worktree: TargetResolutionSnapshot.Worktree) -> UUID? {
+    let selectedTab = worktree.tabs.first { $0.selected } ?? worktree.tabs.first
+    return selectedTab?.focusedPaneID
+  }
+
+  private static func rejectionText(
+    _ rejection: WorkflowBindingRejection, requirements: WorkflowLaunchRequirements
+  ) -> String {
+    switch rejection {
+    case .missing:
+      return "The profile no longer exists."
+    case .disabled:
+      return "Disabled in Settings."
+    case .agentNotAllowed:
+      let allowed = (requirements.agents ?? []).joined(separator: ", ")
+      return "This role needs \(allowed.isEmpty ? "another agent" : allowed)."
+    case .promptUnsupported:
+      return "This profile's runtime cannot take a launch prompt."
+    }
+  }
+}

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -265,12 +265,24 @@ extension SupacodeApp {
             of: profile, requirements: requirements, context: resolverContext
           ).map { rejectionText($0, requirements: requirements) })
       }
+      // "Create profile from suggestion…" is for when nothing matches (011 decision 4):
+      // once an enabled, admissible profile already matches the suggestion exactly,
+      // creating another indistinguishable one would only clutter Settings.
+      let hasExactSuggestionMatch =
+        requirements.suggest.map { suggested in
+          settings.agentProfiles.contains { profile in
+            profile.isEnabled
+              && WorkflowBindingResolver.rejection(
+                of: profile, requirements: requirements, context: resolverContext) == nil
+              && WorkflowBindingResolver.matches(profile, suggestion: suggested)
+          }
+        } ?? false
       return WorkflowStartLaunchRole(
         name: role.name,
         effectiveBind: bindOverride.map { $0 == .auto ? WorkflowBindMode.auto : .ask } ?? requirements.bind,
         resolvedProfileID: resolvedProfileID,
         candidates: candidates,
-        suggestion: suggestion ?? requirements.suggest,
+        suggestion: hasExactSuggestionMatch ? nil : (suggestion ?? requirements.suggest),
         rejectedNote: rejectedNote)
     }
   }

--- a/supacode/CLIService/WorkflowRunAdmission.swift
+++ b/supacode/CLIService/WorkflowRunAdmission.swift
@@ -508,7 +508,7 @@ enum WorkflowRunAdmission {
   }
 
   /// dsl-spec §3: a `current` role needs a detected agent only when a `message` to it survives the skips.
-  static func deliversToCurrentRole(_ definition: WorkflowDefinition, skipped: Set<String>) -> Bool {
+  nonisolated static func deliversToCurrentRole(_ definition: WorkflowDefinition, skipped: Set<String>) -> Bool {
     guard let current = definition.roles.first(where: { $0.source == .current }) else { return false }
     return definition.flattenedSteps.contains { step in
       if case .message(let role, _, _) = step.action, role == current.name { return !skipped.contains(step.id) }

--- a/supacode/Clients/Workflow/WorkflowStartClient.swift
+++ b/supacode/Clients/Workflow/WorkflowStartClient.swift
@@ -1,0 +1,40 @@
+// supacode/Clients/Workflow/WorkflowStartClient.swift
+// GUI-side access to workflow starts (docs-ai 063 C2). The live value is assembled in
+// WorkflowRuntimeComposition from the same catalog, resolver, settings, and coordinator the
+// CLI path uses — the GUI never grows its own run-creation logic (011 decision 1).
+
+import ComposableArchitecture
+import Foundation
+
+struct WorkflowStartClient: Sendable {
+  /// Workflows visible to a worktree, for the entry points. Includes validation-failing files
+  /// (the capsule popover dims them); excludes definitions disabled in Settings entirely.
+  var catalog: @MainActor @Sendable (_ worktreeID: String) -> [WorkflowStartCatalogItem]
+  /// The sheet's raw material for one workflow, or nil when the workflow or worktree is gone.
+  var context:
+    @MainActor @Sendable (_ workflowKey: String, _ worktreeID: String, _ preferredSourceSurfaceID: UUID?)
+      -> WorkflowStartContext?
+  /// Submits through the coordinator — the same entry `prowl workflow run` uses.
+  var run: @MainActor @Sendable (_ request: WorkflowStartRequest) async -> WorkflowStartOutcome
+}
+
+extension WorkflowStartClient: DependencyKey {
+  static let liveValue = WorkflowStartClient(
+    catalog: { _ in [] },
+    context: { _, _, _ in nil },
+    run: { _ in .failed(code: CLIErrorCode.transportFailed, message: "Workflow runtime is not available.") }
+  )
+
+  static let testValue = WorkflowStartClient(
+    catalog: { _ in [] },
+    context: { _, _, _ in nil },
+    run: { _ in .failed(code: CLIErrorCode.transportFailed, message: "No test workflow runtime configured.") }
+  )
+}
+
+extension DependencyValues {
+  var workflowStartClient: WorkflowStartClient {
+    get { self[WorkflowStartClient.self] }
+    set { self[WorkflowStartClient.self] = newValue }
+  }
+}

--- a/supacode/Clients/Workflow/WorkflowStartClient.swift
+++ b/supacode/Clients/Workflow/WorkflowStartClient.swift
@@ -18,11 +18,24 @@ struct WorkflowStartClient: Sendable {
   var run: @MainActor @Sendable (_ request: WorkflowStartRequest) async -> WorkflowStartOutcome
 }
 
+/// The live client is assembled with the app store (`WorkflowStartComposition`) and published
+/// here as well: views read this dependency outside any store scope (the Agents popover, the
+/// Active Agents context menu), where `@Dependency` resolves the global default rather than
+/// the store's installed value.
+@MainActor
+final class WorkflowStartClientRegistry {
+  static let shared = WorkflowStartClientRegistry()
+  var client: WorkflowStartClient?
+}
+
 extension WorkflowStartClient: DependencyKey {
   static let liveValue = WorkflowStartClient(
-    catalog: { _ in [] },
-    context: { _, _, _ in nil },
-    run: { _ in .failed(code: CLIErrorCode.transportFailed, message: "Workflow runtime is not available.") }
+    catalog: { WorkflowStartClientRegistry.shared.client?.catalog($0) ?? [] },
+    context: { WorkflowStartClientRegistry.shared.client?.context($0, $1, $2) },
+    run: {
+      await WorkflowStartClientRegistry.shared.client?.run($0)
+        ?? .failed(code: CLIErrorCode.transportFailed, message: "Workflow runtime is not available.")
+    }
   )
 
   static let testValue = WorkflowStartClient(

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -231,7 +231,9 @@ nonisolated struct WorkflowRunMachine {
       guard step.action.expect != nil else { throw .skipNotExpecting(stepID) }
     }
     for stepID in skippedSteps.sorted() {
-      if case .endsRun(let dependent) = Self.skipConsequence(forStep: stepID, in: run, fromStart: true) {
+      if case .endsRun(let dependent) = Self.startConsequence(
+        forStep: stepID, definition: definition, preSkipped: skippedSteps)
+      {
         throw .skipNotAllowed(step: stepID, dependent: dependent)
       }
     }
@@ -522,13 +524,42 @@ nonisolated struct WorkflowRunMachine {
   // MARK: Skip consequence
 
   func skipConsequence(forStep stepID: String) -> WorkflowSkipConsequence {
-    Self.skipConsequence(forStep: stepID, in: run, fromStart: false)
+    Self.skipConsequence(forStep: stepID, in: run)
+  }
+
+  /// The §5 Skip rule at start time, for the start sheet and `--skip` validation alike: the
+  /// consequence of skipping `stepID` given the other steps already chosen to skip, or nil when
+  /// the step carries no `expect` (or does not exist) and so offers no skip choice.
+  static func startSkipConsequence(
+    forStep stepID: String, definition: WorkflowDefinition, alreadySkipped: Set<String>
+  ) -> WorkflowSkipConsequence? {
+    guard let step = definition.flattenedSteps.first(where: { $0.id == stepID }),
+      step.action.expect != nil
+    else { return nil }
+    return startConsequence(forStep: stepID, definition: definition, preSkipped: alreadySkipped)
+  }
+
+  /// The start-time slice of the Skip rule: only top-level steps up to (and including) the first
+  /// `repeat` without `until` can run — nothing after it does, so it ends the run as
+  /// `max_rounds_reached` and later readers never count.
+  private static func startConsequence(
+    forStep stepID: String, definition: WorkflowDefinition, preSkipped: Set<String>
+  ) -> WorkflowSkipConsequence {
+    guard let name = definition.flattenedSteps.first(where: { $0.id == stepID })?.outputName else {
+      return .noOutput
+    }
+    var remaining: [WorkflowStepDefinition] = []
+    for step in definition.steps {
+      remaining.append(step)
+      if case .repeat(_, nil, _) = step.action { break }
+    }
+    return consequence(of: name, forStep: stepID, remaining: remaining, preSkipped: preSkipped)
   }
 
   /// The §5 Skip rule, resolved at the moment of the skip (decision H11): every step that can
   /// still run — the rest of the current loop body (the next iteration re-reads all of it),
   /// its `until`, and the top-level steps after it — is scanned for a reader of the output.
-  private static func skipConsequence(forStep stepID: String, in run: WorkflowRun, fromStart: Bool)
+  private static func skipConsequence(forStep stepID: String, in run: WorkflowRun)
     -> WorkflowSkipConsequence
   {
     let steps = run.definition.steps
@@ -538,14 +569,7 @@ nonisolated struct WorkflowRunMachine {
     var remaining: [WorkflowStepDefinition] = []
     var loopUntil: WorkflowUntilCondition?
     var loopID: String?
-    if fromStart {
-      // Nothing after a `repeat` without `until` can run: it ends the run as `max_rounds_reached`.
-      remaining = []
-      for step in steps {
-        remaining.append(step)
-        if case .repeat(_, nil, _) = step.action { break }
-      }
-    } else if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
+    if let loop = run.position.loop, case .repeat(_, let until, let body) = steps[run.position.index].action {
       // Readers later in this iteration always count; readers earlier in the body only when
       // another iteration can follow; steps after the loop only when an `until` can exit it
       // (without one the loop ends the run as `max_rounds_reached`).
@@ -565,12 +589,21 @@ nonisolated struct WorkflowRunMachine {
     } else {
       remaining = Array(steps[(run.position.index + 1)...])
     }
+    return consequence(
+      of: name, forStep: stepID, remaining: remaining, preSkipped: run.preSkippedSteps,
+      loopUntil: loopUntil, loopID: loopID)
+  }
+
+  private static func consequence(
+    of name: String, forStep stepID: String, remaining: [WorkflowStepDefinition],
+    preSkipped: Set<String>, loopUntil: WorkflowUntilCondition? = nil, loopID: String? = nil
+  ) -> WorkflowSkipConsequence {
     var optional: [String] = []
     if let loopUntil, loopUntil.output == name, let loopID {
       return .endsRun(dependent: loopID)
     }
-    for step in remaining where step.id != stepID && !run.preSkippedSteps.contains(step.id) {
-      if let dependent = reader(of: name, in: step, run: run, optional: &optional) {
+    for step in remaining where step.id != stepID && !preSkipped.contains(step.id) {
+      if let dependent = reader(of: name, in: step, preSkipped: preSkipped, optional: &optional) {
         return .endsRun(dependent: dependent)
       }
     }
@@ -579,7 +612,7 @@ nonisolated struct WorkflowRunMachine {
 
   /// The id of the step that reads `name` in a way the Skip rule does not tolerate, or nil.
   private static func reader(
-    of name: String, in step: WorkflowStepDefinition, run: WorkflowRun, optional: inout [String]
+    of name: String, in step: WorkflowStepDefinition, preSkipped: Set<String>, optional: inout [String]
   ) -> String? {
     if let title = step.title, references(name, in: title) { return step.id }
     switch step.action {
@@ -602,8 +635,8 @@ nonisolated struct WorkflowRunMachine {
       }
     case .repeat(_, let until, let body):
       if until?.output == name { return step.id }
-      for inner in body where !run.preSkippedSteps.contains(inner.id) {
-        if let dependent = reader(of: name, in: inner, run: run, optional: &optional) { return dependent }
+      for inner in body where !preSkipped.contains(inner.id) {
+        if let dependent = reader(of: name, in: inner, preSkipped: preSkipped, optional: &optional) { return dependent }
       }
     }
     return nil

--- a/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
+++ b/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
@@ -32,6 +32,9 @@ struct ActiveAgentsFeature {
     /// Context-menu "Hand Off…": parents perform the selection (Repositories)
     /// and open the HUD for this entry's pane (App).
     case handOffTapped(ActiveAgentEntry.ID)
+    /// Context-menu "Run Workflow ▸": parents select the entry (Repositories) and open the
+    /// start sheet with this entry's pane fixed as the source (App, docs-ai 063 C2).
+    case runWorkflowTapped(ActiveAgentEntry.ID, workflowKey: String)
     /// Context-menu "Mark as Read": handled by RepositoriesFeature.
     case markAsReadTapped(ActiveAgentEntry.ID)
     case focusedSurfaceChanged(UUID?)
@@ -55,7 +58,7 @@ struct ActiveAgentsFeature {
         state.entries.remove(id: id)
         return .none
 
-      case .entryTapped(let id), .handOffTapped(let id):
+      case .entryTapped(let id), .handOffTapped(let id), .runWorkflowTapped(let id, _):
         // Mirror the tapped surface into the focus anchor so the panel highlight and
         // keyboard navigation step from the just-selected agent immediately. The async
         // `focusChanged` event can't be relied on here: it is deduplicated per worktree

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -7,6 +7,9 @@ struct ActiveAgentsPanel: View {
   /// Per-entry repository/branch labels resolved from each agent's working directory by the parent
   /// (see `SidebarListView.activeAgentRowDisplays`); keeps this view presentational.
   let rowDisplays: [ActiveAgentEntry.ID: ActiveAgentRowDisplay]
+  /// `in <workflow> · <role>` labels for panes bound to an active run, resolved by AppFeature
+  /// (docs-ai 063 C2); replaces the branch/title subtitle while the run lives.
+  let workflowBadges: [UUID: String]
   let selectedSurfaceID: UUID?
   /// Merged "⌥⌃↑↓" hint shown while Cmd is held; `nil` hides it (bindings customized
   /// or Cmd not held). Resolved by the parent so the panel stays presentational.
@@ -124,12 +127,15 @@ struct ActiveAgentsPanel: View {
     min(maximumHeight, max(ActiveAgentsFeature.minimumPanelHeight, height))
   }
 
+  @Dependency(WorkflowStartClient.self) private var workflowStartClient
+
   @ViewBuilder
   private func contextMenu(for entry: ActiveAgentEntry) -> some View {
     Button("Hand Off…") {
       store.send(.handOffTapped(entry.id))
     }
     .help("Save this agent's progress and hand the task off to another agent")
+    runWorkflowMenu(for: entry)
     Button("Mark as Read") {
       store.send(.markAsReadTapped(entry.id))
     }
@@ -160,6 +166,22 @@ struct ActiveAgentsPanel: View {
         )
       }
       .help("Select this agent's session log in Finder")
+    }
+  }
+
+  /// The catalog is read when the menu opens, so file edits show without a relaunch.
+  @ViewBuilder
+  private func runWorkflowMenu(for entry: ActiveAgentEntry) -> some View {
+    let workflows = workflowStartClient.catalog(entry.worktreeID).filter(\.isRunnable)
+    if !workflows.isEmpty {
+      Menu("Run Workflow") {
+        ForEach(workflows) { item in
+          Button(item.name) {
+            store.send(.runWorkflowTapped(entry.id, workflowKey: item.key))
+          }
+          .help(item.workflowDescription ?? "Run \(item.name) from this agent's pane")
+        }
+      }
     }
   }
 

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -197,7 +197,8 @@ struct ActiveAgentsPanel: View {
     Self.subtitle(
       for: entry,
       branchName: branchName(for: entry),
-      showTabTitles: showTabTitles
+      showTabTitles: showTabTitles,
+      workflowBadge: workflowBadges[entry.surfaceID]
     )
   }
 
@@ -228,9 +229,10 @@ struct ActiveAgentsPanel: View {
   static func subtitle(
     for entry: ActiveAgentEntry,
     branchName: String,
-    showTabTitles: Bool
+    showTabTitles: Bool,
+    workflowBadge: String? = nil
   ) -> String {
-    showTabTitles ? paneTitle(for: entry) : branchName
+    workflowBadge ?? (showTabTitles ? paneTitle(for: entry) : branchName)
   }
 
   static func helpText(

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -7,12 +7,19 @@ extension AppFeature {
     state: inout State
   ) -> Effect<Action> {
     switch action {
+    case .setPresented(true):
+      refreshWorkflowPaletteItems(state: &state)
+      return .none
+
     case .setPresented(false):
       guard state.commandPalette.isPresented else { return .none }
       return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
 
     case .togglePresented:
-      guard state.commandPalette.isPresented else { return .none }
+      guard state.commandPalette.isPresented else {
+        refreshWorkflowPaletteItems(state: &state)
+        return .none
+      }
       return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
 
     case .delegate(let delegate):
@@ -291,6 +298,10 @@ extension AppFeature {
 
     case .launchAgentProfile(let profileID):
       return .send(.launchAgentProfile(profileID))
+
+    case .runWorkflow(let key):
+      return .send(
+        .openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: false))
 
     case .ghosttyCommand(let action):
       guard let worktree = actionTargetWorktree(repositories: state.repositories) else {

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -52,6 +52,9 @@ extension AppFeature {
     if let effect = reduceCommandPaletteHandoffDelegate(delegate, state: &state) {
       return effect
     }
+    if let effect = reduceCommandPaletteWorkflowDelegate(delegate, state: &state) {
+      return effect
+    }
     if let effect = reduceCommandPalettePullRequestDelegate(delegate) {
       return effect
     }
@@ -299,10 +302,6 @@ extension AppFeature {
     case .launchAgentProfile(let profileID):
       return .send(.launchAgentProfile(profileID))
 
-    case .runWorkflow(let key):
-      return .send(
-        .openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: false))
-
     case .ghosttyCommand(let action):
       guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
         return .none
@@ -343,6 +342,17 @@ extension AppFeature {
     // One execution path: the palette row opens the same staged HUD as the
     // toolbar capsule (docs-ai 049).
     return openHandoffHud(state: &state)
+  }
+
+  func reduceCommandPaletteWorkflowDelegate(
+    _ delegate: CommandPaletteFeature.Delegate,
+    state: inout State
+  ) -> Effect<Action>? {
+    guard case .runWorkflow(let key) = delegate else { return nil }
+    // One execution path: the palette row goes through the same opener as the
+    // Agents popover and the Active Agents menu (docs-ai 063.011 decision 1).
+    return openWorkflowStart(
+      state: &state, workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: false)
   }
 
   func reduceCommandPalettePullRequestDelegate(

--- a/supacode/Features/App/Reducer/AppFeature+Support.swift
+++ b/supacode/Features/App/Reducer/AppFeature+Support.swift
@@ -78,6 +78,7 @@ extension AppFeature.State {
   fileprivate var hasBlockingRenameBranchPresentation: Bool {
     isRunScriptPromptPresented
       || handoffHud != nil
+      || workflowStart != nil
       || alert != nil
       || repositories.isOpenPanelPresented
       || repositories.worktreeCreationPrompt != nil

--- a/supacode/Features/App/Reducer/AppFeature+Support.swift
+++ b/supacode/Features/App/Reducer/AppFeature+Support.swift
@@ -111,10 +111,11 @@ extension AppFeature {
   ) -> Bool {
     switch delegate {
     case .selectWorktree, .jumpToLatestUnread, .viewArchivedWorktrees,
-      .newWorktree, .toggleCanvas, .renameBranch, .handOff:
+      .newWorktree, .toggleCanvas, .renameBranch, .handOff, .runWorkflow:
       // `.handOff` opens the HUD, whose key-capture view takes first
       // responder; restoring terminal focus here would steal it back and
-      // leak arrow keys into the live agent session.
+      // leak arrow keys into the live agent session. `.runWorkflow` presents
+      // the start sheet, whose controls own the keyboard the same way.
       return true
     default:
       return false

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -38,3 +38,16 @@ extension AppFeature {
     return .none
   }
 }
+
+extension AppFeature {
+  /// Palette rows come from a state snapshot because the assembler runs on every body
+  /// evaluation; the catalog scan happens only when the palette opens.
+  func refreshWorkflowPaletteItems(state: inout State) {
+    guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
+      state.workflowPaletteItems = []
+      return
+    }
+    @Dependency(WorkflowStartClient.self) var workflowStartClient
+    state.workflowPaletteItems = workflowStartClient.catalog(worktree.id)
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -51,3 +51,21 @@ extension AppFeature {
     state.workflowPaletteItems = workflowStartClient.catalog(worktree.id)
   }
 }
+
+extension AppFeature {
+  /// The Active Agents rows' `in <workflow> · <role>` subtitles (000-plan entry points),
+  /// derived from the live runs' bindings whenever WorkflowRunsFeature state changes.
+  func syncWorkflowRoleBadges(state: inout State) {
+    var badges: [UUID: String] = [:]
+    for session in state.workflowRuns.activeSessions {
+      let name = session.run.definition.name
+      for (role, binding) in session.run.bindings {
+        guard let surfaceID = binding.pane?.surfaceID else { continue }
+        badges[surfaceID] = "in \(name) \u{00B7} \(role)"
+      }
+    }
+    if state.repositories.workflowRoleBadgesBySurfaceID != badges {
+      state.repositories.workflowRoleBadgesBySurfaceID = badges
+    }
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -57,16 +57,23 @@ extension AppFeature {
   /// The Active Agents rows' `in <workflow> · <role>` subtitles (000-plan entry points),
   /// derived from the live runs' bindings whenever WorkflowRunsFeature state changes.
   func syncWorkflowRoleBadges(state: inout State) {
+    let badges = Self.workflowRoleBadges(for: state.workflowRuns)
+    if state.repositories.workflowRoleBadgesBySurfaceID != badges {
+      state.repositories.workflowRoleBadgesBySurfaceID = badges
+    }
+  }
+
+  /// Pure derivation, unit-tested directly: every pane bound to an active run wears
+  /// `in <workflow> \u{00B7} <role>`.
+  static func workflowRoleBadges(for runs: WorkflowRunsFeature.State) -> [UUID: String] {
     var badges: [UUID: String] = [:]
-    for session in state.workflowRuns.activeSessions {
+    for session in runs.activeSessions {
       let name = session.run.definition.name
       for (role, binding) in session.run.bindings {
         guard let surfaceID = binding.pane?.surfaceID else { continue }
         badges[surfaceID] = "in \(name) \u{00B7} \(role)"
       }
     }
-    if state.repositories.workflowRoleBadgesBySurfaceID != badges {
-      state.repositories.workflowRoleBadgesBySurfaceID = badges
-    }
+    return badges
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -1,0 +1,40 @@
+import ComposableArchitecture
+import Foundation
+
+extension AppFeature {
+  /// Open the workflow start sheet, or start the run at once when nothing is undecided
+  /// (docs-ai 063.011 decisions 2 and 6). `worktreeID` pins an entry's worktree (the Active
+  /// Agents menu); nil resolves the action target. `sourceSurfaceID` pre-selects — and for
+  /// the Active Agents menu fixes — the "You" row; nil lets the client take the worktree's
+  /// focused pane. `forceSheet` is the capsule popover's "Run with Options…" escape hatch.
+  func openWorkflowStart(
+    state: inout State,
+    workflowKey: String,
+    worktreeID: Worktree.ID?,
+    sourceSurfaceID: UUID?,
+    forceSheet: Bool
+  ) -> Effect<Action> {
+    guard state.workflowStart == nil else { return .none }
+    let worktree =
+      worktreeID.flatMap { state.repositories.terminalWorktree(for: $0) }
+      ?? actionTargetWorktree(repositories: state.repositories)
+    guard let worktree else { return .none }
+    @Dependency(WorkflowStartClient.self) var workflowStartClient
+    guard let context = workflowStartClient.context(workflowKey, worktree.id, sourceSurfaceID)
+    else {
+      return .send(
+        .repositories(.showToast(.warning("This workflow cannot start — check its file with `prowl workflow validate`"))))
+    }
+    if !forceSheet, context.canStartImmediately {
+      // dsl-spec §3 `bind: auto`: no sheet; C1's status center is the start feedback.
+      let request = WorkflowStartFeature.State(context: context).request
+      return .run { send in
+        if case .failed(_, let message) = await workflowStartClient.run(request) {
+          await send(.repositories(.showToast(.warning(message))))
+        }
+      }
+    }
+    state.workflowStart = WorkflowStartFeature.State(context: context)
+    return .none
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -23,7 +23,8 @@ extension AppFeature {
     guard let context = workflowStartClient.context(workflowKey, worktree.id, sourceSurfaceID)
     else {
       return .send(
-        .repositories(.showToast(.warning("This workflow cannot start — check its file with `prowl workflow validate`"))))
+        .repositories(
+          .showToast(.warning("This workflow cannot start — check its file with `prowl workflow validate`"))))
     }
     if !forceSheet, context.canStartImmediately {
       // dsl-spec §3 `bind: auto`: no sheet; C1's status center is the start feedback.

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -63,8 +63,8 @@ extension AppFeature {
     }
   }
 
-  /// Pure derivation, unit-tested directly: every pane bound to an active run wears
-  /// `in <workflow> \u{00B7} <role>`.
+  /// Pure derivation (covered by `WorkflowRoleBadgeTests`): every pane bound to an active
+  /// run wears `in <workflow> \u{00B7} <role>`.
   static func workflowRoleBadges(for runs: WorkflowRunsFeature.State) -> [UUID: String] {
     var badges: [UUID: String] = [:]
     for session in runs.activeSessions {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -33,6 +33,8 @@ struct AppFeature {
     var leftSidebarVisibility: NavigationSplitViewVisibility = .all
     @Presents var handoffHud: HandoffHudFeature.State?
     @Presents var workflowStart: WorkflowStartFeature.State?
+    /// Workflows visible to the action-target worktree, refreshed when the palette opens.
+    var workflowPaletteItems: [WorkflowStartCatalogItem] = []
     @Presents var alert: AlertState<Alert>?
 
     init(

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -32,6 +32,7 @@ struct AppFeature {
     var launchedAt: Date?
     var leftSidebarVisibility: NavigationSplitViewVisibility = .all
     @Presents var handoffHud: HandoffHudFeature.State?
+    @Presents var workflowStart: WorkflowStartFeature.State?
     @Presents var alert: AlertState<Alert>?
 
     init(
@@ -92,6 +93,11 @@ struct AppFeature {
     case terminalEvent(TerminalClient.Event)
     case openHandoffHud
     case handoffHud(PresentationAction<HandoffHudFeature.Action>)
+    /// Open the workflow start sheet — or start at once when nothing is undecided (063 C2).
+    /// `worktreeID` pins an entry's worktree (Active Agents menu); nil uses the action target.
+    /// `forceSheet` is the "Run with Options…" escape hatch.
+    case openWorkflowStart(workflowKey: String, worktreeID: Worktree.ID?, sourceSurfaceID: UUID?, forceSheet: Bool)
+    case workflowStart(PresentationAction<WorkflowStartFeature.Action>)
     /// A CLI handoff completed (announced by the socket-service handler); the
     /// HUD uses it to observe the request it injected into the source pane.
     case handoffCliCompleted(HandoffCLICompletion)
@@ -1056,6 +1062,26 @@ struct AppFeature {
       case .openHandoffHud:
         return openHandoffHud(state: &state)
 
+      case .openWorkflowStart(let workflowKey, let worktreeID, let sourceSurfaceID, let forceSheet):
+        return openWorkflowStart(
+          state: &state, workflowKey: workflowKey, worktreeID: worktreeID,
+          sourceSurfaceID: sourceSurfaceID, forceSheet: forceSheet)
+
+      case .workflowStart(.presented(.delegate(.dismiss))),
+        .workflowStart(.presented(.delegate(.started))),
+        .workflowStart(.dismiss):
+        state.workflowStart = nil
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
+          return .none
+        }
+        // Hand keyboard focus back to the terminal the sheet captured it from.
+        return .run { _ in
+          await terminalClient.send(.focusSelectedTab(worktree))
+        }
+
+      case .workflowStart:
+        return .none
+
       case .handoffHud(.presented(.delegate(.dismiss))), .handoffHud(.dismiss):
         let worktree = state.handoffHud?.worktree
         state.handoffHud = nil
@@ -1079,6 +1105,9 @@ struct AppFeature {
     core
       .ifLet(\.$handoffHud, action: \.handoffHud) {
         HandoffHudFeature()
+      }
+      .ifLet(\.$workflowStart, action: \.workflowStart) {
+        WorkflowStartFeature()
       }
     Reduce<State, Action> { state, action in
       // Default-on focus restore: every command-palette delegate action that

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1062,11 +1062,9 @@ struct AppFeature {
             break
           }
         }
-        syncWorkflowRoleBadges(state: &state)
         return .merge(effects)
 
       case .workflowRuns:
-        syncWorkflowRoleBadges(state: &state)
         return .none
 
       case .openHandoffHud:
@@ -1145,6 +1143,14 @@ struct AppFeature {
     }
     Scope(state: \.workflowRuns, action: \.workflowRuns) {
       WorkflowRunsFeature()
+    }
+    Reduce<State, Action> { state, action in
+      // Badge sync must observe the state WorkflowRunsFeature just reduced — running it in
+      // `core` (before the Scope) reads the pre-action sessions and a freshly started run's
+      // panes would stay unlabeled until some later event (review round 2 finding 2).
+      guard case .workflowRuns = action else { return .none }
+      syncWorkflowRoleBadges(state: &state)
+      return .none
     }
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1013,6 +1013,12 @@ struct AppFeature {
       case .repositories(.activeAgents(.handOffTapped(let entryID))):
         return openHandoffHud(state: &state, entryID: entryID)
 
+      case .repositories(.activeAgents(.runWorkflowTapped(let entryID, let workflowKey))):
+        guard let entry = state.repositories.activeAgents.entries[id: entryID] else { return .none }
+        return openWorkflowStart(
+          state: &state, workflowKey: workflowKey, worktreeID: entry.worktreeID,
+          sourceSurfaceID: entry.surfaceID, forceSheet: false)
+
       case .repositories:
         return .none
 
@@ -1056,9 +1062,11 @@ struct AppFeature {
             break
           }
         }
+        syncWorkflowRoleBadges(state: &state)
         return .merge(effects)
 
       case .workflowRuns:
+        syncWorkflowRoleBadges(state: &state)
         return .none
 
       case .openHandoffHud:

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -90,6 +90,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case runCustomCommand(EffectiveCustomCommand.Identifier, systemImage: String)
     case handOff
     case launchAgentProfile(AgentProfile.ID)
+    case runWorkflow(String)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -178,7 +179,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .openRepositorySettings,
       .runCustomCommand,
       .handOff,
-      .launchAgentProfile:
+      .launchAgentProfile,
+      .runWorkflow:
       return nil
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -74,6 +74,7 @@ struct CommandPaletteFeature {
     case runCustomCommand(EffectiveCustomCommand.Identifier)
     case handOff
     case launchAgentProfile(AgentProfile.ID)
+    case runWorkflow(String)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -227,7 +228,8 @@ struct CommandPaletteFeature {
     customCommands: [EffectiveCustomCommand] = [],
     runScriptStatusByWorktreeID: [Worktree.ID: Bool] = [:],
     actionTargetWorktreeID: Worktree.ID? = nil,
-    ghosttyCommands: [GhosttyCommand] = []
+    ghosttyCommands: [GhosttyCommand] = [],
+    workflowItems: [WorkflowStartCatalogItem] = []
   ) -> [CommandPaletteItem] {
     let showsNewWorktreeAction =
       repositories.repositories.isEmpty
@@ -266,6 +268,9 @@ struct CommandPaletteFeature {
     }
     items.append(contentsOf: customCommandItems(customCommands))
     items.append(contentsOf: handoffCommandItems(repositories))
+    items.append(
+      contentsOf: workflowCommandItems(
+        workflowItems, repositories: repositories, actionTargetWorktreeID: worktreeActionTargetID))
     items.append(
       contentsOf: agentProfileLaunchItems(
         repositories,
@@ -586,6 +591,33 @@ func agentProfileLaunchItems(
       defaultSuggestion: false,
       keywords: ["launch", "agent", "profile", "start", profile.name],
       agentProfileIconSource: profile.iconSource
+    )
+  }
+}
+
+/// One `Run Workflow:` row per runnable workflow visible to the action-target
+/// worktree (docs-ai 063 C2). The list is refreshed when the palette opens;
+/// validation-failing files stay out of the palette (the Agents popover is the
+/// diagnostic surface, 011 decision 3).
+func workflowCommandItems(
+  _ workflows: [WorkflowStartCatalogItem],
+  repositories: RepositoriesFeature.State,
+  actionTargetWorktreeID: Worktree.ID? = nil
+) -> [CommandPaletteItem] {
+  guard
+    let worktree = repositories.actionTargetTerminalWorktree(
+      explicitTargetID: actionTargetWorktreeID
+    )
+  else { return [] }
+  return workflows.filter(\.isRunnable).map { item in
+    CommandPaletteItem(
+      id: CommandPaletteItemID.runWorkflow(item.key),
+      title: "Run Workflow: \(item.name)",
+      subtitle: item.workflowDescription ?? "Start this workflow in \(worktree.name)",
+      kind: .runWorkflow(item.key),
+      category: .terminal,
+      defaultSuggestion: false,
+      keywords: ["workflow", "run", item.name, item.workflowID]
     )
   }
 }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
@@ -156,6 +156,9 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
   if let appAction = appDelegateAction(for: kind) {
     return appAction
   }
+  if let agentAction = agentDelegateAction(for: kind) {
+    return agentAction
+  }
   switch kind {
   case .worktreeSelect(let id):
     return .selectWorktree(id)
@@ -171,12 +174,6 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     return .openRepositorySettings(repositoryID)
   case .runCustomCommand(let id, _):
     return .runCustomCommand(id)
-  case .handOff:
-    return .handOff
-  case .launchAgentProfile(let profileID):
-    return .launchAgentProfile(profileID)
-  case .runWorkflow(let key):
-    return .runWorkflow(key)
   case .openPullRequest,
     .openRepositoryOnCodeHost,
     .markPullRequestReady,
@@ -222,6 +219,23 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     .stopRunScript,
     .renameBranch:
     fatalError("appDelegateAction should handle app-level command palette actions")
+  case .handOff, .launchAgentProfile, .runWorkflow:
+    fatalError("agentDelegateAction should handle agent-scoped command palette actions")
+  }
+}
+
+/// The agent-scoped kinds, split out to keep `delegateAction`'s switch within the
+/// complexity budget.
+func agentDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .handOff:
+    return .handOff
+  case .launchAgentProfile(let profileID):
+    return .launchAgentProfile(profileID)
+  case .runWorkflow(let key):
+    return .runWorkflow(key)
+  default:
+    return nil
   }
 }
 

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
@@ -46,6 +46,10 @@ enum CommandPaletteItemID {
     "agent-profile.launch.\(id.uuidString)"
   }
 
+  static func runWorkflow(_ key: String) -> String {
+    "workflow.run.\(key)"
+  }
+
   static var globalIDs: [CommandPaletteItem.ID] {
     [
       globalCheckForUpdates,
@@ -171,6 +175,8 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     return .handOff
   case .launchAgentProfile(let profileID):
     return .launchAgentProfile(profileID)
+  case .runWorkflow(let key):
+    return .runWorkflow(key)
   case .openPullRequest,
     .openRepositoryOnCodeHost,
     .markPullRequestReady,
@@ -353,7 +359,8 @@ func pullRequestDelegateAction(
     .openRepositorySettings,
     .runCustomCommand,
     .handOff,
-    .launchAgentProfile:
+    .launchAgentProfile,
+    .runWorkflow:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -526,7 +526,7 @@ private struct CommandPaletteRowView: View {
       .toggleShelf, .showDiff, .outgoingChanges,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
-      .openRepositorySettings, .runCustomCommand, .handOff, .launchAgentProfile:
+      .openRepositorySettings, .runCustomCommand, .handOff, .launchAgentProfile, .runWorkflow:
       return nil
     case .deleteWorktree:
       return "Delete"
@@ -625,6 +625,8 @@ private struct CommandPaletteRowView: View {
       return "arrow.left.arrow.right"
     case .launchAgentProfile:
       return "play.circle"
+    case .runWorkflow:
+      return "rectangle.stack.badge.play"
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
@@ -650,7 +652,7 @@ private struct CommandPaletteRowView: View {
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings,
-      .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile:
+      .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile, .runWorkflow:
       return true
     case .worktreeSelect:
       return false
@@ -821,6 +823,8 @@ private struct CommandPaletteRowView: View {
     case .handOff:
       base = row.title
     case .launchAgentProfile:
+      base = row.title
+    case .runWorkflow:
       base = row.title
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -15,7 +15,8 @@ extension RepositoriesFeature {
       .workspaceCreation:
       return .none
 
-    case .activeAgents(.entryTapped(let id)), .activeAgents(.handOffTapped(let id)):
+    case .activeAgents(.entryTapped(let id)), .activeAgents(.handOffTapped(let id)),
+      .activeAgents(.runWorkflowTapped(let id, _)):
       guard let entry = state.activeAgents.entries[id: id] else { return .none }
       if state.isShowingCanvas {
         requestCanvasFocus(.tab(entry.tabID), openedWorktreeID: entry.worktreeID, state: &state)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -379,6 +379,9 @@ struct RepositoriesFeature {
     var nextCanvasCommandRequestID = 0
     var pendingCanvasCommandRequest: CanvasCommandRequest?
     var activeAgents = ActiveAgentsFeature.State()
+    /// `in <workflow> · <role>` labels for panes bound to an active run, synced by AppFeature
+    /// from WorkflowRunsFeature state (docs-ai 063 C2).
+    var workflowRoleBadgesBySurfaceID: [UUID: String] = [:]
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var workspaceCreationPrompt: WorkspaceCreationPromptFeature.State?

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -335,7 +335,6 @@ private struct AgentsPopoverRow: View {
   }
 }
 
-
 /// A runnable workflow row: the wide button starts it (skipping the sheet when
 /// nothing is undecided), the trailing control forces the start sheet — the
 /// "Run with Options…" escape hatch (docs-ai 063.011 decision 5).

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 enum LeadingToolbarControlMetrics {
@@ -55,9 +56,13 @@ struct AgentsLauncherItem: Equatable, Identifiable {
 struct AgentsToolbarButton: View {
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]
+  /// The worktree whose workflows the popover lists; nil hides the section.
+  let workflowsWorktreeID: Worktree.ID?
   let onHandOff: () -> Void
   let onLaunchProfile: (AgentProfile.ID) -> Void
   let onManageProfiles: () -> Void
+  let onRunWorkflow: (String) -> Void
+  let onRunWorkflowWithOptions: (String) -> Void
   @State private var isPopoverPresented = false
 
   var body: some View {
@@ -73,6 +78,7 @@ struct AgentsToolbarButton: View {
       AgentsPopoverContent(
         capsule: capsule,
         launcherItems: launcherItems,
+        workflowsWorktreeID: workflowsWorktreeID,
         onHandOff: {
           isPopoverPresented = false
           onHandOff()
@@ -84,6 +90,14 @@ struct AgentsToolbarButton: View {
         onManageProfiles: {
           isPopoverPresented = false
           onManageProfiles()
+        },
+        onRunWorkflow: { key in
+          isPopoverPresented = false
+          onRunWorkflow(key)
+        },
+        onRunWorkflowWithOptions: { key in
+          isPopoverPresented = false
+          onRunWorkflowWithOptions(key)
         }
       )
     }
@@ -171,9 +185,14 @@ struct AgentsQuickLaunchButton: View {
 private struct AgentsPopoverContent: View {
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]
+  let workflowsWorktreeID: Worktree.ID?
   let onHandOff: () -> Void
   let onLaunchProfile: (AgentProfile.ID) -> Void
   let onManageProfiles: () -> Void
+  let onRunWorkflow: (String) -> Void
+  let onRunWorkflowWithOptions: (String) -> Void
+  @Dependency(WorkflowStartClient.self) private var workflowStartClient
+  @State private var workflowItems: [WorkflowStartCatalogItem] = []
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -184,9 +203,31 @@ private struct AgentsPopoverContent: View {
           systemImage: "arrow.left.arrow.right",
           action: onHandOff
         )
-        if !launcherItems.isEmpty {
+        if !launcherItems.isEmpty || !workflowItems.isEmpty {
           Divider().padding(.vertical, 4)
         }
+      }
+      if !workflowItems.isEmpty {
+        Text("Run a workflow")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 8)
+          .padding(.top, 4)
+          .padding(.bottom, 2)
+        ForEach(workflowItems) { item in
+          if let failure = item.validationFailure {
+            // The popover is the diagnostic surface (063.011 decision 3): a
+            // failing file stays listed with its reason but offers no action.
+            AgentsWorkflowInvalidRow(name: item.name, reason: failure)
+          } else {
+            AgentsWorkflowRow(
+              item: item,
+              onRun: { onRunWorkflow(item.key) },
+              onRunWithOptions: { onRunWorkflowWithOptions(item.key) }
+            )
+          }
+        }
+        Divider().padding(.vertical, 4)
       }
       if !launcherItems.isEmpty {
         Text("New agent in this worktree")
@@ -225,6 +266,11 @@ private struct AgentsPopoverContent: View {
     // Runtimes still warned about (or unanswered) re-probe on every open, so
     // a CLI installed mid-session clears its warning without a relaunch.
     .task { await AgentRuntimeAvailabilityProbe.refresh() }
+    // Workflows re-list on every open so file edits show without a relaunch.
+    .task {
+      guard let workflowsWorktreeID else { return }
+      workflowItems = workflowStartClient.catalog(workflowsWorktreeID)
+    }
   }
 }
 
@@ -286,5 +332,88 @@ private struct AgentsPopoverRow: View {
         .fill(isHovered ? Color.accentColor.opacity(0.2) : Color.clear)
     )
     .onHover { isHovered = $0 }
+  }
+}
+
+
+/// A runnable workflow row: the wide button starts it (skipping the sheet when
+/// nothing is undecided), the trailing control forces the start sheet — the
+/// "Run with Options…" escape hatch (docs-ai 063.011 decision 5).
+private struct AgentsWorkflowRow: View {
+  let item: WorkflowStartCatalogItem
+  let onRun: () -> Void
+  let onRunWithOptions: () -> Void
+  @State private var isHovered = false
+
+  var body: some View {
+    HStack(spacing: 0) {
+      Button(action: onRun) {
+        HStack(alignment: .top, spacing: 8) {
+          Image(systemName: "rectangle.stack.badge.play")
+            .frame(width: 16)
+            .accessibilityHidden(true)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(item.name)
+              .lineLimit(1)
+            if let description = item.workflowDescription {
+              Text(description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .help("Run \(item.name)")
+      Button(action: onRunWithOptions) {
+        Image(systemName: "ellipsis.circle")
+          .foregroundStyle(.secondary)
+          .frame(width: 20, height: 20)
+          .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .padding(.trailing, 6)
+      .help("Run \(item.name) with options…")
+      .accessibilityLabel("Run \(item.name) with options")
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 6)
+        .fill(isHovered ? Color.accentColor.opacity(0.2) : Color.clear)
+    )
+    .onHover { isHovered = $0 }
+  }
+}
+
+/// A workflow file that failed validation: named so the author can find it,
+/// dimmed, and deliberately inert.
+private struct AgentsWorkflowInvalidRow: View {
+  let name: String
+  let reason: String
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: "exclamationmark.triangle")
+        .frame(width: 16)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(name)
+          .lineLimit(1)
+        Text(reason)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 6)
+    .opacity(0.5)
+    .help("Fix the file, then reopen this menu — `prowl workflow validate` shows the errors.")
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
+++ b/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
@@ -52,6 +52,7 @@ struct SidebarActiveAgentsOverlay: View {
     ActiveAgentsPanel(
       store: store.scope(state: \.activeAgents, action: \.activeAgents),
       rowDisplays: rowDisplays,
+      workflowBadges: state.workflowRoleBadgesBySurfaceID,
       selectedSurfaceID: selectedSurfaceID,
       navigationShortcutHint: shortcutHint,
       showTabTitles: state.showActiveAgentTabTitles,

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -248,6 +248,7 @@ private struct WorktreeToolbarPreview: View {
   init() {
     toolbarState = WorktreeDetailView.WorktreeToolbarState(
       shared: WorktreeDetailView.ToolbarSharedState(
+        actionTargetWorktreeID: nil,
         agentsCapsule: AgentsCapsuleState(
           displayName: "codex",
           iconSource: CommandIconMap.iconForFirstToken("codex"),
@@ -316,6 +317,8 @@ private struct WorktreeToolbarPreview: View {
         onHandOff: {},
         onLaunchProfile: { _ in },
         onManageProfiles: {},
+        onRunWorkflow: { _ in },
+        onRunWorkflowWithOptions: { _ in },
         onWorkflowIntent: { _ in }
       )
     }
@@ -348,9 +351,12 @@ private struct CanvasToolbarPreview: View {
             agentsLauncherItems: [],
             notificationGroups: [],
             unseenNotificationWorktreeCount: 0,
+            workflowsWorktreeID: nil,
             onHandOff: {},
             onLaunchProfile: { _ in },
             onManageProfiles: {},
+            onRunWorkflow: { _ in },
+            onRunWorkflowWithOptions: { _ in },
             onSelectNotification: { _, _ in },
             onDismissAllNotifications: {},
             isUpdateAvailable: true,

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -157,6 +157,12 @@ struct WorktreeDetailView: View {
       onHandOff: { store.send(.openHandoffHud) },
       onLaunchProfile: { store.send(.launchAgentProfile($0)) },
       onManageProfiles: { store.send(.openAgentProfilesSettings) },
+      onRunWorkflow: { key in
+        store.send(.openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: false))
+      },
+      onRunWorkflowWithOptions: { key in
+        store.send(.openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: true))
+      },
       onWorkflowIntent: handleWorkflowIntent
     )
   }
@@ -165,6 +171,7 @@ struct WorktreeDetailView: View {
     input: ToolbarSharedStateInput
   ) -> ToolbarSharedState {
     ToolbarSharedState(
+      actionTargetWorktreeID: input.actionTargetWorktree?.id,
       agentsCapsule: agentsCapsuleState(for: input.actionTargetWorktree),
       agentsLauncherItems: agentsLauncherItems(for: input.actionTargetWorktree),
       statusToast: input.repositories.statusToast,
@@ -199,9 +206,16 @@ struct WorktreeDetailView: View {
       agentsLauncherItems: state.agentsLauncherItems,
       notificationGroups: state.notificationGroups,
       unseenNotificationWorktreeCount: state.unseenNotificationWorktreeCount,
+      workflowsWorktreeID: state.actionTargetWorktreeID,
       onHandOff: { store.send(.openHandoffHud) },
       onLaunchProfile: { store.send(.launchAgentProfile($0)) },
       onManageProfiles: { store.send(.openAgentProfilesSettings) },
+      onRunWorkflow: { key in
+        store.send(.openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: false))
+      },
+      onRunWorkflowWithOptions: { key in
+        store.send(.openWorkflowStart(workflowKey: key, worktreeID: nil, sourceSurfaceID: nil, forceSheet: true))
+      },
       onSelectNotification: selectToolbarNotification,
       onDismissAllNotifications: {
         dismissAllToolbarNotifications(in: state.notificationGroups)
@@ -806,6 +820,7 @@ struct WorktreeDetailView: View {
   }
 
   struct ToolbarSharedState {
+    let actionTargetWorktreeID: Worktree.ID?
     let agentsCapsule: AgentsCapsuleState?
     let agentsLauncherItems: [AgentsLauncherItem]
     let statusToast: RepositoriesFeature.StatusToast?
@@ -839,9 +854,12 @@ struct WorktreeDetailView: View {
     let agentsLauncherItems: [AgentsLauncherItem]
     let notificationGroups: [ToolbarNotificationRepositoryGroup]
     let unseenNotificationWorktreeCount: Int
+    let workflowsWorktreeID: Worktree.ID?
     let onHandOff: () -> Void
     let onLaunchProfile: (AgentProfile.ID) -> Void
     let onManageProfiles: () -> Void
+    let onRunWorkflow: (String) -> Void
+    let onRunWorkflowWithOptions: (String) -> Void
     let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
     let onDismissAllNotifications: () -> Void
     let isUpdateAvailable: Bool
@@ -854,9 +872,12 @@ struct WorktreeDetailView: View {
         AgentsToolbarButton(
           capsule: agentsCapsule,
           launcherItems: agentsLauncherItems,
+          workflowsWorktreeID: workflowsWorktreeID,
           onHandOff: onHandOff,
           onLaunchProfile: onLaunchProfile,
-          onManageProfiles: onManageProfiles
+          onManageProfiles: onManageProfiles,
+          onRunWorkflow: onRunWorkflow,
+          onRunWorkflowWithOptions: onRunWorkflowWithOptions
         )
         if let quickLaunchItem = agentsLauncherItems.first {
           AgentsQuickLaunchButton(item: quickLaunchItem, onLaunch: onLaunchProfile)
@@ -902,6 +923,8 @@ struct WorktreeDetailView: View {
     let onHandOff: () -> Void
     let onLaunchProfile: (AgentProfile.ID) -> Void
     let onManageProfiles: () -> Void
+    let onRunWorkflow: (String) -> Void
+    let onRunWorkflowWithOptions: (String) -> Void
     let onWorkflowIntent: (WorkflowRunPanelIntent) -> Void
     @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
@@ -911,9 +934,12 @@ struct WorktreeDetailView: View {
         agentsLauncherItems: toolbarState.shared.agentsLauncherItems,
         notificationGroups: toolbarState.shared.notificationGroups,
         unseenNotificationWorktreeCount: toolbarState.shared.unseenNotificationWorktreeCount,
+        workflowsWorktreeID: toolbarState.shared.actionTargetWorktreeID,
         onHandOff: onHandOff,
         onLaunchProfile: onLaunchProfile,
         onManageProfiles: onManageProfiles,
+        onRunWorkflow: onRunWorkflow,
+        onRunWorkflowWithOptions: onRunWorkflowWithOptions,
         onSelectNotification: onSelectNotification,
         onDismissAllNotifications: onDismissAllNotifications,
         isUpdateAvailable: toolbarState.shared.isUpdateAvailable,

--- a/supacode/Features/Settings/Models/UserGlobalSettings.swift
+++ b/supacode/Features/Settings/Models/UserGlobalSettings.swift
@@ -10,6 +10,9 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
   var disabledWorkflowIDs: [String]
   /// Remembered `launch` role bindings (dsl-spec §3): one profile per requirements-digest key.
   var workflowBindings: [WorkflowRememberedBinding]
+  /// Per-workflow bind-mode overrides (docs-ai 063 C2): "Don't ask again" writes `auto`, D1's
+  /// Settings control drives the same value; an absent key follows the YAML `bind` declaration.
+  var workflowBindModeOverrides: [WorkflowBindModeOverride]
 
   static let `default` = UserGlobalSettings(customCommands: [])
 
@@ -19,6 +22,7 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
     case didSeedAgentProfiles
     case disabledWorkflowIDs
     case workflowBindings
+    case workflowBindModeOverrides
   }
 
   init(
@@ -26,13 +30,15 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
     agentProfiles: [AgentProfile] = [],
     didSeedAgentProfiles: Bool = false,
     disabledWorkflowIDs: [String] = [],
-    workflowBindings: [WorkflowRememberedBinding] = []
+    workflowBindings: [WorkflowRememberedBinding] = [],
+    workflowBindModeOverrides: [WorkflowBindModeOverride] = []
   ) {
     self.customCommands = UserCustomCommand.normalizedCommands(customCommands)
     self.agentProfiles = AgentProfile.normalizedProfiles(agentProfiles)
     self.didSeedAgentProfiles = didSeedAgentProfiles
     self.disabledWorkflowIDs = Self.normalizedWorkflowIDs(disabledWorkflowIDs)
     self.workflowBindings = WorkflowRememberedBinding.normalized(workflowBindings)
+    self.workflowBindModeOverrides = WorkflowBindModeOverride.normalized(workflowBindModeOverrides)
   }
 
   init(from decoder: Decoder) throws {
@@ -46,6 +52,9 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
     disabledWorkflowIDs = Self.normalizedWorkflowIDs(disabled)
     let bindings = try container.decodeIfPresent([WorkflowRememberedBinding].self, forKey: .workflowBindings) ?? []
     workflowBindings = WorkflowRememberedBinding.normalized(bindings)
+    let modeOverrides =
+      try container.decodeIfPresent([WorkflowBindModeOverride].self, forKey: .workflowBindModeOverrides) ?? []
+    workflowBindModeOverrides = WorkflowBindModeOverride.normalized(modeOverrides)
   }
 
   func normalized() -> UserGlobalSettings {
@@ -54,7 +63,8 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
       agentProfiles: agentProfiles,
       didSeedAgentProfiles: didSeedAgentProfiles,
       disabledWorkflowIDs: disabledWorkflowIDs,
-      workflowBindings: workflowBindings
+      workflowBindings: workflowBindings,
+      workflowBindModeOverrides: workflowBindModeOverrides
     )
   }
 
@@ -67,9 +77,51 @@ nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
       workflowBindings.filter { $0.key != key } + [WorkflowRememberedBinding(key: key, profileID: profileID)])
   }
 
+  /// The user's bind-mode override for a `<scope>/<id>` workflow key; nil follows the YAML `bind`.
+  func workflowBindMode(for workflowKey: String) -> WorkflowBindModeOverride.Mode? {
+    workflowBindModeOverrides.first { $0.workflowKey == workflowKey }?.mode
+  }
+
+  mutating func setWorkflowBindMode(_ mode: WorkflowBindModeOverride.Mode?, for workflowKey: String) {
+    let kept = workflowBindModeOverrides.filter { $0.workflowKey != workflowKey }
+    guard let mode else {
+      workflowBindModeOverrides = WorkflowBindModeOverride.normalized(kept)
+      return
+    }
+    workflowBindModeOverrides = WorkflowBindModeOverride.normalized(
+      kept + [WorkflowBindModeOverride(workflowKey: workflowKey, mode: mode)])
+  }
+
   /// Stable order, no duplicates: the set semantics of a persisted list.
   static func normalizedWorkflowIDs(_ ids: [String]) -> [String] {
     Array(Set(ids)).sorted()
+  }
+}
+
+/// A per-workflow bind-mode override (docs-ai 063 C2), keyed like `disabledWorkflowIDs`.
+nonisolated struct WorkflowBindModeOverride: Codable, Equatable, Sendable {
+  enum Mode: String, Codable, Sendable {
+    case ask
+    case auto
+  }
+
+  /// `<scope>/<id>` of the workflow definition.
+  let workflowKey: String
+  let mode: Mode
+
+  enum CodingKeys: String, CodingKey {
+    case workflowKey = "workflow_key"
+    case mode
+  }
+
+  /// One entry per key (last write wins), in a stable order.
+  static func normalized(_ overrides: [WorkflowBindModeOverride]) -> [WorkflowBindModeOverride] {
+    var seen: Set<String> = []
+    var unique: [WorkflowBindModeOverride] = []
+    for override in overrides.reversed() where seen.insert(override.workflowKey).inserted {
+      unique.append(override)
+    }
+    return unique.sorted { $0.workflowKey < $1.workflowKey }
   }
 }
 

--- a/supacode/Features/Workflow/Models/WorkflowStartContext.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStartContext.swift
@@ -111,7 +111,8 @@ nonisolated struct WorkflowStartContext: Equatable, Sendable {
 }
 
 /// What the sheet (or the immediate-start path) submits — the same vocabulary `workflow run`
-/// accepts, so admission stays the single authority.
+/// accepts, so admission stays the single authority. Persisting "Don't ask again" is the
+/// reducer's business, not the run's.
 nonisolated struct WorkflowStartRequest: Equatable, Sendable {
   let workflowID: String
   let worktreeID: String
@@ -122,13 +123,9 @@ nonisolated struct WorkflowStartRequest: Equatable, Sendable {
   /// `<name>=<value>` strings for inputs the user edited (defaults are left to admission).
   let inputValues: [String]
   let skippedSteps: [String]
-  /// "Don't ask again for this workflow": persist an `auto` bind-mode override on success.
-  let rememberAutoBind: Bool
-  /// The `<scope>/<id>` key the override is stored under.
-  let workflowKey: String
 }
 
 nonisolated enum WorkflowStartOutcome: Equatable, Sendable {
-  case started(runID: String)
+  case started
   case failed(code: String, message: String)
 }

--- a/supacode/Features/Workflow/Models/WorkflowStartContext.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStartContext.swift
@@ -70,6 +70,9 @@ nonisolated struct WorkflowStartSource: Equatable, Sendable {
   let roleName: String
   let candidates: [WorkflowStartPaneCandidate]
   let preselectedSurfaceID: UUID?
+  /// An Active Agents row pins its own pane as the source (011 decision 2 "fixed there");
+  /// the picker renders read-only and re-selection is refused.
+  var isPreselectionFixed = false
 }
 
 nonisolated struct WorkflowStartContext: Equatable, Sendable {

--- a/supacode/Features/Workflow/Models/WorkflowStartContext.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStartContext.swift
@@ -1,0 +1,134 @@
+// supacode/Features/Workflow/Models/WorkflowStartContext.swift
+// The start sheet's raw material (docs-ai 063 C2): what the GUI needs to show the sheet or
+// decide a run can start immediately, assembled by the live WorkflowStartClient from the same
+// catalog, resolver, and settings the CLI path reads. Submission still goes through admission;
+// nothing here re-derives eligibility beyond presenting the resolver's own answer.
+
+import Foundation
+
+/// One workflow as an entry point lists it (palette, capsule popover, Active Agents menu).
+nonisolated struct WorkflowStartCatalogItem: Equatable, Sendable, Identifiable {
+  /// `<scope>/<id>` — the key `disabledWorkflowIDs` and the bind-mode override use.
+  let key: String
+  let workflowID: String
+  let name: String
+  let workflowDescription: String?
+  /// Set for a file that failed validation: listed only in the capsule popover, dimmed with this.
+  let validationFailure: String?
+
+  var id: String { key }
+  var isRunnable: Bool { validationFailure == nil }
+}
+
+/// A pane offered as the `current` source or a `pick` binding. `agentToken == nil` is a bare
+/// shell — offered only as a source, and only valid while no delivery to `current` survives.
+nonisolated struct WorkflowStartPaneCandidate: Equatable, Sendable, Identifiable {
+  let surfaceID: UUID
+  /// The short CLI handle ("p7") when known; stable for the app's lifetime.
+  let handle: String?
+  let agentToken: String?
+  let agentDisplayName: String?
+  let paneTitle: String
+
+  var id: UUID { surfaceID }
+}
+
+/// A `launch` role as the sheet presents it: the resolver's answer plus picker material.
+nonisolated struct WorkflowStartLaunchRole: Equatable, Sendable, Identifiable {
+  struct Candidate: Equatable, Sendable, Identifiable {
+    let profileID: UUID
+    let name: String
+    let agentToken: String
+    /// nil = selectable; otherwise why the profile cannot serve this role (dimmed row).
+    let unavailableReason: String?
+
+    var id: UUID { profileID }
+  }
+
+  let name: String
+  /// The YAML `bind` with the per-workflow override applied.
+  let effectiveBind: WorkflowBindMode
+  /// The resolver's pre-selection (any tier); nil when it ended at `ask`.
+  let resolvedProfileID: UUID?
+  let candidates: [Candidate]
+  let suggestion: WorkflowProfileSuggestion?
+  /// A remembered binding or override that failed re-validation, for the picker footnote.
+  let rejectedNote: String?
+
+  var id: String { name }
+}
+
+nonisolated struct WorkflowStartPickRole: Equatable, Sendable, Identifiable {
+  let name: String
+  let candidates: [WorkflowStartPaneCandidate]
+
+  var id: String { name }
+}
+
+/// The `current` role's source picker material (the GUI equivalent of the CLI `[source]`).
+nonisolated struct WorkflowStartSource: Equatable, Sendable {
+  let roleName: String
+  let candidates: [WorkflowStartPaneCandidate]
+  let preselectedSurfaceID: UUID?
+}
+
+nonisolated struct WorkflowStartContext: Equatable, Sendable {
+  let item: WorkflowStartCatalogItem
+  let definition: WorkflowDefinition
+  let worktreeID: String
+  let worktreeName: String
+  /// nil when the workflow declares no `current` role (it runs against the worktree).
+  let source: WorkflowStartSource?
+  let launchRoles: [WorkflowStartLaunchRole]
+  let pickRoles: [WorkflowStartPickRole]
+  let cliInstalled: Bool
+  /// The user's per-workflow tri-state override, already folded into each role's
+  /// `effectiveBind`; carried so the sheet can show the "Don't ask again" toggle state.
+  let bindModeOverride: WorkflowBindModeOverride.Mode?
+
+  /// Steps offering a "Skip" choice at start: every step with an `expect` (§9 `--skip`).
+  var skipOptions: [(stepID: String, title: String?)] {
+    definition.flattenedSteps.compactMap { step in
+      step.action.expect == nil ? nil : (step.id, step.title)
+    }
+  }
+
+  /// dsl-spec §3 `bind: auto`: the sheet appears only when something is genuinely undecided.
+  /// Nothing is undecided when every launch role is effectively `auto` and resolved, there is
+  /// no `pick` role (those are always an explicit choice), every input has a default, and the
+  /// preselected source satisfies the delivery requirement with nothing skipped.
+  var canStartImmediately: Bool {
+    guard item.isRunnable, cliInstalled, pickRoles.isEmpty else { return false }
+    guard launchRoles.allSatisfy({ $0.effectiveBind == .auto && $0.resolvedProfileID != nil })
+    else { return false }
+    guard definition.inputs.allSatisfy({ $0.defaultValue != nil }) else { return false }
+    guard let source else { return true }
+    guard let preselected = source.candidates.first(where: { $0.surfaceID == source.preselectedSurfaceID })
+    else { return false }
+    let needsAgent = WorkflowRunAdmission.deliversToCurrentRole(definition, skipped: [])
+    return !needsAgent || preselected.agentToken != nil
+  }
+}
+
+/// What the sheet (or the immediate-start path) submits — the same vocabulary `workflow run`
+/// accepts, so admission stays the single authority.
+nonisolated struct WorkflowStartRequest: Equatable, Sendable {
+  let workflowID: String
+  let worktreeID: String
+  /// The chosen `current` source pane; nil runs against the worktree.
+  let sourceSurfaceID: UUID?
+  /// `<role>=<binding>` strings in the CLI's own grammar (dsl-spec §9).
+  let roleBindings: [String]
+  /// `<name>=<value>` strings for inputs the user edited (defaults are left to admission).
+  let inputValues: [String]
+  let skippedSteps: [String]
+  /// "Don't ask again for this workflow": persist an `auto` bind-mode override on success.
+  let rememberAutoBind: Bool
+  /// The `<scope>/<id>` key the override is stored under.
+  let workflowKey: String
+}
+
+nonisolated enum WorkflowStartOutcome: Equatable, Sendable {
+  case started(runID: String)
+  case failed(code: String, message: String)
+}

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -52,13 +52,21 @@ struct WorkflowStartFeature {
       role.candidates + (createdCandidatesByRole[role.name] ?? [])
     }
 
-    /// A suggestion can only form a profile when it names a known runtime; a Create action
-    /// for anything else would be dead (dsl-spec §3 allows agent-less suggestions).
+    /// A suggestion can only form a profile when it names a known runtime AND the resulting
+    /// profile would actually qualify for the role — judged by the same resolver rejection
+    /// rule admission applies, so Create never manufactures a profile the run then refuses
+    /// (dsl-spec §3 allows agent-less suggestions and agent/`agents` mismatches; the
+    /// validator only warns about them).
     func canCreateSuggestion(for roleName: String) -> Bool {
       guard let role = context.launchRoles.first(where: { $0.name == roleName }),
-        let agent = role.suggestion?.agent
+        let agent = role.suggestion?.agent,
+        let runtime = AgentProfileRuntime(rawValue: agent),
+        let requirements = context.definition.roles.first(where: { $0.name == roleName })?.launch
       else { return false }
-      return AgentProfileRuntime(rawValue: agent) != nil
+      let probe = AgentProfile(id: UUID(), name: "probe", runtime: runtime)
+      return WorkflowBindingResolver.rejection(
+        of: probe, requirements: requirements,
+        context: WorkflowBindingResolverContext(profiles: [])) == nil
     }
 
     /// Whether the chosen source must host a detected agent, given the current skip choices.
@@ -226,6 +234,7 @@ struct WorkflowStartFeature {
 
     case .createSuggestionConfirmed:
       guard let roleName = state.creatingSuggestionForRole,
+        state.canCreateSuggestion(for: roleName),
         let role = state.context.launchRoles.first(where: { $0.name == roleName }),
         let profile = Self.profile(
           from: role.suggestion, name: state.suggestionProfileName, id: uuid())

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -1,0 +1,272 @@
+// supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+// The start sheet's interaction state (docs-ai 063 C2, 011 decisions 2-6). The sheet gathers
+// the same overrides/inputs/skips `workflow run` accepts and submits through
+// WorkflowStartClient.run; it presents the resolver's answers and never re-derives eligibility.
+
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct WorkflowStartFeature {
+  @ObservableState
+  struct State: Equatable {
+    let context: WorkflowStartContext
+    var selectedSourceSurfaceID: UUID?
+    /// Launch role name → chosen profile. Pre-filled from the resolver's answer.
+    var launchSelections: [String: UUID]
+    /// Pick role name → chosen pane.
+    var pickSelections: [String: UUID] = [:]
+    /// Input name → current value. Pre-filled from declared defaults.
+    var inputValues: [String: String]
+    var skippedSteps: Set<String> = []
+    var dontAskAgain: Bool
+    /// The launch role whose inline "create from suggestion" confirm block is open.
+    var creatingSuggestionForRole: String?
+    var suggestionProfileName: String = ""
+    var isSubmitting = false
+    var submissionError: String?
+
+    init(context: WorkflowStartContext) {
+      self.context = context
+      selectedSourceSurfaceID = context.source?.preselectedSurfaceID
+      launchSelections = Dictionary(
+        uniqueKeysWithValues: context.launchRoles.compactMap { role in
+          role.resolvedProfileID.map { (role.name, $0) }
+        })
+      inputValues = Dictionary(
+        uniqueKeysWithValues: context.definition.inputs.compactMap { input in
+          input.defaultValue.map { (input.name, $0.stringValue) }
+        })
+      dontAskAgain = context.bindModeOverride == .auto
+    }
+
+    /// Whether the chosen source must host a detected agent, given the current skip choices.
+    var sourceRequiresAgent: Bool {
+      WorkflowRunAdmission.deliversToCurrentRole(context.definition, skipped: skippedSteps)
+    }
+
+    /// The §5 Skip rule for one step, aware of the other skips already chosen.
+    func skipConsequence(for stepID: String) -> WorkflowSkipConsequence? {
+      WorkflowRunMachine.startSkipConsequence(
+        forStep: stepID, definition: context.definition,
+        alreadySkipped: skippedSteps.subtracting([stepID]))
+    }
+
+    var canRun: Bool {
+      guard !isSubmitting, context.cliInstalled, context.item.isRunnable else { return false }
+      if let source = context.source {
+        guard let selected = selectedSourceSurfaceID,
+          let candidate = source.candidates.first(where: { $0.surfaceID == selected })
+        else { return false }
+        if sourceRequiresAgent, candidate.agentToken == nil { return false }
+      }
+      for role in context.launchRoles {
+        guard let chosen = launchSelections[role.name],
+          let candidate = role.candidates.first(where: { $0.profileID == chosen }),
+          candidate.unavailableReason == nil
+        else { return false }
+      }
+      let picks = context.pickRoles.compactMap { pickSelections[$0.name] }
+      guard picks.count == context.pickRoles.count, Set(picks).count == picks.count else {
+        return false
+      }
+      if context.source != nil, let source = selectedSourceSurfaceID, picks.contains(source) {
+        return false
+      }
+      for input in context.definition.inputs where input.defaultValue == nil {
+        guard let value = inputValues[input.name],
+          !value.trimmingCharacters(in: .whitespaces).isEmpty
+        else { return false }
+      }
+      return true
+    }
+
+    /// The submission in the CLI's own vocabulary (011 decision 1).
+    var request: WorkflowStartRequest {
+      WorkflowStartRequest(
+        workflowID: context.item.workflowID,
+        worktreeID: context.worktreeID,
+        sourceSurfaceID: context.source != nil ? selectedSourceSurfaceID : nil,
+        roleBindings: context.launchRoles.compactMap { role in
+          launchSelections[role.name].map { "\(role.name)=\($0.uuidString)" }
+        }
+          + context.pickRoles.compactMap { role in
+            pickSelections[role.name].map { "\(role.name)=\($0.uuidString)" }
+          },
+        inputValues: context.definition.inputs.compactMap { input in
+          guard let value = inputValues[input.name] else { return nil }
+          return value == input.defaultValue?.stringValue ? nil : "\(input.name)=\(value)"
+        },
+        skippedSteps: skippedSteps.sorted())
+    }
+  }
+
+  enum Action: Equatable {
+    case sourceSelected(UUID?)
+    case launchProfileSelected(role: String, profileID: UUID?)
+    case pickPaneSelected(role: String, surfaceID: UUID?)
+    case inputChanged(name: String, value: String)
+    case skipToggled(stepID: String)
+    case dontAskAgainToggled(Bool)
+    case createSuggestionTapped(role: String)
+    case suggestionNameChanged(String)
+    case createSuggestionConfirmed
+    case createSuggestionCancelled
+    case cancelTapped
+    case runTapped
+    case runResponse(WorkflowStartOutcome)
+    case delegate(Delegate)
+
+    enum Delegate: Equatable {
+      case dismiss
+      case started
+    }
+  }
+
+  @Dependency(WorkflowStartClient.self) var workflowStartClient
+  @Dependency(\.uuid) var uuid
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      handle(state: &state, action: action)
+    }
+  }
+
+  private func handle(state: inout State, action: Action) -> Effect<Action> {
+    switch action {
+      case .sourceSelected(let surfaceID):
+        state.selectedSourceSurfaceID = surfaceID
+        return .none
+
+      case .launchProfileSelected(let role, let profileID):
+        state.launchSelections[role] = profileID
+        return .none
+
+      case .pickPaneSelected(let role, let surfaceID):
+        state.pickSelections[role] = surfaceID
+        return .none
+
+      case .inputChanged(let name, let value):
+        state.inputValues[name] = value
+        return .none
+
+      case .skipToggled(let stepID):
+        if state.skippedSteps.contains(stepID) {
+          state.skippedSteps.remove(stepID)
+          return .none
+        }
+        // §9: a step without an `expect` offers no skip choice, and a skip whose output a
+        // later step needs is refused by admission; the sheet shows the consequence and
+        // never arms either.
+        guard let consequence = state.skipConsequence(for: stepID) else { return .none }
+        if case .endsRun = consequence { return .none }
+        state.skippedSteps.insert(stepID)
+        return .none
+
+      case .dontAskAgainToggled(let isOn):
+        state.dontAskAgain = isOn
+        return .none
+
+      case .createSuggestionTapped(let role):
+        state.creatingSuggestionForRole = role
+        state.suggestionProfileName = Self.suggestedProfileName(role: role, state: state)
+        return .none
+
+      case .suggestionNameChanged(let name):
+        state.suggestionProfileName = name
+        return .none
+
+      case .createSuggestionConfirmed:
+        guard let roleName = state.creatingSuggestionForRole,
+          let role = state.context.launchRoles.first(where: { $0.name == roleName }),
+          let profile = Self.profile(
+            from: role.suggestion, name: state.suggestionProfileName, id: uuid())
+        else {
+          state.creatingSuggestionForRole = nil
+          return .none
+        }
+        // Synchronous inside the reducer, like AgentProfilesFeature.persist: a cancelled
+        // effect must not drop the new profile.
+        @Shared(.userGlobalSettings) var settings
+        $settings.withLock {
+          $0.agentProfiles = AgentProfile.normalizedProfiles($0.agentProfiles + [profile])
+        }
+        state.launchSelections[roleName] = profile.id
+        state.creatingSuggestionForRole = nil
+        state.suggestionProfileName = ""
+        return .none
+
+      case .createSuggestionCancelled:
+        state.creatingSuggestionForRole = nil
+        state.suggestionProfileName = ""
+        return .none
+
+      case .cancelTapped:
+        return .send(.delegate(.dismiss))
+
+      case .runTapped:
+        guard state.canRun else { return .none }
+        state.isSubmitting = true
+        state.submissionError = nil
+        let request = state.request
+        return .run { send in
+          await send(.runResponse(workflowStartClient.run(request)))
+        }
+
+      case .runResponse(.started):
+        state.isSubmitting = false
+        Self.persistBindModeChoice(state: state)
+        return .send(.delegate(.started))
+
+      case .runResponse(.failed(_, let message)):
+        state.isSubmitting = false
+        state.submissionError = message
+        return .none
+
+    case .delegate:
+      return .none
+    }
+  }
+
+  /// "Don't ask again" writes the tri-state override (011 decision 5): checked persists
+  /// `auto`; unchecked clears a previously persisted `auto` and otherwise leaves the
+  /// stored mode (D1's Settings control owns `ask`) alone.
+  private static func persistBindModeChoice(state: State) {
+    @Shared(.userGlobalSettings) var settings
+    let key = state.context.item.key
+    if state.dontAskAgain {
+      $settings.withLock { $0.setWorkflowBindMode(.auto, for: key) }
+    } else if state.context.bindModeOverride == .auto {
+      $settings.withLock { $0.setWorkflowBindMode(nil, for: key) }
+    }
+  }
+
+  private static func suggestedProfileName(role: String, state: State) -> String {
+    let launchRole = state.context.launchRoles.first { $0.name == role }
+    let runtimeName =
+      launchRole?.suggestion?.agent
+      .flatMap { AgentProfileRuntime(rawValue: $0) }
+      .map { AgentRuntimeAdapterRegistry.displayName(for: $0) }
+    let roleTitle = role.prefix(1).uppercased() + role.dropFirst()
+    return runtimeName.map { "\(roleTitle) (\($0))" } ?? roleTitle
+  }
+
+  /// A real, Settings-manageable profile from the workflow author's `suggest` block.
+  private static func profile(
+    from suggestion: WorkflowProfileSuggestion?, name: String, id: UUID
+  ) -> AgentProfile? {
+    guard let suggestion, let agent = suggestion.agent,
+      let runtime = AgentProfileRuntime(rawValue: agent)
+    else { return nil }
+    let trimmed = name.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return nil }
+    return AgentProfile(
+      id: id,
+      name: trimmed,
+      runtime: runtime,
+      model: suggestion.model,
+      reasoningEffort: suggestion.reasoningEffort,
+      executionMode: suggestion.executionMode.flatMap { AgentExecutionMode(rawValue: $0) }
+        ?? .standard)
+  }
+}

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -25,9 +25,12 @@ struct WorkflowStartFeature {
     var suggestionProfileName: String = ""
     var isSubmitting = false
     var submissionError: String?
+    /// Starts as the context's snapshot and flips when the inline Install succeeds.
+    var cliInstalled: Bool
 
     init(context: WorkflowStartContext) {
       self.context = context
+      cliInstalled = context.cliInstalled
       selectedSourceSurfaceID = context.source?.preselectedSurfaceID
       launchSelections = Dictionary(
         uniqueKeysWithValues: context.launchRoles.compactMap { role in
@@ -53,7 +56,7 @@ struct WorkflowStartFeature {
     }
 
     var canRun: Bool {
-      guard !isSubmitting, context.cliInstalled, context.item.isRunnable else { return false }
+      guard !isSubmitting, cliInstalled, context.item.isRunnable else { return false }
       if let source = context.source {
         guard let selected = selectedSourceSurfaceID,
           let candidate = source.candidates.first(where: { $0.surfaceID == selected })
@@ -112,6 +115,8 @@ struct WorkflowStartFeature {
     case suggestionNameChanged(String)
     case createSuggestionConfirmed
     case createSuggestionCancelled
+    case installCLITapped
+    case cliInstallCompleted(success: Bool)
     case cancelTapped
     case runTapped
     case runResponse(WorkflowStartOutcome)
@@ -124,6 +129,7 @@ struct WorkflowStartFeature {
   }
 
   @Dependency(WorkflowStartClient.self) var workflowStartClient
+  @Dependency(CLIInstallClient.self) var cliInstallClient
   @Dependency(\.uuid) var uuid
 
   var body: some Reducer<State, Action> {
@@ -199,6 +205,24 @@ struct WorkflowStartFeature {
       case .createSuggestionCancelled:
         state.creatingSuggestionForRole = nil
         state.suggestionProfileName = ""
+        return .none
+
+      case .installCLITapped:
+        return .run { [cliInstallClient] send in
+          do {
+            try await cliInstallClient.install(cliDefaultInstallPath)
+            await send(.cliInstallCompleted(success: true))
+          } catch {
+            await send(.cliInstallCompleted(success: false))
+          }
+        }
+
+      case .cliInstallCompleted(let success):
+        if success {
+          state.cliInstalled = true
+        } else {
+          state.submissionError = "The prowl command line tool could not be installed."
+        }
         return .none
 
       case .cancelTapped:

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -20,6 +20,10 @@ struct WorkflowStartFeature {
     var inputValues: [String: String]
     var skippedSteps: Set<String> = []
     var dontAskAgain: Bool
+    /// Candidates the sheet itself created from a suggestion, per role — the context's
+    /// candidate list is immutable, and a profile created inline must be pickable and
+    /// runnable immediately (review round 2 finding 1).
+    var createdCandidatesByRole: [String: [WorkflowStartLaunchRole.Candidate]] = [:]
     /// The launch role whose inline "create from suggestion" confirm block is open.
     var creatingSuggestionForRole: String?
     var suggestionProfileName: String = ""
@@ -41,6 +45,20 @@ struct WorkflowStartFeature {
         },
         uniquingKeysWith: { first, _ in first })
       dontAskAgain = context.bindModeOverride == .auto
+    }
+
+    /// The role's picker candidates: the resolver's list plus anything created inline.
+    func candidates(for role: WorkflowStartLaunchRole) -> [WorkflowStartLaunchRole.Candidate] {
+      role.candidates + (createdCandidatesByRole[role.name] ?? [])
+    }
+
+    /// A suggestion can only form a profile when it names a known runtime; a Create action
+    /// for anything else would be dead (dsl-spec §3 allows agent-less suggestions).
+    func canCreateSuggestion(for roleName: String) -> Bool {
+      guard let role = context.launchRoles.first(where: { $0.name == roleName }),
+        let agent = role.suggestion?.agent
+      else { return false }
+      return AgentProfileRuntime(rawValue: agent) != nil
     }
 
     /// Whether the chosen source must host a detected agent, given the current skip choices.
@@ -65,7 +83,7 @@ struct WorkflowStartFeature {
       }
       for role in context.launchRoles {
         guard let chosen = launchSelections[role.name],
-          let candidate = role.candidates.first(where: { $0.profileID == chosen }),
+          let candidate = candidates(for: role).first(where: { $0.profileID == chosen }),
           candidate.unavailableReason == nil
         else { return false }
       }
@@ -221,6 +239,10 @@ struct WorkflowStartFeature {
       $settings.withLock {
         $0.agentProfiles = AgentProfile.normalizedProfiles($0.agentProfiles + [profile])
       }
+      state.createdCandidatesByRole[roleName, default: []].append(
+        WorkflowStartLaunchRole.Candidate(
+          profileID: profile.id, name: profile.name,
+          agentToken: profile.runtime.agent.rawValue, unavailableReason: nil))
       state.launchSelections[roleName] = profile.id
       state.creatingSuggestionForRole = nil
       state.suggestionProfileName = ""

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -33,13 +33,13 @@ struct WorkflowStartFeature {
       cliInstalled = context.cliInstalled
       selectedSourceSurfaceID = context.source?.preselectedSurfaceID
       launchSelections = Dictionary(
-        uniqueKeysWithValues: context.launchRoles.compactMap { role in
-          role.resolvedProfileID.map { (role.name, $0) }
-        })
+        context.launchRoles.compactMap { role in role.resolvedProfileID.map { (role.name, $0) } },
+        uniquingKeysWith: { first, _ in first })
       inputValues = Dictionary(
-        uniqueKeysWithValues: context.definition.inputs.compactMap { input in
+        context.definition.inputs.compactMap { input in
           input.defaultValue.map { (input.name, $0.stringValue) }
-        })
+        },
+        uniquingKeysWith: { first, _ in first })
       dontAskAgain = context.bindModeOverride == .auto
     }
 
@@ -121,11 +121,11 @@ struct WorkflowStartFeature {
     case runTapped
     case runResponse(WorkflowStartOutcome)
     case delegate(Delegate)
+  }
 
-    enum Delegate: Equatable {
-      case dismiss
-      case started
-    }
+  enum Delegate: Equatable {
+    case dismiss
+    case started
   }
 
   @Dependency(WorkflowStartClient.self) var workflowStartClient
@@ -140,114 +140,150 @@ struct WorkflowStartFeature {
 
   private func handle(state: inout State, action: Action) -> Effect<Action> {
     switch action {
-      case .sourceSelected(let surfaceID):
-        state.selectedSourceSurfaceID = surfaceID
-        return .none
+    case .sourceSelected, .launchProfileSelected, .pickPaneSelected, .inputChanged,
+      .skipToggled, .dontAskAgainToggled:
+      return handleEdit(state: &state, action: action)
+    case .createSuggestionTapped, .suggestionNameChanged, .createSuggestionConfirmed,
+      .createSuggestionCancelled:
+      return handleSuggestion(state: &state, action: action)
+    default:
+      return handleRemainder(state: &state, action: action)
+    }
+  }
 
-      case .launchProfileSelected(let role, let profileID):
-        state.launchSelections[role] = profileID
-        return .none
+  /// Selection, input, and skip edits: pure state changes with no effects.
+  private func handleEdit(state: inout State, action: Action) -> Effect<Action> {
+    switch action {
+    case .sourceSelected(let surfaceID):
+      guard state.context.source?.isPreselectionFixed != true else { return .none }
+      state.selectedSourceSurfaceID = surfaceID
+      return .none
 
-      case .pickPaneSelected(let role, let surfaceID):
-        state.pickSelections[role] = surfaceID
-        return .none
+    case .launchProfileSelected(let role, let profileID):
+      state.launchSelections[role] = profileID
+      return .none
 
-      case .inputChanged(let name, let value):
-        state.inputValues[name] = value
-        return .none
+    case .pickPaneSelected(let role, let surfaceID):
+      state.pickSelections[role] = surfaceID
+      return .none
 
-      case .skipToggled(let stepID):
-        if state.skippedSteps.contains(stepID) {
-          state.skippedSteps.remove(stepID)
-          return .none
-        }
-        // §9: a step without an `expect` offers no skip choice, and a skip whose output a
-        // later step needs is refused by admission; the sheet shows the consequence and
-        // never arms either.
-        guard let consequence = state.skipConsequence(for: stepID) else { return .none }
-        if case .endsRun = consequence { return .none }
-        state.skippedSteps.insert(stepID)
-        return .none
+    case .inputChanged(let name, let value):
+      state.inputValues[name] = value
+      return .none
 
-      case .dontAskAgainToggled(let isOn):
-        state.dontAskAgain = isOn
+    case .skipToggled(let stepID):
+      if state.skippedSteps.contains(stepID) {
+        state.skippedSteps.remove(stepID)
         return .none
+      }
+      // §9: a step without an `expect` offers no skip choice, and a skip whose output a
+      // later step needs is refused by admission; the sheet shows the consequence and
+      // never arms either.
+      guard let consequence = state.skipConsequence(for: stepID) else { return .none }
+      if case .endsRun = consequence { return .none }
+      state.skippedSteps.insert(stepID)
+      return .none
 
-      case .createSuggestionTapped(let role):
-        state.creatingSuggestionForRole = role
-        state.suggestionProfileName = Self.suggestedProfileName(role: role, state: state)
-        return .none
+    case .dontAskAgainToggled(let isOn):
+      state.dontAskAgain = isOn
+      return .none
 
-      case .suggestionNameChanged(let name):
-        state.suggestionProfileName = name
-        return .none
+    default:
+      assertionFailure("handle(state:action:) routes only edit actions here.")
+      return .none
+    }
+  }
 
-      case .createSuggestionConfirmed:
-        guard let roleName = state.creatingSuggestionForRole,
-          let role = state.context.launchRoles.first(where: { $0.name == roleName }),
-          let profile = Self.profile(
-            from: role.suggestion, name: state.suggestionProfileName, id: uuid())
-        else {
-          state.creatingSuggestionForRole = nil
-          return .none
-        }
-        // Synchronous inside the reducer, like AgentProfilesFeature.persist: a cancelled
-        // effect must not drop the new profile.
-        @Shared(.userGlobalSettings) var settings
-        $settings.withLock {
-          $0.agentProfiles = AgentProfile.normalizedProfiles($0.agentProfiles + [profile])
-        }
-        state.launchSelections[roleName] = profile.id
+  /// The inline "create profile from suggestion" block (011 decision 4).
+  private func handleSuggestion(state: inout State, action: Action) -> Effect<Action> {
+    switch action {
+    case .createSuggestionTapped(let role):
+      state.creatingSuggestionForRole = role
+      state.suggestionProfileName = Self.suggestedProfileName(role: role, state: state)
+      return .none
+
+    case .suggestionNameChanged(let name):
+      state.suggestionProfileName = name
+      return .none
+
+    case .createSuggestionConfirmed:
+      guard let roleName = state.creatingSuggestionForRole,
+        let role = state.context.launchRoles.first(where: { $0.name == roleName }),
+        let profile = Self.profile(
+          from: role.suggestion, name: state.suggestionProfileName, id: uuid())
+      else {
         state.creatingSuggestionForRole = nil
-        state.suggestionProfileName = ""
         return .none
+      }
+      // Synchronous inside the reducer, like AgentProfilesFeature.persist: a cancelled
+      // effect must not drop the new profile.
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock {
+        $0.agentProfiles = AgentProfile.normalizedProfiles($0.agentProfiles + [profile])
+      }
+      state.launchSelections[roleName] = profile.id
+      state.creatingSuggestionForRole = nil
+      state.suggestionProfileName = ""
+      return .none
 
-      case .createSuggestionCancelled:
-        state.creatingSuggestionForRole = nil
-        state.suggestionProfileName = ""
-        return .none
+    case .createSuggestionCancelled:
+      state.creatingSuggestionForRole = nil
+      state.suggestionProfileName = ""
+      return .none
 
-      case .installCLITapped:
-        return .run { [cliInstallClient] send in
-          do {
-            try await cliInstallClient.install(cliDefaultInstallPath)
-            await send(.cliInstallCompleted(success: true))
-          } catch {
-            await send(.cliInstallCompleted(success: false))
-          }
+    default:
+      assertionFailure("handle(state:action:) routes only suggestion actions here.")
+      return .none
+    }
+  }
+
+  private func handleRemainder(state: inout State, action: Action) -> Effect<Action> {
+    switch action {
+    case .installCLITapped:
+      return .run { [cliInstallClient] send in
+        do {
+          try await cliInstallClient.install(cliDefaultInstallPath)
+          await send(.cliInstallCompleted(success: true))
+        } catch {
+          await send(.cliInstallCompleted(success: false))
         }
+      }
 
-      case .cliInstallCompleted(let success):
-        if success {
-          state.cliInstalled = true
-        } else {
-          state.submissionError = "The prowl command line tool could not be installed."
-        }
-        return .none
+    case .cliInstallCompleted(let success):
+      if success {
+        state.cliInstalled = true
+      } else {
+        state.submissionError = "The prowl command line tool could not be installed."
+      }
+      return .none
 
-      case .cancelTapped:
-        return .send(.delegate(.dismiss))
+    case .cancelTapped:
+      return .send(.delegate(.dismiss))
 
-      case .runTapped:
-        guard state.canRun else { return .none }
-        state.isSubmitting = true
-        state.submissionError = nil
-        let request = state.request
-        return .run { send in
-          await send(.runResponse(workflowStartClient.run(request)))
-        }
+    case .runTapped:
+      guard state.canRun else { return .none }
+      state.isSubmitting = true
+      state.submissionError = nil
+      let request = state.request
+      return .run { send in
+        await send(.runResponse(workflowStartClient.run(request)))
+      }
 
-      case .runResponse(.started):
-        state.isSubmitting = false
-        Self.persistBindModeChoice(state: state)
-        return .send(.delegate(.started))
+    case .runResponse(.started):
+      state.isSubmitting = false
+      Self.persistBindModeChoice(state: state)
+      return .send(.delegate(.started))
 
-      case .runResponse(.failed(_, let message)):
-        state.isSubmitting = false
-        state.submissionError = message
-        return .none
+    case .runResponse(.failed(_, let message)):
+      state.isSubmitting = false
+      state.submissionError = message
+      return .none
 
     case .delegate:
+      return .none
+
+    default:
+      assertionFailure("handle(state:action:) routes edit and suggestion actions elsewhere.")
       return .none
     }
   }

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -3,6 +3,7 @@
 // source/role/input collection before a run exists. Every choice is sent as a typed action;
 // the reducer owns eligibility (011 decision 1) and the view renders its answers.
 
+import AppKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -79,6 +80,15 @@ private struct WorkflowStartCard: View {
     .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14))
     .shadow(radius: 32, x: 0, y: 12)
     .padding(16)
+    .background {
+      // Pull the keyboard away from the terminal once when the sheet appears, so Esc and
+      // Return reach the sheet. Unlike the handoff HUD's capture view this never re-grabs:
+      // the sheet hosts text fields, and a focused field must keep the keyboard.
+      WorkflowStartKeyAnchor(
+        onEscape: { store.send(.cancelTapped) },
+        onReturn: { store.send(.runTapped) }
+      )
+    }
   }
 
   private var header: some View {
@@ -111,14 +121,21 @@ private struct WorkflowStartCard: View {
 
   private func sourceSection(_ source: WorkflowStartSource) -> some View {
     VStack(alignment: .leading, spacing: 4) {
-      Picker(selection: sourceBinding) {
-        ForEach(source.candidates) { candidate in
-          Text(paneLabel(candidate)).tag(candidate.surfaceID as UUID?)
+      if source.isPreselectionFixed,
+        let fixed = source.candidates.first(where: { $0.surfaceID == source.preselectedSurfaceID })
+      {
+        LabeledContent("You (\(source.roleName))", value: paneLabel(fixed))
+          .help("This workflow was started from the Active Agents row, so its pane is the source.")
+      } else {
+        Picker(selection: sourceBinding) {
+          ForEach(source.candidates) { candidate in
+            Text(paneLabel(candidate)).tag(candidate.surfaceID as UUID?)
+          }
+        } label: {
+          Text("You (\(source.roleName))")
         }
-      } label: {
-        Text("You (\(source.roleName))")
+        .help("The pane this workflow runs from — the CLI's [source] argument.")
       }
-      .help("The pane this workflow runs from — the CLI's [source] argument.")
       if store.selectedSourceIsBareShell, store.sourceRequiresAgent {
         Text("A step messages this role, so the source pane must host a detected agent.")
           .font(.footnote)
@@ -359,5 +376,48 @@ extension WorkflowStartFeature.State {
       let candidate = source.candidates.first(where: { $0.surfaceID == selected })
     else { return false }
     return candidate.agentToken == nil
+  }
+}
+
+private struct WorkflowStartKeyAnchor: NSViewRepresentable {
+  let onEscape: () -> Void
+  let onReturn: () -> Void
+
+  func makeNSView(context: Context) -> AnchorNSView {
+    let view = AnchorNSView()
+    view.onEscape = onEscape
+    view.onReturn = onReturn
+    return view
+  }
+
+  func updateNSView(_ nsView: AnchorNSView, context: Context) {
+    nsView.onEscape = onEscape
+    nsView.onReturn = onReturn
+  }
+
+  final class AnchorNSView: NSView {
+    var onEscape: (() -> Void)?
+    var onReturn: (() -> Void)?
+    private var didGrabFocus = false
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      guard !didGrabFocus, let window else { return }
+      didGrabFocus = true
+      window.makeFirstResponder(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+      switch event.keyCode {
+      case 53:  // escape
+        onEscape?()
+      case 36, 76:  // return, keypad enter
+        onReturn?()
+      default:
+        super.keyDown(with: event)
+      }
+    }
   }
 }

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -148,9 +148,13 @@ private struct WorkflowStartCard: View {
     VStack(alignment: .leading, spacing: 4) {
       Picker(selection: launchBinding(role: role.name)) {
         Text("Choose a profile…").tag(nil as UUID?)
-        ForEach(role.candidates) { candidate in
+        ForEach(store.state.candidates(for: role)) { candidate in
           if let reason = candidate.unavailableReason {
-            Text("\(candidate.name) — \(reason)").tag(candidate.profileID as UUID?)
+            // Contract: unavailable rows are dimmed with their reason and cannot be chosen.
+            Text("\(candidate.name) — \(reason)")
+              .foregroundStyle(.secondary)
+              .tag(candidate.profileID as UUID?)
+              .selectionDisabled()
           } else {
             Text(candidate.name).tag(candidate.profileID as UUID?)
           }
@@ -164,7 +168,7 @@ private struct WorkflowStartCard: View {
           .font(.footnote)
           .foregroundStyle(.secondary)
       }
-      if role.suggestion != nil, store.creatingSuggestionForRole != role.name {
+      if store.state.canCreateSuggestion(for: role.name), store.creatingSuggestionForRole != role.name {
         Button("Create profile from suggestion…") {
           store.send(.createSuggestionTapped(role: role.name))
         }

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -1,0 +1,363 @@
+// supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+// The workflow start sheet (docs-ai 063 C2): the handoff HUD's centered card pattern hosting
+// source/role/input collection before a run exists. Every choice is sent as a typed action;
+// the reducer owns eligibility (011 decision 1) and the view renders its answers.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct WorkflowStartOverlayView: View {
+  let store: StoreOf<WorkflowStartFeature>
+
+  var body: some View {
+    ZStack {
+      Color.clear
+        .contentShape(.rect)
+        .onTapGesture {
+          store.send(.cancelTapped)
+        }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("Dismiss Workflow Start")
+
+      GeometryReader { geometry in
+        VStack {
+          WorkflowStartCard(store: store)
+            .zIndex(1)
+          Spacer(minLength: 0)
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height, alignment: .top)
+        .padding(.top, max(0, geometry.size.height * 0.16))
+      }
+    }
+  }
+}
+
+private struct WorkflowStartCard: View {
+  let store: StoreOf<WorkflowStartFeature>
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      header
+      Divider()
+      ScrollView {
+        VStack(alignment: .leading, spacing: 14) {
+          if !store.cliInstalled {
+            cliBanner
+          }
+          if let source = store.context.source {
+            sourceSection(source)
+          }
+          ForEach(store.context.launchRoles) { role in
+            launchRoleSection(role)
+          }
+          ForEach(store.context.pickRoles) { role in
+            pickRoleSection(role)
+          }
+          if !store.context.definition.inputs.isEmpty {
+            inputsSection
+          }
+          if !store.context.skipOptions.isEmpty {
+            skipSection
+          }
+          if store.showsDontAskAgain {
+            Toggle("Don't ask again for this workflow", isOn: dontAskAgainBinding)
+              .help("Start this workflow without the sheet whenever nothing needs a decision.")
+          }
+          if let error = store.submissionError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+              .font(.callout)
+              .foregroundStyle(.red)
+          }
+        }
+        .padding(16)
+      }
+      .frame(maxHeight: 420)
+      Divider()
+      footer
+    }
+    .frame(maxWidth: 560)
+    .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14))
+    .shadow(radius: 32, x: 0, y: 12)
+    .padding(16)
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(store.context.item.name)
+        .font(.headline)
+      Text(store.context.item.workflowDescription ?? "Run this workflow in \(store.context.worktreeName).")
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var cliBanner: some View {
+    HStack(spacing: 8) {
+      Label(
+        "Workflows need the prowl command line tool.",
+        systemImage: "exclamationmark.triangle.fill"
+      )
+      .foregroundStyle(.orange)
+      Spacer()
+      Button("Install") {
+        store.send(.installCLITapped)
+      }
+      .help("Install the prowl command line tool to /usr/local/bin.")
+    }
+    .font(.callout)
+  }
+
+  private func sourceSection(_ source: WorkflowStartSource) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Picker(selection: sourceBinding) {
+        ForEach(source.candidates) { candidate in
+          Text(paneLabel(candidate)).tag(candidate.surfaceID as UUID?)
+        }
+      } label: {
+        Text("You (\(source.roleName))")
+      }
+      .help("The pane this workflow runs from — the CLI's [source] argument.")
+      if store.selectedSourceIsBareShell, store.sourceRequiresAgent {
+        Text("A step messages this role, so the source pane must host a detected agent.")
+          .font(.footnote)
+          .foregroundStyle(.orange)
+      }
+    }
+  }
+
+  private func launchRoleSection(_ role: WorkflowStartLaunchRole) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Picker(selection: launchBinding(role: role.name)) {
+        Text("Choose a profile…").tag(nil as UUID?)
+        ForEach(role.candidates) { candidate in
+          if let reason = candidate.unavailableReason {
+            Text("\(candidate.name) — \(reason)").tag(candidate.profileID as UUID?)
+          } else {
+            Text(candidate.name).tag(candidate.profileID as UUID?)
+          }
+        }
+      } label: {
+        Text(roleTitle(role.name))
+      }
+      .help("The Agent Profile launched for the \(role.name) role.")
+      if let note = role.rejectedNote {
+        Text(note)
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+      if role.suggestion != nil, store.creatingSuggestionForRole != role.name {
+        Button("Create profile from suggestion…") {
+          store.send(.createSuggestionTapped(role: role.name))
+        }
+        .buttonStyle(.link)
+        .font(.callout)
+        .help("Create a profile from this workflow's suggested agent configuration.")
+      }
+      if store.creatingSuggestionForRole == role.name {
+        suggestionConfirmBlock(role)
+      }
+    }
+  }
+
+  private func suggestionConfirmBlock(_ role: WorkflowStartLaunchRole) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      TextField("Profile name", text: suggestionNameBinding)
+      if let suggestion = role.suggestion {
+        Text(suggestionSummary(suggestion))
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          store.send(.createSuggestionCancelled)
+        }
+        .help("Close without creating a profile.")
+        Button("Create") {
+          store.send(.createSuggestionConfirmed)
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(store.suggestionProfileName.trimmingCharacters(in: .whitespaces).isEmpty)
+        .help("Create this profile and select it for the role. Manage it later in Settings.")
+      }
+    }
+    .padding(10)
+    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+  }
+
+  private func pickRoleSection(_ role: WorkflowStartPickRole) -> some View {
+    Picker(selection: pickBinding(role: role.name)) {
+      Text("Choose a pane…").tag(nil as UUID?)
+      ForEach(role.candidates.filter { $0.surfaceID != store.selectedSourceSurfaceID }) { candidate in
+        Text(paneLabel(candidate)).tag(candidate.surfaceID as UUID?)
+      }
+    } label: {
+      Text(roleTitle(role.name))
+    }
+    .help("An agent already running in this worktree takes the \(role.name) role.")
+  }
+
+  private var inputsSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ForEach(store.context.definition.inputs, id: \.name) { input in
+        if !input.values.isEmpty {
+          Picker(input.name, selection: inputBinding(name: input.name)) {
+            ForEach(input.values, id: \.self) { value in
+              Text(value).tag(value)
+            }
+          }
+          .help(input.prompt ?? "The \(input.name) input.")
+        } else {
+          TextField(input.name, text: inputBinding(name: input.name), prompt: Text(input.prompt ?? input.name))
+            .help(input.prompt ?? "The \(input.name) input.")
+        }
+      }
+    }
+  }
+
+  private var skipSection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ForEach(store.context.skipOptions, id: \.stepID) { option in
+        let consequence = store.state.skipConsequence(for: option.stepID)
+        let endsRun = isEndsRun(consequence)
+        VStack(alignment: .leading, spacing: 2) {
+          Toggle(
+            "Skip \(option.title ?? option.stepID)",
+            isOn: skipBinding(stepID: option.stepID)
+          )
+          .disabled(endsRun && !store.skippedSteps.contains(option.stepID))
+          .help("Start the run without this step.")
+          if let text = consequenceText(consequence) {
+            Text(text)
+              .font(.footnote)
+              .foregroundStyle(endsRun ? .orange : .secondary)
+          }
+        }
+      }
+    }
+  }
+
+  private var footer: some View {
+    HStack {
+      Spacer()
+      Button("Cancel") {
+        store.send(.cancelTapped)
+      }
+      .keyboardShortcut(.cancelAction)
+      .help("Close without starting the workflow (Esc).")
+      Button(store.isSubmitting ? "Starting…" : "Run") {
+        store.send(.runTapped)
+      }
+      .keyboardShortcut(.defaultAction)
+      .disabled(!store.canRun)
+      .help("Start the workflow (Return).")
+    }
+    .padding(12)
+  }
+
+  // MARK: - Labels
+
+  private func paneLabel(_ candidate: WorkflowStartPaneCandidate) -> String {
+    let name = candidate.agentDisplayName ?? candidate.paneTitle
+    let handle = candidate.handle.map { " in \($0)" } ?? ""
+    let shell = candidate.agentToken == nil ? " (no agent)" : ""
+    return "\(name)\(handle)\(shell)"
+  }
+
+  private func roleTitle(_ role: String) -> String {
+    role.prefix(1).uppercased() + role.dropFirst()
+  }
+
+  private func suggestionSummary(_ suggestion: WorkflowProfileSuggestion) -> String {
+    var parts: [String] = []
+    if let agent = suggestion.agent { parts.append(agent) }
+    if let model = suggestion.model { parts.append("model \(model)") }
+    if let effort = suggestion.reasoningEffort { parts.append("\(effort) effort") }
+    if let mode = suggestion.executionMode { parts.append("\(mode) mode") }
+    return "Suggested by the workflow: " + parts.joined(separator: " · ")
+  }
+
+  private func isEndsRun(_ consequence: WorkflowSkipConsequence?) -> Bool {
+    if case .endsRun = consequence { return true }
+    return false
+  }
+
+  private func consequenceText(_ consequence: WorkflowSkipConsequence?) -> String? {
+    switch consequence {
+    case .endsRun(let dependent):
+      return "Cannot skip: step '\(dependent)' needs its output."
+    case .continues(let optional) where !optional.isEmpty:
+      return "The run continues; \(optional.joined(separator: ", ")) proceeds without this output."
+    case .continues, .noOutput, nil:
+      return nil
+    }
+  }
+
+  // MARK: - Bindings
+
+  private var sourceBinding: Binding<UUID?> {
+    Binding(
+      get: { store.selectedSourceSurfaceID },
+      set: { store.send(.sourceSelected($0)) }
+    )
+  }
+
+  private func launchBinding(role: String) -> Binding<UUID?> {
+    Binding(
+      get: { store.launchSelections[role] },
+      set: { store.send(.launchProfileSelected(role: role, profileID: $0)) }
+    )
+  }
+
+  private func pickBinding(role: String) -> Binding<UUID?> {
+    Binding(
+      get: { store.pickSelections[role] },
+      set: { store.send(.pickPaneSelected(role: role, surfaceID: $0)) }
+    )
+  }
+
+  private func inputBinding(name: String) -> Binding<String> {
+    Binding(
+      get: { store.inputValues[name] ?? "" },
+      set: { store.send(.inputChanged(name: name, value: $0)) }
+    )
+  }
+
+  private func skipBinding(stepID: String) -> Binding<Bool> {
+    Binding(
+      get: { store.skippedSteps.contains(stepID) },
+      set: { _ in store.send(.skipToggled(stepID: stepID)) }
+    )
+  }
+
+  private var dontAskAgainBinding: Binding<Bool> {
+    Binding(
+      get: { store.dontAskAgain },
+      set: { store.send(.dontAskAgainToggled($0)) }
+    )
+  }
+
+  private var suggestionNameBinding: Binding<String> {
+    Binding(
+      get: { store.suggestionProfileName },
+      set: { store.send(.suggestionNameChanged($0)) }
+    )
+  }
+}
+
+extension WorkflowStartFeature.State {
+  /// The toggle appears exactly when a launch role would ask again next time (011 decision 5).
+  var showsDontAskAgain: Bool {
+    context.launchRoles.contains { $0.effectiveBind == .ask } || dontAskAgain
+  }
+
+  var selectedSourceIsBareShell: Bool {
+    guard let source = context.source,
+      let selected = selectedSourceSurfaceID,
+      let candidate = source.candidates.first(where: { $0.surfaceID == selected })
+    else { return false }
+    return candidate.agentToken == nil
+  }
+}

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -253,6 +253,23 @@ struct ActiveAgentsFeatureTests {
     )
   }
 
+  @Test func panelSubtitleShowsTheWorkflowBadgeWhileTheRunLives() {
+    let entry = entry(id: UUID(0), paneTitle: "Review issue 385", state: .working, changedAt: Date())
+
+    #expect(
+      ActiveAgentsPanel.subtitle(
+        for: entry, branchName: "main", showTabTitles: false,
+        workflowBadge: "in Adversarial Review \u{00B7} reviewer")
+        == "in Adversarial Review \u{00B7} reviewer"
+    )
+    // The branch/title subtitle returns when the run ends.
+    #expect(
+      ActiveAgentsPanel.subtitle(
+        for: entry, branchName: "main", showTabTitles: true, workflowBadge: nil)
+        == "Review issue 385"
+    )
+  }
+
   @Test func panelPaneTitleFallsBackForEmptyTitles() {
     let entry = entry(id: UUID(0), paneTitle: "   ", state: .idle, changedAt: Date())
 

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1778,7 +1778,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     .mergePullRequest, .closePullRequest, .copyFailingJobURL, .copyCiFailureLogs,
     .rerunFailedJobs, .openFailingCheckDetails:
     return .pullRequest
-  case .ghosttyCommand, .handOff, .launchAgentProfile:
+  case .ghosttyCommand, .handOff, .launchAgentProfile, .runWorkflow:
     return .terminal
   case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
     .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
@@ -1806,7 +1806,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     return true
   case .worktreeSelect, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,
-    .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile:
+    .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile, .runWorkflow:
     return false
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacodeTests/WorkflowBindModeOverrideTests.swift
+++ b/supacodeTests/WorkflowBindModeOverrideTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowBindModeOverrideTests {
+  @Test func overrideRoundTripsThroughCoding() throws {
+    var settings = UserGlobalSettings(customCommands: [])
+    settings.setWorkflowBindMode(.auto, for: "bundle/prowl.adversarial-review")
+    settings.setWorkflowBindMode(.ask, for: "user/my-review")
+
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(UserGlobalSettings.self, from: data)
+
+    #expect(decoded.workflowBindMode(for: "bundle/prowl.adversarial-review") == .auto)
+    #expect(decoded.workflowBindMode(for: "user/my-review") == .ask)
+    #expect(decoded.workflowBindMode(for: "repo:abc/other") == nil)
+  }
+
+  @Test func settingNilClearsTheOverride() {
+    var settings = UserGlobalSettings(customCommands: [])
+    settings.setWorkflowBindMode(.auto, for: "user/my-review")
+    settings.setWorkflowBindMode(nil, for: "user/my-review")
+
+    #expect(settings.workflowBindMode(for: "user/my-review") == nil)
+    #expect(settings.workflowBindModeOverrides.isEmpty)
+  }
+
+  @Test func lastWriteWinsPerKeyAndOrderIsStable() {
+    let overrides = [
+      WorkflowBindModeOverride(workflowKey: "user/b", mode: .ask),
+      WorkflowBindModeOverride(workflowKey: "user/a", mode: .ask),
+      WorkflowBindModeOverride(workflowKey: "user/b", mode: .auto),
+    ]
+
+    let normalized = WorkflowBindModeOverride.normalized(overrides)
+
+    #expect(normalized == [
+      WorkflowBindModeOverride(workflowKey: "user/a", mode: .ask),
+      WorkflowBindModeOverride(workflowKey: "user/b", mode: .auto),
+    ])
+  }
+
+  @Test func decodingWithoutTheKeyDefaultsToEmpty() throws {
+    let json = #"{"customCommands":[]}"#
+    let decoded = try JSONDecoder().decode(UserGlobalSettings.self, from: Data(json.utf8))
+    #expect(decoded.workflowBindModeOverrides.isEmpty)
+  }
+
+  @Test func normalizedForwardsOverrides() {
+    var settings = UserGlobalSettings(customCommands: [])
+    settings.setWorkflowBindMode(.auto, for: "user/my-review")
+    #expect(settings.normalized().workflowBindMode(for: "user/my-review") == .auto)
+  }
+}

--- a/supacodeTests/WorkflowBindModeOverrideTests.swift
+++ b/supacodeTests/WorkflowBindModeOverrideTests.swift
@@ -35,10 +35,11 @@ struct WorkflowBindModeOverrideTests {
 
     let normalized = WorkflowBindModeOverride.normalized(overrides)
 
-    #expect(normalized == [
-      WorkflowBindModeOverride(workflowKey: "user/a", mode: .ask),
-      WorkflowBindModeOverride(workflowKey: "user/b", mode: .auto),
-    ])
+    #expect(
+      normalized == [
+        WorkflowBindModeOverride(workflowKey: "user/a", mode: .ask),
+        WorkflowBindModeOverride(workflowKey: "user/b", mode: .auto),
+      ])
   }
 
   @Test func decodingWithoutTheKeyDefaultsToEmpty() throws {

--- a/supacodeTests/WorkflowRoleBadgeTests.swift
+++ b/supacodeTests/WorkflowRoleBadgeTests.swift
@@ -1,0 +1,50 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorkflowRoleBadgeTests {
+  @Test func activeRunPanesWearTheirRoleBadge() throws {
+    let definition = try #require(
+      WorkflowDocumentParser.parse(WorkflowStartContextTests.autoFlow).definition)
+    let authorPane = WorkflowPaneIdentity(
+      surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+      tabID: UUID(uuidString: "00000000-0000-0000-0000-000000000011")!,
+      handle: "p1", displayName: "Claude Code", agent: "claude")
+    let started = try WorkflowRunMachine.start(
+      WorkflowRunStartRequest(
+        definition: definition,
+        runID: UUID(uuidString: "0BADCAFE-0000-4000-8000-000000000042")!,
+        context: WorkflowRunContext(
+          scope: .user, definitionPath: "/tmp/auto.yaml",
+          worktree: WorkflowRunWorktree(id: "/tmp/repo/wt", name: "wt", branch: "main", path: "/tmp/repo/wt")),
+        bindings: [
+          "author": .current(authorPane),
+          "reviewer": .launch(
+            WorkflowProfileBinding(
+              id: UUID(uuidString: "00000000-0000-0000-0000-000000000009")!,
+              name: "Pi Reviewer", agent: "pi"),
+            pane: nil),
+        ],
+        inputs: [:],
+        skippedSteps: [],
+        selfInitiated: false),
+      now: { Date(timeIntervalSince1970: 1_760_000_000) },
+      makeToken: { "TOKEN" })
+    let session = WorkflowRunSession(
+      run: started.machine.run,
+      worktree: Worktree(
+        id: "/tmp/repo/wt", name: "wt", detail: "detail",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")),
+      launchPlans: [:], bindingMemoryKeys: [:], skills: [:])
+
+    var runs = WorkflowRunsFeature.State()
+    runs.sessions[session.run.id] = session
+
+    let badges = AppFeature.workflowRoleBadges(for: runs)
+    #expect(badges == [authorPane.surfaceID: "in Auto Flow \u{00B7} author"])
+  }
+}

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -735,6 +735,50 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.status == .maxRoundsReached)
   }
 
+  @Test func startSkipConsequenceForTheStartSheet() throws {
+    let review = try definition(Self.adversarialReview)
+    #expect(
+      WorkflowRunMachine.startSkipConsequence(forStep: "brief", definition: review, alreadySkipped: [])
+        == .endsRun(dependent: "launch"))
+    // A step without an `expect` offers no skip choice at all.
+    #expect(WorkflowRunMachine.startSkipConsequence(forStep: "done", definition: review, alreadySkipped: []) == nil)
+    #expect(WorkflowRunMachine.startSkipConsequence(forStep: "nope", definition: review, alreadySkipped: []) == nil)
+
+    let handoff = try definition(Self.handoff)
+    #expect(
+      WorkflowRunMachine.startSkipConsequence(forStep: "brief", definition: handoff, alreadySkipped: [])
+        == .continues(optionalInputs: ["transition"]))
+  }
+
+  @Test func startSkipConsequenceIgnoresReadersAlreadySkipped() throws {
+    let chain = try definition(
+      """
+      schema: prowl.workflow/v1
+      id: chain
+      name: Chain
+      roles:
+        author:
+          source: current
+      steps:
+        - id: produce
+          message: author
+          text: "Write it."
+          expect: { output: draft }
+        - id: consume
+          message: author
+          text: "Polish {{ outputs.draft.path }}."
+          expect: { output: final }
+        - id: done
+          notify: "done"
+      """)
+    #expect(
+      WorkflowRunMachine.startSkipConsequence(forStep: "produce", definition: chain, alreadySkipped: [])
+        == .endsRun(dependent: "consume"))
+    #expect(
+      WorkflowRunMachine.startSkipConsequence(forStep: "produce", definition: chain, alreadySkipped: ["consume"])
+        == .continues(optionalInputs: []))
+  }
+
   @Test func startTimeSkipIgnoresReadersAfterALoopWithoutUntil() throws {
     let yaml = """
       schema: prowl.workflow/v1

--- a/supacodeTests/WorkflowStartContextTests.swift
+++ b/supacodeTests/WorkflowStartContextTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorkflowStartContextTests {
+  static let autoFlow = """
+    schema: prowl.workflow/v1
+    id: auto-flow
+    name: Auto Flow
+    inputs:
+      focus: { type: string, default: "" }
+    roles:
+      author:
+        source: current
+      reviewer:
+        source: launch
+        bind: auto
+    steps:
+      - id: brief
+        message: author
+        text: "Write about {{ inputs.focus }}."
+        expect: { output: brief }
+      - id: launch
+        launch: reviewer
+        prompt: "Read {{ outputs.brief.path }}."
+    """
+
+  static let worktreeOnly = """
+    schema: prowl.workflow/v1
+    id: worktree-only
+    name: Worktree Only
+    roles:
+      runner:
+        source: launch
+        bind: auto
+    steps:
+      - id: launch
+        launch: runner
+        prompt: "Do the thing."
+    """
+
+  private static let agentPane = WorkflowStartPaneCandidate(
+    surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+    handle: "p1", agentToken: "claude", agentDisplayName: "Claude Code", paneTitle: "claude")
+  private static let bareShellPane = WorkflowStartPaneCandidate(
+    surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+    handle: "p2", agentToken: nil, agentDisplayName: nil, paneTitle: "zsh")
+  private static let profileID = UUID(uuidString: "00000000-0000-0000-0000-000000000009")!
+
+  private func definition(_ yaml: String) throws -> WorkflowDefinition {
+    try #require(WorkflowDocumentParser.parse(yaml).definition)
+  }
+
+  private func context(
+    yaml: String = autoFlow,
+    source: WorkflowStartSource?,
+    launchRoles: [WorkflowStartLaunchRole],
+    pickRoles: [WorkflowStartPickRole] = [],
+    cliInstalled: Bool = true,
+    validationFailure: String? = nil
+  ) throws -> WorkflowStartContext {
+    let definition = try definition(yaml)
+    return WorkflowStartContext(
+      item: WorkflowStartCatalogItem(
+        key: "user/\(definition.id)", workflowID: definition.id, name: definition.name,
+        workflowDescription: nil, validationFailure: validationFailure),
+      definition: definition,
+      worktreeID: "/tmp/wt/", worktreeName: "main",
+      source: source,
+      launchRoles: launchRoles,
+      pickRoles: pickRoles,
+      cliInstalled: cliInstalled,
+      bindModeOverride: nil)
+  }
+
+  private func launchRole(bind: WorkflowBindMode = .auto, resolved: UUID? = profileID) -> WorkflowStartLaunchRole {
+    WorkflowStartLaunchRole(
+      name: "reviewer", effectiveBind: bind, resolvedProfileID: resolved,
+      candidates: [], suggestion: nil, rejectedNote: nil)
+  }
+
+  private func source(preselected: WorkflowStartPaneCandidate?) -> WorkflowStartSource {
+    WorkflowStartSource(
+      roleName: "author",
+      candidates: [Self.agentPane, Self.bareShellPane],
+      preselectedSurfaceID: preselected?.surfaceID)
+  }
+
+  @Test func startsImmediatelyWhenNothingIsUndecided() throws {
+    let context = try context(source: source(preselected: Self.agentPane), launchRoles: [launchRole()])
+    #expect(context.canStartImmediately)
+  }
+
+  @Test func askBindAlwaysPresentsTheSheet() throws {
+    let context = try context(source: source(preselected: Self.agentPane), launchRoles: [launchRole(bind: .ask)])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func unresolvedAutoRolePresentsTheSheet() throws {
+    let context = try context(source: source(preselected: Self.agentPane), launchRoles: [launchRole(resolved: nil)])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func pickRolesAreAlwaysAnExplicitChoice() throws {
+    let context = try context(
+      source: source(preselected: Self.agentPane), launchRoles: [launchRole()],
+      pickRoles: [WorkflowStartPickRole(name: "partner", candidates: [Self.agentPane])])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func defaultlessInputPresentsTheSheet() throws {
+    let yaml = Self.autoFlow.replacing("focus: { type: string, default: \"\" }", with: "focus: { type: string }")
+    let context = try context(yaml: yaml, source: source(preselected: Self.agentPane), launchRoles: [launchRole()])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func missingCLIPresentsTheSheet() throws {
+    let context = try context(
+      source: source(preselected: Self.agentPane), launchRoles: [launchRole()], cliInstalled: false)
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func bareShellSourceNeedsTheSheetWhenAMessageDelivers() throws {
+    let context = try context(source: source(preselected: Self.bareShellPane), launchRoles: [launchRole()])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func missingPreselectionPresentsTheSheet() throws {
+    let context = try context(source: source(preselected: nil), launchRoles: [launchRole()])
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func workflowWithoutACurrentRoleRunsAgainstTheWorktree() throws {
+    let context = try context(yaml: Self.worktreeOnly, source: nil, launchRoles: [launchRole()])
+    #expect(context.canStartImmediately)
+  }
+
+  @Test func invalidWorkflowNeverStartsImmediately() throws {
+    let context = try context(
+      source: source(preselected: Self.agentPane), launchRoles: [launchRole()],
+      validationFailure: "2 validation errors")
+    #expect(!context.canStartImmediately)
+  }
+
+  @Test func skipOptionsListEveryExpectCarryingStep() throws {
+    let context = try context(source: source(preselected: Self.agentPane), launchRoles: [launchRole()])
+    #expect(context.skipOptions.map(\.stepID) == ["brief"])
+  }
+}

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -128,7 +128,8 @@ struct WorkflowStartFeatureTests {
   }
 
   @Test func skippingTheOnlyDeliveryMakesABareShellSourceValid() async throws {
-    let context = try makeContext(yaml: Self.skippableNote, preselected: Self.shellPaneID,
+    let context = try makeContext(
+      yaml: Self.skippableNote, preselected: Self.shellPaneID,
       resolvedProfileID: Self.profileID)
     let store = TestStore(initialState: WorkflowStartFeature.State(context: context)) {
       WorkflowStartFeature()
@@ -237,7 +238,9 @@ struct WorkflowStartFeatureTests {
     }
 
     await store.send(.runTapped) { $0.isSubmitting = true }
-    await store.receive(.runResponse(.failed(code: "PANE_BUSY", message: "The source pane already belongs to a run."))) {
+    let failure = WorkflowStartOutcome.failed(
+      code: "PANE_BUSY", message: "The source pane already belongs to a run.")
+    await store.receive(.runResponse(failure)) {
       $0.isSubmitting = false
       $0.submissionError = "The source pane already belongs to a run."
     }

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -1,0 +1,282 @@
+import ComposableArchitecture
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorkflowStartFeatureTests {
+  static let review = """
+    schema: prowl.workflow/v1
+    id: review
+    name: Review
+    inputs:
+      focus: { type: string, default: "everything" }
+      goal: { type: string }
+    roles:
+      author:
+        source: current
+      reviewer:
+        source: launch
+        agents: [pi]
+    steps:
+      - id: brief
+        message: author
+        text: "Brief on {{ inputs.goal }}."
+        expect: { output: brief }
+      - id: launch
+        launch: reviewer
+        prompt: "Read {{ outputs.brief.path }}."
+    """
+
+  static let skippableNote = """
+    schema: prowl.workflow/v1
+    id: note-flow
+    name: Note Flow
+    roles:
+      author:
+        source: current
+      runner:
+        source: launch
+        bind: auto
+    steps:
+      - id: note
+        message: author
+        text: "Write a note."
+        expect: { output: note }
+      - id: launch
+        launch: runner
+        prompt: "Just do it."
+    """
+
+  static let profileID = UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!
+  static let agentPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+  static let shellPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+
+  static let agentPane = WorkflowStartPaneCandidate(
+    surfaceID: agentPaneID, handle: "p1", agentToken: "claude",
+    agentDisplayName: "Claude Code", paneTitle: "claude")
+  static let shellPane = WorkflowStartPaneCandidate(
+    surfaceID: shellPaneID, handle: "p2", agentToken: nil, agentDisplayName: nil, paneTitle: "zsh")
+
+  private func makeContext(
+    yaml: String = review,
+    preselected: UUID? = agentPaneID,
+    resolvedProfileID: UUID? = nil,
+    suggestion: WorkflowProfileSuggestion? = nil,
+    bindModeOverride: WorkflowBindModeOverride.Mode? = nil,
+    candidateUnavailableReason: String? = nil
+  ) throws -> WorkflowStartContext {
+    let definition = try #require(WorkflowDocumentParser.parse(yaml).definition)
+    let launchRoles = definition.roles.filter { $0.source == .launch }.map { role in
+      WorkflowStartLaunchRole(
+        name: role.name,
+        effectiveBind: bindModeOverride == .auto ? .auto : (role.launch?.bind ?? .ask),
+        resolvedProfileID: resolvedProfileID,
+        candidates: [
+          WorkflowStartLaunchRole.Candidate(
+            profileID: Self.profileID, name: "Pi Reviewer", agentToken: "pi",
+            unavailableReason: candidateUnavailableReason)
+        ],
+        suggestion: suggestion,
+        rejectedNote: nil)
+    }
+    return WorkflowStartContext(
+      item: WorkflowStartCatalogItem(
+        key: "user/\(definition.id)", workflowID: definition.id, name: definition.name,
+        workflowDescription: nil, validationFailure: nil),
+      definition: definition,
+      worktreeID: "/tmp/wt/", worktreeName: "main",
+      source: WorkflowStartSource(
+        roleName: "author",
+        candidates: [Self.agentPane, Self.shellPane],
+        preselectedSurfaceID: preselected),
+      launchRoles: launchRoles,
+      pickRoles: [],
+      cliInstalled: true,
+      bindModeOverride: bindModeOverride)
+  }
+
+  @Test func initPrefillsFromTheResolverAnswers() throws {
+    let context = try makeContext(resolvedProfileID: Self.profileID)
+    let state = WorkflowStartFeature.State(context: context)
+
+    #expect(state.selectedSourceSurfaceID == Self.agentPaneID)
+    #expect(state.launchSelections == ["reviewer": Self.profileID])
+    #expect(state.inputValues == ["focus": "everything"])
+    #expect(!state.dontAskAgain)
+  }
+
+  @Test func canRunNeedsSelectionsAndRequiredInputs() throws {
+    let context = try makeContext(resolvedProfileID: Self.profileID)
+    var state = WorkflowStartFeature.State(context: context)
+
+    #expect(!state.canRun)  // `goal` has no default
+    state.inputValues["goal"] = "ship C2"
+    #expect(state.canRun)
+    state.launchSelections = [:]
+    #expect(!state.canRun)
+  }
+
+  @Test func unavailableProfileSelectionBlocksRun() throws {
+    let context = try makeContext(
+      resolvedProfileID: Self.profileID, candidateUnavailableReason: "This role needs pi.")
+    var state = WorkflowStartFeature.State(context: context)
+    state.inputValues["goal"] = "x"
+    #expect(!state.canRun)
+  }
+
+  @Test func skippingTheOnlyDeliveryMakesABareShellSourceValid() async throws {
+    let context = try makeContext(yaml: Self.skippableNote, preselected: Self.shellPaneID,
+      resolvedProfileID: Self.profileID)
+    let store = TestStore(initialState: WorkflowStartFeature.State(context: context)) {
+      WorkflowStartFeature()
+    }
+
+    #expect(!store.state.canRun)  // bare shell + a surviving delivery
+    await store.send(.skipToggled(stepID: "note")) {
+      $0.skippedSteps = ["note"]
+    }
+    #expect(store.state.canRun)
+  }
+
+  @Test func endsRunSkipsAreNeverArmed() async throws {
+    let context = try makeContext(resolvedProfileID: Self.profileID)
+    let store = TestStore(initialState: WorkflowStartFeature.State(context: context)) {
+      WorkflowStartFeature()
+    }
+    // `brief` feeds the launch prompt: skipping it at start is refused by admission (§9).
+    await store.send(.skipToggled(stepID: "brief"))
+    #expect(store.state.skippedSteps.isEmpty)
+  }
+
+  @Test func runSubmitsTheCLIVocabularyAndPersistsDontAskAgain() async throws {
+    let storage = UserGlobalSettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/prowl-global-settings-\(UUID().uuidString).json")
+    let submitted = LockIsolated<WorkflowStartRequest?>(nil)
+    let context = try makeContext(resolvedProfileID: Self.profileID)
+
+    try await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.userGlobalSettingsURL = url
+    } operation: {
+      var initial = WorkflowStartFeature.State(context: context)
+      initial.inputValues["goal"] = "ship C2"
+      initial.inputValues["focus"] = "everything"  // untouched default: must not submit
+      initial.dontAskAgain = true
+      let store = TestStore(initialState: initial) {
+        WorkflowStartFeature()
+      } withDependencies: {
+        $0[WorkflowStartClient.self].run = { request in
+          submitted.setValue(request)
+          return .started
+        }
+      }
+
+      await store.send(.runTapped) {
+        $0.isSubmitting = true
+      }
+      await store.receive(.runResponse(.started)) {
+        $0.isSubmitting = false
+      }
+      await store.receive(.delegate(.started))
+
+      let request = try #require(submitted.value)
+      #expect(request.workflowID == "review")
+      #expect(request.sourceSurfaceID == Self.agentPaneID)
+      #expect(request.roleBindings == ["reviewer=\(Self.profileID.uuidString)"])
+      #expect(request.inputValues == ["goal=ship C2"])
+      #expect(request.skippedSteps.isEmpty)
+
+      @Shared(.userGlobalSettings) var settings: UserGlobalSettings
+      #expect(settings.workflowBindMode(for: "user/review") == .auto)
+    }
+  }
+
+  @Test func uncheckingDontAskAgainClearsAPersistedAuto() async throws {
+    let storage = UserGlobalSettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/prowl-global-settings-\(UUID().uuidString).json")
+    let context = try makeContext(resolvedProfileID: Self.profileID, bindModeOverride: .auto)
+
+    try await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.userGlobalSettingsURL = url
+    } operation: {
+      @Shared(.userGlobalSettings) var settings: UserGlobalSettings
+      $settings.withLock { $0.setWorkflowBindMode(.auto, for: "user/review") }
+
+      var initial = WorkflowStartFeature.State(context: context)
+      initial.inputValues["goal"] = "x"
+      #expect(initial.dontAskAgain)  // reflects the stored override
+      initial.dontAskAgain = false
+      let store = TestStore(initialState: initial) {
+        WorkflowStartFeature()
+      } withDependencies: {
+        $0[WorkflowStartClient.self].run = { _ in .started }
+      }
+
+      await store.send(.runTapped) { $0.isSubmitting = true }
+      await store.receive(.runResponse(.started)) { $0.isSubmitting = false }
+      await store.receive(.delegate(.started))
+
+      #expect(settings.workflowBindMode(for: "user/review") == nil)
+    }
+  }
+
+  @Test func failedSubmissionShowsTheError() async throws {
+    let context = try makeContext(resolvedProfileID: Self.profileID)
+    var initial = WorkflowStartFeature.State(context: context)
+    initial.inputValues["goal"] = "x"
+    let store = TestStore(initialState: initial) {
+      WorkflowStartFeature()
+    } withDependencies: {
+      $0[WorkflowStartClient.self].run = { _ in
+        .failed(code: "PANE_BUSY", message: "The source pane already belongs to a run.")
+      }
+    }
+
+    await store.send(.runTapped) { $0.isSubmitting = true }
+    await store.receive(.runResponse(.failed(code: "PANE_BUSY", message: "The source pane already belongs to a run."))) {
+      $0.isSubmitting = false
+      $0.submissionError = "The source pane already belongs to a run."
+    }
+  }
+
+  @Test func createFromSuggestionPersistsARealProfileAndSelectsIt() async throws {
+    let storage = UserGlobalSettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/prowl-global-settings-\(UUID().uuidString).json")
+    let suggestion = WorkflowProfileSuggestion(
+      agent: "pi", model: nil, reasoningEffort: "xhigh", executionMode: "standard")
+    let context = try makeContext(suggestion: suggestion)
+
+    try await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.userGlobalSettingsURL = url
+    } operation: {
+      let store = TestStore(initialState: WorkflowStartFeature.State(context: context)) {
+        WorkflowStartFeature()
+      } withDependencies: {
+        $0.uuid = .incrementing
+      }
+
+      await store.send(.createSuggestionTapped(role: "reviewer")) {
+        $0.creatingSuggestionForRole = "reviewer"
+        $0.suggestionProfileName = "Reviewer (Pi)"
+      }
+      let expected = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+      await store.send(.createSuggestionConfirmed) {
+        $0.creatingSuggestionForRole = nil
+        $0.suggestionProfileName = ""
+        $0.launchSelections = ["reviewer": expected]
+      }
+
+      @Shared(.userGlobalSettings) var settings: UserGlobalSettings
+      let created = try #require(settings.agentProfiles.first { $0.id == expected })
+      #expect(created.name == "Reviewer (Pi)")
+      #expect(created.runtime == .pi)
+      #expect(created.reasoningEffort == "xhigh")
+      #expect(created.isEnabled)
+    }
+  }
+}

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -66,7 +66,8 @@ struct WorkflowStartFeatureTests {
     resolvedProfileID: UUID? = nil,
     suggestion: WorkflowProfileSuggestion? = nil,
     bindModeOverride: WorkflowBindModeOverride.Mode? = nil,
-    candidateUnavailableReason: String? = nil
+    candidateUnavailableReason: String? = nil,
+    includeCandidates: Bool = true
   ) throws -> WorkflowStartContext {
     let definition = try #require(WorkflowDocumentParser.parse(yaml).definition)
     let launchRoles = definition.roles.filter { $0.source == .launch }.map { role in
@@ -74,11 +75,12 @@ struct WorkflowStartFeatureTests {
         name: role.name,
         effectiveBind: bindModeOverride == .auto ? .auto : (role.launch?.bind ?? .ask),
         resolvedProfileID: resolvedProfileID,
-        candidates: [
-          WorkflowStartLaunchRole.Candidate(
-            profileID: Self.profileID, name: "Pi Reviewer", agentToken: "pi",
-            unavailableReason: candidateUnavailableReason)
-        ],
+        candidates: includeCandidates
+          ? [
+            WorkflowStartLaunchRole.Candidate(
+              profileID: Self.profileID, name: "Pi Reviewer", agentToken: "pi",
+              unavailableReason: candidateUnavailableReason)
+          ] : [],
         suggestion: suggestion,
         rejectedNote: nil)
     }
@@ -272,6 +274,13 @@ struct WorkflowStartFeatureTests {
         $0.creatingSuggestionForRole = nil
         $0.suggestionProfileName = ""
         $0.launchSelections = ["reviewer": expected]
+        $0.createdCandidatesByRole = [
+          "reviewer": [
+            WorkflowStartLaunchRole.Candidate(
+              profileID: expected, name: "Reviewer (Pi)", agentToken: "pi",
+              unavailableReason: nil)
+          ]
+        ]
       }
 
       @Shared(.userGlobalSettings) var settings: UserGlobalSettings
@@ -281,5 +290,47 @@ struct WorkflowStartFeatureTests {
       #expect(created.reasoningEffort == "xhigh")
       #expect(created.isEnabled)
     }
+  }
+
+  @Test func createFromSuggestionEnablesRunWhenNoProfileMatched() async throws {
+    let storage = UserGlobalSettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/prowl-global-settings-\(UUID().uuidString).json")
+    let suggestion = WorkflowProfileSuggestion(agent: "pi")
+    // The first-session path: no enabled profile qualifies for the role at all.
+    let context = try makeContext(suggestion: suggestion, includeCandidates: false)
+
+    try await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.userGlobalSettingsURL = url
+    } operation: {
+      var initial = WorkflowStartFeature.State(context: context)
+      initial.inputValues["goal"] = "ship C2"
+      let store = TestStore(initialState: initial) {
+        WorkflowStartFeature()
+      } withDependencies: {
+        $0.uuid = .incrementing
+      }
+      store.exhaustivity = .off
+
+      #expect(!store.state.canRun)
+      await store.send(.createSuggestionTapped(role: "reviewer"))
+      await store.send(.createSuggestionConfirmed)
+      #expect(store.state.canRun)
+      let created = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+      #expect(store.state.request.roleBindings == ["reviewer=\(created.uuidString)"])
+    }
+  }
+
+  @Test func suggestionWithoutAnAgentOffersNoCreateAction() throws {
+    // dsl-spec §3 allows a `suggest` that omits `agent`; it cannot form a profile, so the
+    // sheet must not offer a dead Create action for it.
+    let context = try makeContext(
+      suggestion: WorkflowProfileSuggestion(reasoningEffort: "xhigh"), includeCandidates: false)
+    let state = WorkflowStartFeature.State(context: context)
+    #expect(!state.canCreateSuggestion(for: "reviewer"))
+
+    let piContext = try makeContext(
+      suggestion: WorkflowProfileSuggestion(agent: "pi"), includeCandidates: false)
+    #expect(WorkflowStartFeature.State(context: piContext).canCreateSuggestion(for: "reviewer"))
   }
 }

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -321,6 +321,37 @@ struct WorkflowStartFeatureTests {
     }
   }
 
+  @Test func suggestionOutsideTheRoleAgentListOffersNoCreateAction() async throws {
+    // dsl-spec §3: `agents: [pi]` with `suggest: { agent: claude }` is legal (validator
+    // warns only); creating that profile would be refused by admission as agentNotAllowed,
+    // so the sheet must not offer it — and a stray confirm must not persist anything.
+    let context = try makeContext(
+      suggestion: WorkflowProfileSuggestion(agent: "claude"), includeCandidates: false)
+    let state = WorkflowStartFeature.State(context: context)
+    #expect(!state.canCreateSuggestion(for: "reviewer"))
+
+    let storage = UserGlobalSettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/prowl-global-settings-\(UUID().uuidString).json")
+    try await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.userGlobalSettingsURL = url
+    } operation: {
+      var initial = WorkflowStartFeature.State(context: context)
+      initial.creatingSuggestionForRole = "reviewer"
+      initial.suggestionProfileName = "Sneaky"
+      let store = TestStore(initialState: initial) {
+        WorkflowStartFeature()
+      } withDependencies: {
+        $0.uuid = .incrementing
+      }
+      await store.send(.createSuggestionConfirmed) {
+        $0.creatingSuggestionForRole = nil
+      }
+      @Shared(.userGlobalSettings) var settings: UserGlobalSettings
+      #expect(settings.agentProfiles.isEmpty)
+    }
+  }
+
   @Test func suggestionWithoutAnAgentOffersNoCreateAction() throws {
     // dsl-spec §3 allows a `suggest` that omits `agent`; it cannot form a profile, so the
     // sheet must not offer a dead Create action for it.


### PR DESCRIPTION
Implements 063 C2 ([slice record](docs-ai/063-agent-workflows/011-c2-start-sheet.md), grilled 2026-09-01), the first R2b slice.

## What this is

R2a left exactly one way to start a workflow: `prowl workflow run` in a terminal. This PR gives GUI users the same power without changing what a run is — every start goes through the same coordinator, admission, and binding resolution the CLI uses, and the C1 status center takes over the moment the run exists.

**Three entry points:**

- **Command Palette**: `Run Workflow: <name>` per runnable workflow, refreshed when the palette opens.
- **Agents capsule popover**: a "Run a workflow" section — each row starts the workflow, its trailing `ellipsis.circle` is **Run with Options…** (forces the sheet; the GUI escape hatch matching an explicit CLI `--role`), and validation-failing files are listed dimmed with their reason (the popover is the diagnostic surface).
- **Active Agents row context menu**: **Run Workflow ▸** starts with that row's pane pinned as the `current` source; rows bound to an active run show an `in <workflow> · <role>` subtitle.

**The start sheet** (`WorkflowStartOverlay`, the handoff HUD's centered card pattern) collects what the run needs: a "You" source picker (the GUI equivalent of the CLI `[source]` argument), one profile picker per `launch` role pre-filled from binding resolution with rejection reasons on dimmed candidates and an inline **Create profile from suggestion…** confirm block, pane pickers for `pick` roles, inputs, per-step Skip choices with their §5 consequence (ends-run skips are never armed, matching admission), a "Don't ask again for this workflow" toggle, and a CLI-not-installed banner with inline Install. `bind: auto` with nothing undecided skips the sheet entirely — the toolbar status item is the start feedback.

## Mechanics

- `WorkflowStartClient` (assembled in the composition root) reads the same catalog/resolver/settings as the CLI path and submits through `WorkflowRuntimeCoordinator.run`; the GUI never grows its own run-creation logic.
- `WorkflowRunMachine.startSkipConsequence` exposes the existing start-time Skip rule for the sheet; the in-run Skip path is untouched.
- "Don't ask again" persists a tri-state per-workflow bind-mode override in `UserGlobalSettings` (D1's Settings page will drive the same value).
- Handoff is untouched (the HUD keeps its choose stage until D3).

## Verification

- `make check` clean; `make test` 2940+ tests, zero failures.
- New coverage: bind-mode override storage, start-time skip rule, `canStartImmediately`, and the full reducer surface (prefill, gating, skip/delivery interplay, CLI-vocabulary submission, don't-ask-again persistence, inline profile creation, failure surfacing).
- Live E2E and 061 visual verification (Normal/Shelf/Canvas) follow in review.

https://claude.ai/code/session_01M5cFnjhGxu2wxhB7yU48Yt
