### PR TITLE
Confirm terminal closure after recent editing

### DIFF
--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -172,3 +172,16 @@ their own hotkey — see [`components/custom-actions.md`](../components/custom-a
   Command distinguishes them.
 - `select_previous/next_worktree` (⌘⌃↑/↓) is overloaded by design: in Shelf view
   it cycles the open book's **tabs**; elsewhere it changes the selected worktree.
+
+### Recent input close protection
+
+Closing a pane or tab asks for confirmation if any affected pane received text,
+paste, dropped text or file paths, or deletion input within the last 10 seconds.
+Active input-method composition also requires confirmation, even after 10 seconds.
+This applies to idle agents and ordinary terminals, alongside existing protection
+for active agents, unseen results, and long-running commands.
+
+Navigation, copying, scrolling, and the close shortcut itself do not extend this
+window. Enter and Escape do not clear it. This guards against accidental closure
+while editing; it does not detect saved drafts or protect input indefinitely.
+Explicit no-confirmation close operations retain their existing behavior.

--- a/supacode/Features/Terminal/Models/TerminalCloseConfirmationPolicy.swift
+++ b/supacode/Features/Terminal/Models/TerminalCloseConfirmationPolicy.swift
@@ -4,9 +4,12 @@ struct TerminalCloseProtectionCandidate: Equatable {
   let hasAgent: Bool
   let agentDisplayState: AgentDisplayState?
   let commandRunningDuration: TimeInterval?
+  var editingAge: TimeInterval?
+  var hasMarkedText = false
 }
 
 enum TerminalCloseProtectionReason: Equatable, Hashable {
+  case recentInput
   case agentActive
   case longRunningCommand
 }
@@ -21,6 +24,7 @@ struct TerminalCloseConfirmationDecision: Equatable {
 }
 
 enum TerminalCloseConfirmationPolicy {
+  static let recentEditingThreshold: TimeInterval = 10
   static let longRunningCommandThreshold: TimeInterval = 10
 
   static func decision(
@@ -31,9 +35,16 @@ enum TerminalCloseConfirmationPolicy {
     var reasons: Set<TerminalCloseProtectionReason> = []
 
     for candidate in candidates {
-      guard let reason = protectionReason(for: candidate, threshold: threshold) else { continue }
+      var paneReasons: Set<TerminalCloseProtectionReason> = []
+      if candidate.hasMarkedText || candidate.editingAge.map({ $0 <= recentEditingThreshold }) == true {
+        paneReasons.insert(.recentInput)
+      }
+      if let reason = protectionReason(for: candidate, threshold: threshold) {
+        paneReasons.insert(reason)
+      }
+      guard !paneReasons.isEmpty else { continue }
       protectedPaneCount += 1
-      reasons.insert(reason)
+      reasons.formUnion(paneReasons)
     }
 
     return TerminalCloseConfirmationDecision(
@@ -51,7 +62,18 @@ enum TerminalCloseConfirmationPolicy {
   ) -> String {
     let paneText = decision.protectedPaneCount == 1 ? "pane" : "panes"
     let reasonText: String
-    if decision.reasons == Set([.agentActive]) {
+    if decision.reasons.contains(.recentInput) {
+      var activities = ["recent input"]
+      if decision.reasons.contains(.agentActive) {
+        activities.append("active agent work or an unseen agent result")
+      }
+      if decision.reasons.contains(.longRunningCommand) {
+        activities.append("a command that has been running for at least 10 seconds")
+      }
+      return
+        "This will close \(decision.protectedPaneCount) \(paneText) in “\(worktreeName)” with "
+        + activities.joined(separator: ", ") + ". Closing may lose unsubmitted input."
+    } else if decision.reasons == Set([.agentActive]) {
       reasonText = "active agent work or an unseen agent result"
     } else if decision.reasons == Set([.longRunningCommand]) {
       reasonText = "a command that has been running for at least 10 seconds"

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -37,13 +37,16 @@ extension WorktreeTerminalState {
 
   func closeProtectionCandidates(surfaceIDs: [UUID]) -> [TerminalCloseProtectionCandidate] {
     let now = Date()
+    let uptime = ProcessInfo.processInfo.systemUptime
     return surfaceIDs.map { surfaceID in
       let agentState = surfaceAgentStates[surfaceID]
       let runningDuration = surfaceRunningStartedAtById[surfaceID].map { now.timeIntervalSince($0) }
       return TerminalCloseProtectionCandidate(
         hasAgent: agentState?.detectedAgent != nil,
         agentDisplayState: agentState?.displayState,
-        commandRunningDuration: runningDuration
+        commandRunningDuration: runningDuration,
+        editingAge: surfaces[surfaceID]?.lastEditingAt.map { uptime - $0 },
+        hasMarkedText: surfaces[surfaceID]?.hasMarkedText() ?? false
       )
     }
   }

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime+Callbacks.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime+Callbacks.swift
@@ -251,6 +251,7 @@ extension GhosttyRuntime {
     guard let value = NSPasteboard.ghostty(location)?.getOpinionatedStringContents() else {
       return false
     }
+    if !value.isEmpty { bridge.surfaceView?.recordEditingActivity() }
     value.withCString { ptr in
       ghostty_surface_complete_clipboard_request(surface, ptr, state, false)
     }
@@ -269,6 +270,7 @@ extension GhosttyRuntime {
     guard let bridge = surfaceBridge(fromUserdata: userdata), let surface = bridge.surface else {
       return
     }
+    if !value.isEmpty { bridge.surfaceView?.recordEditingActivity() }
     value.withCString { ptr in
       ghostty_surface_complete_clipboard_request(surface, ptr, state, true)
     }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
@@ -478,6 +478,16 @@ extension GhosttySurfaceView {
       composing: composing
     )
     let finalText = text ?? ghosttyCharacters(resolvedEvent)
+    // Bound keys can close a pane synchronously inside ghostty_surface_key.
+    // Never let the close shortcut itself create editing activity.
+    if action != GHOSTTY_ACTION_RELEASE,
+      TerminalEditingActivity.isEditingKey(
+        keyCode: event.keyCode, modifiers: event.modifierFlags, text: finalText
+      ),
+      bindingFlags(for: event, surface: surface) == nil
+    {
+      recordEditingActivity()
+    }
     if let finalText, !finalText.isEmpty,
       let codepoint = finalText.utf8.first, codepoint >= 0x20
     {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+TextInput.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+TextInput.swift
@@ -29,6 +29,7 @@ extension GhosttySurfaceView: NSTextInputClient {
     default:
       return
     }
+    if markedText.length > 0 { recordEditingActivity() }
     if keyTextAccumulator == nil {
       syncPreedit()
     }
@@ -128,6 +129,7 @@ extension GhosttySurfaceView: NSTextInputClient {
   func insertCommittedTextForBroadcast(_ text: String) {
     guard let surface else { return }
     guard !text.isEmpty else { return }
+    recordEditingActivity()
     unmarkText()
     let len = text.utf8CString.count
     guard len > 0 else { return }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -156,6 +156,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
   var focused = false
   private var detachedFocusClearTask: Task<Void, Never>?
   var markedText = NSMutableAttributedString()
+  private(set) var lastEditingAt: TimeInterval?
+
+  func recordEditingActivity() {
+    lastEditingAt = ProcessInfo.processInfo.systemUptime
+  }
+
   var keyboardLayoutChangeKeyUpSuppression: KeyboardLayoutChangeKeyUpSuppression?
   var keyTextAccumulator: [String]?
   var cellSize: CGSize = .zero

--- a/supacode/Infrastructure/Ghostty/TerminalEditingActivity.swift
+++ b/supacode/Infrastructure/Ghostty/TerminalEditingActivity.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+/// Classifies editing intent, without reconstructing an application's input buffer.
+enum TerminalEditingActivity {
+  static func isEditingKey(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, text: String?) -> Bool {
+    if keyCode == 51 || keyCode == 117 { return true }
+    guard modifiers.isDisjoint(with: [.command, .control]) else { return false }
+    guard let text else { return false }
+    return text.unicodeScalars.contains {
+      !CharacterSet.controlCharacters.contains($0) && !(0xF700...0xF8FF).contains($0.value)
+    }
+  }
+}

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -7,6 +7,43 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceViewTests {
+  @Test func editingAndCompositionAreLocalToEachSurface() {
+    let runtime = GhosttyRuntime()
+    let edited = GhosttySurfaceView(
+      runtime: runtime, workingDirectory: nil, context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let sibling = GhosttySurfaceView(
+      runtime: runtime, workingDirectory: nil, context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let state = WorktreeTerminalState(
+      runtime: runtime,
+      worktree: Worktree(
+        id: "/tmp/input-test", name: "input-test", detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/input-test"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp")
+      ),
+      skipsSurfaceCreationForTesting: true
+    )
+    state.surfaces[edited.id] = edited
+    state.surfaces[sibling.id] = sibling
+    #expect(edited.lastEditingAt == nil)
+    edited.setMarkedText("draft", selectedRange: NSRange(location: 5, length: 0), replacementRange: NSRange())
+    #expect(edited.hasMarkedText())
+    #expect(edited.lastEditingAt != nil)
+    #expect(sibling.lastEditingAt == nil)
+    #expect(!sibling.hasMarkedText())
+    let candidates = state.closeProtectionCandidates(surfaceIDs: [edited.id, sibling.id])
+    #expect(candidates[0].hasMarkedText)
+    #expect(candidates[0].editingAge != nil)
+    #expect(candidates[1].editingAge == nil)
+    #expect(TerminalCloseConfirmationPolicy.decision(for: candidates).protectedPaneCount == 1)
+    edited.unmarkText()
+    #expect(!edited.hasMarkedText())
+    #expect(edited.lastEditingAt != nil)
+  }
+
   @Test func mainMenuExactMatchRejectsShiftVariantOfCommandComma() throws {
     let menu = NSMenu()
     let item = NSMenuItem(title: "Settings", action: nil, keyEquivalent: ",")

--- a/supacodeTests/TerminalCloseConfirmationPolicyTests.swift
+++ b/supacodeTests/TerminalCloseConfirmationPolicyTests.swift
@@ -1,9 +1,58 @@
+import AppKit
 import Foundation
 import Testing
 
 @testable import supacode
 
 struct TerminalCloseConfirmationPolicyTests {
+  @Test func multipleReasonsCountEachPaneOnce() {
+    var candidate = TerminalCloseProtectionCandidate(
+      hasAgent: true, agentDisplayState: .working, commandRunningDuration: nil
+    )
+    candidate.editingAge = 1
+    let decision = TerminalCloseConfirmationPolicy.decision(for: [candidate])
+    #expect(decision.protectedPaneCount == 1)
+    #expect(decision.reasons == [.recentInput, .agentActive])
+  }
+
+  @Test func recentEditingProtectsIdlePanesUntilThreshold() {
+    for hasAgent in [true, false] {
+      for age in [0.0, 9.9, 10.0, 10.1] {
+        var candidate = TerminalCloseProtectionCandidate(
+          hasAgent: hasAgent, agentDisplayState: .idle, commandRunningDuration: nil
+        )
+        candidate.editingAge = age
+        let decision = TerminalCloseConfirmationPolicy.decision(for: [candidate])
+        #expect(decision.requiresConfirmation == (age <= 10))
+      }
+    }
+  }
+
+  @Test func compositionProtectsEvenAfterEditingTimeout() {
+    var candidate = TerminalCloseProtectionCandidate(
+      hasAgent: true, agentDisplayState: .idle, commandRunningDuration: nil
+    )
+    candidate.editingAge = 60
+    candidate.hasMarkedText = true
+    let decision = TerminalCloseConfirmationPolicy.decision(for: [candidate])
+    #expect(decision.reasons == [.recentInput])
+    #expect(
+      TerminalCloseConfirmationPolicy.informativeMessage(for: decision, worktreeName: "wt")
+        .contains("may lose unsubmitted input"))
+  }
+
+  @Test func editingKeyClassificationExcludesNavigationAndShortcuts() {
+    #expect(TerminalEditingActivity.isEditingKey(keyCode: 0, modifiers: [], text: "a"))
+    #expect(TerminalEditingActivity.isEditingKey(keyCode: 51, modifiers: [], text: nil))
+    #expect(TerminalEditingActivity.isEditingKey(keyCode: 117, modifiers: [.option], text: nil))
+    for code: UInt16 in [36, 48, 53, 123, 124, 125, 126] {
+      #expect(!TerminalEditingActivity.isEditingKey(keyCode: code, modifiers: [], text: nil))
+    }
+    #expect(!TerminalEditingActivity.isEditingKey(keyCode: 13, modifiers: [.command], text: "w"))
+    #expect(!TerminalEditingActivity.isEditingKey(keyCode: 8, modifiers: [.control], text: "c"))
+    #expect(!TerminalEditingActivity.isEditingKey(keyCode: 0, modifiers: [], text: "\u{F700}"))
+  }
+
   @Test func agentWorkingBlockedAndDoneRequireConfirmation() {
     let protectedStates: [AgentDisplayState] = [.working, .blocked, .done]
 


### PR DESCRIPTION
Closing an idle agent pane while typing previously discarded input without confirmation. Closing a pane or tab now prompts when an affected pane has received editing input within the last 10 seconds, or still has active input-method composition.

The protection is shared across agents and ordinary terminals. Text input, paste, dropped text or paths, and deletion keys record per-surface activity; close shortcuts do not create activity, and Enter or Escape do not clear the timer. Existing active-agent and long-running-command protection remains in place. The shortcut documentation describes the time-limited behavior.

Validation:
- 39 targeted close-policy and surface tests passed, including threshold boundaries, composition, and pane isolation.
- `make check` passed, including 82 script tests.
- `make build-app` passed with zero errors or warnings.
- Manual GUI verification of input-method composition and accidental closure remains outstanding.
