### PR TITLE
Move handoff migration into R2b and defer review workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,8 +18,8 @@ Build, sign, notarize, and publish a Prowl release.
      routes, then `--mode publish --report PATH` before bump/tag. Commit the generated receipt,
      version baseline, and matrix. Publication requires the original artifacts/result bundles
      and unchanged source, binaries, and routes within 24 hours; rerun after relevant changes.
-     Report T1 headless results separately from D2 interactive/workflow acceptance;
-     inventory alone is not a contract pass, and T1 success does not establish D2 readiness.
+     Report T1 headless results separately from D3 handoff acceptance in R2b and D2 review acceptance in R3;
+     inventory alone is not a contract pass, and T1 success does not establish workflow release readiness.
    - Run the `sync-docs` skill. It diffs `docs/.sync-meta.json`'s `last_synced_commit`
      against the current `main` HEAD (the code about to ship), updates any docs whose
      implementation changed, and sets `last_synced_commit` to the **current HEAD** —

--- a/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
+++ b/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
@@ -88,13 +88,13 @@ Use the owner's existing DeepSeek V4 Flash configuration for compatible runtimes
   Follow the linked runbook for exact commands and version/matrix checks.
 - Keep headless results separate from interactive permission/lifecycle and workflow E2E.
   A successful report has `contract_passed: true` and `release_ready: false`. T1's headless
-  scope does not replace D2 under the [release plan](../063-agent-workflows/release-plan.md).
+  scope does not replace D3/D2 workflow acceptance under the [release plan](../063-agent-workflows/release-plan.md).
 - Present a short maintainer-facing status with the release-notes confirmation: passed,
   failed, blocked, or not run; name incomplete runtimes and link the evidence. An incomplete
   required check needs resolution or an explicit owner-approved release-scope exception,
   recorded in the release plan. It must not be silently treated as success.
 - Add targeted Debug workflow E2E for workflow behavior changes and important release
