### PR TITLE
Hide workflow UI behind a runtime feature flag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,7 +13,7 @@ Build, sign, notarize, and publish a Prowl release.
    - If dirty, list the changes and ask whether to proceed or abort
 3. Sync the docs to the code being released — **before** the version bump and tag:
    - First read `docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md`'s
-     **Agent contract release check** and surface its status to the user. Follow the linked
+     **Workflow UI release scope** and **Agent contract release check**, and surface their status to the user. Follow the linked
      contract runbook: run the full `--mode verify` suite with the owner's configured model
      routes, then `--mode publish --report PATH` before bump/tag. Commit the generated receipt,
      version baseline, and matrix. Publication requires the original artifacts/result bundles

--- a/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
+++ b/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
@@ -73,6 +73,22 @@ make build-app
 
 ## Release Workflow
 
+### Workflow UI release scope
+
+For the next public release, ship the merged Agent Island and runtime detection improvements;
+action bundles, handoff migration, and adversarial review remain deferred. Follow the
+[workflow release scope](../063-agent-workflows/release-plan.md).
+
+- Launch the candidate without `PROWL_WORKFLOW_UI`: no workflow sections, launch rows,
+  status controls, role labels, or workflow skill row should appear in the UI.
+- A fresh process with `PROWL_WORKFLOW_UI=1` restores the development UI. This variable is
+  runtime-only; do not set it in distribution defaults or turn it into a build flag.
+- Confirm the CLI still lists/validates/runs workflows and exposes the bundled workflow skill.
+  Keep workflows out of this release's advertised UI features; do not require completion of
+  deferred action/D3/D2 work to release the hidden-UI candidate.
+- Keep normal signing/notarization, version checks, and runtime contract verification below.
+  Surface these results in maintainer approval before publishing.
+
 ### Agent contract release check
 
 Before every public release, before bumping the version or creating a tag, follow the
@@ -94,7 +110,8 @@ Use the owner's existing DeepSeek V4 Flash configuration for compatible runtimes
   required check needs resolution or an explicit owner-approved release-scope exception,
   recorded in the release plan. It must not be silently treated as success.
 - Add targeted Debug workflow E2E for workflow behavior changes and important release
-  acceptance; R2b/D3 handoff requires first built-in E2E; R3/D2 adds review-loop E2E.
+  acceptance. D3 handoff and D2 review require their own E2E when they ship; they are not
+  acceptance gates for the intervening release with workflow UI hidden.
 
 The `/release` skill surfaces this reminder. Direct invocation of `scripts/release.sh` does
 not currently enforce T1; maintainers running the script must complete this check first.

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -9,6 +9,8 @@
 
 > Design amendment under review: [015 — action bundles, context, and control flow](015-action-bundles-and-control-flow.md). The owner redirected the current session to this foundation before handoff implementation. The existing V1 specification describes current behavior; the amendment describes proposed replacements.
 
+> Release scope update: [016 — workflow UI gate](016-workflow-ui-release-gate.md). The next release ships Island/detection improvements with workflow UI hidden by default; action bundles, handoff migration, and review workflows are deferred.
+
 ## Background
 
 Prowl already runs several coding agents side by side, identifies them per pane, launches
@@ -668,3 +670,5 @@ attaches hooks through A2's launch boundary.
 - Updated 2026-09-05 (owner sequencing decision): D3 moves before D2 into R2b; handoff/checkpoint carry the first built-in Debug E2E. Consider R2b release after acceptance, with adversarial review deferred to R3. This supersedes earlier D2-first/migrate-handoff-last ordering; CLI retirement and artifact contracts remain unchanged.
 
 - Updated 2026-09-05: Recorded accepted action/bundle authorization, workflow-wide context, typed state, conditions/unbounded loops, sequential scheduling, and no recovery decisions in [015](015-action-bundles-and-control-flow.md). Consolidated syntax remains under review; no implementation yet.
+
+- Updated 2026-09-05: Added the process-scoped workflow UI release gate in [016](016-workflow-ui-release-gate.md); the CLI/runtime remain available and future workflow slices do not block this release.

