### PR TITLE
Keep agent completions unread until their pane is viewed

### DIFF
--- a/docs-ai/066-agent-island/000-plan.md
+++ b/docs-ai/066-agent-island/000-plan.md
@@ -146,3 +146,6 @@ until it reconnects. The picker matches by UUID only (`AgentIslandDisplaySelecti
 
 - Updated 2026-09-05: consolidated agent presentation settings and refined the floating grip — see
   [004-agent-display-settings.md](004-agent-display-settings.md).
+
+- Updated 2026-09-08: preserve completion acknowledgements across session lookup suspension — see
+  [005-completion-acknowledgement.md](005-completion-acknowledgement.md).

--- a/docs-ai/066-agent-island/005-completion-acknowledgement.md
+++ b/docs-ai/066-agent-island/005-completion-acknowledgement.md
@@ -1,0 +1,33 @@
+# 066.005 — Completion acknowledgement across session resolution
+
+## Context
+
+PR #781 and the original #778, resubmitted as #782 by @SunChJ, route automatic
+acknowledgement through the viewed-surface predicate. A session lookup can suspend
+while the user acknowledges a completion and then leaves the window. Deriving read
+state from the pre-lookup snapshot can restore Done when session metadata changes.
+
+## Change
+
+After session resolution, merge the current acknowledgement for the same observed
+state into the polling result. Preserve its change timestamp. A new working/blocked
+to idle transition must still become unread when unviewed; do not treat an earlier
+acknowledgement as permission to read future completions. Keep the read policy private.
+
+The implementation uses a per-call session resolver seam and controlled suspension
+in behavior tests. Tests cover changed and unchanged session metadata, a new
+completion after acknowledgement, and state changes during suspension.
+
+If state other than acknowledgement or its timestamp changed during suspension,
+discard the stale poll. The next scheduled poll observes the new state.
+
+## Validation
+
+The controlled suspension test failed on #781 before the fix: Done reappeared and
+the acknowledgement timestamp was replaced. It passes with the fix, with and without
+new session metadata. Related local tests passed; no live-agent GUI reproduction
+was performed for this polling-state change.
+
+## Refs
+
+PR #781; related original implementation #778 and resubmission #782.

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -55,7 +55,8 @@ A row whose pane is bound to an active workflow run replaces its subtitle with
 ## Interactions
 
 - **Click a row** → focuses that worktree + tab + pane and brings Prowl forward. A
-  **Done** row downgrades to **Idle** once focused.
+  **Done** row downgrades to **Idle** once viewed in the active, visible Prowl window.
+  Internal focus changes while the window is inactive do not clear the completion.
 - **Right-click a row** for the context menu:
   - **Hand Off…** — opens the Hand Off HUD for that agent's pane
     (selecting and focusing it first), regardless of which pane currently has

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -118,7 +118,9 @@ frames keep the last trusted state instead of forcing Idle.
 A **Done** pane becomes **Idle** when it is actually viewed: its worktree and tab are selected,
 its pane is focused, and the Prowl window is key and visible. Keeping a pane selected while
 Prowl is inactive, hidden, or minimized does not mark its completion as read. Unknown window
-state is conservatively treated as not viewed. See [Canvas](canvas.md) for Canvas-specific behavior.
+state is conservatively treated as not viewed. An acknowledged completion stays read when
+a pending session lookup finishes; a later unviewed completion still becomes **Done**.
+See [Canvas](canvas.md) for Canvas-specific behavior.
 
 ## Cooperative signal bus
 

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -115,7 +115,10 @@ frames keep the last trusted state instead of forcing Idle.
 | **Done**    | raw `idle` + **unseen** | just finished; you haven't looked yet |
 | **Idle**    | raw `idle` + **seen**   | nothing running                       |
 
-A **Done** pane becomes **Idle** the moment you focus it.
+A **Done** pane becomes **Idle** when it is actually viewed: its worktree and tab are selected,
+its pane is focused, and the Prowl window is key and visible. Keeping a pane selected while
+Prowl is inactive, hidden, or minimized does not mark its completion as read. Unknown window
+state is conservatively treated as not viewed. See [Canvas](canvas.md) for Canvas-specific behavior.
 
 ## Cooperative signal bus
 

--- a/docs/components/agent-island.md
+++ b/docs/components/agent-island.md
@@ -61,7 +61,10 @@ badge takes the subtitle position, as in the sidebar. The displayed priority ord
 first, then unviewed Done, newest first within each state. Cells
 cannot be dismissed from the island. A
 Blocked cell clears when the agent leaves that state, a Done cell clears once the entry is viewed,
-and a removed entry disappears with the roster.
+and a removed entry disappears with the roster. A selected pane is not considered viewed while
+Prowl's window is inactive, hidden, or minimized, so its Done reminder remains. Unknown window
+state also retains reminders rather than automatically marking them read. See [Canvas](canvas.md)
+for Canvas-specific behavior.
 
 ## Interactions
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,7 +65,7 @@ user-visible states:
 - **Blocked** — waiting for you (a confirmation/permission prompt). This is the
   one that needs your attention.
 - **Done** — finished and you haven't looked yet (an unseen completion). Becomes
-  **Idle** once you focus it.
+  **Idle** once you view the focused pane in the active, visible Prowl window.
 - **Idle** — nothing running / seen.
 
 How this is detected (process inspection + on-screen heuristics) and the full

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -56,7 +56,16 @@ extension WorktreeTerminalState {
     }
   }
 
-  func detectAgentState(for view: GhosttySurfaceView, tabId: TerminalTabID) async -> Bool {
+  typealias RetainedSessionResolver =
+    @MainActor (
+      IdentifiedAgentProcess?, PaneAgentState, URL?, String, URL?
+    ) async -> (session: AgentSession?, missStreak: Int)
+
+  func detectAgentState(
+    for view: GhosttySurfaceView,
+    tabId: TerminalTabID,
+    resolveSession: RetainedSessionResolver? = nil
+  ) async -> Bool {
     let surfaceID = view.id
     let childPID = view.bridge.childPID()
     let processGroupID = view.bridge.foregroundProcessGroupID()
@@ -94,7 +103,7 @@ extension WorktreeTerminalState {
     }
 
     let now = Date()
-    let previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
+    var previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
     let activeText = view.bridge.readActiveText() ?? ""
     // Reuse the previous scan while the screen and detected agent are unchanged.
     // A live-but-idle agent is polled every 300 ms and `detectState` re-splits,
@@ -112,17 +121,20 @@ extension WorktreeTerminalState {
 
     let iconLookupToken = identified?.iconLookupToken ?? previous.iconLookupToken ?? agent.iconLookupToken
     let workingDirectory = activeAgentWorkingDirectory(surfaceID: surfaceID)
-    let (session, sessionMissStreak) = await resolveRetainedSession(
-      identified: identified,
-      previous: previous,
-      workingDirectory: workingDirectory,
-      activeText: activeText,
-      configRoot: launchProfilesBySurface[surfaceID]?.configRoot(forDetected: agent)
+    let (session, sessionMissStreak) = await (resolveSession ?? Self.resolveRetainedSession)(
+      identified, previous, workingDirectory, activeText,
+      launchProfilesBySurface[surfaceID]?.configRoot(forDetected: agent)
     )
     // Re-check after the suspension: the pane may have been closed and its
     // agent state cleaned up while the resolver was doing file inspection;
     // writing below would resurrect a ghost Active Agents entry.
     guard surfaces[surfaceID] != nil else { return false }
+    // Acknowledgement can change while session inspection is suspended. Preserve it,
+    // but discard this observation if any other state changed in the meantime.
+    guard let current = surfaceAgentStates[surfaceID] else { return false }
+    previous.seen = current.seen
+    previous.lastChangedAt = current.lastChangedAt
+    guard previous == current else { return true }
     let launchObservation = resolvedLaunchObservation(identified: identified, previous: previous)
     let lastChangedAt = (previous.detectedAgent != agent || previous.state != stabilized) ? now : previous.lastChangedAt
     var next = PaneAgentState(
@@ -263,7 +275,7 @@ extension WorktreeTerminalState {
     )
   }
 
-  private func resolveRetainedSession(
+  private static func resolveRetainedSession(
     identified: IdentifiedAgentProcess?,
     previous: PaneAgentState,
     workingDirectory: URL?,

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -110,11 +110,6 @@ extension WorktreeTerminalState {
       raw: raw
     )
 
-    let seen = Self.resolvedSeen(
-      previous: previous,
-      stabilized: stabilized,
-      isForeground: isSelected() && isFocusedSurface(surfaceID)
-    )
     let iconLookupToken = identified?.iconLookupToken ?? previous.iconLookupToken ?? agent.iconLookupToken
     let workingDirectory = activeAgentWorkingDirectory(surfaceID: surfaceID)
     let (session, sessionMissStreak) = await resolveRetainedSession(
@@ -141,7 +136,7 @@ extension WorktreeTerminalState {
       iconLookupToken: iconLookupToken,
       fallbackState: raw,
       state: stabilized,
-      seen: seen,
+      seen: resolvedSeen(previous: previous, stabilized: stabilized, surfaceID: surfaceID),
       lastChangedAt: lastChangedAt
     )
     next.sessionMissStreak = sessionMissStreak
@@ -209,12 +204,12 @@ extension WorktreeTerminalState {
     return detection
   }
 
-  private static func resolvedSeen(
+  private func resolvedSeen(
     previous: PaneAgentState,
     stabilized: AgentRawState,
-    isForeground: Bool
+    surfaceID: UUID
   ) -> Bool {
-    if isForeground || stabilized == .blocked {
+    if isViewedSurface(surfaceID) {
       return true
     }
     if (previous.state == .working || previous.state == .blocked) && stabilized == .idle {
@@ -293,7 +288,8 @@ extension WorktreeTerminalState {
   }
 
   func markAgentSeen(surfaceID: UUID) {
-    guard var state = surfaceAgentStates[surfaceID], !state.seen else { return }
+    // Focus bookkeeping can run while the window is inactive or before a tab is selected.
+    guard isViewedSurface(surfaceID), var state = surfaceAgentStates[surfaceID], !state.seen else { return }
     state.seen = true
     state.lastChangedAt = Date()
     surfaceAgentStates[surfaceID] = state

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyKit
 import Testing
 
 @testable import supacode
@@ -42,6 +43,41 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(!state.isViewedSurface(UUID()))
   }
 
+  @Test func inactiveFocusedCompletionPollRemainsUnread() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .working,
+      seen: true
+    )
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(
+      currentAgent: .claude
+    )
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude,
+      text: "",
+      detection: AgentScreenDetection(state: .idle, reason: .legacyDetector)
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func inactiveFocusBookkeepingDoesNotAcknowledgeCompletion() {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+
+    fixture.state.recordActiveSurface(fixture.surface, in: fixture.tabID)
+
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -61,5 +97,40 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     state.lastWindowIsKey = true
     state.lastWindowIsVisible = true
     return (state, surfaceId)
+  }
+
+  private struct DetectionFixture {
+    let state: WorktreeTerminalState
+    let tabID: TerminalTabID
+    let surface: GhosttySurfaceView
+  }
+
+  private func makeDetectionFixture() -> DetectionFixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/wt-1",
+        name: "wt-1",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let surface = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: state.worktree.workingDirectory,
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabID = state.tabManager.createTab(title: "tab", icon: nil)
+    state.tabManager.selectTab(tabID)
+    state.surfaces[surface.id] = surface
+    state.trees[tabID] = SplitTree<GhosttySurfaceView>(view: surface)
+    state.focusedSurfaceIdByTab[tabID] = surface.id
+    state.isSelected = { true }
+    state.lastWindowIsKey = true
+    state.lastWindowIsVisible = true
+    return DetectionFixture(state: state, tabID: tabID, surface: surface)
   }
 }

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -78,6 +78,94 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
   }
 
+  enum ViewingCondition: CaseIterable {
+    case viewed, inactive, hidden, unknown, canvas, otherWorktree, otherPane, otherTab
+  }
+
+  @Test(arguments: ViewingCondition.allCases, [AgentRawState.working, .blocked])
+  func completionPollingRequiresViewedSurface(
+    condition: ViewingCondition,
+    previousState: AgentRawState
+  ) async {
+    let fixture = makeDetectionFixture()
+    apply(condition, to: fixture.state)
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: previousState, seen: true),
+      detected: .idle
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(
+      fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState
+        == (condition == .viewed ? .idle : .done)
+    )
+  }
+
+  @Test(arguments: ViewingCondition.allCases)
+  func automaticAcknowledgementRequiresViewedSurface(condition: ViewingCondition) {
+    let fixture = makeDetectionFixture()
+    apply(condition, to: fixture.state)
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+
+    #expect(
+      fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState
+        == (condition == .viewed ? .idle : .done)
+    )
+  }
+
+  @Test func inactiveStableIdlePollDoesNotCreateCompletion() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: true),
+      detected: .idle
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+  }
+
+  @Test func inactiveUnreadStateSurvivesBlockedRoundTrip() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: false),
+      detected: .blocked
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.seen == false)
+
+    prepareDetection(fixture, detected: .idle)
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func returningToViewedSurfaceAcknowledgesCompletion() {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+
+    fixture.state.lastWindowIsKey = true
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -132,5 +220,50 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     state.lastWindowIsKey = true
     state.lastWindowIsVisible = true
     return DetectionFixture(state: state, tabID: tabID, surface: surface)
+  }
+
+  private func apply(_ condition: ViewingCondition, to state: WorktreeTerminalState) {
+    switch condition {
+    case .viewed:
+      break
+    case .inactive:
+      state.lastWindowIsKey = false
+    case .hidden:
+      state.lastWindowIsVisible = false
+    case .unknown:
+      state.lastWindowIsKey = nil
+      state.lastWindowIsVisible = nil
+    case .canvas:
+      state.isCanvasManaged = true
+    case .otherWorktree:
+      state.isSelected = { false }
+    case .otherPane:
+      if let tabID = state.tabManager.selectedTabId {
+        state.focusedSurfaceIdByTab[tabID] = UUID()
+      }
+    case .otherTab:
+      let tabID = state.tabManager.createTab(title: "other", icon: nil)
+      state.tabManager.selectTab(tabID)
+    }
+  }
+
+  private func preparePoll(
+    _ fixture: DetectionFixture,
+    previous: PaneAgentState,
+    detected: AgentRawState
+  ) {
+    fixture.state.surfaceAgentStates[fixture.surface.id] = previous
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(
+      currentAgent: .claude
+    )
+    prepareDetection(fixture, detected: detected)
+  }
+
+  private func prepareDetection(_ fixture: DetectionFixture, detected: AgentRawState) {
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude,
+      text: "",
+      detection: AgentScreenDetection(state: detected, reason: .legacyDetector)
+    )
   }
 }

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -166,6 +166,79 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
   }
 
+  @Test(arguments: [false, true])
+  func acknowledgementDuringSessionLookupIsPreserved(metadataChanges: Bool) async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(
+        detectedAgent: .claude, fallbackState: .idle, state: .idle, seen: false),
+      detected: .idle
+    )
+    let session =
+      metadataChanges ? AgentSession(id: "resolved", transcriptPath: nil, source: .recentFile) : nil
+    let (started, signalStarted) = AsyncStream<Void>.makeStream()
+    let (resume, signalResume) = AsyncStream<Void>.makeStream()
+    let poll = Task {
+      await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID) {
+        _, _, _, _, _ in
+        signalStarted.yield(())
+        signalStarted.finish()
+        for await _ in resume { break }
+        return (session, 0)
+      }
+    }
+    for await _ in started { break }
+    fixture.state.lastWindowIsKey = true
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    let acknowledgedAt = fixture.state.surfaceAgentStates[fixture.surface.id]?.lastChangedAt
+    fixture.state.lastWindowIsKey = false
+    signalResume.yield(())
+    signalResume.finish()
+
+    #expect(await poll.value)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.lastChangedAt == acknowledgedAt)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.session == session)
+
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .working, seen: true),
+      detected: .idle
+    )
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func stateChangedDuringSessionLookupIsNotOverwritten() async {
+    let fixture = makeDetectionFixture()
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: false),
+      detected: .idle
+    )
+    let (started, signalStarted) = AsyncStream<Void>.makeStream()
+    let (resume, signalResume) = AsyncStream<Void>.makeStream()
+    let poll = Task {
+      await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID) {
+        _, _, _, _, _ in
+        signalStarted.yield(())
+        signalStarted.finish()
+        for await _ in resume { break }
+        return (nil, 0)
+      }
+    }
+    for await _ in started { break }
+    let newer = PaneAgentState(detectedAgent: .claude, state: .working, seen: true)
+    fixture.state.surfaceAgentStates[fixture.surface.id] = newer
+    signalResume.yield(())
+    signalResume.finish()
+
+    #expect(await poll.value)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id] == newer)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),


### PR DESCRIPTION
## Summary

Keep completed panes unread until they are viewed in the active, visible Prowl window. Use the shared viewing predicate for polling and automatic focus acknowledgement, including a fresh visibility check after asynchronous session resolution.

Preserve acknowledgements made while session resolution is suspended, including their timestamp. Discard the pending observation if other pane state changed during suspension. A later unviewed working/blocked-to-idle transition still becomes Done.

Fixes #777.

## Validation

- Reproduced the stale acknowledgement on the previous head with a controlled resolver suspension: Done reappeared and the acknowledgement timestamp was overwritten.
- The regression passes with the fix, with and without new session metadata.
- Related local Xcode tests passed in two runs (62 and 26 test methods), including polling, focus, session retention, Active Agents, Island, entry coalescing/deduplication, and state changes during suspension.
- `make check` passed, including 146 script tests.
- `make build-app` passed.
- `git diff --check` passed.
- No live-agent GUI reproduction was performed for this state-management fix.

## Related work and credit

Thanks to @SunChJ for the original implementation in #778, resubmitted as #782, and to @onevtail for identifying the session-resolution race in that review. This PR consolidates the shared fix with behavior-level regression coverage and resolves that race. #785 continues the separate Canvas viewing companion from #783, retaining its original author commit.
