### PR TITLE
Acknowledge viewed Canvas panes after Agent Island navigation

### DIFF
--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -92,6 +92,15 @@ or the repository page otherwise.
 - The left nav band is tinted with the focused card's repository color
   (`windowTintMode`).
 
+### Agent Island completion reminders
+
+Clicking an Agent Island **Done** reminder keeps the existing Canvas navigation: Prowl comes
+forward and focuses the target card and pane. The completion becomes read once that terminal
+is the actual keyboard responder in its key, visible window. A logical focus request alone,
+an inactive window, or a hidden/detached terminal does not count as viewing it. Other cards
+and splits are not acknowledged merely because they are selected or receive broadcast input.
+**Blocked** reminders remain until the agent leaves the blocked state.
+
 ## Layout & sizing
 
 - Default card size adapts to screen width (roughly 800×550 on a 14", larger on a

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -696,10 +696,18 @@ extension WorktreeTerminalState {
     return isSelected() && lastWindowIsKey == true && lastWindowIsVisible == true
   }
 
-  /// Whether the user is actively looking at `surfaceId` right now: its worktree
-  /// is visible and it is the focused pane of the selected tab.
+  /// Whether the user is actively looking at `surfaceId` right now.
   func isViewedSurface(_ surfaceId: UUID) -> Bool {
-    isViewingWorktree() && isFocusedSurface(surfaceId)
+    if isCanvasManaged {
+      // Canvas owns focus separately from normal-mode selection and window observers.
+      // Its logical focus callback runs before requestFocus actually installs the responder.
+      guard isFocusedSurface(surfaceId), let view = surfaces[surfaceId],
+        view.focused, !view.isHiddenOrHasHiddenAncestor,
+        let window = view.window
+      else { return false }
+      return window.isKeyWindow && window.occlusionState.contains(.visible) && window.firstResponder === view
+    }
+    return isViewingWorktree() && isFocusedSurface(surfaceId)
   }
 
   func updateRunningState(for tabId: TerminalTabID) {

--- a/supacodeTests/CanvasViewedSurfaceTests.swift
+++ b/supacodeTests/CanvasViewedSurfaceTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CanvasViewedSurfaceTests {
+  @Test func actualCanvasFocusDoesNotDependOnNormalModeSelectionOrWindowCache() {
+    let fixture = Fixture()
+
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+    #expect(!fixture.state.isViewingWorktree())
+  }
+
+  enum UnviewedCondition: CaseIterable {
+    case inactiveWindow, occludedWindow, detached, hidden, hiddenAncestor
+    case logicalFocusOnly, clearedFocus, otherPane, otherTab
+  }
+
+  @Test(arguments: UnviewedCondition.allCases)
+  func canvasDoesNotTreatUnviewedSurfacesAsRead(condition: UnviewedCondition) {
+    let fixture = Fixture()
+    // Stale normal-mode flags must never override the live Canvas window.
+    fixture.state.lastWindowIsKey = true
+    fixture.state.lastWindowIsVisible = true
+    fixture.state.isSelected = { true }
+
+    switch condition {
+    case .inactiveWindow: fixture.window.reportsKey = false
+    case .occludedWindow: fixture.window.reportsVisible = false
+    case .detached: fixture.surface.removeFromSuperview()
+    case .hidden: fixture.surface.isHidden = true
+    case .hiddenAncestor: fixture.window.contentView?.isHidden = true
+    case .logicalFocusOnly: fixture.window.makeFirstResponder(nil)
+    case .clearedFocus: fixture.surface.focused = false
+    case .otherPane:
+      fixture.state.focusedSurfaceIdByTab[fixture.tabID] = UUID()
+    case .otherTab:
+      let other = fixture.state.tabManager.createTab(title: "Other", icon: nil)
+      fixture.state.tabManager.selectTab(other)
+    }
+
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func becomingTheActualResponderCompletesTheViewingTransition() {
+    let fixture = Fixture()
+    fixture.window.makeFirstResponder(nil)
+    fixture.surface.focused = true
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    #expect(fixture.window.makeFirstResponder(fixture.surface))
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.window.reportsKey = false
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+    fixture.window.reportsKey = true
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func leavingCanvasRestoresTheNormalViewingPolicy() {
+    let fixture = Fixture()
+    fixture.state.isCanvasManaged = false
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.state.isSelected = { true }
+    fixture.state.lastWindowIsKey = true
+    fixture.state.lastWindowIsVisible = true
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let surface: GhosttySurfaceView
+    let window: CanvasTestWindow
+    let tabID: TerminalTabID
+
+    init() {
+      let runtime = GhosttyRuntime()
+      state = WorktreeTerminalState(
+        runtime: runtime,
+        worktree: Worktree(
+          id: "/tmp/repo/canvas",
+          name: "canvas",
+          detail: "",
+          workingDirectory: URL(fileURLWithPath: "/tmp/repo/canvas"),
+          repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+        ),
+        skipsSurfaceCreationForTesting: true
+      )
+      surface = GhosttySurfaceView(
+        runtime: runtime,
+        workingDirectory: nil,
+        context: GHOSTTY_SURFACE_CONTEXT_TAB,
+        skipsSurfaceCreationForTesting: true
+      )
+      tabID = state.tabManager.createTab(title: "Canvas", icon: nil)
+      state.tabManager.selectTab(tabID)
+      state.surfaces[surface.id] = surface
+      state.focusedSurfaceIdByTab[tabID] = surface.id
+      state.isCanvasManaged = true
+      state.isSelected = { false }
+      state.lastWindowIsKey = nil
+      state.lastWindowIsVisible = nil
+
+      window = CanvasTestWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+        styleMask: [.titled],
+        backing: .buffered,
+        defer: true
+      )
+      window.contentView?.addSubview(surface)
+      #expect(window.makeFirstResponder(surface))
+      // No Ghostty C surface is created in these tests, so its focus callback is skipped.
+      surface.focused = true
+    }
+  }
+}
+
+@MainActor
+private final class CanvasTestWindow: NSWindow {
+  var reportsKey = true
+  var reportsVisible = true
+
+  override var isKeyWindow: Bool { reportsKey }
+  override var occlusionState: NSWindow.OcclusionState { reportsVisible ? [.visible] : [] }
+}


### PR DESCRIPTION
## Summary
Fixes #779 together with #778. **Merge #778 first**: that PR routes automatic completion acknowledgment through `isViewedSurface`; this companion gives the predicate a working Canvas branch. Both branches are independently based on main, without duplicating each other's implementation commits.

- Keep Island window activation, Canvas card/pane navigation, viewport positioning, and animation unchanged.
- For Canvas, inspect the target surface's actual window, requiring a key/visible window, the selected tab's focused surface, its logical focus, a non-hidden attached view, and actual first-responder identity.
- Do not use stale normal-mode window flags or the normal-mode selected worktree.
- Preserve `isViewingWorktree` and its workflow-notification behavior. Surface-scoped notification viewing uses the corrected predicate too.
- Document Canvas completion acknowledgment. Blocked reminders still follow agent state rather than clicks.

Canvas's logical focus callback precedes the asynchronous `makeFirstResponder` call, so that callback alone is not proof of viewing. The existing detection loop rechecks actual focus after navigation, without a new timer or an Island-specific dismissal path.

## Validation
- New Canvas viewing tests failed before the predicate change, then passed.
- Focused tests passed for Canvas viewing, normal-mode viewing, Canvas focus resolution, and selection. Coverage includes actual vs logical-only focus, inactive/occluded windows, detached/hidden views and ancestors, other panes/tabs, returning to the window, and leaving Canvas.
- Also temporarily applied #778's source/test patch locally and ran a composed test with real first-responder transitions: Done remained unread before actual focus and while inactive, became Idle after actual focus, and Blocked remained Blocked. Composed Canvas/viewing/Active Agents tests passed. The temporary dependency patch and dependency-specific test were removed afterward to keep this PR independently buildable against main.
- `make build-app` passed, zero warnings/errors.
- `make check` passed full-tree formatting lint, SwiftLint, and 146 script tests. The changed-file formatter hit the existing macOS Bash `mapfile` issue; both changed Swift files were explicitly formatted with `xcrun swift-format`.
- `git diff --check` passed.
- No manual live-agent GUI reproduction performed.

## Scope
This is the narrow acknowledgment fix agreed in #779, not a new Canvas viewport/readability policy. It adds no center-point/visible-percentage threshold, animation completion gate, broadcast behavior change, or navigation refactor.