--- a/docs-ai/063-agent-workflows/016-workflow-ui-release-gate.md
+++ b/docs-ai/063-agent-workflows/016-workflow-ui-release-gate.md
@@ -1,0 +1,49 @@
+# 063.016 — Workflow UI Release Gate
+
+Status: implemented and verified; release preparation, 2026-09-05.
+
+The owner approved shipping the merged Agent Island, detection fixes, and other changes
+before action bundles, handoff migration, or adversarial review are ready. Hide workflow UI
+by default for this release; retain the existing CLI, engine, bundled resources, and skill
+installation capability. #770 and #771 are merged; the action proposal is documentation only.
+
+Introduce a small process-environment `FeatureFlags` dependency. `PROWL_WORKFLOW_UI=1` opts
+into workflow UI; missing, empty, and other values leave it off. Read once per process;
+there is no persistent setting or runtime toggle. Tests can inject both configurations.
+
+Hide the Agents popover workflow section, workflow status control, Active Agents/Island
+workflow menus and role labels, command-palette launch rows, global/repository Workflow
+Settings, authoring UI, workflow start overlays, and the bundled workflow skill's Settings
+row. Guard GUI navigation entry points as well as presentation. Keep agent profiles,
+legacy handoff, Island behavior, CLI & Skills, and non-workflow skill rows available.
+Runtime status remains queryable through CLI; suppress workflow-specific UI notices while
+hidden, without suppressing the engine's explicit workflow steps or CLI behavior.
+
+Verify default and opted-in presentation in Debug, focused flag/navigation tests, existing
+workflow UI/reducer tests, strict formatting/lint, and build. Release checklist must confirm
+the default-off UI and CLI reachability; future workflow/action acceptance is not a gate for
+this maintenance release. Do not publish a release as part of this implementation PR.
+
+## Implementation and verification
+
+`FeatureFlags` is a process-scoped, injectable dependency shared by views and reducers.
+The release default is off; existing workflow tests explicitly use the dependency's enabled
+test default, while release-gate tests inject the disabled configuration. GUI admission,
+catalog presentation, role badges, and automatic UI notices are gated. CLI admission and
+explicit workflow steps remain independent of UI visibility.
+
+- Focused flag, Settings, workflow notice, role badge, runtime harness, and toolbar suites:
+  52 tests passed. The new tests cover exact opt-in parsing, hidden Settings selection,
+  skill filtering, and blocked GUI navigation/notices with a valid selected worktree.
+- `make check`: passed, including 131 script tests and strict Swift formatting/lint.
+- `make build-app`: passed without warnings; release skill metadata validation also passed.
+- Live Debug checks with an isolated socket and a temporary repository: Agents workflow
+  rows, global/repository Settings, workflow skill, and command-palette rows were absent
+  without the variable and present after relaunch with `PROWL_WORKFLOW_UI=1`. The Agents
+  popover was visually inspected in both configurations; ordinary profile controls remained.
+- With the variable absent, CLI catalog listing succeeded, a local notification-only
+  workflow reached `completed`, and `skills list` still exposed `prowl-workflow`. No model
+  calls or credential/configuration changes were required.
+
+This is targeted pre-PR validation, not the release-time contract sweep or notarization.
+Those remain required by the release runbook when publishing the candidate.

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -5,6 +5,14 @@
 > slices themselves — what each PR contains — are defined in the owning plan's
 > "Delivery slicing" section. Update this file when scope moves between releases.
 
+> **Next public release (owner decision, 2026-09-05):** ship the merged Agent Island,
+> Pi/OMP/Copilot detection fixes, terminal-close protection, and other accepted changes.
+> Workflow UI is off unless Prowl starts with `PROWL_WORKFLOW_UI=1`; CLI/runtime capabilities
+> remain available. Action bundles, D3 handoff migration, and D2 adversarial review are deferred
+> and are not gates for this release. The [UI gate](016-workflow-ui-release-gate.md) is the final
+> planned implementation PR before release preparation. The R2b/R3 tables below describe the
+> deferred workflow roadmap, not the scope of this intervening release.
+
 ## Ownership
 
 | Prefix | Owner | Meaning |
