### PR TITLE
Reduce release size and incremental build work

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -34,10 +34,14 @@ runs:
       uses: actions/cache@v4
       with:
         path: .build
-        key: ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ hashFiles('ProwlCLI/**/*.swift', 'ProwlCLITests/**/*.swift', 'supacode/CLIService/Shared/**/*.swift') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-${{ hashFiles('ProwlCLI/**/*.swift', 'ProwlCLITests/**', 'ProwlCLIContracts/**', 'supacode/CLIService/Shared/**/*.swift') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved') }}-
-          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-
+          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-
+          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-
+
+    - name: Restore unchanged CLI source times
+      shell: bash
+      run: python3 scripts/ci-source-mtimes.py restore
 
     - name: Ghostty cache key
       shell: bash
@@ -73,7 +77,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/Library/Caches/supacode-spm-cache/SourcePackages
-        key: ${{ runner.os }}-${{ runner.arch }}-spm-v0-${{ hashFiles('**/Package.resolved') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-spm-v0-${{ hashFiles('supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-spm-v0-
 
@@ -85,7 +89,7 @@ runs:
         # successful changed build saves newly compiled objects; restore-keys select the
         # newest compatible CAS. Never restore across Xcode builds because compiler cache
         # keys and storage formats are toolchain-specific.
-        key: ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.resolved', 'supacode.xcodeproj/project.pbxproj') }}-${{ hashFiles('supacode/**/*.swift', 'supacodeTests/**/*.swift') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'supacode.xcodeproj/project.pbxproj', 'supacode.xcodeproj/xcshareddata/xcschemes/**', 'Makefile', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml') }}-${{ hashFiles('supacode/**/*.swift', 'supacodeTests/**/*.swift') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.resolved', 'supacode.xcodeproj/project.pbxproj') }}-
+          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'supacode.xcodeproj/project.pbxproj', 'supacode.xcodeproj/xcshareddata/xcschemes/**', 'Makefile', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml') }}-
           ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -34,9 +34,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: .build
-        key: ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-${{ hashFiles('ProwlCLI/**/*.swift', 'ProwlCLITests/**', 'ProwlCLIContracts/**', 'supacode/CLIService/Shared/**/*.swift') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'supacode/CLIService/Shared/Package.swift', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-${{ hashFiles('ProwlCLI/**/*.swift', 'ProwlCLITests/**', 'ProwlCLIContracts/**', 'supacode/CLIService/Shared/**/*.swift') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-
+          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'supacode/CLIService/Shared/Package.swift', 'Makefile', 'supacode.xcodeproj/project.pbxproj', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-
           ${{ runner.os }}-${{ runner.arch }}-cli-spm-v2-${{ env.XCODE_CACHE_ID }}-
 
     - name: Restore unchanged CLI source times
@@ -93,3 +93,24 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'supacode.xcodeproj/project.pbxproj', 'supacode.xcodeproj/xcshareddata/xcschemes/**', 'Makefile', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml') }}-
           ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-
+
+    - name: App incremental cache identity
+      shell: bash
+      run: |
+        set -euo pipefail
+        # A changed file roster starts a fresh build to exclude stale source/resource outputs.
+        APP_INPUT_PATHS_ID="$(git ls-files -z -- supacode supacodeTests Resources docs skills | shasum -a 256 | cut -d ' ' -f 1)"
+        APP_WORKSPACE_ID="$(pwd -P | shasum -a 256 | cut -d ' ' -f 1)"
+        printf '%s\n' "APP_INPUT_PATHS_ID=$APP_INPUT_PATHS_ID" "APP_WORKSPACE_ID=$APP_WORKSPACE_ID" >> "$GITHUB_ENV"
+    - name: App incremental build cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.PROWL_DERIVED_DATA_PATH }}
+        # Incremental state needs a stricter boundary than the content-addressed cache.
+        # Reuse across source edits, but not changed paths, build settings or toolchains.
+        key: ${{ runner.os }}-${{ runner.arch }}-app-incremental-v1-${{ env.XCODE_CACHE_ID }}-${{ env.APP_WORKSPACE_ID }}-${{ env.GHOSTTY_SHA }}-${{ env.APP_INPUT_PATHS_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'supacode/CLIService/Shared/Package.swift', 'supacode.xcodeproj/**', 'Makefile', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-${{ hashFiles('supacode/**/*.swift', 'supacodeTests/**/*.swift') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-app-incremental-v1-${{ env.XCODE_CACHE_ID }}-${{ env.APP_WORKSPACE_ID }}-${{ env.GHOSTTY_SHA }}-${{ env.APP_INPUT_PATHS_ID }}-${{ hashFiles('Package.swift', 'Package.resolved', 'supacode/CLIService/Shared/Package.swift', 'supacode.xcodeproj/**', 'Makefile', '.github/actions/setup-macos/action.yml', '.github/workflows/test.yml', 'scripts/ci-source-mtimes.py') }}-
+    - name: Restore unchanged App source times
+      shell: bash
+      run: python3 scripts/ci-source-mtimes.py restore --scope app --manifest "$PROWL_DERIVED_DATA_PATH/source-times.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             local name="$1"
             shift
             local log="build/ci-logs/${name}.log"
+            local started=$SECONDS
             echo "::group::${name}"
             # Capture the command's own exit code. Reading $? after an
             # `if cmd; then ...; fi` block yields the `if` status (0 when the
@@ -44,6 +45,7 @@ jobs:
             # failures and let the step pass on a failing build.
             local status=0
             "$@" >"$log" 2>&1 || status=$?
+            printf '| %s | %s | %s |\n' "$name" "$((SECONDS - started))" "$status" >"build/ci-logs/${name}.timing"
             cat "$log"
             echo "::endgroup::"
             return "$status"
@@ -63,7 +65,24 @@ jobs:
           wait "$pid_smoke" || failed=1
           wait "$pid_cli" || failed=1
           wait "$pid_scripts" || failed=1
+          {
+            printf '## Build and test wall time\n\n| Task | Seconds | Exit status |\n| --- | ---: | ---: |\n'
+            cat build/ci-logs/*.timing
+            printf '\nTasks run in parallel; their times must not be added.\n\n'
+            python3 scripts/summarize-xcode-build.py build/test-results/*.build.json
+          } >> "$GITHUB_STEP_SUMMARY"
           exit "$failed"
+      - name: Upload build and test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            build/ci-logs/
+            build/test-results/*.log
+            build/test-results/*.build.json
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Upload xcresult bundle (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,16 +53,14 @@ jobs:
 
           run_task app-tests make test-app &
           pid_app=$!
-          run_task cli-smoke make test-cli-smoke &
-          pid_smoke=$!
-          run_task cli-tests make test-cli-unit test-cli-integration &
+          # SwiftPM serializes access to .build; keep its checks in one branch.
+          run_task cli-tests make test-cli-smoke test-cli-unit test-cli-integration &
           pid_cli=$!
           run_task scripts make test-scripts &
           pid_scripts=$!
 
           failed=0
           wait "$pid_app" || failed=1
-          wait "$pid_smoke" || failed=1
           wait "$pid_cli" || failed=1
           wait "$pid_scripts" || failed=1
           {
@@ -72,6 +70,8 @@ jobs:
             python3 scripts/summarize-xcode-build.py build/test-results/*.build.json
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$failed"
+      - name: Save CLI source times
+        run: python3 scripts/ci-source-mtimes.py save
       - name: Upload build and test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
     env:
+      PROWL_DERIVED_DATA_PATH: ${{ github.workspace }}/build/ci-derived-data
       MISE_HTTP_TIMEOUT: 120
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -70,8 +71,10 @@ jobs:
             python3 scripts/summarize-xcode-build.py build/test-results/*.build.json
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$failed"
-      - name: Save CLI source times
-        run: python3 scripts/ci-source-mtimes.py save
+      - name: Save build input times
+        run: |
+          python3 scripts/ci-source-mtimes.py save
+          python3 scripts/ci-source-mtimes.py save --scope app --manifest "$PROWL_DERIVED_DATA_PATH/source-times.json"
       - name: Upload build and test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CLI_SOURCE_INPUTS := \
 	$(CURRENT_MAKEFILE_DIR)/Package.swift \
 	$(CURRENT_MAKEFILE_DIR)/Package.resolved \
 	$(CURRENT_MAKEFILE_DIR)/supacode.xcodeproj/project.pbxproj \
-	$(shell find $(CLI_SOURCE_DIRS) -type f 2>/dev/null)
+	$(shell find $(CLI_SOURCE_DIRS) -name .build -prune -o -type f -print 2>/dev/null)
 VERSION ?=
 BUILD ?=
 XCODEBUILD_FLAGS ?=
@@ -366,6 +366,9 @@ test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 		local expected_test_count="$$3"; \
 		shift 3; \
 		rm -rf "$$result_bundle"; \
+		if [ -n "$${PROWL_DERIVED_DATA_PATH:-}" ]; then \
+			set -- -derivedDataPath "$$PROWL_DERIVED_DATA_PATH" "$$@"; \
+		fi; \
 		set +e; \
 		xcodebuild "$$action" -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" $(TEST_SIGNING_ARGS) -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) -showBuildTimingSummary SWIFT_COMPILATION_MODE=incremental "$$@" 2>&1 | tee "$$result_bundle.log" | mise exec -- xcsift -w --build-info --format toon; \
 		local xcodebuild_status=$${PIPESTATUS[0]}; \

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ embed-cli: build-cli-release # Build release CLI and copy into Resources for dis
 	dst="$(CURRENT_MAKEFILE_DIR)/Resources/prowl-cli"; \
 	mkdir -p "$$dst"; \
 	cp "$$bin" "$$dst/prowl"; \
+	strip -S -x "$$dst/prowl"; \
 	chmod +x "$$dst/prowl"; \
 	echo "embedded CLI binary at $$dst/prowl"
 
@@ -366,9 +367,13 @@ test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 		shift 3; \
 		rm -rf "$$result_bundle"; \
 		set +e; \
-		xcodebuild "$$action" -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" $(TEST_SIGNING_ARGS) -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) SWIFT_COMPILATION_MODE=incremental "$$@" 2>&1 | mise exec -- xcsift -w --format toon; \
+		xcodebuild "$$action" -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" $(TEST_SIGNING_ARGS) -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) -showBuildTimingSummary SWIFT_COMPILATION_MODE=incremental "$$@" 2>&1 | tee "$$result_bundle.log" | mise exec -- xcsift -w --build-info --format toon; \
 		local xcodebuild_status=$${PIPESTATUS[0]}; \
 		set -e; \
+		if [ "$$action" = "test" ] && [ -d "$$result_bundle" ]; then \
+			xcrun xcresulttool get log --path "$$result_bundle" --type build --compact > "$$result_bundle.build.json" \
+				|| echo "warning: could not export Xcode build metrics" >&2; \
+		fi; \
 		if [ "$$xcodebuild_status" -ne 0 ]; then \
 			bash "$(CURRENT_MAKEFILE_DIR)/scripts/print-xcresult-failures.sh" "$$result_bundle" || true; \
 			return "$$xcodebuild_status"; \

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
       dependencies: [
         .product(name: "Yams", package: "Yams"),
       ],
-      path: "supacode/CLIService/Shared"
+      path: "supacode/CLIService/Shared",
+      exclude: ["Package.swift"]
     ),
     .executableTarget(
       name: "prowl",

--- a/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
+++ b/docs-ai/001-fork-bootstrap-and-release-pipeline/release-runbook.md
@@ -26,6 +26,12 @@ Each release produces:
 - `Prowl.app.zip` — signed zip for Sparkle updates
 - `appcast.xml` — Sparkle feed with EdDSA signature
 
+The DMG uses LZMA (`ULMO`). `create-dmg` first produces the Finder layout, then
+`scripts/recompress-dmg.sh` converts the image before signing and notarization.
+Conversion invalidates an existing image signature, so always sign the final image.
+The bundled release CLI has local and debug symbols stripped from its staged copy;
+the SwiftPM executable and its matching dSYM remain available for symbolication.
+
 ## Branch Strategy
 
 - `upstream/main`: source of truth (read-only remote branch)

--- a/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
@@ -96,3 +96,5 @@ Anchor wave, all landed 2026-04-04/05:
   [005-build-test-time-optimization.md](005-build-test-time-optimization.md)
 - Updated 2026-09-06: content-checked CLI source timestamps and cache input coverage — see
   [006-ci-source-cache-reuse.md](006-ci-source-cache-reuse.md)
+- Updated 2026-09-06: App incremental-state reuse and measured module extraction — see
+  [007-app-incremental-and-module-boundaries.md](007-app-incremental-and-module-boundaries.md)

--- a/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
@@ -94,3 +94,5 @@ Anchor wave, all landed 2026-04-04/05:
 - Updated 2026-08-05: fixed-path build benchmarks, rotating toolchain-scoped caches, an
   integrated CI build/test graph, and measured type-checker hotspot cleanup — see
   [005-build-test-time-optimization.md](005-build-test-time-optimization.md)
+- Updated 2026-09-06: content-checked CLI source timestamps and cache input coverage — see
+  [006-ci-source-cache-reuse.md](006-ci-source-cache-reuse.md)

--- a/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
@@ -173,7 +173,9 @@ pre-change median, and both were below the requested five-to-six-minute steady-s
   first successful `main` run for that toolchain populates the default-branch cache; later
   PRs can restore it, and changed PR source states save updated entries.
 - An exact-source rerun is the upper-bound cache case. Ordinary source changes restore the
-  newest compatible CAS through the toolchain/project prefix, then compile affected files.
+  newest compatible CAS through the toolchain/project prefix. With clean DerivedData,
+  a change in one App file can invalidate every App compilation batch; see
+  [006-ci-source-cache-reuse.md](006-ci-source-cache-reuse.md).
 - GitHub runner/network variance remains visible: the two equivalent warm jobs differed by
   82 s. Trend decisions should continue to use multiple samples and step-level timings.
 - Full DerivedData remains uncached; only compiler CAS and deterministic dependency/build

--- a/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
@@ -1,5 +1,8 @@
 # 016.006 — CI Source Cache Reuse
 
+Follow-up: [007](007-app-incremental-and-module-boundaries.md) records the later App
+incremental-state and Shared module experiments, which extend this CLI-only change.
+
 ## Context
 
 An exact CLI build-cache hit still recompiles checked-out sources. SwiftPM uses source

--- a/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
@@ -19,9 +19,10 @@ lockfile paths rather than searching restored dependency trees. Run CLI smoke/un
 checks sequentially within one parallel branch, because they share SwiftPM's build lock.
 
 Keep Xcode CAS caching. Do not add full DerivedData caching in this change: the measured
-Build directory adds 1.4 GB before compression, and existing repository caches already total
-10.4 GB. A local same-path experiment reduced build time from 43.7 s to 25.6 s by retaining
-incremental state, but archive transfer and fresh-checkout invalidation need separate trials.
+Build directory adds 1.4 GB before compression (291 MB with zstd), and existing repository
+caches already total 10.4 GB. A local same-path experiment reduced build time from 43.7 s
+to 25.6 s by retaining incremental state, but archive transfer and fresh-checkout
+invalidation need separate trials.
 
 The App compiles 532 Swift files as one module. With clean DerivedData and a warm CAS, a
 single comment change caused 22 Swift compilation misses plus one module-emission miss.
@@ -41,4 +42,9 @@ Six source-time regression tests pass. After updating modification times for all
 inputs and restoring 106 content-matched files, `swift build --product prowl` completed in
 0.57 s without source compilation. Touching one file without restoration compiled that
 file and emitted its module. `make check`, CLI build/smoke/unit/integration checks, and all 143 script tests pass.
-GitHub cross-run verification is pending.
+The App build, actionlint, and diff checks also pass. GitHub cache-population and reuse
+runs are linked in PR #773; source-time correctness tests remain part of every CI run.
+
+Performance decisions use repeated local comparisons with fixed paths and toolchains.
+Hosted CI validates cross-run cache restoration and test correctness; its wall times are
+not a controlled performance comparison because runner capacity varies.

--- a/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/006-ci-source-cache-reuse.md
@@ -1,0 +1,44 @@
+# 016.006 — CI Source Cache Reuse
+
+## Context
+
+An exact CLI build-cache hit still recompiles checked-out sources. SwiftPM uses source
+modification times for incremental builds, and checkout gives unchanged files new times.
+The source-state key also omits CLI contract resources and build configuration inputs.
+
+## Change
+
+Store source hashes and nanosecond modification times inside the CLI build cache after a
+successful test step. Restore times only for current tracked, regular input files whose
+SHA-256 matches the saved content. Require the same absolute workspace path. Missing or
+invalid manifests are cache misses. Never restore times based only on Git commit dates.
+Changed, new, deleted, and symlink inputs retain normal build-system invalidation.
+
+Include package, contract, project, and workflow inputs in immutable cache keys. Use exact
+lockfile paths rather than searching restored dependency trees. Run CLI smoke/unit/integration
+checks sequentially within one parallel branch, because they share SwiftPM's build lock.
+
+Keep Xcode CAS caching. Do not add full DerivedData caching in this change: the measured
+Build directory adds 1.4 GB before compression, and existing repository caches already total
+10.4 GB. A local same-path experiment reduced build time from 43.7 s to 25.6 s by retaining
+incremental state, but archive transfer and fresh-checkout invalidation need separate trials.
+
+The App compiles 532 Swift files as one module. With clean DerivedData and a warm CAS, a
+single comment change caused 22 Swift compilation misses plus one module-emission miss.
+The previous amendment's claim that ordinary changed CI runs compile only affected files
+was too broad: dependency modules can remain cached while every App batch recompiles.
+
+## Verification plan
+
+Test identical, changed, new, deleted, symlink, invalid-manifest, and relocated-workspace
+inputs. Compare SwiftPM logs before and after a content-identical timestamp change. Run the
+normal build and checks, then inspect CI cache hits and compilation logs. Module extraction
+remains a separate experiment; `ProwlCLIShared` is an existing dependency boundary to assess.
+
+## Local verification
+
+Six source-time regression tests pass. After updating modification times for all CLI
+inputs and restoring 106 content-matched files, `swift build --product prowl` completed in
+0.57 s without source compilation. Touching one file without restoration compiled that
+file and emitted its module. `make check`, CLI build/smoke/unit/integration checks, and all 143 script tests pass.
+GitHub cross-run verification is pending.

--- a/docs-ai/016-dev-build-and-ci-workflow/007-app-incremental-and-module-boundaries.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/007-app-incremental-and-module-boundaries.md
@@ -1,0 +1,53 @@
+# 016.007 — App Incremental Builds and Module Boundaries
+
+## Plan
+
+Measure two independent changes on the same local Mac with fixed Xcode, paths and build
+flags. Hosted CI checks cache restoration and test correctness; its elapsed time is not
+used as a performance comparison. Transfer and decompression are outside this investigation.
+
+1. Retain App incremental build state across checkout. Extend content-checked timestamp
+   restoration to App inputs, and validate unchanged, edited, new, deleted and resource
+   inputs against the actual build system before enabling it in CI. Scope state to the
+   compiler, project, dependency and workspace identities. A miss must build normally.
+2. Make the App consume the existing ProwlCLIShared library rather than compile its source
+   files in the App module. Preserve isolation, visibility and static linkage. Compare
+   cold builds, an App implementation edit and a Shared implementation edit before and
+   after extraction. Keep the change only if measurements justify its maintenance cost.
+
+Use the existing test surface to check behavior. Do not broadly expose internal declarations
+or change test counts to make extraction compile. Check release output size and linkage.
+Document failed approaches and retained results here once the experiments finish.
+
+## Implementation decisions
+
+The App uses a small package manifest in `supacode/CLIService/Shared/Package.swift` with
+only Yams as a dependency. Referencing the root CLI package also resolved CLI-only packages
+and added about 26 seconds before build activity locally. The CLI keeps its existing library
+product and source path, and excludes the nested manifest from its source target.
+
+The App synchronized source group treats Shared as an explicit folder and excludes that
+folder from target membership. A directory membership exception alone did not exclude its
+Swift children; the initial compiler errors exposed duplicate type definitions. The final
+App Swift source list contains no Shared files. Imports make dependencies explicit. Only
+`WorkflowValidator.isSingleLine`, already called by the App, needed public visibility.
+
+App state is cached at a fixed CI DerivedData path. Its restore prefix includes the workspace,
+Xcode build, Ghostty revision, project/package/build configuration and tracked input paths.
+Added/deleted source or resource paths therefore start fresh instead of retaining stale
+products. CLI-owned Shared timestamps are excluded from App timestamp restoration. Content
+changes retain normal compiler/resource invalidation; the existing CAS remains available.
+
+## Verification so far
+
+- `make check`: all formatting/lint checks and 146 script tests pass.
+- App Debug build and full App tests pass; no test filters were removed.
+- CLI build, smoke, 233 unit tests and 110 integration tests pass.
+- Simulated checkout restores unchanged input times without compiler misses. Changed and
+  newly added invalid Swift files both fail compilation, rather than using stale outputs.
+- An edited fixture reaches the built test bundle; restoring it restores the bundle content.
+- The optional test build path is covered with the system Bash and with a path containing
+  spaces. An injected Xcode failure still fails Make. This caught and fixed an empty-array
+  expansion error under Bash `nounset` before publication.
+
+Release output comparison and hosted cache-restoration checks remain to be completed.

--- a/docs-ai/016-dev-build-and-ci-workflow/007-app-incremental-and-module-boundaries.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/007-app-incremental-and-module-boundaries.md
@@ -38,11 +38,20 @@ Added/deleted source or resource paths therefore start fresh instead of retainin
 products. CLI-owned Shared timestamps are excluded from App timestamp restoration. Content
 changes retain normal compiler/resource invalidation; the existing CAS remains available.
 
-## Verification so far
+## Verification
 
 - `make check`: all formatting/lint checks and 146 script tests pass.
 - App Debug build and full App tests pass; no test filters were removed.
 - CLI build, smoke, 233 unit tests and 110 integration tests pass.
+- Universal Release builds successfully for arm64 and x86_64. Both executable UUIDs match
+  the retained dSYM. Neither architecture adds a Shared dynamic library.
+- Hosted cache-population [run 34003502189, attempt 1](https://github.com/onevcat/Prowl/actions/runs/34003502189/attempts/1)
+  passes all checks and saves the new App incremental cache.
+- Hosted [attempt 2](https://github.com/onevcat/Prowl/actions/runs/34003502189/attempts/2)
+  restores that cache plus 943 unchanged App and 107 CLI input timestamps. All checks pass.
+  App handwritten sources, Shared sources and test sources do not compile again. The sole
+  Swift compile miss is `GeneratedAssetSymbols.swift`; module emission is a cache hit.
+  CLI source compilation is also absent; SwiftPM still reports documentation plugin builds.
 - Simulated checkout restores unchanged input times without compiler misses. Changed and
   newly added invalid Swift files both fail compilation, rather than using stale outputs.
 - An edited fixture reaches the built test bundle; restoring it restores the bundle content.
@@ -50,4 +59,40 @@ changes retain normal compiler/resource invalidation; the existing CAS remains a
   spaces. An injected Xcode failure still fails Make. This caught and fixed an empty-array
   expansion error under Bash `nounset` before publication.
 
-Release output comparison and hosted cache-restoration checks remain to be completed.
+## Local measurements
+
+Single paired samples on the same Mac, Xcode, paths and flags; these are not medians or
+predictions of hosted CI elapsed time. The implementation-edit comparisons use warm CAS
+and fresh DerivedData to isolate module extraction from retained incremental state.
+
+| Build activity | Before extraction | After extraction |
+| --- | ---: | ---: |
+| Cold build-for-testing | 90.12 s | 73.46 s |
+| App implementation edit | 38.54 s | 35.94 s |
+| Shared implementation edit | 39.16 s | 21.64 s |
+
+The Shared edit changes a control-character comparison to an equivalent expression. Before
+extraction it misses 22 App compile tasks and one module task. After extraction it misses
+12 Shared compile tasks and one Shared module task; App compilation is reused. This is the
+strongest reason to retain the module boundary. App-only edits have a smaller benefit.
+
+With retained incremental state, a simulated checkout plus a new App function-body edit
+produced one compile miss and one module miss (21.14 s build activity). The Shared
+implementation edit likewise produced one compile miss and one module miss (13.03 s). This was repeated
+without driver diagnostic flags and with unique source content to avoid replaying an earlier
+probe's exact cache entry. Earlier cache/state transitions produced broader recompilation;
+this result describes a warm steady state, not an unconditional one-file rebuild guarantee.
+
+Cache miss counters count compiler tasks, which may batch multiple source files. They are
+not source-file counts. Restored incremental state and content-addressed cache reuse are
+separate mechanisms. A warm cache does not guarantee narrow recompilation after every edit;
+changes to public interfaces, dependency graphs or build flags can require broader work.
+
+For a Release arm64 build with coverage disabled, identical optimization and stripping,
+the main executable changes from 34,731,928 to 34,780,504 bytes: +48,576 bytes (+0.14%).
+The Shared module is statically linked; `otool -L` reports no added Shared dynamic library.
+This small size cost is accepted for the measured compilation isolation. These bytes must
+not be mixed with older artifacts built under different coverage/build settings.
+
+Raw logs, xcresult build metrics, paired binaries and probe scripts are under the ignored
+`build/module-research/` directory. No release was published.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -73,7 +73,7 @@ agent-facing manual for that).
 | 013 | [prowl-cli](013-prowl-cli/000-plan.md) | 2026-03-30 | Contract-first `prowl` CLI: socket service, v1 commands, hardening, agents |
 | 014 | [terminal-layout-persistence](014-terminal-layout-persistence/000-plan.md) | 2026-03-31 | Layout snapshot save/restore; font-size persistence; launch races |
 | 015 | [repositories-feature-refactor](015-repositories-feature-refactor/000-plan.md) | 2026-04-03 | TCA decomposition of RepositoriesFeature and later code-health splits |
-| 016 | [dev-build-and-ci-workflow](016-dev-build-and-ci-workflow/000-plan.md) | 2026-04-04 | Build/test tooling, CI parallelism, Debug identity, content-checked cache reuse |
+| 016 | [dev-build-and-ci-workflow](016-dev-build-and-ci-workflow/000-plan.md) | 2026-04-04 | Build/test tooling, CI parallelism, Debug identity, incremental caching, Shared module boundary |
 | 017 | [upstream-sync-process](017-upstream-sync-process/000-plan.md) | 2026-04-08 | Upstream review discipline, baselines, batch decisions |
 | 018 | [archived-worktrees](018-archived-worktrees/000-plan.md) | 2026-04-09 | Archived worktree discoverability and auto-delete |
 | 019 | [worktree-creation-and-lifecycle](019-worktree-creation-and-lifecycle/000-plan.md) | 2026-04-12 | Creation/merge flows, safe deletion, Add-to-Prowl redesign |

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -73,7 +73,7 @@ agent-facing manual for that).
 | 013 | [prowl-cli](013-prowl-cli/000-plan.md) | 2026-03-30 | Contract-first `prowl` CLI: socket service, v1 commands, hardening, agents |
 | 014 | [terminal-layout-persistence](014-terminal-layout-persistence/000-plan.md) | 2026-03-31 | Layout snapshot save/restore; font-size persistence; launch races |
 | 015 | [repositories-feature-refactor](015-repositories-feature-refactor/000-plan.md) | 2026-04-03 | TCA decomposition of RepositoriesFeature and later code-health splits |
-| 016 | [dev-build-and-ci-workflow](016-dev-build-and-ci-workflow/000-plan.md) | 2026-04-04 | Build/test tooling, CI parallelism, Debug identity, build speed |
+| 016 | [dev-build-and-ci-workflow](016-dev-build-and-ci-workflow/000-plan.md) | 2026-04-04 | Build/test tooling, CI parallelism, Debug identity, content-checked cache reuse |
 | 017 | [upstream-sync-process](017-upstream-sync-process/000-plan.md) | 2026-04-08 | Upstream review discipline, baselines, batch decisions |
 | 018 | [archived-worktrees](018-archived-worktrees/000-plan.md) | 2026-04-09 | Archived worktree discoverability and auto-delete |
 | 019 | [worktree-creation-and-lifecycle](019-worktree-creation-and-lifecycle/000-plan.md) | 2026-04-12 | Creation/merge flows, safe deletion, Add-to-Prowl redesign |

--- a/scripts/ci-source-mtimes.py
+++ b/scripts/ci-source-mtimes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preserve SwiftPM input times only when cached content still matches checkout."""
+"""Preserve build input times only when cached content still matches checkout."""
 
 import argparse
 import hashlib
@@ -12,6 +12,21 @@ INPUTS = [
     "Package.swift", "Package.resolved", "ProwlCLI", "ProwlCLITests",
     "ProwlCLIContracts", "supacode/CLIService/Shared",
 ]
+
+
+def tracked_inputs(root, scope):
+    def listed(paths):
+        output = subprocess.check_output(
+            ["git", "ls-files", "-z", "--", *paths], cwd=root, text=True
+        )
+        return {name for name in output.split("\0") if name}
+
+    cli = listed(INPUTS)
+    if scope == "cli":
+        return sorted(cli)
+    # The CLI cache owns shared-source timestamps. Restoring a second timestamp
+    # for those files would invalidate SwiftPM's restored incremental state.
+    return sorted(listed(["supacode", "supacodeTests", "supacode.xcodeproj"]) - cli)
 
 
 def regular_input(root, name):
@@ -69,19 +84,20 @@ def restore(root, names, manifest):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("action", choices=["save", "restore"])
+    parser.add_argument("--scope", choices=["cli", "app"], default="cli")
+    parser.add_argument("--manifest", type=Path)
     args = parser.parse_args()
     root = Path.cwd().resolve()
-    names = subprocess.check_output(
-        ["git", "ls-files", "-z", "--", *INPUTS], text=True
-    ).split("\0")
-    names = [name for name in names if name]
-    manifest = root / ".build/prowl-ci-source-mtimes.json"
+    names = tracked_inputs(root, args.scope)
+    manifest = args.manifest or root / ".build/prowl-ci-source-mtimes.json"
+    if args.scope == "app" and args.manifest is None:
+        parser.error("--scope app requires --manifest")
     if args.action == "save":
         save(root, names, manifest)
-        print("Saved CLI source content and modification times.")
+        print(f"Saved {args.scope} source content and modification times.")
     else:
         count = restore(root, names, manifest)
-        print(f"Restored modification times for {count} unchanged CLI inputs.")
+        print(f"Restored modification times for {count} unchanged {args.scope} inputs.")
 
 
 if __name__ == "__main__":

--- a/scripts/ci-source-mtimes.py
+++ b/scripts/ci-source-mtimes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Preserve SwiftPM input times only when cached content still matches checkout."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+INPUTS = [
+    "Package.swift", "Package.resolved", "ProwlCLI", "ProwlCLITests",
+    "ProwlCLIContracts", "supacode/CLIService/Shared",
+]
+
+
+def regular_input(root, name):
+    path = Path(name)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    current = root
+    for part in path.parts:
+        current = current / part
+        if current.is_symlink():
+            return None
+    return current if current.is_file() else None
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def save(root, names, manifest):
+    files = {}
+    for name in names:
+        path = regular_input(root, name)
+        if path is not None:
+            files[name] = {"sha256": digest(path), "mtime_ns": path.stat().st_mtime_ns}
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(json.dumps({"version": 1, "root": str(root), "files": files}))
+
+
+def restore(root, names, manifest):
+    try:
+        data = json.loads(manifest.read_text())
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(data, dict) or data.get("version") != 1 or data.get("root") != str(root):
+        return 0
+    files = data.get("files")
+    if not isinstance(files, dict):
+        return 0
+    restored = 0
+    for name in names:
+        entry = files.get(name)
+        path = regular_input(root, name)
+        if path is None or not isinstance(entry, dict):
+            continue
+        timestamp = entry.get("mtime_ns")
+        if type(timestamp) is not int or not 0 <= timestamp < 2**63:
+            continue
+        if entry.get("sha256") != digest(path):
+            continue
+        os.utime(path, ns=(path.stat().st_atime_ns, timestamp))
+        restored += 1
+    return restored
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["save", "restore"])
+    args = parser.parse_args()
+    root = Path.cwd().resolve()
+    names = subprocess.check_output(
+        ["git", "ls-files", "-z", "--", *INPUTS], text=True
+    ).split("\0")
+    names = [name for name in names if name]
+    manifest = root / ".build/prowl-ci-source-mtimes.json"
+    if args.action == "save":
+        save(root, names, manifest)
+        print("Saved CLI source content and modification times.")
+    else:
+        count = restore(root, names, manifest)
+        print(f"Restored modification times for {count} unchanged CLI inputs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recompress-dmg.sh
+++ b/scripts/recompress-dmg.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Conversion removes the image signature. Sign the output before notarization.
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: recompress-dmg.sh SOURCE.dmg OUTPUT.dmg" >&2
+  exit 2
+fi
+
+source_image="$1"
+output_image="$2"
+temporary_dir="$(mktemp -d "$(dirname "$output_image")/.dmg-compression.XXXXXX")"
+trap 'rm -rf "$temporary_dir"' EXIT
+
+# ULMO uses LZMA and is supported by every macOS version that Prowl supports.
+# Keep the previous output intact if conversion fails or is interrupted.
+hdiutil convert "$source_image" -format ULMO -o "$temporary_dir/Prowl.dmg"
+mv -f "$temporary_dir/Prowl.dmg" "$output_image"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -361,13 +361,18 @@ DMG_PATH="build/Prowl.dmg"
 mise exec -- create-dmg "$APP_PATH" build/ \
   --overwrite \
   --dmg-title="Prowl" \
-  --identity="$IDENTITY_SHA"
+  --no-code-sign
 
 DMG_OUTPUT="$(find build -name "*.dmg" -maxdepth 1 -newer build/ExportOptions.plist | head -1)"
 if [[ "$DMG_OUTPUT" != "$DMG_PATH" ]] && [[ -n "$DMG_OUTPUT" ]]; then
   mv "$DMG_OUTPUT" "$DMG_PATH"
 fi
 [[ -f "$DMG_PATH" ]] || die "DMG not found at $DMG_PATH"
+
+log "compressing DMG with LZMA..."
+bash "$SCRIPT_DIR/recompress-dmg.sh" "$DMG_PATH" "$DMG_PATH"
+codesign -s "$IDENTITY_SHA" --timestamp "$DMG_PATH"
+codesign --verify --strict "$DMG_PATH"
 
 # ── Notarize ─────────────────────────────────────────────────────────────────
 

--- a/scripts/summarize-xcode-build.py
+++ b/scripts/summarize-xcode-build.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Summarize xcresulttool build logs without adding overlapping task times."""
+
+import json
+from pathlib import Path
+import sys
+
+
+def summarize(log, name):
+    lines = [f"### {name}", "", f"Build wall time: **{log['duration']:.1f} s**", ""]
+    counters = {}
+    for attachment in log.get("attachments", []):
+        if attachment.get("uniformTypeIdentifier", "").endswith(".BuildOperationMetrics"):
+            counters.update(json.loads(attachment["data"]).get("counters", {}))
+    if counters:
+        lines.extend(f"- {key}: {value}" for key, value in sorted(counters.items()))
+    else:
+        lines.append("Cache counters unavailable for this build.")
+    lines.extend(["", "Slowest build tasks (times overlap):", "", "| Task | Seconds |", "| --- | ---: |"])
+    tasks = sorted(log.get("subsections", []), key=lambda task: task.get("duration", 0), reverse=True)
+    for task in tasks[:10]:
+        title = " ".join(task.get("title", "Unknown").split()).replace("|", "\\|")
+        if len(title) > 180:
+            title = title[:177] + "..."
+        lines.append(f"| {title} | {task.get('duration', 0):.1f} |")
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    for argument in sys.argv[1:]:
+        path = Path(argument)
+        try:
+            print(summarize(json.loads(path.read_text()), path.name))
+        except (OSError, ValueError, KeyError, TypeError) as error:
+            # Build diagnostics must not replace the build or test exit status.
+            print(f"Build metrics unavailable for {path.name}: {error}", file=sys.stderr)

--- a/scripts/test_app_build_path.py
+++ b/scripts/test_app_build_path.py
@@ -1,0 +1,47 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class AppBuildPathTests(unittest.TestCase):
+    def run_failed_build(self, derived_path):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            shutil.copyfile(Path(__file__).resolve().parents[1] / "Makefile", root / "Makefile")
+            (root / "overrides.mk").write_text("ensure-ghostty:\n\t@true\n")
+            (root / "xcodebuild").write_text(
+                '#!/usr/bin/env python3\nimport json, pathlib, sys\n'
+                'pathlib.Path("arguments.json").write_text(json.dumps(sys.argv[1:]))\n'
+                'sys.exit(23)\n'
+            )
+            (root / "mise").write_text("#!/bin/sh\ncat\n")
+            for name in ["xcodebuild", "mise"]:
+                (root / name).chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}")
+            env.pop("PROWL_DERIVED_DATA_PATH", None)
+            if derived_path is not None:
+                env["PROWL_DERIVED_DATA_PATH"] = derived_path
+            result = subprocess.run(
+                ["make", "-f", "Makefile", "-f", "overrides.mk", "test-app", "SHELL=/bin/bash"],
+                cwd=root, env=env, capture_output=True, text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue((root / "arguments.json").exists(), result.stderr)
+            return json.loads((root / "arguments.json").read_text())
+
+    def test_default_build_reaches_xcodebuild_with_bash_nounset(self):
+        arguments = self.run_failed_build(None)
+        self.assertNotIn("-derivedDataPath", arguments)
+        self.assertEqual(arguments[0], "test")
+
+    def test_explicit_build_path_preserves_spaces_and_failure(self):
+        arguments = self.run_failed_build("/tmp/build path")
+        self.assertEqual(arguments[arguments.index("-derivedDataPath") + 1], "/tmp/build path")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_source_mtimes.py
+++ b/scripts/test_ci_source_mtimes.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 import tempfile
+import subprocess
 import unittest
 
 spec = importlib.util.spec_from_file_location(
@@ -27,6 +28,20 @@ class SourceMtimeTests(unittest.TestCase):
 
     def save(self):
         module.save(self.root, ["Source.swift"], self.manifest)
+
+    def test_app_scope_excludes_cli_owned_inputs(self):
+        files = ["Package.swift", "supacode/CLIService/Shared/Model.swift",
+                 "supacode/Support/Model.swift", "supacodeTests/ModelTests.swift"]
+        for name in files:
+            path = self.root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("source")
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "add", "--", *files], check=True)
+        app = set(module.tracked_inputs(self.root, "app"))
+        cli = set(module.tracked_inputs(self.root, "cli"))
+        self.assertEqual(app, {"supacode/Support/Model.swift", "supacodeTests/ModelTests.swift"})
+        self.assertFalse(app & cli)
 
     def test_restores_only_identical_content(self):
         self.save()

--- a/scripts/test_ci_source_mtimes.py
+++ b/scripts/test_ci_source_mtimes.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "ci_source_mtimes", Path(__file__).with_name("ci-source-mtimes.py")
+)
+module = importlib.util.module_from_spec(spec)
+
+
+class SourceMtimeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        spec.loader.exec_module(module)
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.source = self.root / "Source.swift"
+        self.source.write_text("let value = 1\n")
+        os.utime(self.source, ns=(1000000000, 1000000000))
+        self.manifest = self.root / "manifest.json"
+
+    def save(self):
+        module.save(self.root, ["Source.swift"], self.manifest)
+
+    def test_restores_only_identical_content(self):
+        self.save()
+        os.utime(self.source, ns=(2000000000, 2000000000))
+        self.assertEqual(module.restore(self.root, ["Source.swift"], self.manifest), 1)
+        self.assertEqual(self.source.stat().st_mtime_ns, 1000000000)
+
+    def test_changed_content_keeps_new_time_even_with_same_size(self):
+        self.save()
+        self.source.write_text("let value = 2\n")
+        os.utime(self.source, ns=(2000000000, 2000000000))
+        self.assertEqual(module.restore(self.root, ["Source.swift"], self.manifest), 0)
+        self.assertEqual(self.source.stat().st_mtime_ns, 2000000000)
+
+    def test_new_and_deleted_files_are_not_restored(self):
+        self.save()
+        self.source.unlink()
+        (self.root / "New.swift").write_text("new")
+        self.assertEqual(module.restore(self.root, ["New.swift"], self.manifest), 0)
+
+    def test_missing_or_invalid_manifest_is_a_cache_miss(self):
+        self.assertEqual(module.restore(self.root, ["Source.swift"], self.manifest), 0)
+        self.manifest.write_text("invalid")
+        self.assertEqual(module.restore(self.root, ["Source.swift"], self.manifest), 0)
+
+    def test_unlisted_paths_and_symlinks_are_not_restored(self):
+        self.save()
+        os.utime(self.source, ns=(2000000000, 2000000000))
+        self.assertEqual(module.restore(self.root, [], self.manifest), 0)
+        (self.root / "Link.swift").symlink_to(self.source)
+        self.assertEqual(module.restore(self.root, ["Link.swift", "../Source.swift"], self.manifest), 0)
+        self.assertEqual(self.source.stat().st_mtime_ns, 2000000000)
+
+    def test_wrong_workspace_does_not_restore(self):
+        self.save()
+        data = json.loads(self.manifest.read_text())
+        data["root"] = "/different/workspace"
+        self.manifest.write_text(json.dumps(data))
+        self.assertEqual(module.restore(self.root, ["Source.swift"], self.manifest), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_recompress_dmg.py
+++ b/scripts/test_recompress_dmg.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("recompress-dmg.sh")
+
+
+class RecompressDMGTests(unittest.TestCase):
+    def run_case(self, failure, in_place=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "Prowl input.dmg"
+            source.write_bytes(b"original image")
+            output = source if in_place else root / "Prowl output.dmg"
+            if not in_place:
+                output.write_bytes(b"previous image")
+            tool = root / "hdiutil"
+            tool.write_text(
+                "#!/bin/bash\n"
+                '[[ "$1" == convert && "$3" == -format && "$4" == ULMO && "$5" == -o ]] || exit 90\n'
+                'printf "compressed image" > "$6"\n'
+                f"exit {failure}\n"
+            )
+            tool.chmod(0o755)
+            result = subprocess.run(
+                ["bash", str(SCRIPT), str(source), str(output)],
+                env={**os.environ, "PATH": f"{root}:{os.environ['PATH']}"},
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, failure, result.stderr)
+            if not in_place or failure:
+                self.assertEqual(source.read_bytes(), b"original image")
+            previous = b"original image" if in_place else b"previous image"
+            expected = previous if failure else b"compressed image"
+            self.assertEqual(output.read_bytes(), expected)
+            expected_files = ["Prowl input.dmg", "hdiutil"]
+            if not in_place:
+                expected_files.insert(1, "Prowl output.dmg")
+            self.assertEqual(sorted(p.name for p in root.iterdir()), expected_files)
+
+    def test_success_replaces_output_after_conversion(self):
+        self.run_case(0)
+
+    def test_failure_preserves_source_and_previous_output(self):
+        self.run_case(23)
+
+    def test_success_replaces_image_in_place(self):
+        self.run_case(0, in_place=True)
+
+    def test_failure_preserves_image_in_place(self):
+        self.run_case(23, in_place=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_summarize_xcode_build.py
+++ b/scripts/test_summarize_xcode_build.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+spec = importlib.util.spec_from_file_location(
+    "summarize_xcode_build", Path(__file__).with_name("summarize-xcode-build.py")
+)
+module = importlib.util.module_from_spec(spec)
+
+
+class BuildSummaryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        spec.loader.exec_module(module)
+
+    def test_reports_wall_time_separately_from_overlapping_tasks(self):
+        log = {
+            "duration": 10,
+            "subsections": [
+                {"title": "Compile A", "duration": 8},
+                {"title": "Compile B", "duration": 7},
+            ],
+            "attachments": [{
+                "uniformTypeIdentifier": "com.apple.dt.ActivityLogSectionAttachment.BuildOperationMetrics",
+                "data": '{"counters":{"swiftCacheHits":2,"swiftCacheMisses":3}}',
+            }],
+        }
+        result = module.summarize(log, "test.build.json")
+        self.assertIn("Build wall time: **10.0 s**", result)
+        self.assertIn("swiftCacheHits: 2", result)
+        self.assertIn("swiftCacheMisses: 3", result)
+        self.assertIn("| Compile A | 8.0 |", result)
+        self.assertNotIn("15.0", result)
+
+    def test_missing_metrics_remain_unknown(self):
+        result = module.summarize({"duration": 2}, "test.build.json")
+        self.assertIn("Cache counters unavailable", result)
+        self.assertNotIn("0%", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -7,12 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A77100000000000000000003 /* ProwlCLIShared in Frameworks */ = {isa = PBXBuildFile; productRef = A77100000000000000000002 /* ProwlCLIShared */; };
+		A77100000000000000000004 /* ProwlCLIShared in Frameworks */ = {isa = PBXBuildFile; productRef = A77100000000000000000002 /* ProwlCLIShared */; };
+
 		32513D1E25BB4F418CABB2A8 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8B2985744DB94333AE1B5878 /* Sentry */; };
 		886A649F771240E8A5AC792D /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 8D787DCF45744283A83F226F /* Dependencies */; };
 		C8B33B9AFE69E738ABFA08BE /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 497B582F42253CBC8FBF101F /* ComposableArchitecture */; };
 		D1BB05892F5ACB5900553512 /* YiTong in Frameworks */ = {isa = PBXBuildFile; productRef = D1BB05882F5ACB5900553512 /* YiTong */; };
 		66055880DA0BAF0D05D67D02 /* GlyphonKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0C10F7612452A2EF85A71541 /* GlyphonKit */; };
-		7A1D5E2C9B3F4A6D8E0C1B2C /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */; };
 		D63D00F72F2A5EEE00018D05 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */; };
 		D64162B02F23CAF100260CA3 /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = D64162AD2F23CAF100260CA3 /* ghostty */; };
 		D64162B12F23CAF100260CA3 /* terminfo in Resources */ = {isa = PBXBuildFile; fileRef = D64162AE2F23CAF100260CA3 /* terminfo */; };
@@ -57,6 +59,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				CLIService/Shared,
 			);
 			target = D69CE0492F1F378200584C57 /* supacode */;
 		};
@@ -67,6 +70,9 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				D4C9CFFBF3C440848B2DA2B0 /* Exceptions for "supacode" folder in "supacode" target */,
+			);
+			explicitFolders = (
+				CLIService/Shared,
 			);
 			path = supacode;
 			sourceTree = "<group>";
@@ -88,7 +94,7 @@
 			files = (
 				D1BB05892F5ACB5900553512 /* YiTong in Frameworks */,
 				66055880DA0BAF0D05D67D02 /* GlyphonKit in Frameworks */,
-				7A1D5E2C9B3F4A6D8E0C1B2C /* Yams in Frameworks */,
+				A77100000000000000000003 /* ProwlCLIShared in Frameworks */,
 				C8B33B9AFE69E738ABFA08BE /* ComposableArchitecture in Frameworks */,
 				886A649F771240E8A5AC792D /* Dependencies in Frameworks */,
 				D6A1CB312F1F4ABF004FDABD /* GhosttyKit.xcframework in Frameworks */,
@@ -105,6 +111,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D63D00F72F2A5EEE00018D05 /* DependenciesTestSupport in Frameworks */,
+				A77100000000000000000004 /* ProwlCLIShared in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,7 +183,7 @@
 				D6D054272F2E3EBF00D70ED5 /* PostHog */,
 				D1BB05882F5ACB5900553512 /* YiTong */,
 				0C10F7612452A2EF85A71541 /* GlyphonKit */,
-				7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */,
+				A77100000000000000000002 /* ProwlCLIShared */,
 			);
 			productName = supacode;
 			productReference = D69CE04A2F1F378200584C57 /* Prowl.app */;
@@ -201,6 +208,7 @@
 			name = supacodeTests;
 			packageProductDependencies = (
 				D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */,
+				A77100000000000000000002 /* ProwlCLIShared */,
 			);
 			productName = supacodeTests;
 			productReference = D6F821012F1FCBC1004B4174 /* supacodeTests.xctest */;
@@ -235,6 +243,7 @@
 			mainGroup = D69CE0412F1F378200584C57;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				A77100000000000000000001 /* XCLocalSwiftPackageReference "Shared" */,
 				911B4AAD84AF4B34BE232133 /* XCRemoteSwiftPackageReference "swift-case-paths" */,
 				8E10C2184F9342AC850013F5 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				46ECCA2394D141A89BE74516 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
@@ -243,7 +252,6 @@
 				D6D054262F2E3EB300D70ED5 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				D1BB05872F5ACB5900553512 /* XCRemoteSwiftPackageReference "YiTong" */,
 				AA918EA35EA8913669138FE5 /* XCRemoteSwiftPackageReference "GlyphonKit" */,
-				7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = D69CE04B2F1F378200584C57 /* Products */;
@@ -673,6 +681,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		A77100000000000000000001 /* XCLocalSwiftPackageReference "Shared" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = supacode/CLIService/Shared;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		46ECCA2394D141A89BE74516 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -730,14 +745,6 @@
 				minimumVersion = 0.1.0;
 			};
 		};
-		7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/jpsim/Yams.git";
-			requirement = {
-				kind = exactVersion;
-				version = 6.2.2;
-			};
-		};
 		D6D054262F2E3EB300D70ED5 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
@@ -749,6 +756,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		A77100000000000000000002 /* ProwlCLIShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A77100000000000000000001 /* XCLocalSwiftPackageReference "Shared" */;
+			productName = ProwlCLIShared;
+		};
 		497B582F42253CBC8FBF101F /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B43B9188E1D223E6F7344501 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
