### PR TITLE
Focus the new custom command's name editor

### DIFF
--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -85,24 +85,36 @@ struct CustomCommandsEditor: View {
       VStack(spacing: 0) {
         customCommandsHeaderRow
         Divider()
-        ScrollView {
-          LazyVStack(spacing: 4) {
-            ForEach(commands) { command in
-              customCommandRow(command)
-                .id(command.id)
-            }
-            localCommandDropTarget
-            if showsGlobalCommands {
-              ForEach(globalCommands) { command in
-                globalCustomCommandRow(command)
-                  .id("global-\(command.id)")
+        ScrollViewReader { proxy in
+          ScrollView {
+            LazyVStack(spacing: 4) {
+              ForEach(commands) { command in
+                customCommandRow(command)
+                  .id(command.id)
+              }
+              localCommandDropTarget
+              if showsGlobalCommands {
+                ForEach(globalCommands) { command in
+                  globalCustomCommandRow(command)
+                    .id("global-\(command.id)")
+                }
               }
             }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 6)
           }
-          .padding(.horizontal, 6)
-          .padding(.vertical, 6)
+          .frame(height: customCommandsListHeight)
+          .onChange(of: editingNameCommandID) { _, commandID in
+            // The lazy stack never builds a row below the viewport, so scroll
+            // the row being renamed in before its field takes focus.
+            guard let commandID else { return }
+            var transaction = Transaction()
+            transaction.animation = nil
+            withTransaction(transaction) {
+              proxy.scrollTo(commandID)
+            }
+          }
         }
-        .frame(height: customCommandsListHeight)
       }
       .clipShape(RoundedRectangle(cornerRadius: 8))
 
@@ -174,8 +186,8 @@ struct CustomCommandsEditor: View {
     .onChange(of: selectedCustomCommandID) { _, selectedID in
       if editingNameCommandID != selectedID {
         editingNameCommandID = nil
+        focusedNameEditorCommandID = nil
       }
-      focusedNameEditorCommandID = nil
       if let iconPickerCommandID, iconPickerCommandID != selectedID {
         self.iconPickerCommandID = nil
       }
@@ -277,7 +289,14 @@ struct CustomCommandsEditor: View {
           }
       }
       .onAppear {
-        focusedNameEditorCommandID = command.id
+        // A focus request made in the same update that installs the field is a
+        // no-op — SwiftUI has no responder to move yet, and AppKit falls back
+        // to the window's first text field (the repository name).
+        let commandID = command.id
+        Task { @MainActor in
+          guard editingNameCommandID == commandID else { return }
+          focusedNameEditorCommandID = commandID
+        }
       }
     } else {
       InlineEditableCellButton {
@@ -953,9 +972,10 @@ struct CustomCommandsEditor: View {
       focusedNameEditorCommandID = nil
       return
     }
+    // Hold the first responder inside the editor until the row's field exists.
+    focusCustomCommandsArea()
     selectedCustomCommandID = commandID
     editingNameCommandID = commandID
-    focusedNameEditorCommandID = commandID
     iconPickerCommandID = nil
     commandEditorCommandID = nil
     recordingCustomCommandID = nil


### PR DESCRIPTION
Clicking + in a repository's Custom Commands moved the keyboard focus to the repository name field at the top of Display instead of starting the inline rename of the new row, so typing renamed the repository.

Three things had to hold for the row to take focus:

- The selection-change handler cleared the focus request unconditionally, right after the add set it. Clear it only when the new selection is not the row being renamed.
- A row appended below the viewport is never built by the lazy list, so no field exists to focus. Scroll the row being renamed into view.
- A focus request made in the same update that installs the field is a no-op — SwiftUI has no responder to move yet, and AppKit falls back to the window's first text field. Apply the request from the field's onAppear and hold the first responder inside the editor until then.

Verified against a Debug build driven with agent-ctrl: after the click the accessibility focused element is the new row's name cell (previously the repository name field, probed by frame), and typing renames the command instead of the repository.