@@ -321,3 +329,5 @@ R3+: V2 / S5 rest
 - Updated 2026-09-05 (T1 closure): Full eight-runtime verification and explicit scoped publication passed; the baseline and matrix were advanced while preserving interactive history. Release guidance now uses `verify` then `publish`. See [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md). Merge this closure, then proceed to D2; GUI E2E is outside #726 T1.
 
 - 2026-09-05 — Owner changed the release order: D3 handoff/checkpoint migrates in R2b and supplies the first built-in E2E; consider releasing after its acceptance. D2 adversarial review moves to R3. Keep slice IDs and CLI retirement semantics; remove stubs one release after their actual introduction. T1 #769 is merged.
+
+- Updated 2026-09-05 (release scope): #770/#771 merged. Release the Island/detection improvements now with workflow UI opt-in; defer action bundles, handoff, and review workflow acceptance. See [016](016-workflow-ui-release-gate.md).

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -1,5 +1,7 @@
 # Active Agents Panel
 
+> Workflow launch menus and role labels are shown only when Prowl starts with `PROWL_WORKFLOW_UI=1`. Agent Island and ordinary agent controls remain available without the flag.
+
 > A live list of every running agent across all worktrees, with status and
 > one-click jump-to-agent. Your mission-control roster.
 

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -1,5 +1,7 @@
 # Command Palette
 
+> Workflow launch entries are hidden unless Prowl starts with `PROWL_WORKFLOW_UI=1`; other commands are unaffected.
+
 > The `⌘P` searchable launcher for (almost) every action in Prowl. Type a name,
 > hit Return.
 

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -1,5 +1,7 @@
 # Settings
 
+> Workflow Settings (global and repository-local) and the `prowl-workflow` skill row are hidden unless Prowl starts with `PROWL_WORKFLOW_UI=1`. CLI workflow and skill commands remain available.
+
 > The Settings window (`⌘,`): what each tab controls. For the exhaustive
 > field-by-field list, see [`reference/settings-fields.md`](../reference/settings-fields.md).
 

--- a/docs/components/workflows.md
+++ b/docs/components/workflows.md
@@ -1,5 +1,7 @@
 # Agent Workflows
 
+> Workflow UI is currently an opt-in preview. Start Prowl with `PROWL_WORKFLOW_UI=1` to show workflow launch menus, Settings, status controls, and role labels. Without it, the `prowl workflow` CLI and execution engine remain available. The flag is read at process startup; relaunch to change it.
+
 > Multi-step, multi-agent orchestrations that Prowl runs and supervises for
 > you: a YAML file declares the roles (the pane you start from, an agent Prowl
 > launches, an agent you pick) and the steps (message a role, launch one, loop

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct ContentView: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   @Bindable var store: StoreOf<AppFeature>
   @Bindable var repositoriesStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
@@ -167,7 +168,7 @@ struct ContentView: View {
             ? terminalManager.canvasFocusedWorktreeID
             : nil,
           ghosttyCommands: ghosttyShortcuts.commandPaletteEntries,
-          workflowItems: store.workflowPaletteItems
+          workflowItems: featureFlags.workflowUI ? store.workflowPaletteItems : []
         ),
         resolvedKeybindings: store.resolvedKeybindings
       )