@@ -778,11 +790,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA918EA35EA8913669138FE5 /* XCRemoteSwiftPackageReference "GlyphonKit" */;
 			productName = GlyphonKit;
-		};
-		7A1D5E2C9B3F4A6D8E0C1B2B /* Yams */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7A1D5E2C9B3F4A6D8E0C1B2A /* XCRemoteSwiftPackageReference "Yams" */;
-			productName = Yams;
 		};
 		D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7643fa12a28d827327bdbe83f87db88bb3a3e9b400463e3aa384776ca321786f",
+  "originHash" : "64029e49b2df7565ff32fb09948035f80c1a86a77fa5fb74dd6055a98a34ca5d",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -1,3 +1,4 @@
+import ProwlCLIShared
 import SwiftUI
 
 struct AppShortcut: Equatable {

--- a/supacode/App/WorkflowRuntimeComposition.swift
+++ b/supacode/App/WorkflowRuntimeComposition.swift
@@ -6,6 +6,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 /// Lets the responder dependency (installed before the store exists) reach the coordinator that
 /// is built with the CLI router.

--- a/supacode/App/WorkflowSettingsComposition.swift
+++ b/supacode/App/WorkflowSettingsComposition.swift
@@ -5,6 +5,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 extension SupacodeApp {
   @MainActor

--- a/supacode/App/WorkflowStartComposition.swift
+++ b/supacode/App/WorkflowStartComposition.swift
@@ -5,6 +5,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 extension SupacodeApp {
   @MainActor

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 import Foundation
 import GhosttyKit
 import PostHog
+import ProwlCLIShared
 import Sentry
 import Sharing
 import SwiftUI

--- a/supacode/CLIService/AgentConditionEvidence.swift
+++ b/supacode/CLIService/AgentConditionEvidence.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// The per-poll view of one pane that condition evidence is evaluated against.
 struct AgentConditionSnapshot: Sendable {

--- a/supacode/CLIService/AgentDispatchCommandHandler.swift
+++ b/supacode/CLIService/AgentDispatchCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 private let dispatchLogger = SupaLogger("AgentDispatchCommandHandler")
 

--- a/supacode/CLIService/AgentNativeHookCommandHandler.swift
+++ b/supacode/CLIService/AgentNativeHookCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class AgentNativeHookCommandHandler: CommandHandler {

--- a/supacode/CLIService/AgentReadCommandHandler.swift
+++ b/supacode/CLIService/AgentReadCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct AgentReadRuntimeSnapshot: Sendable {
   let target: ReadTarget

--- a/supacode/CLIService/AgentSignalCommandHandler.swift
+++ b/supacode/CLIService/AgentSignalCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// What the app did with a cooperative signal from a live caller pane.
 nonisolated enum AgentSignalRecordOutcome: Equatable, Sendable {

--- a/supacode/CLIService/AgentWaitCommandHandler.swift
+++ b/supacode/CLIService/AgentWaitCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class AgentWaitCommandHandler: CommandHandler {

--- a/supacode/CLIService/AgentsCommandHandler.swift
+++ b/supacode/CLIService/AgentsCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct AgentsRuntimeSnapshot {
   let repositoriesState: RepositoriesFeature.State

--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -2,6 +2,7 @@
 // Routes incoming command envelopes to the appropriate handler.
 
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class CLICommandRouter {

--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -2,6 +2,7 @@
 // Unix domain socket server that listens for CLI command requests.
 
 import Foundation
+import ProwlCLIShared
 
 #if canImport(Darwin)
   import Darwin

--- a/supacode/CLIService/CommandHandlerProtocol.swift
+++ b/supacode/CLIService/CommandHandlerProtocol.swift
@@ -2,6 +2,7 @@
 // Protocol for command handlers on the app side.
 
 import Foundation
+import ProwlCLIShared
 
 /// Each CLI command has a corresponding handler that executes
 /// within the app's process context.

--- a/supacode/CLIService/FocusCommandHandler.swift
+++ b/supacode/CLIService/FocusCommandHandler.swift
@@ -2,6 +2,7 @@
 // Handles `prowl focus` by resolving, focusing, and returning final pane context.
 
 import Foundation
+import ProwlCLIShared
 
 /// Resolved target metadata for focus payload construction.
 struct FocusResolvedTarget: Sendable {

--- a/supacode/CLIService/HandoffCommandHandler.swift
+++ b/supacode/CLIService/HandoffCommandHandler.swift
@@ -1,6 +1,7 @@
 // supacode/CLIService/HandoffCommandHandler.swift
 
 import Foundation
+import ProwlCLIShared
 
 /// A handoff source resolved on the main actor: the runnable root to store the
 /// artifact under and the agent currently detected in that pane.

--- a/supacode/CLIService/KeyCommandHandler.swift
+++ b/supacode/CLIService/KeyCommandHandler.swift
@@ -2,6 +2,7 @@
 // Handles `prowl key` by resolving target, delivering key events, and building response.
 
 import Foundation
+import ProwlCLIShared
 
 private let keyLogger = SupaLogger("KeyCommandHandler")
 

--- a/supacode/CLIService/LifecycleCommandHandler.swift
+++ b/supacode/CLIService/LifecycleCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct LifecycleResolvedTarget: Sendable, Equatable {
   let resource: LifecycleResource

--- a/supacode/CLIService/ListCommandHandler.swift
+++ b/supacode/CLIService/ListCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct ListRuntimeSnapshot: Sendable {
   struct Worktree: Sendable {

--- a/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
+++ b/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 enum ListRuntimeSnapshotBuilder {

--- a/supacode/CLIService/OpenCommandHandler.swift
+++ b/supacode/CLIService/OpenCommandHandler.swift
@@ -4,6 +4,7 @@
 
 import AppKit
 import Foundation
+import ProwlCLIShared
 
 // MARK: - Resolution
 

--- a/supacode/CLIService/PaneCommandHandler.swift
+++ b/supacode/CLIService/PaneCommandHandler.swift
@@ -1,6 +1,7 @@
 // supacode/CLIService/PaneCommandHandler.swift
 
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class PaneCommandHandler: CommandHandler {

--- a/supacode/CLIService/ProfilesCommandHandler.swift
+++ b/supacode/CLIService/ProfilesCommandHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct ProfilesRuntimeSnapshot {
   let profiles: [AgentProfile]

--- a/supacode/CLIService/ReadCommandHandler.swift
+++ b/supacode/CLIService/ReadCommandHandler.swift
@@ -2,6 +2,7 @@
 // Handles `prowl read` by resolving target and reading snapshot/last text.
 
 import Foundation
+import ProwlCLIShared
 
 private struct ReadCapture {
   let text: String

--- a/supacode/CLIService/SendCommandHandler.swift
+++ b/supacode/CLIService/SendCommandHandler.swift
@@ -2,6 +2,7 @@
 // Handles `prowl send` by resolving target, delivering text, and optionally waiting.
 
 import Foundation
+import ProwlCLIShared
 
 private let sendLogger = SupaLogger("SendCommandHandler")
 

--- a/supacode/CLIService/Shared/Package.swift
+++ b/supacode/CLIService/Shared/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+  name: "ProwlShared",
+  platforms: [.macOS(.v13)],
+  products: [
+    .library(name: "ProwlCLIShared", targets: ["ProwlCLIShared"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/jpsim/Yams.git", exact: "6.2.2")
+  ],
+  targets: [
+    .target(
+      name: "ProwlCLIShared",
+      dependencies: [.product(name: "Yams", package: "Yams")],
+      path: "."
+    )
+  ]
+)

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -51,7 +51,7 @@ nonisolated public enum WorkflowValidator {
     return walker.collector.diagnostics
   }
 
-  static func isSingleLine(_ text: String) -> Bool {
+  public static func isSingleLine(_ text: String) -> Bool {
     !text.unicodeScalars.contains { scalar in
       scalar == "\u{2028}" || scalar == "\u{2029}" || scalar.value < 0x20 || (0x7F...0x9F).contains(scalar.value)
     }

--- a/supacode/CLIService/TabCommandHandler.swift
+++ b/supacode/CLIService/TabCommandHandler.swift
@@ -1,6 +1,7 @@
 // supacode/CLIService/TabCommandHandler.swift
 
 import Foundation
+import ProwlCLIShared
 
 struct TabResolvedTarget: Sendable, Equatable {
   let worktreeID: String

--- a/supacode/CLIService/TargetResolver.swift
+++ b/supacode/CLIService/TargetResolver.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 
 /// Fully resolved target with metadata for response payload.
 struct ResolvedTarget: Sendable {

--- a/supacode/CLIService/WorkflowCLIRendezvous.swift
+++ b/supacode/CLIService/WorkflowCLIRendezvous.swift
@@ -6,6 +6,7 @@
 // synchronously inside `store.send` cannot race past the waiter — the answer is buffered.
 
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class WorkflowCLIRendezvous {

--- a/supacode/CLIService/WorkflowCommandHandler.swift
+++ b/supacode/CLIService/WorkflowCommandHandler.swift
@@ -5,6 +5,7 @@
 // the caller pane and routed to the runtime coordinator.
 
 import Foundation
+import ProwlCLIShared
 
 struct WorkflowRuntimeSnapshot {
   let resolution: TargetResolutionSnapshot

--- a/supacode/CLIService/WorkflowRoleWaitPolicy.swift
+++ b/supacode/CLIService/WorkflowRoleWaitPolicy.swift
@@ -1,10 +1,11 @@
+import Foundation
+import ProwlCLIShared
+
 // supacode/CLIService/WorkflowRoleWaitPolicy.swift
 // The pure decision core of a `message` step's idle wait (docs-ai 063 B3, dsl-spec §10): the
 // #733 evidence rules without their five-second cap, evaluated against the baseline captured
 // when the wait started so a fresh exact `turn-ended` ends the wait even while the screen
 // detector still shows `working`. Exact `needs-input` wins over every idle path.
-
-import Foundation
 
 @MainActor
 struct WorkflowRoleWaitPolicy {

--- a/supacode/CLIService/WorkflowRunAdmission.swift
+++ b/supacode/CLIService/WorkflowRunAdmission.swift
@@ -6,6 +6,7 @@
 // effect beyond the run directory it may have created for a run that then started.
 
 import Foundation
+import ProwlCLIShared
 
 /// The pane (or worktree only) the run is started from, as the handler resolved it.
 struct WorkflowRunSource: Sendable {

--- a/supacode/CLIService/WorkflowRunPayload+App.swift
+++ b/supacode/CLIService/WorkflowRunPayload+App.swift
@@ -5,6 +5,7 @@
 // already holds it (the `role` of the payload).
 
 import Foundation
+import ProwlCLIShared
 
 extension WorkflowRunPayload {
   nonisolated static func makeDateFormatter() -> ISO8601DateFormatter {

--- a/supacode/CLIService/WorkflowRuntimeCoordinator.swift
+++ b/supacode/CLIService/WorkflowRuntimeCoordinator.swift
@@ -4,6 +4,7 @@
 // through actions, and awaits the `done` rendezvous (decision W1). It owns no run state.
 
 import Foundation
+import ProwlCLIShared
 
 /// A wire response carried as a failure through `Result`.
 nonisolated struct WorkflowCommandRefusal: Error {

--- a/supacode/Clients/CLIInstall/CLIInstallClient.swift
+++ b/supacode/Clients/CLIInstall/CLIInstallClient.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 typealias CLIInstallStatus = SymlinkInstallStatus
 

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Darwin
 import Foundation
+import ProwlCLIShared
 
 // A login shell sources `.zprofile` / `.zlogin` before `gh` runs, so a banner or version-manager
 // line can prepend to captured stdout and corrupt the JSON.

--- a/supacode/Clients/Shell/ShellClientError.swift
+++ b/supacode/Clients/Shell/ShellClientError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct ShellClientError: LocalizedError, Equatable, Sendable {
   let command: String

--- a/supacode/Clients/SkillInstall/SkillInstallClient.swift
+++ b/supacode/Clients/SkillInstall/SkillInstallClient.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 struct SkillInstallError: Error, Equatable, Sendable, LocalizedError {
   let message: String

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 struct TerminalClient {
   var send: @MainActor @Sendable (Command) -> Void

--- a/supacode/Clients/Workflow/WorkflowStartClient.swift
+++ b/supacode/Clients/Workflow/WorkflowStartClient.swift
@@ -5,6 +5,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 struct WorkflowStartClient: Sendable {
   /// Workflows visible to a worktree, for the entry points. Includes validation-failing files

--- a/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
+++ b/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 struct WorktreeInfoWatcherClient {
   var send: @MainActor @Sendable (Command) -> Void

--- a/supacode/Domain/AgentDetection/AgentSignal.swift
+++ b/supacode/Domain/AgentDetection/AgentSignal.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct AgentProcessGeneration: Equatable, Hashable, Sendable {
   let pid: pid_t

--- a/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// One shared availability judgment for every profile launcher surface
 /// (Agents popover, Command Palette), so entry points can never disagree

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct AgentHookResources: Equatable, Sendable {
   let bundledCLIPath: String

--- a/supacode/Domain/AgentRuntime/AgentManagedHookPreparer.swift
+++ b/supacode/Domain/AgentRuntime/AgentManagedHookPreparer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// Droid's `--settings` takes a path only, so its merged object must be written to an
 /// owner-only file before the argv can name it. The merge is pure; the write belongs to the

--- a/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
+++ b/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct AgentSignalHookCapability: Equatable, Sendable {
   let runtime: AgentNativeHookRuntime

--- a/supacode/Domain/AgentRuntime/CodexForwardingRecordStore.swift
+++ b/supacode/Domain/AgentRuntime/CodexForwardingRecordStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 #if canImport(Darwin)
   import Darwin

--- a/supacode/Domain/AgentRuntime/ManagedHookRendering.swift
+++ b/supacode/Domain/AgentRuntime/ManagedHookRendering.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated enum ClaudeSettingsReadResult: Equatable, Sendable {
   case stable(Data)

--- a/supacode/Domain/ExternalDiffTool.swift
+++ b/supacode/Domain/ExternalDiffTool.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated enum ExternalDiffLaunchMode: Equatable, Sendable {
   case builtIn

--- a/supacode/Domain/Handoff/HandoffInjection.swift
+++ b/supacode/Domain/Handoff/HandoffInjection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// The one-line, self-contained request the UI types into the live source
 /// agent. The agent composes the heredoc itself — nothing multi-line is ever

--- a/supacode/Domain/Handoff/HandoffStore.swift
+++ b/supacode/Domain/Handoff/HandoffStore.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import ProwlCLIShared
 
 /// How the transition's briefing was (or wasn't) obtained. `current.md` exists
 /// iff a validated briefing produced it, so this value is the whole story of

--- a/supacode/Domain/Workflow/LiveWorkflowActivationBridge.swift
+++ b/supacode/Domain/Workflow/LiveWorkflowActivationBridge.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// Production adapter for B2 activation effects. It resolves the exact live surface at issuance
 /// time, then delegates all lifecycle ownership to the existing dispatch store.

--- a/supacode/Domain/Workflow/WorkflowBindingResolver.swift
+++ b/supacode/Domain/Workflow/WorkflowBindingResolver.swift
@@ -6,6 +6,7 @@
 
 import CryptoKit
 import Foundation
+import ProwlCLIShared
 
 /// The four-tuple key of the binding memory. Codable so the wiring layer can keep it in
 /// `@Shared` storage; the digest is SHA-256 over the canonical requirement JSON.

--- a/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
+++ b/supacode/Domain/Workflow/WorkflowDeliveryValidator.swift
@@ -3,6 +3,7 @@
 // caps, format, required sections, and the verdict declaration.
 
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct WorkflowDeliveryLimits: Equatable, Sendable {
   static let defaultMaximumBytes = 1 << 20

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -4,6 +4,7 @@
 // and the rendered-text boundary every typed line crosses.
 
 import Foundation
+import ProwlCLIShared
 
 /// A rendered line would not survive as one terminal line (`RENDERED_TEXT_INVALID`).
 nonisolated struct WorkflowRenderedTextError: Error, Equatable, Sendable {

--- a/supacode/Domain/Workflow/WorkflowNativeActions.swift
+++ b/supacode/Domain/Workflow/WorkflowNativeActions.swift
@@ -5,6 +5,7 @@
 
 import Darwin
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct WorkflowActionContext: Sendable {
   let runID: UUID

--- a/supacode/Domain/Workflow/WorkflowPreferenceKey.swift
+++ b/supacode/Domain/Workflow/WorkflowPreferenceKey.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// The local-settings identity of one effective workflow definition. Bundle and user
 /// definitions are global; repository definitions include the canonical repository root so

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -4,6 +4,7 @@
 // vocabulary the panel renders. Transitions live in WorkflowRunMachine.
 
 import Foundation
+import ProwlCLIShared
 
 // MARK: - Identity and bindings
 

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -4,6 +4,7 @@
 // happens here; every transport concern is an effect.
 
 import Foundation
+import ProwlCLIShared
 
 // MARK: - Watchdog vocabulary shared with the driver
 

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -6,6 +6,7 @@
 
 import Darwin
 import Foundation
+import ProwlCLIShared
 
 // MARK: - run.json
 

--- a/supacode/Domain/Workflow/WorkflowSettingsCatalog.swift
+++ b/supacode/Domain/Workflow/WorkflowSettingsCatalog.swift
@@ -4,6 +4,7 @@
 // overrides, and the binding memory hold — and can be tested without the disk.
 
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct WorkflowSettingsRepositoryContext: Equatable, Sendable {
   let repositoryID: String

--- a/supacode/Domain/Workflow/WorkflowStarterTemplate.swift
+++ b/supacode/Domain/Workflow/WorkflowStarterTemplate.swift
@@ -4,6 +4,7 @@
 // the file's stem so several starters never shadow each other.
 
 import Foundation
+import ProwlCLIShared
 
 nonisolated enum WorkflowStarterTemplate {
   static let fileStem = "new-workflow"

--- a/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowTemplateRenderer.swift
@@ -3,6 +3,7 @@
 // re-scanned, and a reference to a skipped output is the runtime side of the §5 Skip rule.
 
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct WorkflowTemplateContext: Equatable, Sendable {
   struct Run: Equatable, Sendable {

--- a/supacode/Domain/Workflow/WorkflowWatchdog.swift
+++ b/supacode/Domain/Workflow/WorkflowWatchdog.swift
@@ -5,6 +5,7 @@
 // state at every expiry so a later event alone never decides anything.
 
 import Foundation
+import ProwlCLIShared
 
 // MARK: - Settings and vocabulary
 

--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   let id: UUID

--- a/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
+++ b/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Sharing
 
 extension AppFeature {

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import ProwlCLIShared
 
 extension AppFeature {
   func reduceCommandPaletteAction(

--- a/supacode/Features/App/Reducer/AppFeature+Support.swift
+++ b/supacode/Features/App/Reducer/AppFeature+Support.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 let appLogger = SupaLogger("App")
 let notificationJumpLogger = SupaLogger("NotificationJump")

--- a/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
+++ b/supacode/Features/App/Reducer/AppFeature+WorkflowStart.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 extension AppFeature {
   /// Open the workflow start sheet, or start the run at once when nothing is undecided

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -2,6 +2,7 @@ import AppKit
 import ComposableArchitecture
 import Foundation
 import PostHog
+import ProwlCLIShared
 import SwiftUI
 
 @Reducer

--- a/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
+++ b/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 struct CanvasFocusRequest: Equatable, Sendable {
   enum Target: Equatable, Sendable {

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ProwlCLIShared
 import SwiftUI
 
 struct CanvasCardView: View {

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Sharing
 
 @Reducer

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import SwiftUI
 
 struct CommandPaletteOverlayView: View {

--- a/supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift
+++ b/supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 /// A row in the hand-off HUD's choose step.
 struct HandoffTargetOption: Equatable, Identifiable, Sendable {

--- a/supacode/Features/HandoffHud/Views/HandoffHudOverlayView.swift
+++ b/supacode/Features/HandoffHud/Views/HandoffHudOverlayView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 /// Command-palette-style overlay hosting the hand-off flow (docs-ai 047.004).

--- a/supacode/Features/Help/WorkflowAuthoringPrompt.swift
+++ b/supacode/Features/Help/WorkflowAuthoringPrompt.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// The copyable prompt behind Settings › Agents › Workflows › "Ask an Agent…" (docs-ai 063
 /// D1): it points a coding agent at the bundled `prowl-workflow` skill and the workflows

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -1,5 +1,6 @@
 import Dispatch
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 final class WorktreeInfoWatcherManager {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 
 extension RepositoriesFeature.State {
   var selectedWorktreeID: Worktree.ID? {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -3,6 +3,7 @@ import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
 import PostHog
+import ProwlCLIShared
 import SwiftUI
 
 nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(15)

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct ToolbarStatusView: View {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import ProwlCLIShared
 import Sharing
 import SwiftUI
 

--- a/supacode/Features/Settings/Models/UserRepositorySettings.swift
+++ b/supacode/Features/Settings/Models/UserRepositorySettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct UserRepositorySettings: Codable, Equatable, Sendable {
   var customCommands: [UserCustomCommand]

--- a/supacode/Features/Settings/Reducer/AgentSkillsFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentSkillsFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 /// Settings → Agents → CLI & Skills → Agent Skills (docs-ai 065): the `user`-audience
 /// skills bundled in this app, one status chip per detected user target, and one explicit

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -251,7 +251,7 @@ struct SettingsFeature {
 
   var body: some Reducer<State, Action> {
     BindingReducer()
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       switch action {
       case .task:
         @Shared(.settingsFile) var settingsFile

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import SwiftUI
 
 @Reducer

--- a/supacode/Features/Settings/Reducer/WorkflowSettingsDetailFeature.swift
+++ b/supacode/Features/Settings/Reducer/WorkflowSettingsDetailFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 @Reducer
 struct WorkflowSettingsDetailFeature {

--- a/supacode/Features/Settings/Reducer/WorkflowsSettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/WorkflowsSettingsFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Sharing
 
 /// Shared workflow Settings domain for the global Built-in/personal index and one repository's

--- a/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
+++ b/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 /// Settings → Agents → Profiles: the profile list, with a native drill-in editor page per

--- a/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
+++ b/supacode/Features/Settings/Views/AgentSkillsSectionView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 /// Settings → Agents → CLI & Skills → Agent Skills: one row per bundled `user`

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct AppearanceSettingsView: View {

--- a/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
+++ b/supacode/Features/Settings/Views/CommandLineToolSettingsView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 /// Settings → Agents → CLI & Skills: install/status for the bundled `prowl`

--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ProwlCLIShared
 import SwiftUI
 
 /// Shared inline table editor for custom commands. Hosts pass the command

--- a/supacode/Features/Settings/Views/NotificationsSettingsView.swift
+++ b/supacode/Features/Settings/Views/NotificationsSettingsView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct NotificationsSettingsView: View {

--- a/supacode/Features/Settings/Views/ShortcutSettingsEditor.swift
+++ b/supacode/Features/Settings/Views/ShortcutSettingsEditor.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct ShortcutSettingsEditor: View {

--- a/supacode/Features/Settings/Views/WorkflowSettingsDetailView.swift
+++ b/supacode/Features/Settings/Views/WorkflowSettingsDetailView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct WorkflowSettingsDetailView: View {

--- a/supacode/Features/Terminal/BusinessLogic/AgentDispatchStore.swift
+++ b/supacode/Features/Terminal/BusinessLogic/AgentDispatchStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated enum AgentDispatchRecord: Equatable, Sendable {
   case pending(id: String, createdAt: Date)

--- a/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
+++ b/supacode/Features/Terminal/BusinessLogic/AgentObservationStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 private let observationLogger = SupaLogger("AgentObservation")
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import ProwlCLIShared
 import Sharing
 import SwiftUI
 

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 /// Who currently owns a tab's icon slot. The precedence chain runs
 /// `auto < script < user`: stronger owners block weaker writes.

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import ProwlCLIShared
 
 @MainActor
 @Observable

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+CLI.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+CLI.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 
 struct CLIWorktreeTerminalSnapshot: Sendable {
   let tabs: [CLITerminalTabSnapshot]

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Notifications.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Notifications.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 extension WorktreeTerminalState {
   /// How recently the user must have typed for us to consider the exit user-initiated.

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -2,6 +2,7 @@ import AppKit
 import CoreGraphics
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 
 enum SplitCreationError: Error, Equatable, Sendable {
   case anchorNotFound(UUID)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+TabIcons.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+TabIcons.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 extension WorktreeTerminalState {
   // MARK: - Tab Icon Auto-Detection

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -3,6 +3,7 @@ import CoreGraphics
 import Foundation
 import GhosttyKit
 import Observation
+import ProwlCLIShared
 import Sharing
 
 let terminalStateLogger = SupaLogger("TerminalState")

--- a/supacode/Features/Workflow/Models/WorkflowRunNotice.swift
+++ b/supacode/Features/Workflow/Models/WorkflowRunNotice.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated struct WorkflowRunNotice: Equatable, Sendable {
   enum Kind: Equatable, Sendable {

--- a/supacode/Features/Workflow/Models/WorkflowStartContext.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStartContext.swift
@@ -5,6 +5,7 @@
 // nothing here re-derives eligibility beyond presenting the resolver's own answer.
 
 import Foundation
+import ProwlCLIShared
 
 /// One workflow as an entry point lists it (palette, capsule popover, Active Agents menu).
 nonisolated struct WorkflowStartCatalogItem: Equatable, Sendable, Identifiable {

--- a/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 @MainActor
 struct WorkflowStatusCenterPresentation: Equatable {

--- a/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
@@ -6,6 +6,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 /// The in-memory part of a run that `run.json` deliberately excludes: the worktree object, the
 /// frozen profile launch plans (their surface environment carries override values), the binding

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -5,6 +5,7 @@
 
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 
 @Reducer
 struct WorkflowStartFeature {

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import ComposableArchitecture
+import ProwlCLIShared
 import SwiftUI
 
 struct WorkflowStartOverlayView: View {

--- a/supacode/Infrastructure/Ghostty/CLIKeySpec.swift
+++ b/supacode/Infrastructure/Ghostty/CLIKeySpec.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon
+import ProwlCLIShared
 
 /// Maps canonical CLI key tokens to macOS NSEvent parameters.
 struct CLIKeySpec {

--- a/supacode/Infrastructure/Ghostty/MirroredTerminalKey.swift
+++ b/supacode/Infrastructure/Ghostty/MirroredTerminalKey.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import ProwlCLIShared
 
 struct MirroredTerminalKey: Equatable, Sendable {
   enum Kind: Equatable, Sendable {

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 
 nonisolated enum SupacodePaths {
   static var baseDirectory: URL {

--- a/supacodeTests/AgentDispatchCommandHandlerTests.swift
+++ b/supacodeTests/AgentDispatchCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentDispatchStoreTests.swift
+++ b/supacodeTests/AgentDispatchStoreTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentEvidenceEpochTests.swift
+++ b/supacodeTests/AgentEvidenceEpochTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentHookContractExportTests.swift
+++ b/supacodeTests/AgentHookContractExportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentHookRenderingTests.swift
+++ b/supacodeTests/AgentHookRenderingTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentNativeHookPayloadTests.swift
+++ b/supacodeTests/AgentNativeHookPayloadTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentObservationTests.swift
+++ b/supacodeTests/AgentObservationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentProfileHookCarrierTests.swift
+++ b/supacodeTests/AgentProfileHookCarrierTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentReadCommandHandlerTests.swift
+++ b/supacodeTests/AgentReadCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentS3bHookPayloadTests.swift
+++ b/supacodeTests/AgentS3bHookPayloadTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentS3bHookRenderingTests.swift
+++ b/supacodeTests/AgentS3bHookRenderingTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentS3cHookPayloadTests.swift
+++ b/supacodeTests/AgentS3cHookPayloadTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentS3cHookRenderingTests.swift
+++ b/supacodeTests/AgentS3cHookRenderingTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentSkillsFeatureTests.swift
+++ b/supacodeTests/AgentSkillsFeatureTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AgentWaitCommandHandlerTests.swift
+++ b/supacodeTests/AgentWaitCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/AppFeatureAgentSkillsTests.swift
+++ b/supacodeTests/AppFeatureAgentSkillsTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureCLIInstallTests.swift
+++ b/supacodeTests/AppFeatureCLIInstallTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -3,6 +3,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import SwiftUI
 import Testing
 

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/AppFeatureDefaultEditorTests.swift
+++ b/supacodeTests/AppFeatureDefaultEditorTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureHandoffTests.swift
+++ b/supacodeTests/AppFeatureHandoffTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeaturePlainFolderTerminalTests.swift
+++ b/supacodeTests/AppFeaturePlainFolderTerminalTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import CustomDump
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import Dependencies
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
+++ b/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import SwiftUI
 import Testing
 

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIAgentNativeHookCommandHandlerTests.swift
+++ b/supacodeTests/CLIAgentNativeHookCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIAgentSignalCommandHandlerTests.swift
+++ b/supacodeTests/CLIAgentSignalCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIAgentsCommandHandlerTests.swift
+++ b/supacodeTests/CLIAgentsCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLICommandEnvelopeTests.swift
+++ b/supacodeTests/CLICommandEnvelopeTests.swift
@@ -2,6 +2,7 @@
 // Contract tests for CommandEnvelope, CommandResponse, and shared types.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLICommandResponseTests.swift
+++ b/supacodeTests/CLICommandResponseTests.swift
@@ -2,6 +2,7 @@
 // Contract tests for CommandResponse and RawJSON encoding/decoding.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLICommandRouterTests.swift
+++ b/supacodeTests/CLICommandRouterTests.swift
@@ -2,6 +2,7 @@
 // Unit tests for CLICommandRouter and StubCommandHandler.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIFocusCommandHandlerTests.swift
+++ b/supacodeTests/CLIFocusCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIInstallClientTests.swift
+++ b/supacodeTests/CLIInstallClientTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIKeyCommandHandlerTests.swift
+++ b/supacodeTests/CLIKeyCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIKeyTokenExpansionTests.swift
+++ b/supacodeTests/CLIKeyTokenExpansionTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLILifecycleCommandHandlerTests.swift
+++ b/supacodeTests/CLILifecycleCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIListCommandHandlerTests.swift
+++ b/supacodeTests/CLIListCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIPaneCommandHandlerTests.swift
+++ b/supacodeTests/CLIPaneCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIProfilesCommandHandlerTests.swift
+++ b/supacodeTests/CLIProfilesCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLIReadCommandHandlerTests.swift
+++ b/supacodeTests/CLIReadCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLISendCommandHandlerTests.swift
+++ b/supacodeTests/CLISendCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLITabCommandHandlerTests.swift
+++ b/supacodeTests/CLITabCommandHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLITargetResolverTests.swift
+++ b/supacodeTests/CLITargetResolverTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLITargetSelectorTests.swift
+++ b/supacodeTests/CLITargetSelectorTests.swift
@@ -2,6 +2,7 @@
 // Tests for TargetSelector mutual exclusivity and encoding.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CLITransportProtocolTests.swift
+++ b/supacodeTests/CLITransportProtocolTests.swift
@@ -2,6 +2,7 @@
 // Tests for the length-prefixed JSON transport encoding/decoding.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CodexForwardingRecordStoreTests.swift
+++ b/supacodeTests/CodexForwardingRecordStoreTests.swift
@@ -1,6 +1,7 @@
 import Clocks
 import Darwin
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/CommandFinishedNotificationTests.swift
+++ b/supacodeTests/CommandFinishedNotificationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/HandoffCommandHandlerTests.swift
+++ b/supacodeTests/HandoffCommandHandlerTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/HandoffHudFeatureTests.swift
+++ b/supacodeTests/HandoffHudFeatureTests.swift
@@ -3,6 +3,7 @@ import ConcurrencyExtras
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/HandoffStoreTests.swift
+++ b/supacodeTests/HandoffStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/ManagedAgentHookObservationTests.swift
+++ b/supacodeTests/ManagedAgentHookObservationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/OpenCommandHandlerTests.swift
+++ b/supacodeTests/OpenCommandHandlerTests.swift
@@ -2,6 +2,7 @@
 // Unit tests for OpenCommandHandler — contract-aligned.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/PlainTextEditorTests.swift
+++ b/supacodeTests/PlainTextEditorTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ProwlCLIShared
 import SwiftUI
 import Testing
 

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4,6 +4,7 @@ import CustomDump
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -1,3 +1,4 @@
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import CustomDump
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/ShortcutResetPlannerTests.swift
+++ b/supacodeTests/ShortcutResetPlannerTests.swift
@@ -1,3 +1,4 @@
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/SkillInstallClientTests.swift
+++ b/supacodeTests/SkillInstallClientTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/SkillInstallFixture.swift
+++ b/supacodeTests/SkillInstallFixture.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/SupacodeAppCLITests.swift
+++ b/supacodeTests/SupacodeAppCLITests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/UserRepositorySettingsKeyTests.swift
+++ b/supacodeTests/UserRepositorySettingsKeyTests.swift
@@ -1,6 +1,7 @@
 import Dependencies
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/WorkflowBindingResolverTests.swift
+++ b/supacodeTests/WorkflowBindingResolverTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowCLIRendezvousTests.swift
+++ b/supacodeTests/WorkflowCLIRendezvousTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowCommandHandlerTests.swift
+++ b/supacodeTests/WorkflowCommandHandlerTests.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowDeliveryValidatorTests.swift
+++ b/supacodeTests/WorkflowDeliveryValidatorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowLineRendererTests.swift
+++ b/supacodeTests/WorkflowLineRendererTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRoleBadgeTests.swift
+++ b/supacodeTests/WorkflowRoleBadgeTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRoleWaitPolicyTests.swift
+++ b/supacodeTests/WorkflowRoleWaitPolicyTests.swift
@@ -3,6 +3,7 @@
 // precedence, detector stabilization, blocked grace, appearance grace, pending records.
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRunAdmissionTests.swift
+++ b/supacodeTests/WorkflowRunAdmissionTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRunsFeatureTests.swift
+++ b/supacodeTests/WorkflowRunsFeatureTests.swift
@@ -5,6 +5,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowRuntimeCoordinatorTests.swift
+++ b/supacodeTests/WorkflowRuntimeCoordinatorTests.swift
@@ -2,6 +2,7 @@
 // `prowl workflow status / done / cancel` attribution and responses (docs-ai 063 B3, W1/W3/W5).
 
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowSettingsCatalogTests.swift
+++ b/supacodeTests/WorkflowSettingsCatalogTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowSettingsDetailFeatureTests.swift
+++ b/supacodeTests/WorkflowSettingsDetailFeatureTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowStartContextTests.swift
+++ b/supacodeTests/WorkflowStartContextTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/WorkflowStarterTemplateTests.swift
+++ b/supacodeTests/WorkflowStarterTemplateTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowStatusCenterPresentationTests.swift
+++ b/supacodeTests/WorkflowStatusCenterPresentationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowTemplateRendererTests.swift
+++ b/supacodeTests/WorkflowTemplateRendererTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowWatchdogTests.swift
+++ b/supacodeTests/WorkflowWatchdogTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import ProwlCLIShared
 import Testing
 
 @testable import supacode

--- a/supacodeTests/WorkflowsSettingsFeatureTests.swift
+++ b/supacodeTests/WorkflowsSettingsFeatureTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import ProwlCLIShared
 import Sharing
 import Testing
 

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -2,6 +2,7 @@ import ConcurrencyExtras
 import DependenciesTestSupport
 import Foundation
 import GhosttyKit
+import ProwlCLIShared
 import Testing
 
 @testable import supacode


### PR DESCRIPTION
The 2026.9.6 DMG is 37,911,552 bytes, up 21% from August 20. Most growth is in the app and CLI executables; the embedded SwiftPM CLI also retains local symbols.

This change strips only the staged release CLI and converts the Finder disk image from LZFSE to LZMA before signing and mandatory notarization. It remains a standard `.dmg`. Conversion failures preserve the previous image, and original CLI products and matching dSYMs remain available.

| Local comparison using the same release payload | DMG size |
| --- | ---: |
| Published universal DMG | 37,911,552 bytes |
| Universal, stripped CLI, LZMA | 28,755,462 bytes (-24.15%) |

The comparison uses ad-hoc signatures; final notarized bytes will differ slightly. No release was published. Complete mounted reads took 1.30 seconds with LZMA versus 0.17 seconds with LZFSE locally.

Build changes:
- Specify the Settings reducer's generic types; a fresh compilation removed its measured 7.264-second type-check hotspot from the 500 ms diagnostic threshold.
- Preserve CLI source timestamps across cache restores only when SHA-256 content and workspace path match. Include contract resources and build inputs in cache keys, and use the exact Xcode dependency lockfile.
- Run CLI checks sequentially within their parallel branch to avoid competing for SwiftPM's `.build` lock. All checks remain required.
- Retain successful build logs and report xcresult build wall time, cache counters, and overlapping task timings without masking failures.

In three alternating local CLI comparisons, simulated checkout timestamps triggered 74 source-compilation log records per run. Content-checked restoration reduced that to zero; command medians were 4.18 and 1.04 seconds. Hosted CI timings are not used as controlled performance comparisons. The App now imports the existing Shared model/parser module through a small local package. Its 38 sources are excluded from the App target, including future files in that folder. Only one existing validation helper needed public visibility. The root CLI library product remains available.

CI also retains App incremental state at a fixed path. Restore keys isolate toolchain, workspace, configuration and tracked input paths; added/deleted paths start fresh. App timestamp restoration excludes CLI-owned shared inputs. Actual build probes confirmed unchanged-source reuse, compilation failures for edited/new invalid Swift, and updated fixture contents in the test bundle.

Validation:
- `make check`, `make build-app`, actionlint, and diff checks pass.
- App tests: 3,122 cases plus two isolated cancellation tests, zero failures; 35 focused Settings tests also passed.
- CLI build, smoke, 233 unit tests and 110 integration tests pass.
- All 146 script tests pass, including source-time ownership and optional build-path cases and DMG failure preservation.
- Re-signed CLI ran as arm64 and x86_64; UUIDs match retained dSYMs. Actual LZMA checksum, mount, signatures and CLI execution passed.
- Injected xcodebuild exit 23 still fails the Make target after log capture.

Cache-population CI [34000598039](https://github.com/onevcat/Prowl/actions/runs/34000598039) passed. Reuse validation [34001143250](https://github.com/onevcat/Prowl/actions/runs/34001143250) also passed: 106 unchanged CLI input timestamps were restored, with no CLI, Shared, or CLI test source compilation in the logs. All App, CLI, and script checks passed.

Local implementation-edit samples with warm CAS and fresh DerivedData: App edit 38.54 → 35.94 seconds; Shared edit 39.16 → 21.64 seconds. Shared edits no longer compile App sources. These are local paired samples, not hosted CI speedup estimates. The full App and CLI suites passed after extraction. With retained incremental state and simulated checkout, new App and Shared function-body edits each missed only one compile task and one module task (21.14 s and 13.03 s). Broader invalidation remains possible; these are warm-state probes, not a guarantee for every change.

A paired arm64 Release comparison with coverage disabled and identical stripping measured 34,731,928 → 34,780,504 bytes (+48,576 bytes, +0.14%). Shared remains statically linked with no extra dynamic library.

Universal Release also builds successfully for arm64 and x86_64. Both executable UUIDs match the retained dSYM; neither architecture adds a Shared dynamic library. App incremental cache population [34003502189, attempt 1](https://github.com/onevcat/Prowl/actions/runs/34003502189/attempts/1) passed and saved the new cache.

App incremental cache [reuse attempt 2](https://github.com/onevcat/Prowl/actions/runs/34003502189/attempts/2) passed all checks. It restored 943 App and 107 CLI input timestamps. No App handwritten, Shared or test sources recompiled; only generated asset symbols incurred a compile miss (module emission hit). CLI source compilation was also absent; documentation plugin builds still appear.
