### PR TITLE
Add the prowl-workflow bundled agent skill

### DIFF
--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -359,7 +359,7 @@ run …` replacement, then removal (see Built-ins).
   are deleted. A self-initiated run returns the first step's instruction and completion
   command in its response instead of typing them into the caller's own pane, so an agent's
   self-handoff stays two commands.
-- `skills/prowl-workflows/SKILL.md`: how to author and run workflows; `prowl workflow
+- `skills/prowl-workflow/SKILL.md`: how to author and run workflows; `prowl workflow
   schema` prints the machine-readable reference.
 
 ### Prerequisite interfaces (A1/A2) and test strategy
@@ -425,7 +425,7 @@ attaches hooks through A2's launch boundary.
 | **B3** | B | A2, 064-S1, B2, #733 | Runner wiring: reducer-owned `WorkflowRunsFeature` effects, per-activation `observeAgentDispatch` + `observeAgentState` watchdog streams, CLI admission preflight, `prowl workflow run/status/done/cancel` + contracts. Engine first powered on. |
 | **C1** | C | B3 | Status center fifth state + run panel + attention triggers + notifications (061 visual verification). Runs become visible. |
 | **C2** | C | B3 | Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu). GUI-initiated runs. |
-| **D1** | D | B1, C2, 065-K1 | `prowl-workflows` authoring skill (registered by adding it to `skills/`; embedding and the registry come from [065](../065-bundled-agent-skills/000-plan.md)), `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group. Distribution and docs. |
+| **D1** | D | B1, C2, 065-K1 | `prowl-workflow` authoring skill (registered by adding it to `skills/`; embedding and the registry come from [065](../065-bundled-agent-skills/000-plan.md)), `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group. Distribution and docs. |
 | **D2** | D | A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification (the exact-signal watchdog's first proof in a real flow). Proves the engine on a fresh flow before touching shipped behavior. |
 | **D3** | D | D2 | `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to\|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill. Migrate the shipped feature last. |
 | **V2** | — | — | observe mode (`expect.status` + `agents read` / hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor. |
@@ -656,3 +656,4 @@ attaches hooks through A2's launch boundary.
 - Updated 2026-08-22: Implemented A1b — `PROWL_PANE_ID` in every pane's environment, manual identity section, and the `prowl-cli` skill rewritten around it — see [004-pane-identity-env.md](004-pane-identity-env.md).
 - Updated 2026-08-22: Implemented A2 with the typed Profile launch boundary, prompted/background `create tab|pane`, and `profiles list`; the final A1/A2 Swift interface question is resolved — see [005-cli-profile-launch.md](005-cli-profile-launch.md).
 - Updated 2026-08-22: Hardened A2 after review: capped prompts bypass canonical PTY input through a zsh/bash/fish-portable surface-environment carrier command, launch failures retain typed reasons, interactive stdin/version skew fail closed, and hidden-worktree background selection is covered — see [005-cli-profile-launch.md](005-cli-profile-launch.md#review-hardening).
+- Updated 2026-09-04: The D1 authoring skill shipped early as `prowl-workflow` (#754) — the singular name supersedes `prowl-workflows`; see the release-plan change log.

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -120,7 +120,7 @@ touch B1's files); #733 must merge before B3 starts. Docs: `workflows.md` (CLI p
 | Order | Slice | Entry | Depends | Outcome |
 | --- | --- | --- | --- | --- |
 | 1 | **C2** start sheet + entry points (capsule popover, palette, Active Agents) | 063 | B3 | GUI-initiated runs |
-| 2 | **D1** `prowl-workflows` authoring skill (skills embedding from 065), `docs/components/workflows.md`, Settings › Workflows page, CLI reachability status (deferred from C0) | 063 | B1, C2, 065-K1 | custom workflows, agent-assisted authoring |
+| 2 | **D1** `prowl-workflow` authoring skill (shipped early in #754; skills embedding from 065), `docs/components/workflows.md`, Settings › Workflows page, CLI reachability status (deferred from C0) | 063 | B1, C2, 065-K1 | custom workflows, agent-assisted authoring |
 | 3 | **#726 T1** headless contract tests against the real tier-A binaries through the production renderers/decoder (`make test-agent-contracts`, passing runs update T0) | 064 | #726 T0, S3 wave 1 | hook contracts fail loudly on binary drift before D2's E2E leans on them |
 | 4 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | first built-in workflow |
 
@@ -194,6 +194,15 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 
 ## Change log
 
+- 2026-09-04 — The D1 authoring skill shipped ahead of the rest of D1 as `prowl-workflow`
+  (#754; singular, matching `prowl workflow …` and `prowl-cli` — the plan's `prowl-workflows`
+  name is superseded). Before merge it was driven end to end from fresh agents that saw only
+  the skill and the CLI: one ran an existing demo workflow, one authored and ran a new
+  two-agent workflow (validated first try, `close:` steps included), and a launched participant
+  loaded the skill from the typed `[Prowl] …` line. That pass surfaced the `max_rounds_reached`
+  trap (a loop is only left through a satisfied `until`; the "poor-man's if" is not an `if`),
+  now spelled out in the skill with a gave-up-verdict pattern. D1's remaining scope (Settings ›
+  Workflows page, `docs/components/workflows.md`, CLI reachability) is unchanged.
 - 2026-08-31 — R2a shipped in v2026.8.31: B1 #740, #733 #741, #726 T0 #739, B2 #743, B3 #744, C1 #747.
   The release also carried the display-sleep fix #746 and two external contributions (#748
   blocked-agent sidebar indicator, #749 fixture `--agent` validation). `make agent-versions` ran

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -6,7 +6,7 @@
 
 **Keywords:** prowl cli, command line, prowl list, prowl agents, prowl agents read, prowl agents signal, prowl agents dispatch, prowl agents wait, prowl profiles list, prowl skills, skills install, agent skills, prowl workflow, workflow status center, workflow run panel, workflow attention, prowl read, prowl send, prowl key, prowl focus, prowl create, prowl close, prowl open, prowl handoff, pane id, agent, profile, automation, json, capture, socket
 
-**Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
+**Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli`** (`skills/prowl-cli/SKILL.md`) and **`prowl-workflow`** (`skills/prowl-workflow/SKILL.md`) skills
 
 > This is the reference for the `prowl` binary. For an opinionated, safety-first
 > *workflow* guide (recipes, pitfalls, quoting), the repository also ships the
@@ -27,7 +27,7 @@ Palette → "Install Command Line Tool". This symlinks `prowl` into
 `/usr/local/bin` (prompting for admin if needed). The Settings page also shows
 the local Unix socket path `prowl` uses to reach the app (`PROWL_CLI_SOCKET`
 overrides it for both processes). Once `prowl` is installed, `prowl skills install` links
-the bundled `prowl-cli` skill into your agents' skill folders (see
+the bundled `prowl-cli` and `prowl-workflow` skills into your agents' skill folders (see
 [`prowl skills`](#prowl-skills)).
 
 ## Global options
@@ -473,7 +473,9 @@ Discover, validate, and **run** Agent Workflow definitions — YAML files
 three sources, later ones winning for the same id: the app bundle
 (`Prowl.app/Contents/Resources/workflows/`, ids `prowl.*` are reserved for it) <
 `~/.prowl/workflows/*.yaml` < `<repo>/.prowl/workflows/*.yaml`. `validate` and `schema` run
-**locally** and work with Prowl closed; every other subcommand needs the app.
+**locally** and work with Prowl closed; every other subcommand needs the app. The bundled
+`prowl-workflow` skill (`skills/prowl-workflow/SKILL.md`, linked by `prowl skills install`)
+teaches an agent to author, validate, run, and take part in workflows.
 
 ```bash
 prowl workflow list [target] [--json]                   # every definition visible to a worktree, with status

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -56,7 +56,7 @@ Legacy `~/.supacode` is migrated to `~/.prowl` on first launch.
 ## Agent Skills
 
 **Agents → CLI & Skills → Agent Skills** lists the user-installable skills bundled in
-the app (`Prowl.app/Contents/Resources/skills/`, today `prowl-cli`) and links them into
+the app (`Prowl.app/Contents/Resources/skills/`, today `prowl-cli` and `prowl-workflow`) and links them into
 your agents' skill folders so every agent reads the version that matches the installed
 app. It is the GUI for [`prowl skills`](cli.md#prowl-skills) in user scope and shows the
 same status as `prowl skills list`.

--- a/skills/prowl-workflow/SKILL.md
+++ b/skills/prowl-workflow/SKILL.md
@@ -49,13 +49,18 @@ prowl workflow status [run-id] [--json]       # no args inside a run: who am I /
 prowl workflow cancel <run-id> [--json]
 ```
 
-- `[source]` is a pane/tab/worktree reference (`pN`, `tN`, UUID, worktree name). Omitted:
-  the caller's own pane serves the `current` role; a workflow without a `current` role needs
-  a worktree. Required inputs without defaults must be passed via `--input k=v`.
-- The run is asynchronous: `run` returns the run id and frozen bindings; watch with
-  `prowl workflow status <run-id>` or read the run directory
-  (`<worktree root>/.prowl/workflow-runs/<run-id>/` — `log.md` is the timeline; layout and
-  error tables in `references/runbook.md`).
+- `[source]` is a pane/tab/worktree reference (`pN`, `tN`, UUID, or the worktree name that
+  `prowl workflow list` prints as `Worktree: <name>` — `main`, not the `Repo:main` label of
+  `prowl list`). Omitted inside a pane: that pane serves the `current` role and its worktree
+  is the run's; outside a pane the focused worktree is used, and a workflow with a `current`
+  role fails with `SOURCE_REQUIRED`. Required inputs without defaults must be passed via
+  `--input k=v`.
+- The run is asynchronous: `run` returns the run id and frozen bindings; poll
+  `prowl workflow status <run-id> --json` (`.data.status.state` is `running`,
+  `needs_attention`, or a terminal state; `.data.finished_at` appears when it ended) or read
+  the run directory (`<worktree root>/.prowl/workflow-runs/<run-id>/` — `log.md` is the
+  timeline; field guide, layout, and error tables in `references/runbook.md`). Finishing never
+  closes launched panes; only a `close:` step does.
 - The GUI starts (Command Palette, Agents capsule popover, Active Agents context menu) go
   through the same admission — behavior is identical to the CLI.
 

--- a/skills/prowl-workflow/SKILL.md
+++ b/skills/prowl-workflow/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: prowl-workflow
+description: >-
+  Author, validate, run, and participate in Prowl Agent Workflows — the `prowl.workflow/v1`
+  YAML files that orchestrate several live coding agents (launch, message, loop on verdicts,
+  collect outputs) inside the running Prowl app. Reach for this whenever the user wants a
+  workflow created or edited ("write me a Prowl workflow that has two agents review each
+  other", "add an input to the guessing-game workflow"), wants one executed ("use Prowl's
+  adversarial-review workflow on this branch", "run the count-files workflow", "跑一下
+  xxx workflow"), asks about a run's progress or its result files, or when a `[Prowl] …`
+  line with a `prowl workflow done` command appears in this pane — that means this agent is
+  a participant in a run and must deliver through the workflow protocol. Not for driving
+  individual panes directly (use prowl-cli) and not for Prowl settings/UI questions.
+metadata:
+  prowl-summary: Teaches an agent to write, validate, and run Prowl Agent Workflow YAML files, to act as a participant when a workflow messages it, and to read a run's logs and output files. Link it into a runtime's skill folder so the agent can build and drive multi-agent workflows on request.
+---
+
+# Prowl Agent Workflows
+
+A workflow is one YAML file (`schema: prowl.workflow/v1`) that scripts several live agents:
+who takes part (`roles`), and what happens in order (`steps` — launch an agent, message one,
+loop until a verdict, ring a notification, close a pane). The running Prowl app executes it;
+every participant is a real terminal pane. Definitions are discovered from three sources,
+later shadowing earlier by id: the app bundle (ids `prowl.*`, reserved), user
+(`~/.prowl/workflows/*.yaml`), repo (`<repo root>/.prowl/workflows/*.yaml`).
+
+Pick the section for the task; load a reference file only when that task is at hand:
+
+| Task | Where |
+| --- | --- |
+| Write or edit a workflow | read [references/authoring.md](references/authoring.md) first — full DSL, validator rules, patterns, worked example |
+| Start a workflow, inspect or debug a run, decode an error | [Running](#running-a-workflow) below; details in [references/runbook.md](references/runbook.md) |
+| A `[Prowl] …` line appeared in this pane | [Participating](#participating-in-a-run) below |
+
+## Authoring loop
+
+Draft → `prowl workflow validate <file>` → fix → place the file → run. Validation is static
+and strict; if it passes, the file is runnable. `validate` and `prowl workflow schema` (the
+authoritative JSON Schema) work with Prowl closed. Never hand over an unvalidated workflow,
+and read `references/authoring.md` before drafting — several rules are not guessable.
+
+## Running a workflow
+
+```bash
+prowl workflow list [--json]                  # what this worktree can see, with validation status
+prowl workflow run <id|name> [source] \
+    [--role r=<profile|auto|pN>] [--input k=v] [--skip <step-id>] [--json]
+prowl workflow status [run-id] [--json]       # no args inside a run: who am I / what is awaited
+prowl workflow cancel <run-id> [--json]
+```
+
+- `[source]` is a pane/tab/worktree reference (`pN`, `tN`, UUID, worktree name). Omitted:
+  the caller's own pane serves the `current` role; a workflow without a `current` role needs
+  a worktree. Required inputs without defaults must be passed via `--input k=v`.
+- The run is asynchronous: `run` returns the run id and frozen bindings; watch with
+  `prowl workflow status <run-id>` or read the run directory
+  (`<worktree root>/.prowl/workflow-runs/<run-id>/` — `log.md` is the timeline; layout and
+  error tables in `references/runbook.md`).
+- The GUI starts (Command Palette, Agents capsule popover, Active Agents context menu) go
+  through the same admission — behavior is identical to the CLI.
+
+## Participating in a run
+
+When a line like this appears in the pane, this agent is a workflow participant:
+
+```
+[Prowl] <instruction…> — finish with: PROWL_WORKFLOW_TOKEN=<token> prowl workflow done [--verdict <v>] -
+```
+
+1. Do the work the instruction asks for, completely, before delivering.
+2. Deliver by running the **exact rendered command** with the body on stdin as markdown
+   (`printf '…' | PROWL_WORKFLOW_TOKEN=… prowl workflow done -`). When verdict variants are
+   offered, pick exactly one and run that variant.
+3. Include the declared sections; an empty body is rejected, and a body missing declared
+   sections/verdict is held as provisional and bothers the user — deliver properly instead.
+4. Lost? `prowl workflow status` (no arguments) answers "who am I": this pane's run, role,
+   awaited step, its requirements and completion command.
+5. Never use `prowl agents dispatch-complete` for a workflow activation — it is rejected
+   with `WORKFLOW_DELIVERY_REQUIRED` naming the correct command.
+6. A launched participant finds the same contract in its kickoff prompt ("Prowl workflow
+   completion protocol"), with the token already in its environment as
+   `PROWL_WORKFLOW_TOKEN`.
+
+This skill ships inside the app: `prowl skills install prowl-workflow` links it into every
+detected agent skill folder; `prowl skills list` shows per-target status. `prowl-cli` is
+the companion skill for driving individual panes outside a workflow.

--- a/skills/prowl-workflow/references/authoring.md
+++ b/skills/prowl-workflow/references/authoring.md
@@ -20,6 +20,7 @@ icon: magnifyingglass.circle      # optional SF Symbol
 
 inputs:
   focus: { type: string, prompt: "What should the reviewer focus on?" }  # no default = required
+  depth: { type: enum, values: [quick, deep], default: quick }            # enum needs `values`; default must be one of them
   max_rounds: { type: integer, default: 3, min: 1, max: 10 }
 
 roles:
@@ -27,8 +28,8 @@ roles:
     source: current               # the pane the run starts from (at most one per workflow)
   reviewer:
     source: launch                # Prowl starts a new agent for this role
-    kind: interactive
-    agents: [claude, codex]       # allow-list of runtime tokens; omit = any launchable
+    kind: interactive             # optional; the only V1 kind
+    agents: [claude, codex]       # allow-list of runtime tokens (see Roles); omit = any launchable
     suggest: { agent: claude }    # used by binding resolution; never a profile name/UUID
     bind: ask                     # ask = start sheet always shows the picker; auto = silent when unambiguous
     placement: split              # split | tab
@@ -47,10 +48,11 @@ steps:
   - id: launch-reviewer
     title: "Reviewer starting"
     launch: reviewer
-    prompt: "Read {{ outputs.brief.path }} and review the work it describes. Deliver '## Findings' and choose a verdict."
+    prompt: "Read {{ outputs.brief.path }} and do a {{ inputs.depth }} review of the work it describes. Deliver '## Findings' and choose a verdict."
     expect: { output: findings, sections: ["## Findings"], verdict: [clean, issues], timeout: 30m }
 
   - id: rounds
+    title: "Reconciling findings"
     repeat:
       max: "{{ inputs.max_rounds }}"     # positive literal 1–20, or exactly one integer input
       until: outputs.findings.verdict == clean
@@ -73,6 +75,14 @@ steps:
     close: reviewer                # closes only the pane this run launched; no confirmation
 ```
 
+## Inputs
+
+Each `inputs.<name>` entry declares a start-time value by `type`: `integer` (optional
+`min`/`max`; a default must lie inside them), `string` (one line, no control characters), or
+`enum` (`values` is required; a default must be one of them). An input without `default` is
+required: the GUI start sheet asks for it (`prompt` is its label) and the CLI needs
+`--input name=value`. Inputs reach steps only through `{{ inputs.<name> }}` and `repeat.max`.
+
 ## Roles
 
 | `source` | Meaning | Key facts |
@@ -87,6 +97,11 @@ resolves silently when unambiguous. The CLI never shows UI — resolution just r
 preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`), never a profile
 name or UUID.
 
+`agents` lists runtime tokens — the agent column of `prowl profiles list`: `claude`, `codex`,
+`gemini`, `pi`, `omp`, `opencode`, `droid`, `cursor-agent`, `copilot`, `kimi`, `amp`,
+`qodercli`, `qwen`, `grok`, `cline`. An unknown token, or a list no installed agent
+satisfies, is a validation warning. `kind` may be omitted (`interactive` is the only V1 kind).
+
 ## Step verbs
 
 Each step has a unique `id`, an optional templated `title` (shown in the status center),
@@ -95,11 +110,11 @@ and exactly one verb:
 | Verb | Payload | Rules |
 | --- | --- | --- |
 | `message: <role>` | `text` (one line, typed into the pane) or `instruction` (multi-line, materialized to a file; a pointer line is typed) | target must be alive: `current`, `pick`, or a `launch` role **after** its launch step. Injected only when the role is idle — a working role queues the step, a blocked one raises attention |
-| `launch: <role>` | `prompt` (templated kickoff), optional `skill` (bundled skill id) | once per role per run; rendered prompt ≤ 32 KiB |
+| `launch: <role>` | `prompt` (templated kickoff; may span lines as a YAML `\|` block), optional `skill` (bundled skill id) | once per role per run; rendered prompt ≤ 32 KiB, no NUL |
 | `action: <id>` | `with` (templated map) | native built-ins: `git.context`, `handoff.transition`, `handoff.checkpoint`; synchronous typed outputs under `{{ actions.<step>.<key> }}`; `prowl workflow schema` prints their input/output schemas; cannot carry `expect` |
 | `notify: <text>` | — | notification bell; click focuses the `current` role's pane (or the source worktree) |
 | `close: <role>` | — | `launch` roles only, no confirmation; a cancelled run never closes panes |
-| `repeat` | `max` (required), `until` (optional), sibling `steps` | while-loop: `until` is checked before entry and after each iteration and compares one declared verdict only (`outputs.<n>.verdict == v` / `in [..]`); no nesting, no `launch` inside; reaching `max` unsatisfied ends the run as `max_rounds_reached` |
+| `repeat` | `max` (required), `until` (optional), sibling `steps` | while-loop: `until` is checked before entry and after each iteration and compares one declared verdict only (`outputs.<n>.verdict == v` / `in [..]`); no nesting, no `launch` inside. A satisfied `until` is the **only** way past a loop: reaching `max` with it unsatisfied — or a loop with no `until` at all — ends the run as `max_rounds_reached` and no later step runs (see the patterns below) |
 
 ## `expect` — waiting for a delivery
 
@@ -113,8 +128,8 @@ expect:
   format: markdown          # markdown (default) | text | json
   sections: ["## Findings"] # required headings (case/level-forgiving; fenced code ignored)
   verdict: [clean, issues]  # 2–4 slugs; makes --verdict mandatory and drives `until`
-  timeout: 30m              # optional hard cap; NO default — omit to wait as long as the agent works
-  on_timeout: attention     # attention (default) | skip | cancel
+  timeout: 30m              # optional hard cap as <n>s|m|h (90s, 10m, 2h); NO default — omit to wait as long as the agent works
+  on_timeout: attention     # only together with timeout; attention (default) | skip | cancel
   strict: false             # false: a delivery missing sections/format/verdict is kept as
                             # provisional and the run asks the user; true: rejected outright
 ```
@@ -131,6 +146,10 @@ warns); the runner's renderer is the only source of that command.
 `{{ outputs.<name>.verdict }}`, `{{ actions.<step>.<key> }}`, `{{ inputs.<k> }}`,
 `{{ loop.index }}`, `{{ loop.count }}`.
 
+`loop.index` is the 1-based round inside a `repeat`; `loop.count` is the number of completed
+rounds of the latest loop, valid inside and after it, and renders `0` after a loop that was
+skipped before entry.
+
 There are no expressions and **no inlined output text** (`outputs.<name>.text` does not
 exist). Content moves between agents by path — the receiver reads the file, which costs an
 agent nothing. An agent-produced value can reach templates only as a verdict. Referencing
@@ -145,7 +164,8 @@ an output at a point where no earlier step could have produced it is a validatio
 - At most one `current` role; `launch` at most once per role; `repeat` not nested, no
   `launch` inside; `max` is 1–20 (a literal, or a template naming exactly one integer input).
 - `verdict` is 2–4 slug values; `until` literals must belong to the declared set.
-- `expect` only on `message` and `launch` steps.
+- `expect` only on `message` and `launch` steps; `on_timeout` only next to a `timeout`;
+  `min`/`max` only on `integer` inputs, `values` only on `enum` inputs.
 - A skippable step (`--skip` / the start sheet's Skip) is one whose output has no
   non-optional consumer; skipping a step whose output a later template needs ends the run
   instead of advancing, and the validator/panel names the dependent step.
@@ -155,9 +175,16 @@ an output at a point where no earlier step could have produced it is a validatio
 - **Seed delivery**: before a loop whose body references `{{ outputs.reply.path }}`, have an
   opening step deliver `reply` once (e.g. with a spare verdict value like `ready`) so the
   first iteration's reference has a producer.
-- **Poor-man's `if`**: `repeat: { max: 1, until: outputs.x.verdict == ok }` runs its body
-  exactly once when the verdict is not `ok` and skips it entirely otherwise (`until` is
-  evaluated before entry).
+- **Poor-man's `if`**: `repeat: { max: 1, until: outputs.x.verdict == ok }` skips its body when
+  the verdict is already `ok` (`until` is evaluated before entry) and runs it once otherwise.
+  It is only an `if` when that one round is certain to make the verdict `ok`: if it does not,
+  the run ends as `max_rounds_reached` right there.
+- **Bounded loop that must go on**: V1 has no "try N times, then continue regardless". Reserve
+  a verdict for giving up — `verdict: [agree, disagree, gave_up]` with
+  `until: outputs.check.verdict in [agree, gave_up]` — and tell the agent in the loop body to
+  choose it on the last round (`Round {{ loop.index }} of {{ inputs.max_rounds }}`); the
+  steps after the loop (notify, close) then always run. Otherwise accept `max_rounds_reached`
+  as an outcome: the status center reports it and launched panes stay open for inspection.
 - **Fork / ordered join**: expect-less `launch` steps return immediately, so two workers run
   wall-clock concurrently; join by messaging each in turn with an `expect`. Phrase the fork
   prompt as "do the work now, deliver only when asked" and the join as "deliver when your

--- a/skills/prowl-workflow/references/authoring.md
+++ b/skills/prowl-workflow/references/authoring.md
@@ -1,0 +1,179 @@
+# Authoring Prowl Workflows
+
+Full reference for writing `prowl.workflow/v1` files. The JSON Schema from
+`prowl workflow schema` is authoritative for field shapes; this file adds the rules a
+schema cannot express and the patterns that work. Validate every draft with
+`prowl workflow validate <file>` — it is static, strict, and fast, and its errors carry
+line numbers.
+
+## Worked example
+
+One existing agent, one launched reviewer, a verdict loop, and an input — most of the
+machinery in ~60 lines:
+
+```yaml
+schema: prowl.workflow/v1
+id: myteam.quick-review           # slug; never the reserved `prowl.` prefix
+name: Quick Review
+description: A launched reviewer checks this pane's work until it is clean.
+icon: magnifyingglass.circle      # optional SF Symbol
+
+inputs:
+  focus: { type: string, prompt: "What should the reviewer focus on?" }  # no default = required
+  max_rounds: { type: integer, default: 3, min: 1, max: 10 }
+
+roles:
+  author:
+    source: current               # the pane the run starts from (at most one per workflow)
+  reviewer:
+    source: launch                # Prowl starts a new agent for this role
+    kind: interactive
+    agents: [claude, codex]       # allow-list of runtime tokens; omit = any launchable
+    suggest: { agent: claude }    # used by binding resolution; never a profile name/UUID
+    bind: ask                     # ask = start sheet always shows the picker; auto = silent when unambiguous
+    placement: split              # split | tab
+    direction: right              # split only: right | left | up | down
+    background: false             # true = do not steal focus
+
+steps:
+  - id: brief
+    title: "Author writing the brief"
+    message: author               # multi-line content -> use `instruction`; single line -> `text`
+    instruction: |
+      Summarize what you just built and how to verify it, focusing on {{ inputs.focus }}.
+      Deliver the summary with the generated completion command.
+    expect: { output: brief, timeout: 15m }
+
+  - id: launch-reviewer
+    title: "Reviewer starting"
+    launch: reviewer
+    prompt: "Read {{ outputs.brief.path }} and review the work it describes. Deliver '## Findings' and choose a verdict."
+    expect: { output: findings, sections: ["## Findings"], verdict: [clean, issues], timeout: 30m }
+
+  - id: rounds
+    repeat:
+      max: "{{ inputs.max_rounds }}"     # positive literal 1–20, or exactly one integer input
+      until: outputs.findings.verdict == clean
+    steps:                               # NOTE: `steps` is a SIBLING of `repeat:`, not nested inside it
+      - id: fix
+        title: "Round {{ loop.index }}: author fixing"
+        message: author
+        text: "Address every finding in {{ outputs.findings.path }}, then deliver your disposition."
+        expect: { output: disposition, timeout: 30m }
+      - id: rereview
+        title: "Round {{ loop.index }}: reviewer re-checking"
+        message: reviewer
+        text: "Re-review against {{ outputs.disposition.path }} and deliver new findings with a verdict."
+        expect: { output: findings, verdict: [clean, issues], timeout: 30m }
+
+  - id: done
+    notify: "Quick review: {{ outputs.findings.verdict }} after {{ loop.count }} round(s)"
+
+  - id: cleanup
+    close: reviewer                # closes only the pane this run launched; no confirmation
+```
+
+## Roles
+
+| `source` | Meaning | Key facts |
+| --- | --- | --- |
+| `current` | the pane the run was started from | at most one per workflow; needs a live agent only if an unskipped `message` targets it; a workflow with no `current` role runs against a worktree instead |
+| `launch` | Prowl launches a new agent | V1 `kind: interactive` only; the profile is chosen at start by binding resolution (remembered binding → exact `suggest` match → Recommended profile filtered by `agents` → ask) and frozen into the run |
+| `pick` | an existing detected agent pane in the source worktree, chosen at start | always explicit: the GUI start sheet shows a pane picker, the CLI requires `--role <role>=<pN\|pane UUID>`; panes already in a run are not offered |
+
+`bind: ask` (default) always shows the role's picker in the GUI start sheet; `bind: auto`
+resolves silently when unambiguous. The CLI never shows UI — resolution just runs, and
+`--role <launch-role>=<profile name|uuid|auto>` overrides it. `suggest` takes profile
+preset fields (`agent`, `model`, `reasoning_effort`, `execution_mode`), never a profile
+name or UUID.
+
+## Step verbs
+
+Each step has a unique `id`, an optional templated `title` (shown in the status center),
+and exactly one verb:
+
+| Verb | Payload | Rules |
+| --- | --- | --- |
+| `message: <role>` | `text` (one line, typed into the pane) or `instruction` (multi-line, materialized to a file; a pointer line is typed) | target must be alive: `current`, `pick`, or a `launch` role **after** its launch step. Injected only when the role is idle — a working role queues the step, a blocked one raises attention |
+| `launch: <role>` | `prompt` (templated kickoff), optional `skill` (bundled skill id) | once per role per run; rendered prompt ≤ 32 KiB |
+| `action: <id>` | `with` (templated map) | native built-ins: `git.context`, `handoff.transition`, `handoff.checkpoint`; synchronous typed outputs under `{{ actions.<step>.<key> }}`; `prowl workflow schema` prints their input/output schemas; cannot carry `expect` |
+| `notify: <text>` | — | notification bell; click focuses the `current` role's pane (or the source worktree) |
+| `close: <role>` | — | `launch` roles only, no confirmation; a cancelled run never closes panes |
+| `repeat` | `max` (required), `until` (optional), sibling `steps` | while-loop: `until` is checked before entry and after each iteration and compares one declared verdict only (`outputs.<n>.verdict == v` / `in [..]`); no nesting, no `launch` inside; reaching `max` unsatisfied ends the run as `max_rounds_reached` |
+
+## `expect` — waiting for a delivery
+
+A `message` or `launch` step with `expect` waits until the target agent explicitly delivers
+via `prowl workflow done`; without one the step is fire-and-forget — the run advances the
+moment injection/launch succeeds, and there is no "wait without delivery" in V1.
+
+```yaml
+expect:
+  output: findings          # name for the delivery; default = the step id
+  format: markdown          # markdown (default) | text | json
+  sections: ["## Findings"] # required headings (case/level-forgiving; fenced code ignored)
+  verdict: [clean, issues]  # 2–4 slugs; makes --verdict mandatory and drives `until`
+  timeout: 30m              # optional hard cap; NO default — omit to wait as long as the agent works
+  on_timeout: attention     # attention (default) | skip | cancel
+  strict: false             # false: a delivery missing sections/format/verdict is kept as
+                            # provisional and the run asks the user; true: rejected outright
+```
+
+Prowl appends the completion command itself — the typed line or kickoff prompt ends with
+the exact `PROWL_WORKFLOW_TOKEN=… prowl workflow done [--verdict v] -` to run. **Never
+write `prowl workflow done` into your own `text`/`instruction`/`prompt`** (the validator
+warns); the runner's renderer is the only source of that command.
+
+## Templates (whitelist; substitution only)
+
+`{{ run.id }}`, `{{ run.dir }}`, `{{ worktree.path|name|branch }}`,
+`{{ roles.<r>.name|agent|pane }}`, `{{ outputs.<name>.path }}`,
+`{{ outputs.<name>.verdict }}`, `{{ actions.<step>.<key> }}`, `{{ inputs.<k> }}`,
+`{{ loop.index }}`, `{{ loop.count }}`.
+
+There are no expressions and **no inlined output text** (`outputs.<name>.text` does not
+exist). Content moves between agents by path — the receiver reads the file, which costs an
+agent nothing. An agent-produced value can reach templates only as a verdict. Referencing
+an output at a point where no earlier step could have produced it is a validation error
+(see the seed pattern below). `roles.<r>.pane` is valid only after that role's launch step.
+
+## Rules the validator enforces (write with these in mind)
+
+- `steps` is a **sibling** of `repeat:` — nesting it inside `repeat` is the classic mistake.
+- `text`, rendered lines, and string inputs are single-line; no control characters.
+- `message`/`close` on a `launch` role must come after its launch step.
+- At most one `current` role; `launch` at most once per role; `repeat` not nested, no
+  `launch` inside; `max` is 1–20 (a literal, or a template naming exactly one integer input).
+- `verdict` is 2–4 slug values; `until` literals must belong to the declared set.
+- `expect` only on `message` and `launch` steps.
+- A skippable step (`--skip` / the start sheet's Skip) is one whose output has no
+  non-optional consumer; skipping a step whose output a later template needs ends the run
+  instead of advancing, and the validator/panel names the dependent step.
+
+## Patterns that work
+
+- **Seed delivery**: before a loop whose body references `{{ outputs.reply.path }}`, have an
+  opening step deliver `reply` once (e.g. with a spare verdict value like `ready`) so the
+  first iteration's reference has a producer.
+- **Poor-man's `if`**: `repeat: { max: 1, until: outputs.x.verdict == ok }` runs its body
+  exactly once when the verdict is not `ok` and skips it entirely otherwise (`until` is
+  evaluated before entry).
+- **Fork / ordered join**: expect-less `launch` steps return immediately, so two workers run
+  wall-clock concurrently; join by messaging each in turn with an `expect`. Phrase the fork
+  prompt as "do the work now, deliver only when asked" and the join as "deliver when your
+  work is complete" — an agent that backgrounds its work reads as idle, so an early
+  "deliver now" can arrive before the work is done.
+- **Broadcast**: several steps delivering to one output name makes `outputs/<name>.md` a
+  shared "latest announcement" file any role can be pointed at.
+- **Conditional behavior** ("whoever won writes the summary") lives in prompts, not the
+  DSL: ask every candidate and let each decide from the run's files. It is a contract with
+  the model, not a guarantee — keep such prompts explicit about both branches.
+- Launch busy helper roles with `background: true` so runs don't steal the user's focus;
+  keep the pane the user should watch in the foreground.
+
+## Placement and ids
+
+User workflows go to `~/.prowl/workflows/<file>.yaml`; repo workflows to
+`<repo root>/.prowl/workflows/<file>.yaml` (shadowing the user file with the same id for
+that repo). Ids are slugs; the `prowl.` prefix is reserved for bundled workflows and
+rejected elsewhere. The file name is free; the id is the identity.

--- a/skills/prowl-workflow/references/runbook.md
+++ b/skills/prowl-workflow/references/runbook.md
@@ -33,33 +33,58 @@ invocation shapes).
   action's optional `with` input; any other reference (`text`/`instruction`/`prompt`/
   `notify` templates, a `repeat` `until`) ends the run as `skipped` — the consequence is
   computed and shown before the skip is confirmed.
-- `prowl workflow cancel <run-id>` revokes all outstanding delivery tokens and never closes
-  panes; only an explicit `close:` step (authored by the workflow) closes a pane the run
-  launched.
-- Run states: `completed`, `max_rounds_reached` (a `repeat` hit `max` with `until`
-  unsatisfied — steps after the loop do NOT execute), `skipped`, `cancelled`, plus failure
-  states surfaced through the status center.
+- Neither finishing nor `prowl workflow cancel <run-id>` (which revokes all outstanding
+  delivery tokens) closes a pane: a `completed` run leaves every launched pane open unless an
+  explicit `close:` step (authored by the workflow) closed it.
+- Run states (`status.state`): `running`, `needs_attention` (the panel waits for the user),
+  then one terminal state — `completed`, `max_rounds_reached` (a `repeat` hit `max` with
+  `until` unsatisfied, or had no `until` — steps after the loop do NOT execute), `skipped`
+  (a skipped output had a consumer), `cancelled`, or `interrupted` (left unfinished by an
+  earlier app instance; V1 does not resume it).
+
+## Watching a run
+
+`prowl workflow status <run-id> --json` is the poll target (the text form omits timestamps):
+
+- `.data.status.state` — see the states above; `.data.finished_at` is set once the run ended.
+  `.data.status.attention` (`reason`, `message`, `step`, `actions`) explains a `needs_attention`.
+- `.data.step` — the step in progress; `.data.activation` — the awaited delivery (`step`,
+  `role`, `output`, `state` `waiting` | `persisting` | `provisional`, `ordinal`, `deadline`,
+  and `expect.completion[]`, the exact commands that complete it).
+- `.data.outputs.<name>` — the latest accepted delivery (`path`, `latest_path`, `ordinal`,
+  `verdict`); `.data.bindings` and `.data.run_directory` are frozen at start.
+- `.data.started_at` / `.data.finished_at` carry milliseconds; `log.md` and `run.json` round
+  to seconds.
+- `.data.source` is `live`, or `record` after an app restart (read back from `run.json`: no
+  activation, no tokens). Without a run id the command answers for the calling pane only and
+  is `RUN_NOT_FOUND` when that pane is not in an active run.
 
 ## Reading a run afterwards
 
 Everything lives under the source worktree:
 
 ```
-<worktree root>/.prowl/workflow-runs/<run-id>/
+<worktree root>/.prowl/workflow-runs/<run-id>/   # self-ignored by Git
 ├── log.md                       # timestamped timeline (start here)
-├── run.json                     # machine record: bindings, invocation map, activations
+├── run.json                     # machine record: bindings, invocations, step states, outputs
 ├── outputs/
 │   ├── <name>.<ordinal>.md      # the ledger — one immutable file per delivery
 │   └── <name>.md                # "latest" view, replaced atomically on each delivery
-└── instructions/
-    └── <step>.<ordinal>.md      # materialized multi-line instructions for message steps
+├── instructions/
+│   └── <step>.<ordinal>.md      # `instruction:` bodies of message steps (empty for `text:` steps)
+└── skills/
+    └── <id>/SKILL.md            # bundled skills named by `launch … skill:` (empty otherwise)
 ```
 
 - `log.md` records every launch (with the frozen profile and pane id), wait, nudge,
   delivery, loop round, skip, and the final state — it answers "what happened" without
   asking any agent.
-- **Ordinals** are run-global and monotonic across all steps and iterations (fire-and-forget
-  steps consume them too), so sorting the ledger by number replays the run in order.
+- **Invocation ordinals** — `log.md` says `(invocation 4)`, `run.json` lists them under
+  `invocations[]` — are run-global and monotonic across all steps and iterations
+  (fire-and-forget steps consume them too), so sorting the ledger by number replays the run
+  in order. A `repeat` whose `until` was already satisfied before entry is recorded in
+  `run.json` with step state `skipped`: the loop was skipped, unrelated to the run's `skipped`
+  terminal state.
 - `<name>.md` always holds the newest accepted delivery of that name: deliveries are
   serialized, persisted before the run advances, and the file is swapped via atomic rename —
   a reader never sees a half-written or stale-after-advance file.
@@ -86,6 +111,9 @@ Every awaited step mints a fresh token for its activation; Skip/Cancel/Relaunch 
 | `SOURCE_REQUIRED` | the workflow has a `current` role and the call wasn't made from a pane — pass a source |
 | `INVALID_ARGUMENT` | bad `--input` value, unknown/duplicate `--role`, or a `--skip` on a step another step depends on (the message names it) |
 | `PANE_BUSY` | the pane chosen for a `pick` role already belongs to a run |
+| `DISPATCH_PENDING` | a `pick` pane still holds a pending `prowl agents dispatch`; complete or abandon it first |
+| `TARGET_NOT_FOUND` / `AGENT_NOT_FOUND` | the source or `--role` pane/worktree does not exist, or a `pick` pane hosts no detected agent |
+| `RUN_NOT_FOUND` | no such run id, or `status` without an id from a pane that is not in an active run |
 | `PROFILE_NOT_FOUND` / `PROFILE_NOT_UNIQUE` | a `--role` override doesn't match exactly one enabled profile |
 | `TOKEN_REQUIRED` / `TOKEN_INVALID` / `STEP_NOT_EXPECTING` | delivering without/with a stale token, or the step has moved on — check `prowl workflow status` |
 | `OUTPUT_INVALID` / `VERDICT_REQUIRED` / `OUTPUT_TOO_LARGE` | empty body / missing mandatory verdict under `strict` / body over the cap |

--- a/skills/prowl-workflow/references/runbook.md
+++ b/skills/prowl-workflow/references/runbook.md
@@ -1,0 +1,93 @@
+# Run Runbook
+
+What happens when a workflow runs, how to observe it, and how to read what it leaves
+behind. Commands: `prowl workflow list | run | status | cancel` (see SKILL.md for the
+invocation shapes).
+
+## What happens at start
+
+1. **Admission** validates the definition, the source (pane or worktree), inputs, `--role`
+   overrides, and `--skip` choices; errors use the codes below.
+2. **Binding resolution** picks a profile for every `launch` role: remembered binding →
+   enabled profile matching `suggest` exactly → the worktree's Recommended profile filtered
+   by `agents` → ask. In the GUI, `bind: ask` roles (and any ambiguity or missing required
+   input) present the start sheet; `bind: auto` with nothing undecided starts silently. The
+   CLI never shows UI; unresolved bindings fail instead — pass `--role r=<profile|auto>`.
+3. Chosen bindings and rendered launch plans are **frozen into the run** — later profile
+   edits do not affect it. The `run` response (with `--json`) carries the run id and every
+   frozen binding.
+
+## While it runs
+
+- Steps execute strictly in order; one step is active at a time. A `message` step injects
+  only when its target is idle — the run sits in "waiting for role to be idle" while the
+  agent works. Nothing is ever typed into a busy pane.
+- Waiting is supervised by a state-driven watchdog, not wall-clock: a working agent is
+  never interrupted; an agent whose turn ends without delivering gets one typed nudge with
+  the completion command; `expect.timeout` (when declared) is the hard cap.
+- Attention states (timeout with `on_timeout: attention`, provisional deliveries under
+  `strict: false`, blocked agents) pause the step and surface in Prowl's status center for
+  the user to resolve (Accept / Ask again / Skip / Cancel); the CLI sees them in
+  `prowl workflow status`.
+- Skipping a step marks its output missing. A missing output is tolerated only by an
+  action's optional `with` input; any other reference (`text`/`instruction`/`prompt`/
+  `notify` templates, a `repeat` `until`) ends the run as `skipped` — the consequence is
+  computed and shown before the skip is confirmed.
+- `prowl workflow cancel <run-id>` revokes all outstanding delivery tokens and never closes
+  panes; only an explicit `close:` step (authored by the workflow) closes a pane the run
+  launched.
+- Run states: `completed`, `max_rounds_reached` (a `repeat` hit `max` with `until`
+  unsatisfied — steps after the loop do NOT execute), `skipped`, `cancelled`, plus failure
+  states surfaced through the status center.
+
+## Reading a run afterwards
+
+Everything lives under the source worktree:
+
+```
+<worktree root>/.prowl/workflow-runs/<run-id>/
+├── log.md                       # timestamped timeline (start here)
+├── run.json                     # machine record: bindings, invocation map, activations
+├── outputs/
+│   ├── <name>.<ordinal>.md      # the ledger — one immutable file per delivery
+│   └── <name>.md                # "latest" view, replaced atomically on each delivery
+└── instructions/
+    └── <step>.<ordinal>.md      # materialized multi-line instructions for message steps
+```
+
+- `log.md` records every launch (with the frozen profile and pane id), wait, nudge,
+  delivery, loop round, skip, and the final state — it answers "what happened" without
+  asking any agent.
+- **Ordinals** are run-global and monotonic across all steps and iterations (fire-and-forget
+  steps consume them too), so sorting the ledger by number replays the run in order.
+- `<name>.md` always holds the newest accepted delivery of that name: deliveries are
+  serialized, persisted before the run advances, and the file is swapped via atomic rename —
+  a reader never sees a half-written or stale-after-advance file.
+- Output bodies are capped (1 MiB default, 4 MiB hard maximum).
+- To summarize or debug a finished run: read `log.md`, then walk `outputs/` in ordinal
+  order; `run.json` maps each ordinal to its step and loop iteration.
+
+## Where the delivery token travels
+
+Every awaited step mints a fresh token for its activation; Skip/Cancel/Relaunch revoke it.
+
+- **Launched roles**: the token is in the pane's environment as `PROWL_WORKFLOW_TOKEN`, and
+  the kickoff prompt's protocol block spells the bare `prowl workflow done [--verdict v] -`.
+- **Messaged panes** (`current`/`pick`): the token rides the typed line as an environment
+  prefix — the command in the `[Prowl] …` line is complete and directly executable.
+- Delivery requires the caller pane and the token to agree; a stale, duplicated, or
+  token-less delivery is rejected instead of misattributed.
+
+## Common errors
+
+| Error | Meaning / fix |
+| --- | --- |
+| `WORKFLOW_NOT_FOUND` / `WORKFLOW_INVALID` | wrong id, or the file fails validation — run `prowl workflow validate` on it |
+| `SOURCE_REQUIRED` | the workflow has a `current` role and the call wasn't made from a pane — pass a source |
+| `INVALID_ARGUMENT` | bad `--input` value, unknown/duplicate `--role`, or a `--skip` on a step another step depends on (the message names it) |
+| `PANE_BUSY` | the pane chosen for a `pick` role already belongs to a run |
+| `PROFILE_NOT_FOUND` / `PROFILE_NOT_UNIQUE` | a `--role` override doesn't match exactly one enabled profile |
+| `TOKEN_REQUIRED` / `TOKEN_INVALID` / `STEP_NOT_EXPECTING` | delivering without/with a stale token, or the step has moved on — check `prowl workflow status` |
+| `OUTPUT_INVALID` / `VERDICT_REQUIRED` / `OUTPUT_TOO_LARGE` | empty body / missing mandatory verdict under `strict` / body over the cap |
+| `WORKFLOW_DELIVERY_REQUIRED` | `dispatch-complete` was used inside a workflow activation — run the `prowl workflow done` command the error echoes |
+| `PROMPT_TOO_LARGE` / `RENDERED_TEXT_INVALID` | a rendered launch prompt over 32 KiB / a rendered line that isn't one clean terminal line — shorten, or move content into an `instruction` |


### PR DESCRIPTION
Front-runs the authoring-skill half of 063 D1 ([release plan](docs-ai/063-agent-workflows/release-plan.md), slice D1).

## What this is

Workflows can be started from the CLI (R2a) and the GUI (C2/#752), but *creating* one still requires reading the DSL spec inside this repo — nothing teaches an arbitrary coding agent how to write, run, or take part in a workflow. This PR adds the bundled `prowl-workflow` agent skill: once linked (`prowl skills install prowl-workflow`), a user can tell **their own agent** "write me a workflow that…" or "use Prowl's X workflow for this" and the agent knows the contract.

Structured per agent-skills conventions (lean entry file, progressive disclosure):

- `skills/prowl-workflow/SKILL.md` — trigger description, task routing, the run commands, and the participant protocol (the time-critical part: what to do when a `[Prowl] … prowl workflow done` line appears in your pane).
- `references/authoring.md` — the full DSL: a validated worked example, roles/verbs/`expect`/template tables, the validator rules that aren't guessable (`steps` as a sibling of `repeat:`, seed-before-loop, never spell `prowl workflow done`, …), and working patterns (poor-man's `if`, fork/ordered join with the idle-gate caveat, broadcast outputs).
- `references/runbook.md` — run lifecycle (admission, binding resolution, watchdog/attention), the run-directory layout (`log.md`, ordinal ledger, atomic latest views), token travel, and the error table.

Patterns and pitfalls are distilled from the recorded boundary experiments (`docs-ai/063-agent-workflows/012-v1-boundary-observations.md`).

## Mechanics

- No code changes: `ProwlSkills` scans `Resources/skills/` at runtime and `make embed-skills` (already in `build-app`/`archive`/`test`) stages the directory, so the skill registers automatically in Settings › Agent Skills and `prowl skills list|install`.
- Named `prowl-workflow` (singular) to match the command surface `prowl workflow …` and the `prowl-cli` convention; the D1 plan's `prowl-workflows` name should be treated as superseded when the slice record is written.
- Product hook for the rest of D1: the bundled directory is addressable via `prowl skills path prowl-workflow`, so a future Settings "Create Workflow… / Ask agent" button can hand the skill to any agent the same way the help button's "Ask agent about Prowl" hands over the docs folder.
- Remaining D1 scope is untouched: Settings › Workflows page, `docs/components/workflows.md`, and the CLI reachability status.

## Verification

- `PROWL_SKILLS_DIR=$PWD/skills prowl skills list` parses both bundled skills (frontmatter contract).
- The worked example in `references/authoring.md` extracted and passed `prowl workflow validate`.
- `make build-app` green with the skill embedded; `docs/components/settings.md` bundled-skill enumeration updated.

https://claude.ai/code/session_01M5cFnjhGxu2wxhB7yU48Yt


## Review pass (2026-09-04)

Driven end to end against a main build with two fresh agents that saw only the skill and the CLI (no repo sources or docs):

- Running an existing workflow (`demo.launch-then-message`): completed in 13 s; the launched helper loaded the skill from the typed `[Prowl] …` line and delivered on the first try.
- Authoring from scratch (`review.swift-count`, two launched agents, verdict loop, notify, close): validated on the first attempt, run completed in 45 s, both `close:` steps closed their panes.
- Validator probes for the documented pitfalls (steps nested inside `repeat`, loop reference without a seed, spelled completion command, `on_timeout: skip` with a consumer) produce exactly the diagnostics the skill describes.

The second commit closes the gaps that pass exposed — above all that a loop is only left through a satisfied `until` (so the "poor-man's if" is not an `if`, and a bounded loop needs a give-up verdict to reach notify/close) — plus the inputs section, agent tokens, timeout grammar, a `status --json` field guide, the full run-directory layout, and the missing error codes. `docs/components/cli.md` now names the skill, and the 063 plan/release plan record the `prowl-workflow` name.

https://claude.ai/code/session_01XTYsDAXaUVUAo3Q329MeZS