-  acceptance; the first R2b/D2 delivery requires its full planned E2E.
+  acceptance; R2b/D3 handoff requires first built-in E2E; R3/D2 adds review-loop E2E.
 
 The `/release` skill surfaces this reminder. Direct invocation of `scripts/release.sh` does
 not currently enforce T1; maintainers running the script must complete this check first.

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — R1 shipped in v2026.8.29; R2a shipped in v2026.8.31: B1 (#740, [006](006-b1-definitions.md)), #733 (#741), #726 T0 (#739), B2 (#743, [007](007-b2-runner-core.md)), B3 (#744, [008](008-b3-runner-wiring.md)), and C1 (#747, [010](010-c1-workflow-status-center.md)); R2b in progress: C2 (#752, [011](011-c2-start-sheet.md)) and D1 (#754/#761, [013](013-d1-workflows-settings.md)) merged; D1's post-merge Settings UI refinement merged in #763 ([014](014-workflow-settings-ui-refinement.md)); #726 T1a inventory/configuration preflight is implemented in [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md); eight-runtime headless checks verified; T1 verification and scoped publication complete (merge pending), then D2 |
+| **Status** | In progress — R1 shipped in v2026.8.29; R2a shipped in v2026.8.31: B1 (#740, [006](006-b1-definitions.md)), #733 (#741), #726 T0 (#739), B2 (#743, [007](007-b2-runner-core.md)), B3 (#744, [008](008-b3-runner-wiring.md)), and C1 (#747, [010](010-c1-workflow-status-center.md)); R2b in progress: C2 (#752, [011](011-c2-start-sheet.md)) and D1 (#754/#761, [013](013-d1-workflows-settings.md)) merged; D1's post-merge Settings UI refinement merged in #763 ([014](014-workflow-settings-ui-refinement.md)); #726 T1a inventory/configuration preflight is implemented in [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md); eight-runtime headless checks verified; T1 verification and scoped publication merged (#769); D3 handoff and first built-in E2E next for R2b; D2 deferred to R3 |
 | **Anchor date** | 2026-08-21 |
 | **Primary PRs** | R1: #709 (C0), #710 (A1), #713 (A1b), #714 (A2) — shipped in v2026.8.29; R2a: #740 (B1), #743 (B2, [007](007-b2-runner-core.md)); #744 (B3, [008](008-b3-runner-wiring.md)); #747 (C1, [010](010-c1-workflow-status-center.md)); R2b: #752 (C2, [011](011-c2-start-sheet.md)), #754 (D1 skill), #761 (D1 rest, [013](013-d1-workflows-settings.md)), D1 Settings UI refinement (#763, [014](014-workflow-settings-ui-refinement.md)); D2–D3 TBD |
 | **Related** | [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), [049 agents-toolbar-entry](../049-agents-toolbar-entry/000-plan.md), [053 agent-profiles](../053-agent-profiles/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [061 native-toolbar-controls](../061-native-toolbar-controls/toolbar-controls.md), [064 agent-completion-signals](../064-agent-completion-signals/000-plan.md) (signal bus, `agents signal` / `agents wait`), [#699 `prowl create pane`](https://github.com/onevcat/Prowl/issues/699), [PR #651 (direction reference, not merged)](https://github.com/onevcat/Prowl/pull/651), [DSL spec (living)](dsl-spec.md), [release plan (living)](release-plan.md), `docs/components/handoff.md`, `docs/components/agent-profiles.md`, `docs/components/cli.md` |
@@ -409,8 +409,8 @@ Shapes are intentionally close to what exists so the runner and the CLI share on
 This section defines **what** each slice contains. **When** it ships and in what order —
 including the interleaving with 064's signal slices — is owned by the living
 [release-plan.md](release-plan.md) (R1 CLI primitives + signals, R2a workflow engine + CLI,
-R2b workflow GUI + first built-in, R3 handoff migration; decisions 2026-08-22 and
-2026-08-29). Only two couplings cross the two
+R2b workflow GUI + handoff migration, R3 adversarial review; latest ordering decision
+2026-09-05). Only two couplings cross the two
 entries: 064-S1 delivers the `ObservedAgentState` observer that B3 consumes, and 064-S3
 attaches hooks through A2's launch boundary.
 
@@ -426,8 +426,8 @@ attaches hooks through A2's launch boundary.
 | **C1** | C | B3 | Status center fifth state + run panel + attention triggers + notifications (061 visual verification). Runs become visible. |
 | **C2** | C | B3 | Start sheet (bindings, suggestion-based profile creation, don't-ask-again, `--skip` equivalent) + entry points (capsule popover, palette, Active Agents context menu). GUI-initiated runs. |
 | **D1** | D | B1, C2, 065-K1 | `prowl-workflow` authoring skill (registered by adding it to `skills/`; embedding and the registry come from [065](../065-bundled-agent-skills/000-plan.md)), `docs/components/workflows.md`, Settings › Workflows page (enable/validate/Reveal/New/Ask-agent/per-workflow auto) added to the Agents group. Distribution and docs. |
-| **D2** | D | A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.adversarial-review` built-in + reviewer skill + E2E self-verification (the exact-signal watchdog's first proof in a real flow). Proves the engine on a fresh flow before touching shipped behavior. |
-| **D3** | D | D2 | `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to\|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill. Migrate the shipped feature last. |
+| **D2** | D | D3 acceptance / R2b shipped; A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.adversarial-review` built-in + reviewer skill + loop/verdict/watchdog E2E. Deferred to R3 after handoff validates the first built-in path. |
+| **D3** | D | A2, C2, D1, 064-S3 wave 1, #733, #726 T1 | `prowl.handoff` + `prowl.handoff-checkpoint` built-ins + `handoff.transition`/`handoff.checkpoint` actions; `prowl handoff to\|save` → `HANDOFF_RETIRED` stubs; remove `HandoffHudFeature`, `HandoffCommandHandler`, `HandoffRequestRegistry`; rewrite `docs/components/handoff.md` and the `prowl-cli` skill. First built-in workflow and Debug E2E in R2b; release candidate after handoff/checkpoint acceptance. |
 | **V2** | — | — | observe mode (`expect.status` + `agents read` / hook `last_assistant_message`), `on_attention: ask <role>`, fan-out (`count`, `wait all`), run persistence/resume, retention, cross-worktree roles, GUI editor. |
 
 ## Alternatives & decisions
@@ -509,16 +509,15 @@ attaches hooks through A2's launch boundary.
   / Execution model). Detection is heuristic, so every trigger is designed to be harmless
   when wrong: grace before acting, a nudge that only asks the agent to finish with `done`
   when it is truly complete, and attention states that never discard a late delivery.
-- **PR order / releases** (revised 2026-08-22): three releases — R1 = C0, A1, A2,
-  064-S1/S2/S3-wave-1, 065-S0/K1/K2/K3 (CLI orchestration + signals + skill distribution);
-  R2 = B1, B2, B3, C1, C2, D1, D2
-  (Agent Workflows); R3 = D3, 064-S4, first V2 items (handoff migration). S3 has no wave 2:
-  runtimes that require global-config, dedicated-home, or project-file writes do not receive
-  Prowl-managed hooks. The single source for order and release assignment is
-  [release-plan.md](release-plan.md);
-  the slice tables in 063/064 define contents only. The new Adversarial Review flow
-  validates the engine before the shipped handoff is migrated; the `ObservedAgentState`
-  observer moved from B3 to 064-S1 so R1 can ship `agents wait`.
+- **PR order / releases** (revised 2026-09-05): R1 CLI/signals and R2a workflow engine/CLI
+  have shipped. R2b = C2, D1, T1, then D3 handoff/checkpoint migration and first built-in E2E;
+  consider releasing at that boundary. D2 adversarial review moves to the next release, R3;
+  064-S4 remains independently planned there. Slice IDs remain stable. Handoff's simpler flow
+  now validates the engine first; D2 adds loop/verdict-specific acceptance later. Preserve
+  the one-release non-executing CLI retirement period from handoff's actual release. The
+  single source for order and release assignment is [release-plan.md](release-plan.md).
+  S3 has no wave 2: runtimes requiring global-config, dedicated-home, or project-file writes
+  do not receive Prowl-managed hooks.
 - **Review round (2026-08-22)** — accepted corrections: runner as an `AppFeature` child
   fed by the single event subscription + a per-surface multicast observer for CLI waits;
   opaque per-step delivery tokens for `done`; `LegacyHandoffAdapter` with a full parameter
@@ -663,3 +662,5 @@ attaches hooks through A2's launch boundary.
 - Updated 2026-09-05: Confirmed D1 refinement #763 merged; T1 remains before D2, with inventory, low-cost model candidates, and a proposed repeatable harness in [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md). No inference verification performed.
 
 - Updated 2026-09-05 (T1 closure): Full eight-runtime verification and explicit scoped publication passed; the baseline and matrix were advanced while preserving interactive history. Release guidance now uses `verify` then `publish`. See [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md). Merge this closure, then proceed to D2; GUI E2E is outside #726 T1.
+
+- Updated 2026-09-05 (owner sequencing decision): D3 moves before D2 into R2b; handoff/checkpoint carry the first built-in Debug E2E. Consider R2b release after acceptance, with adversarial review deferred to R3. This supersedes earlier D2-first/migrate-handoff-last ordering; CLI retirement and artifact contracts remain unchanged.

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -35,8 +35,8 @@ say when each is cut:
 | --- | --- | --- |
 | R1 | **Shipped** — v2026.8.29 (2026-08-29) | — |
 | R2a | **Shipped** — v2026.8.31 (2026-08-31) | — |
-| R2b | In progress — C2 and D1, including Settings refinement, merged (#752/#754/#761/#763) | #726 T1a inventory/configuration preflight implemented; eight-runtime headless checks verified; T1 verification and scoped publication complete (merge pending), then D2 |
-| R3 | Planned | after R2b ships |
+| R2b | In progress — C2 and D1, including Settings refinement, merged (#752/#754/#761/#763) | #726 T1a inventory/configuration preflight implemented; eight-runtime headless checks verified; T1 merged (#767/#769); D3 handoff migration and E2E next, then assess R2b release |
+| R3 | Planned | D2 adversarial review after R2b ships; S4 remains independently planned |
 
 #### R2b PR ledger
 
@@ -46,8 +46,9 @@ say when each is cut:
 | D1 (skill) | Merged | #754: `prowl-workflow` bundled authoring skill (shipped ahead of the rest of D1) |
 | D1 (rest) | Merged | #761: Settings › Agents › Workflows page, `docs/components/workflows.md`, CLI reachability status (deferred from C0); [063.013](013-d1-workflows-settings.md) |
 | D1 (UI refinement) | Merged | #763: post-merge native list/detail refinement, repository-local workflow Settings, Run Setup copy, explicit run targets, file opening, and capsule YAML icons; [063.014](014-workflow-settings-ui-refinement.md) |
-| #726 T1 | Implemented and verified — #767 merged; closure [#769](https://github.com/onevcat/Prowl/pull/769) awaiting merge | [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md): zero-inference inventory and production configuration preflight verified; [runbook](../064-agent-completion-signals/agent-contracts-runbook.md). Eight-runtime headless checks pass; T1 verification and scoped publication are complete (merge pending); GUI acceptance belongs to D2. |
-| D2 | Planned | `prowl.adversarial-review` built-in + reviewer skill + E2E — after #726 T1 |
+| #726 T1 | Implemented and verified — #767 merged; closure [#769](https://github.com/onevcat/Prowl/pull/769) merged | [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md): zero-inference inventory and production configuration preflight verified; [runbook](../064-agent-completion-signals/agent-contracts-runbook.md). Eight-runtime headless checks pass; T1 verification and scoped publication are complete; R2b GUI/workflow acceptance belongs to D3. |
+| D3 | Next | `prowl.handoff` and `prowl.handoff-checkpoint`, legacy retirement, first built-in workflow E2E; R2b release candidate after acceptance |
+| D2 | Deferred to R3 | `prowl.adversarial-review` built-in + reviewer skill + loop-specific E2E — after the handoff-first R2b release |
 
 #### R1 PR ledger
 
@@ -132,25 +133,39 @@ touch B1's files); #733 must merge before B3 starts. Docs: `workflows.md` (CLI p
 | --- | --- | --- | --- | --- |
 | 1 | **C2** start sheet + entry points (capsule popover, palette, Active Agents) | 063 | B3 | GUI-initiated runs |
 | 2 | **D1** `prowl-workflow` authoring skill (shipped early in #754; skills embedding from 065), `docs/components/workflows.md`, Settings › Workflows page, CLI reachability status (deferred from C0) | 063 | B1, C2, 065-K1 | custom workflows, agent-assisted authoring |
-| 3 | **#726 T1** headless contract tests against the real tier-A binaries through the production renderers/decoder (`make test-agent-contracts`, passing runs update T0) | 064 | #726 T0, S3 wave 1 | hook contracts fail loudly on binary drift before D2's E2E leans on them |
-| 4 | **D2** `prowl.adversarial-review` built-in + reviewer skill + E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | first built-in workflow |
+| 3 | **#726 T1** headless contract tests against the real tier-A binaries through the production renderers/decoder (`make test-agent-contracts`, passing runs update T0) | 064 | #726 T0, S3 wave 1 | hook contracts fail loudly on binary drift before D3's E2E leans on them |
+| 4 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint`, native actions, legacy retirement, docs/skill migration, and Debug E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | handoff is the first built-in workflow; assess R2b release after acceptance |
 
-The shipped handoff (HUD + `prowl handoff`) stays untouched through R2a and R2b. The split
-replaces the earlier "one R2" default (decision 2026-08-29): R2's seven slices outweigh R1's
-implementation work, and R1 showed that a slice is only proven once it has been driven end to
-end from the skill, so the CLI route ships and collects that feedback before the GUI is built
-on it. Docs: `workflows.md`, `command-palette.md`, `active-agents.md`, `settings.md`.
+The owner revised the order on 2026-09-05: handoff is simpler than adversarial review and
+will provide the first built-in workflow validation. Keep slice IDs stable (D3 remains handoff,
+D2 remains adversarial review); their numbers no longer imply execution order. This supersedes
+the earlier requirement to leave handoff untouched through R2b and D3's dependency on D2.
 
-### R3 — Handoff migration + signal completion
+R2b becomes eligible for release after D3 acceptance, without waiting for D2:
+
+- Both handoff and checkpoint work through the workflow entry points, including briefing,
+  context-only, self-initiated delivery, and receiver launch where applicable. Preserve the
+  `.prowl/handoff/` archive/current/context semantics and cover failure/cancel paths.
+- Drive the bundled workflow skill and GUI through a Debug app. Verify admission/attribution,
+  permission/attention handling, delivery, and applicable watchdog behavior. T1 headless
+  evidence alone cannot satisfy this first built-in E2E gate.
+- Replace the dedicated handoff HUD/execution path; update docs and skills. The old CLI remains
+  a non-executing `HANDOFF_RETIRED` stub with replacement commands for one release, not a
+  warning-and-forward compatibility adapter.
+- Complete the normal full T1 verify/publication and release checks. Acceptance permits a
+  release decision; it does not automatically publish or waive unresolved failures.
+
+### R3 — Adversarial review + signal completion
 
 | Order | Slice | Entry | Depends | Outcome |
 | --- | --- | --- | --- | --- |
-| 1 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint` built-ins, `HANDOFF_RETIRED` stubs, removal of `HandoffHudFeature` / `HandoffCommandHandler` / `HandoffRequestRegistry`, `docs/components/handoff.md` rewrite | 063 | D2 | handoff is a workflow |
+| 1 | **D2** `prowl.adversarial-review` built-in + reviewer skill + loop/verdict/watchdog E2E | 063 | D3 accepted and R2b shipped; A2, C2, D1, S3 wave 1, #733, #726 T1 | review workflow builds on the validated handoff workflow path |
 | 1 | **S4** transcript file-watch + OSC producers | 064 | S1 | layer-2 signals without hooks |
 
 There is no S3 wave 2. Runtimes that require writes to a global config, dedicated home, or
-project file do not receive Prowl-managed hooks. The `HANDOFF_RETIRED` stubs are deleted one
-release after R3.
+project file do not receive Prowl-managed hooks. S4's scope and independent dependency are
+unchanged. Delete the `HANDOFF_RETIRED` stubs one release after their R2b introduction
+(expected R3), rather than one release after the former R3 handoff slot.
 
 ### R3+ — V2
 
@@ -178,7 +193,7 @@ Agreed 2026-08-29 after R1 shipped; they apply from R2a on.
   PR when a decision changes it.
 - **Drift guard travels with the release.** #726 T0 (`make agent-versions`) ships in R2a and
   runs before every release from then on; T1 (`make test-agent-contracts`) ships in R2b
-  before D2's E2E and is re-run whenever a runtime is upgraded or a release is cut.
+  before D3's first built-in E2E and is re-run whenever a runtime is upgraded or a release is cut.
 - **Records move with the code.** The PR that merges a slice updates this file's ledger and
   change log, the owning plan's Status / Primary PRs lines and Amendments, and the slice's
   own record; the release PR adds the "shipped" line. A stale ledger is a defect of the next
@@ -197,10 +212,10 @@ R1:  C0            A1 ──► A1b                         (shipped v2026.8.29)
      065-S0/K1 ──► 065-K2 ──► 065-K3
 R2a: B1 ──► B2 ──► B3 (◄ A2, S1, #733) ──► C1
      #733 (◄ S2)        #726-T0 (◄ S3w1)
-R2b: C2 (◄ B3) ──► D1 (◄ B1, 065-K1) ──► D2 (◄ S3w1, #733, #726-T1)
+R2b: C2 (◄ B3) ──► D1 (◄ B1, 065-K1) ──► D3 (◄ S3w1, #733, #726-T1)
      #726-T1 (◄ #726-T0)
-R3:  D3 (◄ D2)        S4 (◄ S1)
-R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
+R3:  D2 (◄ D3 / R2b shipped)        S4 (◄ S1); delete HANDOFF_RETIRED stubs
+R3+: V2 / S5 rest
 ```
 
 ## Change log
@@ -304,3 +319,5 @@ R3+: V2 / S5 rest;  delete HANDOFF_RETIRED stubs
 - 2026-09-05 — Continued #726 in #767: all eight real headless runtime/hook checks passed; seven use the owner's DeepSeek key and Qoder uses its existing Flash catalog route. Fixed absent-notifier configuration reads found by the suite. Release preparation now points at implemented live/preflight commands. Scoped attestation publication remained before T1 closure; interactive acceptance belongs to D2; D2 remains separate.
 
 - Updated 2026-09-05 (T1 closure): Full eight-runtime verification and explicit scoped publication passed; the baseline and matrix were advanced while preserving interactive history. Release guidance now uses `verify` then `publish`. See [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md). Merge this closure, then proceed to D2; GUI E2E is outside #726 T1.
+
+- 2026-09-05 — Owner changed the release order: D3 handoff/checkpoint migrates in R2b and supplies the first built-in E2E; consider releasing after its acceptance. D2 adversarial review moves to R3. Keep slice IDs and CLI retirement semantics; remove stubs one release after their actual introduction. T1 #769 is merged.

--- a/docs-ai/064-agent-completion-signals/000-plan.md
+++ b/docs-ai/064-agent-completion-signals/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | In progress — S1 #715, S2 #718, S3 wave 1 #721/#723/#725/#728, and follow-ups #732/#736 shipped in v2026.8.29; #733 re-dispatch (#741) and #726 T0 (#739) shipped in R2a; #726 T1a inventory/configuration preflight implemented in [016](016-t1-contract-test-plan.md) for R2b; eight-runtime headless checks verified; T1 verification and scoped publication complete (merge pending); S4/S5 planned |
+| **Status** | In progress — S1 #715, S2 #718, S3 wave 1 #721/#723/#725/#728, and follow-ups #732/#736 shipped in v2026.8.29; #733 re-dispatch (#741) and #726 T0 (#739) shipped in R2a; #726 T1a inventory/configuration preflight implemented in [016](016-t1-contract-test-plan.md) for R2b; eight-runtime headless checks verified; T1 verification and scoped publication merged (#769); S4/S5 planned |
 | **Anchor date** | 2026-08-22 |
 | **Primary PRs** | #715 (S1); #718 (S2); #721, #723 (S3a); #725 (S3b); #728 (S3c); #732 (012); #736 (013); #741 (re-dispatch); #739 (T0); #767 (runtime contracts, merged) |
 | **Related** | [063 agent-workflows](../063-agent-workflows/000-plan.md) (consumer; defines the `ObservedAgentState` observer this entry feeds), [030 agent-status-detection](../030-agent-status-detection/000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), [055 agent-profile-runtimes](../055-agent-profile-runtimes/000-plan.md), [059 agent-transcript-snapshots](../059-agent-transcript-snapshots/000-plan.md), [060 cli-targeting-and-contract-governance](../060-prowl-cli-targeting-and-contract-governance/000-plan.md), [#473](https://github.com/onevcat/Prowl/issues/473), [#676](https://github.com/onevcat/Prowl/issues/676), `docs/components/agent-detection.md`, `docs/components/cli.md` |
@@ -355,3 +355,5 @@ opencode; partial for qodercli/qwen/amp; docs/bundle for the rest). Key conclusi
 - Updated 2026-09-05 (#726 live checks): Eight runtimes passed the production headless preparation/real bridge suite in #767, including the Codex absent-notifier fix found during execution. See [016](016-t1-contract-test-plan.md) for scoped results and remaining publication work and separate D2 interactive acceptance.
 
 - Updated 2026-09-05 (T1 closure): Full eight-runtime verification and explicit scoped publication passed; the baseline and matrix were advanced while preserving interactive history. Release guidance now uses `verify` then `publish`. See [064.016](016-t1-contract-test-plan.md). Merge this closure, then proceed to D2; GUI E2E is outside #726 T1.
+
+- Updated 2026-09-05 (release order): T1 #769 merged. R2b now proceeds to 063-D3 handoff/checkpoint and first built-in E2E, with 063-D2 adversarial review deferred to R3. T1 remains prerequisite to both; S4 scheduling/dependencies are unchanged.

--- a/docs-ai/064-agent-completion-signals/016-t1-contract-test-plan.md
+++ b/docs-ai/064-agent-completion-signals/016-t1-contract-test-plan.md
@@ -2,9 +2,9 @@
 
 | | |
 | --- | --- |
-| **Status** | T1 implemented and verified 2026-09-05; scoped baseline published; merge pending; D2 GUI acceptance remains separate |
+| **Status** | T1 implemented and verified 2026-09-05; scoped baseline published; #769 merged; R2b/D3 handoff GUI acceptance remains separate |
 | **Anchor date** | 2026-09-05 |
-| **Primary PR** | [#767](https://github.com/onevcat/Prowl/pull/767) (inventory/live); [#769](https://github.com/onevcat/Prowl/pull/769) (closure, open) |
+| **Primary PR** | [#767](https://github.com/onevcat/Prowl/pull/767) (inventory/live); [#769](https://github.com/onevcat/Prowl/pull/769) (closure, merged) |
 | **Related** | [#726](https://github.com/onevcat/Prowl/issues/726), [T0](015-t0-version-attestation.md), [release plan](../063-agent-workflows/release-plan.md), [operating runbook](agent-contracts-runbook.md) |
 
 ## Decision to make
@@ -335,3 +335,11 @@ passed. The final report still matches the current source fingerprint. A scan of
 and final report artifacts found no occurrence of the supplied provider key. Publication tests
 cover stale/partial reports, binary/route changes, artifact mutation, missing/zero-count receipts,
 incorrect responses/events, subset preservation, idempotency, and rollback after a write failure.
+
+## Release-order amendment (2026-09-05)
+
+The owner moved D3 handoff/checkpoint into R2b as the first built-in E2E and release candidate
+boundary; D2 adversarial review now follows in R3. Earlier D2-first references in this record
+describe the original delivery order. T1 #769 is merged, remains prerequisite to both, and
+does not claim either slice's GUI/workflow acceptance. The release plan and operating runbook
+carry the current order; headless evidence and publication semantics are unchanged.

--- a/docs-ai/064-agent-completion-signals/agent-contracts-runbook.md
+++ b/docs-ai/064-agent-completion-signals/agent-contracts-runbook.md
@@ -10,7 +10,7 @@ and an opt-in **eight-runtime contract verification and explicit attestation pub
 Seven routes use the owner's DeepSeek key; Qoder uses the account's explicitly selected Flash
 model. `verify` combines configuration, supported zero-turn lifecycle, and headless model-turn
 scenarios. `publish` advances only the verified rows in T0 and the generated research matrix.
-GUI permission handling and workflow E2E belong to D2; reports keep `release_ready: false`.
+GUI permission handling and first built-in E2E belong to R2b/D3 handoff; D2 review follows in R3; reports keep `release_ready: false`.
 
 The [release checklist](../001-fork-bootstrap-and-release-pipeline/release-runbook.md#agent-contract-release-check)
 and `/release` skill require these checks before bump/tag and surface the evidence during
@@ -263,16 +263,15 @@ DeepSeek route works. Catalog refresh is outside the required T1 scope and the o
 - During ordinary development, run offline regressions and select one live runtime when its
   adapter, provider recipe, or installed binary changes.
 - After shared renderer/decoder/CLI/relay changes, rerun affected runtimes; before each public
-  release, run the full headless command plus the Codex configuration preflight above.
+  release, run the full `verify` suite and explicitly `publish` its successful report above.
 - Inspect failures before retrying. A retry creates a new private report and does not erase
   earlier evidence. Do not silently change models or remove a runtime from the release scope.
-- Keep the headless report separate from T0's interactive attestation. Publication with a
-  scenario-aware schema and interactive needs-input/session lifecycle acceptance still needs
-  implementation. Do not update all T0 version rows based on a headless sweep.
-- D2 must run the bundled workflow skill through a Debug Prowl instance; use the
+- Publish only through the validated entry point; scoped headless receipts preserve the
+  archived interactive baseline and do not claim GUI acceptance.
+- D3 handoff in R2b, then D2 review in R3, must run the bundled workflow skill through a Debug Prowl instance; use the
   [S3c acceptance record](011-s3c-action.md) and the
   [workflow release cadence](../063-agent-workflows/release-plan.md#cadence-and-working-rules).
-  This headless suite does not replace D2's GUI/workflow protocol acceptance.
+  This headless suite does not replace either slice's GUI/workflow protocol acceptance.
 
 Missing accounts remain explicit blockers. Only the owner can approve a release-scope
 exception; autonomous implementation authorization is not a waiver of release acceptance.


### PR DESCRIPTION
Move D3 handoff/checkpoint migration into R2b as the first built-in workflow and Debug E2E acceptance target. Consider releasing R2b after that acceptance; defer D2 adversarial review and its loop-specific verification to R3, retaining the existing slice IDs.

Update dependencies, release conditions, and maintainer reminders together. Preserve non-executing legacy CLI retirement for one release from its actual introduction, with removal expected in R3. Mark T1 closure as merged and correct obsolete publication guidance.

Documentation only. Validation: `make check` passed 131 script tests and strict Swift formatting/lint; release skill validation passed.