@@ -178,7 +179,7 @@ struct ContentView: View {
       }
     }
     .overlay {
-      if !store.workflowStartFromSettings,
+      if featureFlags.workflowUI, !store.workflowStartFromSettings,
         let workflowStartStore = store.scope(state: \.workflowStart, action: \.workflowStart.presented)
       {
         WorkflowStartOverlayView(store: workflowStartStore)

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentRowSupport.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentRowSupport.swift
@@ -39,6 +39,7 @@ enum ActiveAgentRowPresentation {
 }
 
 struct ActiveAgentRowContextMenu: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   let entry: ActiveAgentEntry
   let directory: URL?
   let send: (ActiveAgentsFeature.Action) -> Void
@@ -51,7 +52,9 @@ struct ActiveAgentRowContextMenu: View {
     }
     .help("Save this agent's progress and hand the task off to another agent")
 
-    runWorkflowMenu
+    if featureFlags.workflowUI {
+      runWorkflowMenu
+    }
 
     Button("Mark as Read") {
       send(.markAsReadTapped(entry.id))

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -15,7 +15,7 @@ extension AppFeature {
     forceSheet: Bool,
     fromSettings: Bool = false
   ) -> Effect<Action> {
-    guard state.workflowStart == nil else { return .none }
+    guard featureFlags.workflowUI, state.workflowStart == nil else { return .none }
     let worktree: Worktree
     if let worktreeID {
       guard let explicitWorktree = state.repositories.terminalWorktree(for: worktreeID) else {
@@ -58,7 +58,7 @@ extension AppFeature {
   /// Palette rows come from a state snapshot because the assembler runs on every body
   /// evaluation; the catalog scan happens only when the palette opens.
   func refreshWorkflowPaletteItems(state: inout State) {
-    guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
+    guard featureFlags.workflowUI, let worktree = actionTargetWorktree(repositories: state.repositories) else {
       state.workflowPaletteItems = []
       return
     }
@@ -71,7 +71,7 @@ extension AppFeature {
   /// The Active Agents rows' `in <workflow> · <role>` subtitles (000-plan entry points),
   /// derived from the live runs' bindings whenever WorkflowRunsFeature state changes.
   func syncWorkflowRoleBadges(state: inout State) {
-    let badges = Self.workflowRoleBadges(for: state.workflowRuns)
+    let badges = featureFlags.workflowUI ? Self.workflowRoleBadges(for: state.workflowRuns) : [:]
     if state.repositories.workflowRoleBadgesBySurfaceID != badges {
       state.repositories.workflowRoleBadgesBySurfaceID = badges
     }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -118,6 +118,7 @@ struct AppFeature {
   @Dependency(AnalyticsClient.self) var analyticsClient
   @Dependency(\.date.now) var now
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence
+  @Dependency(FeatureFlags.self) var featureFlags
   @Dependency(WorkspaceClient.self) var workspaceClient
   @Dependency(SettingsWindowClient.self) var settingsWindowClient
   @Dependency(AppLifecycleClient.self) var appLifecycleClient
@@ -812,6 +813,7 @@ struct AppFeature {
         return openSettingsEffect(selecting: .profiles)
 
       case .openWorkflowDetails(let item, let worktreeID):
+        guard featureFlags.workflowUI else { return .none }
         let selection: SettingsSection
         let load: Effect<Action>
         let show: Effect<Action>
@@ -1154,6 +1156,7 @@ struct AppFeature {
         return reduceCommandPaletteAction(action, state: &state)
 
       case .workflowRuns(.delegate(.notice(let notice))):
+        guard featureFlags.workflowUI else { return .none }
         guard let worktree = state.repositories.worktree(for: notice.worktreeID) else {
           return .none
         }

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -188,6 +188,7 @@ struct AgentsQuickLaunchButton: View {
 /// (recommended profile first) so the shared purpose is stated once instead
 /// of repeated per row, and the manage entry closes the list.
 private struct AgentsPopoverContent: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]
   let workflowsWorktreeID: Worktree.ID?
@@ -269,7 +270,7 @@ private struct AgentsPopoverContent: View {
     .task { await AgentRuntimeAvailabilityProbe.refresh() }
     // Workflows re-list on every open so file edits show without a relaunch.
     .task {
-      guard let workflowsWorktreeID else { return }
+      guard featureFlags.workflowUI, let workflowsWorktreeID else { return }
       workflowItems = workflowStartClient.catalog(workflowsWorktreeID)
     }
   }

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -1,6 +1,8 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ToolbarStatusView: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   let toast: RepositoriesFeature.StatusToast?
   let workflow: WorkflowStatusCenterPresentation
   let pullRequest: GithubPullRequest?
@@ -10,17 +12,20 @@ struct ToolbarStatusView: View {
   var body: some View {
     let selection = ToolbarStatusSelection(
       toast: toast,
-      workflow: workflow,
+      workflow: featureFlags.workflowUI
+        ? workflow : WorkflowStatusCenterPresentation(state: .init(), selectedWorktreeID: nil, now: .distantPast),
       pullRequest: pullRequest
     )
     ZStack {
       // Keep this mounted across the last-run transition so its local popover state observes the
       // empty run list and resets before a later run appears.
-      WorkflowStatusPopoverButton(
-        presentation: workflow,
-        isToolbarVisible: selection.isWorkflow,
-        onIntent: onWorkflowIntent
-      )
+      if featureFlags.workflowUI {
+        WorkflowStatusPopoverButton(
+          presentation: workflow,
+          isToolbarVisible: selection.isWorkflow,
+          onIntent: onWorkflowIntent
+        )
+      }
       switch selection {
       case .toast(.inProgress(let message)):
         HStack(spacing: 6) {

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -241,6 +241,7 @@ struct SettingsFeature {
     case cliInstallCompleted(CLIInstallResultMessage)
   }
 
+  @Dependency(FeatureFlags.self) private var featureFlags
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
@@ -531,7 +532,7 @@ struct SettingsFeature {
         return .none
 
       case .setSelection(let selection):
-        let resolvedSelection = selection ?? .general
+        let resolvedSelection = selection == .workflows && !featureFlags.workflowUI ? .profiles : selection ?? .general
         state.selection = resolvedSelection
         // Owned here rather than in AppFeature so `ifLet` observes the removal and cancels an
         // in-flight link effect (or the Workflows page's directory watcher) instead of letting

--- a/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
+++ b/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
@@ -5,7 +5,12 @@ import SwiftUI
 /// skill, with one full-width line per detected target (status, link folder, action).
 /// Link behavior stays in `AgentSkillsFeature`; this view only presents it.
 struct AgentSkillsSectionView: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   @Bindable var store: StoreOf<AgentSkillsFeature>
+
+  private var visibleSkills: [AgentSkillsFeature.SkillRow] {
+    store.skills.filter { featureFlags.showsSkill($0.id) }
+  }
 
   var body: some View {
     Section {
@@ -41,7 +46,7 @@ struct AgentSkillsSectionView: View {
         }
       }
       .font(.callout)
-    } else if store.skills.isEmpty {
+    } else if visibleSkills.isEmpty {
       Text("This app bundles no installable skills.")
         .foregroundStyle(.secondary)
         .font(.callout)
@@ -55,9 +60,9 @@ struct AgentSkillsSectionView: View {
         .foregroundStyle(.secondary)
         .font(.callout)
       }
-      ForEach(store.skills) { row in
+      ForEach(visibleSkills) { row in
         skillRow(row)
-        if row.id != store.skills.last?.id {
+        if row.id != visibleSkills.last?.id {
           Divider()
         }
       }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -4,6 +4,7 @@ import Sharing
 import SwiftUI
 
 struct RepositorySettingsView: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   @Bindable var store: StoreOf<RepositorySettingsFeature>
   @State private var isBranchPickerPresented = false
   @State private var branchSearchText = ""
@@ -288,7 +289,9 @@ struct RepositorySettingsView: View {
           }
         }
 
-        WorkflowSettingsSections(store: workflowsStore, showsIntroduction: false)
+        if featureFlags.workflowUI {
+          WorkflowSettingsSections(store: workflowsStore, showsIntroduction: false)
+        }
 
         Section {
           ScriptEnvironmentRow(
@@ -388,8 +391,10 @@ struct RepositorySettingsView: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .task {
         store.send(.task)
-        store.send(.workflowsAppeared)
-        workflowsStore.send(.task)
+        if featureFlags.workflowUI {
+          store.send(.workflowsAppeared)
+          workflowsStore.send(.task)
+        }
         await githubIdentityViewModel.load()
       }
       .alert($workflowsStore.scope(state: \.alert, action: \.alert))
@@ -404,7 +409,9 @@ struct RepositorySettingsView: View {
         }
       }
     } destination: { detailStore in
-      WorkflowSettingsDetailView(store: detailStore)
+      if featureFlags.workflowUI {
+        WorkflowSettingsDetailView(store: detailStore)
+      }
     }
     .onDisappear { workflowsStore.send(.teardown) }
   }

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct SettingsView: View {
+  @Dependency(FeatureFlags.self) private var featureFlags
   @Bindable var store: StoreOf<AppFeature>
   @Bindable var settingsStore: StoreOf<SettingsFeature>
   @Environment(\.dismiss) private var dismiss
@@ -44,8 +45,10 @@ struct SettingsView: View {
             .tag(SettingsSection.profiles)
           Label("CLI & Skills", systemImage: "terminal")
             .tag(SettingsSection.commandLineTool)
-          Label("Workflows", systemImage: "point.3.connected.trianglepath.dotted")
-            .tag(SettingsSection.workflows)
+          if featureFlags.workflowUI {
+            Label("Workflows", systemImage: "point.3.connected.trianglepath.dotted")
+              .tag(SettingsSection.workflows)
+          }
         }
 
         Section("Repositories") {
@@ -141,11 +144,13 @@ struct SettingsView: View {
         }
       case .workflows:
         SettingsDetailView {
-          if let workflowsStore = settingsStore.scope(state: \.workflows, action: \.workflows) {
-            WorkflowsSettingsView(store: workflowsStore)
-          } else {
-            ProgressView()
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
+          if featureFlags.workflowUI {
+            if let workflowsStore = settingsStore.scope(state: \.workflows, action: \.workflows) {
+              WorkflowsSettingsView(store: workflowsStore)
+            } else {
+              ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
           }
         }
       case .commandLineTool:
@@ -186,7 +191,7 @@ struct SettingsView: View {
     .frame(minWidth: 800, minHeight: 600)
     .disabled(store.workflowStartFromSettings)
     .overlay {
-      if store.workflowStartFromSettings,
+      if featureFlags.workflowUI, store.workflowStartFromSettings,
         let workflowStartStore = store.scope(state: \.workflowStart, action: \.workflowStart.presented)
       {
         WorkflowStartOverlayView(store: workflowStartStore)

--- a/supacode/Support/FeatureFlags.swift
+++ b/supacode/Support/FeatureFlags.swift
@@ -1,0 +1,28 @@
+import ComposableArchitecture
+import Foundation
+
+/// Process-scoped opt-ins for unfinished UI. Flags never gate CLI/runtime capabilities.
+nonisolated struct FeatureFlags: Equatable, Sendable {
+  let workflowUI: Bool
+
+  init(environment: [String: String]) {
+    workflowUI = environment["PROWL_WORKFLOW_UI"] == "1"
+  }
+
+  func showsSkill(_ id: String) -> Bool {
+    workflowUI || id != "prowl-workflow"
+  }
+}
+
+extension FeatureFlags: DependencyKey {
+  static let liveValue = FeatureFlags(environment: ProcessInfo.processInfo.environment)
+  // Existing workflow feature tests exercise the opt-in UI; release-gate tests inject off.
+  static let testValue = FeatureFlags(environment: ["PROWL_WORKFLOW_UI": "1"])
+}
+
+extension DependencyValues {
+  var featureFlags: FeatureFlags {
+    get { self[FeatureFlags.self] }
+    set { self[FeatureFlags.self] = newValue }
+  }
+}

--- a/supacodeTests/AppFeatureWorkflowNoticeTests.swift
+++ b/supacodeTests/AppFeatureWorkflowNoticeTests.swift
@@ -162,6 +162,32 @@ struct AppFeatureWorkflowNoticeTests {
     #expect(contextRequests.value == 0)
   }
 
+  @Test func hiddenWorkflowUIBlocksNavigationAndNotices() async {
+    let worktree = makeWorktree(id: "selected")
+    var repositories = RepositoriesFeature.State(repositories: [makeRepository(worktrees: [worktree])])
+    repositories.selection = .worktree(worktree.id)
+    let requests = LockIsolated(0)
+    let store = TestStore(initialState: AppFeature.State(repositories: repositories)) {
+      AppFeature()
+    } withDependencies: {
+      $0.featureFlags = FeatureFlags(environment: [:])
+      $0.workflowStartClient.context = { _, _, _ in
+        requests.withValue { $0 += 1 }
+        return nil
+      }
+      $0.workflowRuntimeClient.notify = { _, _ in
+        requests.withValue { $0 += 1 }
+      }
+    }
+    await store.send(
+      .openWorkflowStart(
+        workflowKey: "user/review", worktreeID: worktree.id, sourceSurfaceID: nil, forceSheet: true))
+    await store.send(.workflowRuns(.delegate(.notice(makeNotice(kind: .completed, worktree: worktree)))))
+    #expect(requests.value == 0)
+    #expect(store.state.workflowStart == nil)
+    #expect(store.state.repositories.statusToast == nil)
+  }
+
   private func makeNotice(
     kind: WorkflowRunNotice.Kind,
     worktree: Worktree

--- a/supacodeTests/FeatureFlagsTests.swift
+++ b/supacodeTests/FeatureFlagsTests.swift
@@ -1,0 +1,33 @@
+import ComposableArchitecture
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct FeatureFlagsTests {
+  @Test func workflowUIRequiresExplicitOptIn() {
+    for environment in [[:], ["PROWL_WORKFLOW_UI": ""], ["PROWL_WORKFLOW_UI": "0"], ["PROWL_WORKFLOW_UI": "true"]] {
+      #expect(!FeatureFlags(environment: environment).workflowUI)
+    }
+    #expect(FeatureFlags(environment: ["PROWL_WORKFLOW_UI": "1"]).workflowUI)
+  }
+
+  @Test func hiddenWorkflowSettingsCannotBeSelected() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.featureFlags = FeatureFlags(environment: [:])
+    }
+    await store.send(.setSelection(.workflows)) {
+      $0.selection = .profiles
+    }
+    #expect(store.state.workflows == nil)
+  }
+
+  @Test func workflowSkillVisibilityDoesNotHideOtherSkills() {
+    let flags = FeatureFlags(environment: [:])
+    #expect(!flags.showsSkill("prowl-workflow"))
+    #expect(flags.showsSkill("prowl-cli"))
+    #expect(FeatureFlags(environment: ["PROWL_WORKFLOW_UI": "1"]).showsSkill("prowl-workflow"))
+  }
+}


### PR DESCRIPTION
Workflow UI is still awaiting action bundles and built-in workflow acceptance. Hide it by default so the next release can ship the merged Agent Island, runtime detection fixes, and other accepted improvements.

Add a small injectable `FeatureFlags` dependency: only `PROWL_WORKFLOW_UI=1` at process launch enables workflow UI. Gate workflow entries in the Agents capsule, active-agent menus and role badges, toolbar status, command palette, global/repository Settings, authoring/start surfaces, and the workflow skill row. Guard GUI navigation and automatic workflow notices too. Agent profile controls remain available; workflow CLI execution, bundled resources, skill installation, and explicit workflow steps remain unchanged.

Update the workflow release plan, release runbook/skill, and component documentation. Defer action bundles, handoff migration, and adversarial review; this is the final planned implementation PR before release preparation. Publishing still requires the normal runtime contract checks and notarization.

Validation:
- 52 focused app tests passed, including new default-off parsing, navigation, notice, and skill-visibility coverage plus existing workflow runtime harness tests.
- `make check` passed, including 131 script tests and strict formatting/lint; `make build-app` passed without warnings.
- Release skill metadata validation passed.
- Live Debug checks with a separate socket and temporary repository confirmed the capsule, global/repository Settings, skill row, and palette entries are hidden by default and restored with `PROWL_WORKFLOW_UI=1`; visually inspected both capsule states.
- With the flag absent, CLI catalog listing worked, a notification-only workflow completed, and `skills list` still exposed the workflow skill. No model calls or credential changes were needed. The temporary repository registration was removed afterward.

The conflicting action-design PR #771 was resolved and merged before branching from updated main. This PR does not publish a release.
