### PR TITLE
Complete delivery naming in workflow records and CLI

### DIFF
--- a/ProwlCLI/Output/OutputRenderer+Workflow.swift
+++ b/ProwlCLI/Output/OutputRenderer+Workflow.swift
@@ -69,7 +69,7 @@ extension OutputRenderer {
       var line = "Step: \(step)"
       if let activation = payload.activation {
         line +=
-          "  waiting for '\(activation.role)' → output '\(activation.output)' (\(activation.state))"
+          "  waiting for '\(activation.role)' → delivery '\(activation.delivery)' (\(activation.state))"
       }
       lines.append(line)
     }
@@ -115,17 +115,17 @@ extension OutputRenderer {
     switch delivery.state {
     case .delivered:
       lines.append(
-        "\("Delivered".green)  output '\(delivery.output.name)' for step '\(delivery.step)' (invocation \(delivery.ordinal))"
+        "\("Delivered".green)  delivery '\(delivery.record.name)' for step '\(delivery.step)' (invocation \(delivery.ordinal))"
       )
     case .provisional:
       lines.append(
-        "\("Provisional".yellow)  output '\(delivery.output.name)' for step '\(delivery.step)' is on disk but needs a decision in Prowl:"
+        "\("Provisional".yellow)  delivery '\(delivery.record.name)' for step '\(delivery.step)' is on disk but needs a decision in Prowl:"
       )
       for warning in delivery.warnings {
         lines.append("  - \(warning.message) [\(warning.code)]")
       }
     }
-    lines.append("  \(delivery.output.path.dim)")
+    lines.append("  \(delivery.record.path.dim)")
     lines.append("Run: \(payload.run.id)  \(workflowStatusText(payload.run.status))")
     return lines.joined(separator: "\n")
   }

--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -4035,7 +4035,7 @@
         "deliveries": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/workflowOutput"
+            "$ref": "#/$defs/workflowDeliveryRecord"
           }
         },
         "started_at": {
@@ -4122,7 +4122,7 @@
         "deliveries": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/workflowOutput"
+            "$ref": "#/$defs/workflowDeliveryRecord"
           }
         },
         "started_at": {
@@ -4209,7 +4209,7 @@
         "deliveries": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/workflowOutput"
+            "$ref": "#/$defs/workflowDeliveryRecord"
           }
         },
         "started_at": {
@@ -4312,7 +4312,7 @@
         "deliveries": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/workflowOutput"
+            "$ref": "#/$defs/workflowDeliveryRecord"
           }
         },
         "started_at": {
@@ -4515,7 +4515,7 @@
         "step",
         "role",
         "state",
-        "output",
+        "delivery",
         "expect"
       ],
       "properties": {
@@ -4542,7 +4542,7 @@
         "dispatch_id": {
           "type": "string"
         },
-        "output": {
+        "delivery": {
           "type": "string"
         },
         "expect": {
@@ -4594,7 +4594,7 @@
         }
       }
     },
-    "workflowOutput": {
+    "workflowDeliveryRecord": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -4657,7 +4657,7 @@
         "ordinal",
         "step",
         "role",
-        "output",
+        "record",
         "warnings"
       ],
       "properties": {
@@ -4677,8 +4677,8 @@
         "role": {
           "type": "string"
         },
-        "output": {
-          "$ref": "#/$defs/workflowOutput"
+        "record": {
+          "$ref": "#/$defs/workflowDeliveryRecord"
         },
         "warnings": {
           "type": "array",

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1294,7 +1294,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       ok: false, command: "workflow", schemaVersion: "prowl.cli.workflow.v1",
       error: .init(code: "STEP_NOT_EXPECTING", message: "No assigned task."))
     let (request, result) = try runWithMockServer(
-      socketPath: temporarySocketPath(suffix: "workflow-large-done"), response: response,
+      socketPath: temporarySocketPath(suffix: "workflow-large-deliver"), response: response,
       args: ["workflow", "deliver", "--file", file.path, "--json"])
     XCTAssertEqual(result.exitCode, 1)
     XCTAssertGreaterThan(request.count, 32 * 1024 * 1024)
@@ -1331,7 +1331,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(content["total_bytes"] as? Int, 8)
   }
 
-  func testWorkflowRunAndDoneRoundTripThroughTheSocket() throws {
+  func testWorkflowRunAndDeliverRoundTripThroughTheSocket() throws {
     let output = WorkflowDeliveryRecordPayload(
       name: "brief", ordinal: 1, path: "/Projects/App/.prowl/workflow-runs/R/deliveries/brief.1.md",
       latestPath: "/Projects/App/.prowl/workflow-runs/R/deliveries/brief.md", verdict: nil,
@@ -1355,7 +1355,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
             agent: "claude"))
       ],
       activation: WorkflowActivationPayload(
-        ordinal: 1, step: "brief", role: "author", state: "waiting", dispatchID: "d-1", output: "brief",
+        ordinal: 1, step: "brief", role: "author", state: "waiting", dispatchID: "d-1", delivery: "brief",
         expect: WorkflowExpectationPayload(
           format: .markdown, sections: ["## Scope"], verdicts: nil, strict: false,
           completion: ["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]),
@@ -1402,36 +1402,36 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(runText.stdout.contains("Run: 0BADCAFE-0000-4000-8000-000000000042"), runText.stdout)
     XCTAssertTrue(runText.stdout.contains("Follow this line yourself"), runText.stdout)
 
-    let doneResponse = try CommandResponse(
+    let deliverResponse = try CommandResponse(
       ok: true, command: "workflow", schemaVersion: "prowl.cli.workflow.v1",
       data: RawJSON(
         encoding: WorkflowCommandPayload.deliver(
           WorkflowDeliverPayload(
             run: run,
             delivery: WorkflowDeliveryPayload(
-              state: .provisional, ordinal: 1, step: "brief", role: "author", output: output,
+              state: .provisional, ordinal: 1, step: "brief", role: "author", record: output,
               warnings: [WorkflowDeliveryWarningPayload(code: "missing_sections", message: "missing section(s) ## Claims")])
           ))))
-    let (doneRequest, doneResult) = try runWithMockServer(
-      socketPath: temporarySocketPath(suffix: "workflow-done"), response: doneResponse,
+    let (deliverRequest, deliverResult) = try runWithMockServer(
+      socketPath: temporarySocketPath(suffix: "workflow-deliver"), response: deliverResponse,
       args: ["workflow", "deliver", "-", "--verdict", "clean", "--json"],
       stdinData: Data("## Scope\nOnly the scope.\n".utf8),
       environment: [WorkflowSchema.tokenEnvironmentKey: "T"])
-    XCTAssertEqual(doneResult.exitCode, 0, doneResult.stderr)
-    let doneEnvelope = try JSONDecoder().decode(CommandEnvelope.self, from: doneRequest)
-    guard case .workflow(let doneInput) = doneEnvelope.command else { return XCTFail("Expected a workflow envelope") }
-    XCTAssertEqual(doneInput.action, .deliver)
-    XCTAssertEqual(doneInput.body, "## Scope\nOnly the scope.\n")
-    XCTAssertEqual(doneInput.verdict, "clean")
-    XCTAssertEqual(doneInput.token, "T", "the token comes from the environment the step handed out")
-    XCTAssertNil(doneInput.runID)
-    XCTAssertFalse(doneInput.force)
-    let doneText = try runWithMockServer(
-      socketPath: temporarySocketPath(suffix: "workflow-done-text"), response: doneResponse,
+    XCTAssertEqual(deliverResult.exitCode, 0, deliverResult.stderr)
+    let deliverEnvelope = try JSONDecoder().decode(CommandEnvelope.self, from: deliverRequest)
+    guard case .workflow(let deliverInput) = deliverEnvelope.command else { return XCTFail("Expected a workflow envelope") }
+    XCTAssertEqual(deliverInput.action, .deliver)
+    XCTAssertEqual(deliverInput.body, "## Scope\nOnly the scope.\n")
+    XCTAssertEqual(deliverInput.verdict, "clean")
+    XCTAssertEqual(deliverInput.token, "T", "the token comes from the environment the step handed out")
+    XCTAssertNil(deliverInput.runID)
+    XCTAssertFalse(deliverInput.force)
+    let deliverText = try runWithMockServer(
+      socketPath: temporarySocketPath(suffix: "workflow-deliver-text"), response: deliverResponse,
       args: ["workflow", "deliver", "-", "--no-color"], stdinData: Data("x".utf8)).1
-    XCTAssertEqual(doneText.exitCode, 0, doneText.stderr)
-    XCTAssertTrue(doneText.stdout.contains("Provisional"), doneText.stdout)
-    XCTAssertTrue(doneText.stdout.contains("missing_sections"), doneText.stdout)
+    XCTAssertEqual(deliverText.exitCode, 0, deliverText.stderr)
+    XCTAssertTrue(deliverText.stdout.contains("Provisional"), deliverText.stdout)
+    XCTAssertTrue(deliverText.stdout.contains("missing_sections"), deliverText.stdout)
 
     let noStdin = try runProwl(args: ["workflow", "deliver", "-"], environment: [ProwlSocket.environmentKey: "/nonexistent.sock"])
     XCTAssertNotEqual(noStdin.exitCode, 0)

--- a/ProwlCLITests/WorkflowBundleValidatorTests.swift
+++ b/ProwlCLITests/WorkflowBundleValidatorTests.swift
@@ -148,7 +148,7 @@ struct WorkflowBundleValidatorTests {
       - id: after
         notify: '{{ deliveries.report.path }}'
     """, state: "roles: {author: {source: current}}")
-    #expect(diagnostics.contains("output_shadowing"))
+    #expect(diagnostics.contains("delivery_shadowing"))
   }
 
 }

--- a/ProwlCLITests/WorkflowCommandParsingTests.swift
+++ b/ProwlCLITests/WorkflowCommandParsingTests.swift
@@ -47,7 +47,7 @@ final class WorkflowCommandParsingTests: XCTestCase {
     XCTAssertThrowsError(try WorkflowValidateCommand.parse(["x.yaml", "--scope", "global"]))
   }
 
-  func testDoneParsesItsDeliveryOptions() throws {
+  func testDeliverParsesItsDeliveryOptions() throws {
     let deliver = try XCTUnwrap(
       ProwlCommand.parseAsRoot([
         "workflow", "deliver", "-", "--verdict", "clean", "--token", "T", "--run",
@@ -66,7 +66,7 @@ final class WorkflowCommandParsingTests: XCTestCase {
     XCTAssertNil(file.input)
   }
 
-  func testDoneRejectsMissingOrDoubledBodiesAndHalfManualTargets() {
+  func testDeliverRejectsMissingOrDoubledBodiesAndHalfManualTargets() {
     XCTAssertThrowsError(try ProwlCommand.parseAsRoot(["workflow", "deliver"]))
     XCTAssertThrowsError(
       try ProwlCommand.parseAsRoot(["workflow", "deliver", "-", "--file", "/tmp/out.md"]))

--- a/ProwlCLITests/WorkflowSchemaTests.swift
+++ b/ProwlCLITests/WorkflowSchemaTests.swift
@@ -10,37 +10,37 @@ final class WorkflowSchemaTests: XCTestCase {
 
   func testOutputSchemaAcceptsEveryAction() throws {
     let entry =
-      #"{"id":"demo","name":"Demo","description":"d","scope":"user","path":"/Users/me/.prowl/workflows/demo.yaml","enabled":true,"valid":true,"errors":0,"warnings":1,"shadowed":false}"#
+      #"{"id":"demo","name":"Demo","description":"d","scope":"user","path":"/Users/me/.prowl/workflows/demo.pwlworkflow","enabled":true,"valid":true,"errors":0,"warnings":1,"shadowed":false}"#
     let unparsed =
-      #"{"scope":"repo","path":"/Projects/App/.prowl/workflows/broken.yaml","enabled":false,"valid":false,"errors":1,"warnings":0,"shadowed":false}"#
+      #"{"scope":"repo","path":"/Projects/App/.prowl/workflows/broken.pwlworkflow","enabled":false,"valid":false,"errors":1,"warnings":0,"shadowed":false}"#
     let list =
       #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","worktree":{"id":"w","name":"main","path":"/Projects/App","root_path":"/Projects/App"},"sources":{"bundle":"/Applications/Prowl.app/Contents/Resources/workflows","user":"/Users/me/.prowl/workflows","repo":"/Projects/App/.prowl/workflows"},"workflows":[\#(entry),\#(unparsed)]}}"#
     let listWithoutWorktree =
       #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"list","sources":{"user":"/Users/me/.prowl/workflows"},"workflows":[]}}"#
     let validate =
-      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"validate","path":"/x.yaml","valid":true,"workflow":{"id":"demo","name":"Demo"},"diagnostics":[{"severity":"warning","code":"timeout_long","message":"long","line":4,"column":7},{"severity":"warning","code":"skill_unchecked","message":"unchecked"}]}}"#
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"validate","path":"/x.pwlworkflow","valid":true,"workflow":{"id":"demo","name":"Demo"},"diagnostics":[{"severity":"warning","code":"timeout_long","message":"long","line":4,"column":7},{"severity":"warning","code":"skill_unchecked","message":"unchecked"}]}}"#
     let schema =
       #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"schema","schema":{"$id":"x","type":"object"}}}"#
     let error =
-      #"{"ok":false,"command":"workflow","schema_version":"prowl.cli.workflow.v1","error":{"code":"WORKFLOW_INVALID","message":"2 error(s).","details":{"action":"validate","path":"/x.yaml","valid":false,"diagnostics":[]}}}"#
+      #"{"ok":false,"command":"workflow","schema_version":"prowl.cli.workflow.v1","error":{"code":"WORKFLOW_INVALID","message":"2 error(s).","details":{"action":"validate","path":"/x.pwlworkflow","valid":false,"diagnostics":[]}}}"#
     let run =
       ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"run",\###(Self.runFields)}}"###
     let status =
       ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"status",\###(Self.recordFields)}}"###
     let cancel =
       ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"cancel",\###(Self.runFields)}}"###
-    let done =
-      ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"deliver","run":{\###(Self.runFields)},"delivery":{"state":"provisional","ordinal":1,"step":"brief","role":"author","output":\###(Self.output),"warnings":[{"code":"missing_sections","message":"missing ## Claims"}]}}}"###
+    let deliver =
+      ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"deliver","run":{\###(Self.runFields)},"delivery":{"state":"provisional","ordinal":1,"step":"brief","role":"author","record":\###(Self.output),"warnings":[{"code":"missing_sections","message":"missing ## Claims"}]}}}"###
     let read =
       #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"read","run":"0BADCAFE-0000-4000-8000-000000000042","invocation":1,"role":"author","step":"brief","resource":"instruction","body":"Read","encoding":"utf-8","resources":[],"offset":0,"next_offset":4,"total_bytes":8}}"#
-    for instance in [list, listWithoutWorktree, validate, schema, error, run, status, cancel, done, read] {
+    for instance in [list, listWithoutWorktree, validate, schema, error, run, status, cancel, deliver, read] {
       try assertValidity(instance, expected: true)
     }
   }
 
   func testOutputSchemaRejectsMalformedRuntimePayloads() throws {
     let badDeliveryState =
-      ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"deliver","run":{\###(Self.runFields)},"delivery":{"state":"accepted","ordinal":1,"step":"brief","role":"author","output":\###(Self.output),"warnings":[]}}}"###
+      ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"deliver","run":{\###(Self.runFields)},"delivery":{"state":"accepted","ordinal":1,"step":"brief","role":"author","record":\###(Self.output),"warnings":[]}}}"###
     let badBindingSource =
       ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"run",\###(Self.runFields.replacingOccurrences(of: #""source":"current""#, with: #""source":"remote""#))}}"###
     let badState =
@@ -80,7 +80,7 @@ final class WorkflowSchemaTests: XCTestCase {
       id: "0BADCAFE-0000-4000-8000-000000000042",
       workflow: WorkflowIdentity(id: "prowl.adversarial-review", name: "Adversarial Review"),
       scope: .repo,
-      definitionPath: "/Projects/App/.prowl/workflows/review.yaml",
+      definitionPath: "/Projects/App/.prowl/workflows/review.pwlworkflow",
       source: .live,
       status: WorkflowRunStatusPayload(
         state: "needs_attention", step: "brief",
@@ -102,7 +102,7 @@ final class WorkflowSchemaTests: XCTestCase {
           profile: WorkflowProfileBindingPayload(id: "00000000-0000-0000-0000-000000000009", name: "Pi", agent: "pi")),
       ],
       activation: WorkflowActivationPayload(
-        ordinal: 1, step: "brief", role: "author", state: "provisional", dispatchID: "dispatch-1", output: "brief",
+        ordinal: 1, step: "brief", role: "author", state: "provisional", dispatchID: "dispatch-1", delivery: "brief",
         expect: WorkflowExpectationPayload(
           format: .markdown, sections: ["## Scope"], verdicts: nil, strict: false,
           completion: ["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]),
@@ -115,13 +115,41 @@ final class WorkflowSchemaTests: XCTestCase {
         line: "[Prowl] Read /r/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -",
         instructionPath: "/r/instructions/brief.1.md",
         completion: ["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]))
-    let done = WorkflowCommandPayload.deliver(
+    let runObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(run)) as? [String: Any])
+    let activationObject = try XCTUnwrap(runObject["activation"] as? [String: Any])
+    XCTAssertEqual(activationObject["delivery"] as? String, "brief")
+    XCTAssertNil(activationObject["output"])
+    var retiredRun = runObject
+    var retiredActivation = activationObject
+    retiredActivation["output"] = retiredActivation.removeValue(forKey: "delivery")
+    retiredRun["activation"] = retiredActivation
+    let retiredRunData = try JSONSerialization.data(withJSONObject: retiredRun)
+    XCTAssertThrowsError(try JSONDecoder().decode(WorkflowRunPayload.self, from: retiredRunData))
+    try assertValidity(
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"run",\#(String(decoding: retiredRunData, as: UTF8.self).dropFirst().dropLast())}}"#,
+      expected: false)
+
+    let deliver = WorkflowCommandPayload.deliver(
       WorkflowDeliverPayload(
         run: run,
         delivery: WorkflowDeliveryPayload(
-          state: .provisional, ordinal: 1, step: "brief", role: "author", output: output,
+          state: .provisional, ordinal: 1, step: "brief", role: "author", record: output,
           warnings: [WorkflowDeliveryWarningPayload(code: "missing_sections", message: "missing ## Claims")])))
-    for payload in [WorkflowCommandPayload.run(run), .status(run), .cancel(run), done] {
+    let deliveryObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(deliver)) as? [String: Any])
+    let receiptObject = try XCTUnwrap(deliveryObject["delivery"] as? [String: Any])
+    XCTAssertNotNil(receiptObject["record"])
+    XCTAssertNil(receiptObject["output"])
+    var retiredDelivery = deliveryObject
+    var retiredReceipt = receiptObject
+    retiredReceipt["output"] = retiredReceipt.removeValue(forKey: "record")
+    retiredDelivery["delivery"] = retiredReceipt
+    let retiredDeliveryData = try JSONSerialization.data(withJSONObject: retiredDelivery)
+    XCTAssertThrowsError(try JSONDecoder().decode(WorkflowCommandPayload.self, from: retiredDeliveryData))
+    try assertValidity(
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":\#(String(decoding: retiredDeliveryData, as: UTF8.self))}"#,
+      expected: false)
+
+    for payload in [WorkflowCommandPayload.run(run), .status(run), .cancel(run), deliver] {
       let data = try encoder.encode(payload)
       XCTAssertTrue(String(decoding: data, as: UTF8.self).hasPrefix(#"{"action":"\#(payload.action.rawValue)""#))
       XCTAssertEqual(try JSONDecoder().decode(WorkflowCommandPayload.self, from: data), payload)
@@ -135,7 +163,7 @@ final class WorkflowSchemaTests: XCTestCase {
     #"{"name":"brief","ordinal":1,"path":"/r/deliveries/brief.1.md","latest_path":"/r/deliveries/brief.md","delivered_at":"2026-08-30T01:02:03Z"}"#
 
   private static let runFields =
-    ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.adversarial-review","name":"Adversarial Review"},"scope":"repo","definition_path":"/Projects/App/.prowl/workflows/review.yaml","source":"live","status":{"state":"running"},"step":"brief","role":"author","worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"author":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","tab_id":"00000000-0000-0000-0000-000000000011","handle":"p1","display_name":"Claude Code","agent":"claude"}},"reviewer":{"source":"launch","profile":{"id":"00000000-0000-0000-0000-000000000009","name":"Pi Reviewer","agent":"pi"}}},"activation":{"ordinal":1,"step":"brief","role":"author","state":"waiting","dispatch_id":"dispatch-1","output":"brief","expect":{"format":"markdown","sections":["## Scope","## Claims"],"strict":false,"completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]},"deadline":"2026-08-30T01:10:00Z"},"deliveries":{},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:00:00Z","self_initiated":{"line":"[Prowl] Read /r/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -","instruction_path":"/r/instructions/brief.1.md","completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]}"###
+    ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.adversarial-review","name":"Adversarial Review"},"scope":"repo","definition_path":"/Projects/App/.prowl/workflows/review.pwlworkflow","source":"live","status":{"state":"running"},"step":"brief","role":"author","worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"author":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","tab_id":"00000000-0000-0000-0000-000000000011","handle":"p1","display_name":"Claude Code","agent":"claude"}},"reviewer":{"source":"launch","profile":{"id":"00000000-0000-0000-0000-000000000009","name":"Pi Reviewer","agent":"pi"}}},"activation":{"ordinal":1,"step":"brief","role":"author","state":"waiting","dispatch_id":"dispatch-1","delivery":"brief","expect":{"format":"markdown","sections":["## Scope","## Claims"],"strict":false,"completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]},"deadline":"2026-08-30T01:10:00Z"},"deliveries":{},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:00:00Z","self_initiated":{"line":"[Prowl] Read /r/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -","instruction_path":"/r/instructions/brief.1.md","completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]}"###
 
   private static let recordFields =
     ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.handoff","name":"Hand Off"},"scope":"bundle","source":"record","status":{"state":"interrupted"},"worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"source":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","handle":"p1","display_name":"shell"}}},"deliveries":{"brief":\###(WorkflowSchemaTests.output)},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:05:00Z","finished_at":"2026-08-30T01:05:00Z""###
@@ -161,7 +189,7 @@ final class WorkflowSchemaTests: XCTestCase {
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let validate = WorkflowCommandPayload.validate(
       WorkflowValidatePayload(
-        path: "/x.yaml", valid: false, workflow: WorkflowIdentity(id: "demo", name: "Demo"),
+        path: "/x.pwlworkflow", valid: false, workflow: WorkflowIdentity(id: "demo", name: "Demo"),
         diagnostics: [
           WorkflowDiagnosticPayload(severity: .error, code: "undefined_role", message: "Role 'x'", line: 3, column: 5)
         ]))

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -41,7 +41,7 @@ final class WorkflowValidatorTests: XCTestCase {
 
   // MARK: - Ids and roles
 
-  func testSlugsAreEnforcedForIdsRolesStepsOutputsAndInputs() {
+  func testSlugsAreEnforcedForIdsRolesStepsDeliveriesAndInputs() {
     XCTAssertEqual(WorkflowFixtures.codes(minimal(id: "Demo Flow")), ["workflow_id"])
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal(roles: "  Reviewer:\n    source: pick")), ["role_name_slug"])
@@ -50,7 +50,7 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(
       WorkflowFixtures.codes(
         minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { delivery: Bad.Name }")),
-      ["output_name_slug"])
+      ["delivery_name_slug"])
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal() + "inputs:\n  Max: { type: integer }\n"), ["input_name_slug"])
   }
@@ -130,7 +130,7 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(codes("{{ }}"), ["expression_syntax"])
   }
 
-  func testOutputAndActionReferencesFollowProducers() {
+  func testDeliveryAndActionReferencesFollowProducers() {
     let steps = """
         - id: b
           message: author

--- a/docs-ai/013-prowl-cli/contracts/workflow.md
+++ b/docs-ai/013-prowl-cli/contracts/workflow.md
@@ -185,7 +185,7 @@ valid; the app-side `list` always has the bundle.
         "name": "Review",
         "description": "…",
         "scope": "repo",
-        "path": "/Projects/App/.prowl/workflows/review.yaml",
+        "path": "/Projects/App/.prowl/workflows/review.pwlworkflow",
         "enabled": true,
         "valid": true,
         "errors": 0,
@@ -216,7 +216,7 @@ valid; the app-side `list` always has the bundle.
     "id": "0BADCAFE-0000-4000-8000-000000000042",
     "workflow": { "id": "review", "name": "Review" },
     "scope": "repo",
-    "definition_path": "/Projects/App/.prowl/workflows/review.yaml",
+    "definition_path": "/Projects/App/.prowl/workflows/review.pwlworkflow",
     "source": "live",
     "status": { "state": "running" },
     "step": "brief",
@@ -228,7 +228,7 @@ valid; the app-side `list` always has the bundle.
       "reviewer": { "source": "launch", "profile": { "id": "…", "name": "Codex", "agent": "codex" } }
     },
     "activation": {
-      "ordinal": 1, "step": "brief", "role": "author", "state": "waiting", "dispatch_id": "…", "output": "brief",
+      "ordinal": 1, "step": "brief", "role": "author", "state": "waiting", "dispatch_id": "…", "delivery": "brief",
       "expect": { "format": "markdown", "sections": ["## Scope", "## Claims"], "strict": false,
                   "completion": ["PROWL_WORKFLOW_TOKEN=… prowl workflow deliver -"] },
       "deadline": "2026-08-30T01:10:00.000Z"
@@ -261,6 +261,8 @@ valid; the app-side `list` always has the bundle.
   step stuck in an injection or launch attention reports none.
 - `bindings.<role>.profile` is the frozen profile (id, name, agent) of a `launch` role;
   `bindings.<role>.pane` is the role's pane (`launch` roles gain it once launched).
+- `activation.delivery` is the expected delivery name. The `deliver` receipt exposes
+  the resulting record at `delivery.record`.
 - `deliveries` is the latest delivered output per name (`name`, `ordinal`, `path`,
   `latest_path`, `verdict`, `delivered_at`).
 - `self_initiated` appears on `run` only, when the run started from the pane that is its
@@ -280,7 +282,7 @@ valid; the app-side `list` always has the bundle.
     "delivery": {
       "state": "provisional",
       "ordinal": 1, "step": "brief", "role": "author",
-      "output": { "name": "brief", "ordinal": 1, "path": "…/deliveries/brief.1.md", "latest_path": "…/deliveries/brief.md", "delivered_at": "…" },
+      "record": { "name": "brief", "ordinal": 1, "path": "…/deliveries/brief.1.md", "latest_path": "…/deliveries/brief.md", "delivered_at": "…" },
       "warnings": [{ "code": "missing_sections", "message": "missing section(s) ## Claims" }]
     }
   }
@@ -302,7 +304,7 @@ B3 offers no CLI control for that decision, C1 does).
   "schema_version": "prowl.cli.workflow.v1",
   "data": {
     "action": "validate",
-    "path": "/Projects/App/.prowl/workflows/review.yaml",
+    "path": "/Projects/App/.prowl/workflows/review.pwlworkflow",
     "valid": true,
     "workflow": { "id": "review", "name": "Review" },
     "diagnostics": [
@@ -315,7 +317,7 @@ B3 offers no CLI control for that decision, C1 does).
 `diagnostics[]` lists parse diagnostics first, then validation diagnostics; `line` and
 `column` are 1-based and omitted when a diagnostic has no position. `workflow` is present
 whenever the file parsed. Codes are stable identifiers (`unknown_key`, `undefined_role`,
-`message_before_launch`, `until_verdict_literal`, `skill_unchecked`, …) and are the
+`message_before_launch`, `delivery_shadowing`, `skill_unchecked`, …) and are the
 contract; messages are not.
 
 ### `schema`

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -693,3 +693,5 @@ attaches hooks through A2's launch boundary.
 - Updated 2026-09-06: Personal workflow history and fixed retention — see [018-history-storage-plan.md](018-history-storage-plan.md).
 
 - Updated 2026-09-07: Normalize workflow naming before D3; no aliases or migration — see [019](019-workflow-naming.md).
+
+- Updated 2026-09-08: Complete delivery naming in CLI/persisted records, diagnostics, helpers, and active examples — see [019](019-workflow-naming.md).

--- a/docs-ai/063-agent-workflows/019-workflow-naming.md
+++ b/docs-ai/063-agent-workflows/019-workflow-naming.md
@@ -26,6 +26,10 @@ This change does not implement handoff migration, new context collectors, or rev
   single-Git-directory behavior remains unchanged. Broader collection belongs to D3.
 - Participant submission is `prowl workflow deliver` and socket `command: workflow` with `action: deliver`.
   Retain `run`, `status`, `read`, `cancel`, and `test-action`.
+- CLI and persisted activations name their delivery with `delivery`. CLI delivery
+  receipts expose `record`; the schema definition is `workflowDeliveryRecord`.
+  Persisted skipped dependencies use `skipped_deliveries`.
+- Delivery diagnostics use `delivery_shadowing` and `delivery_name_slug`.
 - The terminal loop-limit state is `iteration_limit_reached`.
 
 ## Verification
@@ -77,3 +81,16 @@ Flow-style YAML declaration scanning remains an optional coverage gap. The runti
 workflow/action parsers reject those retired declaration keys; the lightweight
 repository check does not parse all YAML syntax. No new runtime/schema/reference
 naming defect was confirmed in the fourth review.
+
+### Delivery contract follow-up (2026-09-08)
+
+Implemented: complete delivery naming in CLI and persisted records. Use
+`activation.delivery` for the delivery name, `delivery.record` for its record,
+`skipped_deliveries` for skipped-name dependencies, and `workflowDeliveryRecord`
+for the JSON schema definition. Rename delivery-specific diagnostics and internal
+helpers. Correct active CLI examples to bundle paths. No aliases or migration.
+
+Encoded-key assertions and retired-shape rejection cover CLI payloads and persisted
+records. Validation passed: CLI build/smoke, 291 CLI unit tests, 112 integration tests,
+3147 App tests, and `make check` with 152 script tests. The original serialization
+assertions failed before the implementation changed. Final App build passed.

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -599,7 +599,9 @@ prowl workflow cancel "$(printf '%s\n' "$run" | jq -r '.data.id')"
 
 JSON is `prowl.cli.workflow.v1` with `data.action` = `list` | `run` | `status` | `deliver` |
 `cancel` | `read` | `validate` | `schema`; `run`, `status`, and `cancel` share the run shape, `deliver`
-nests it under `.data.run` beside `.data.delivery`.
+nests it under `.data.run` beside `.data.delivery`. The activation names its expected
+delivery with `activation.delivery`; the receipt stores the resulting record in
+`delivery.record`.
 
 `prowl workflow test-action <workflow> <action> [source] --input-json '<JSON object>' [--json]`
 starts a real single-action run from a discovered bundle. Use `builtin:collect-worktree-context` or

--- a/skills/prowl-workflow/references/runbook.md
+++ b/skills/prowl-workflow/references/runbook.md
@@ -74,7 +74,7 @@ delivery is rejected instead and the participant can correct it while the step i
 - `.data.status.state` — see the states above; `.data.finished_at` is set once the run ended.
   `.data.status.attention` (`reason`, `message`, `step`, `actions`) explains a `needs_attention`.
 - `.data.step` — the step in progress; `.data.activation` — the awaited delivery (`step`,
-  `role`, `output`, `state` `waiting` | `persisting` | `provisional`, `ordinal`, `deadline`,
+  `role`, `delivery`, `state` `waiting` | `persisting` | `provisional`, `ordinal`, `deadline`,
   and `expect.completion[]`, the exact commands that complete it).
 - `.data.deliveries.<name>` — the latest accepted delivery (`path`, `latest_path`, `ordinal`,
   `verdict`); `.data.bindings` and `.data.run_directory` are frozen at start.
@@ -148,3 +148,6 @@ Every awaited step mints a fresh token for its activation; Skip/Cancel/Relaunch 
 | `OUTPUT_INVALID` / `VERDICT_REQUIRED` / `OUTPUT_TOO_LARGE` | empty body / missing mandatory verdict under `strict` / body over the cap |
 | `WORKFLOW_DELIVERY_REQUIRED` | `dispatch-complete` was used inside a workflow activation — run the `prowl workflow deliver` command the error echoes |
 | `PROMPT_TOO_LARGE` / `RENDERED_TEXT_INVALID` | a rendered launch prompt over 128 KiB / a rendered line that isn't one clean terminal line — shorten, or move content into an `instruction` |
+
+The `workflow deliver --json` receipt exposes its delivery record at
+`.data.delivery.record`; `.data.activation.delivery` in a status response is the expected delivery name.

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -104,7 +104,7 @@ nonisolated public enum CLIErrorCode {
   public static let workflowInvalid = "WORKFLOW_INVALID"
   /// `workflow run` named a definition the user switched off.
   public static let workflowDisabled = "WORKFLOW_DISABLED"
-  // Run-time codes of the workflow runner (dsl-spec §9); emitted by `workflow run/done` from B3 on.
+  // Run-time codes of the workflow runner (dsl-spec §9); emitted by `workflow run/deliver` from B3 on.
   public static let runNotFound = "RUN_NOT_FOUND"
   public static let paneBusy = "PANE_BUSY"
   public static let roleMismatch = "ROLE_MISMATCH"

--- a/supacode/CLIService/Shared/WorkflowCommandPayload.swift
+++ b/supacode/CLIService/Shared/WorkflowCommandPayload.swift
@@ -398,7 +398,7 @@ nonisolated public struct WorkflowActivationPayload: Codable, Equatable, Sendabl
   /// `waiting`, `persisting`, `provisional`, `delivered`, `skipped`, `revoked`.
   public let state: String
   public let dispatchID: String?
-  public let output: String
+  public let delivery: String
   public let expect: WorkflowExpectationPayload
   /// The absolute `expect.timeout` deadline, when the step declares one.
   public let deadline: String?
@@ -409,7 +409,7 @@ nonisolated public struct WorkflowActivationPayload: Codable, Equatable, Sendabl
     case role
     case state
     case dispatchID = "dispatch_id"
-    case output
+    case delivery
     case expect
     case deadline
   }
@@ -420,7 +420,7 @@ nonisolated public struct WorkflowActivationPayload: Codable, Equatable, Sendabl
     role: String,
     state: String,
     dispatchID: String?,
-    output: String,
+    delivery: String,
     expect: WorkflowExpectationPayload,
     deadline: String?
   ) {
@@ -429,7 +429,7 @@ nonisolated public struct WorkflowActivationPayload: Codable, Equatable, Sendabl
     self.role = role
     self.state = state
     self.dispatchID = dispatchID
-    self.output = output
+    self.delivery = delivery
     self.expect = expect
     self.deadline = deadline
   }
@@ -529,7 +529,7 @@ nonisolated public struct WorkflowDeliveryPayload: Codable, Equatable, Sendable 
   public let ordinal: Int
   public let step: String
   public let role: String
-  public let output: WorkflowDeliveryRecordPayload
+  public let record: WorkflowDeliveryRecordPayload
   public let warnings: [WorkflowDeliveryWarningPayload]
 
   public init(
@@ -537,14 +537,14 @@ nonisolated public struct WorkflowDeliveryPayload: Codable, Equatable, Sendable 
     ordinal: Int,
     step: String,
     role: String,
-    output: WorkflowDeliveryRecordPayload,
+    record: WorkflowDeliveryRecordPayload,
     warnings: [WorkflowDeliveryWarningPayload]
   ) {
     self.state = state
     self.ordinal = ordinal
     self.step = step
     self.role = role
-    self.output = output
+    self.record = record
     self.warnings = warnings
   }
 }

--- a/supacode/CLIService/Shared/WorkflowControlCursor.swift
+++ b/supacode/CLIService/Shared/WorkflowControlCursor.swift
@@ -28,7 +28,7 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
   public private(set) var evaluations: [Evaluation] = []
   private var frames: [Frame]
   public private(set) var state: WorkflowTypedState
-  public private(set) var expiredOutputs: Set<String> = []
+  public private(set) var expiredDeliveries: Set<String> = []
   public private(set) var expiredActions: Set<String> = []
   public private(set) var currentStep: WorkflowStepDefinition?
   public var remainingSteps: [WorkflowStepDefinition] {
@@ -47,7 +47,7 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
   public func values(over context: [String: WorkflowJSONValue]) -> [String: WorkflowJSONValue] {
     var result = context
     result["state"] = Self.object(state.values)
-    for (group, expired) in [("deliveries", expiredOutputs), ("actions", expiredActions)] {
+    for (group, expired) in [("deliveries", expiredDeliveries), ("actions", expiredActions)] {
       if case .object(var fields) = result[group] {
         for name in expired { fields.removeValue(forKey: name) }
         result[group] = .object(fields)
@@ -82,7 +82,7 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
   public mutating func complete() {
     guard let step = currentStep, !frames.isEmpty else { return }
     if case .action = step.action { expiredActions.remove(step.id) }
-    if let output = step.deliveryName { expiredOutputs.remove(output) }
+    if let output = step.deliveryName { expiredDeliveries.remove(output) }
     frames[frames.count - 1].index += 1
     currentStep = nil
   }
@@ -174,7 +174,7 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
   private mutating func expire(_ steps: [WorkflowStepDefinition]) {
     for step in steps {
       if case .action = step.action { expiredActions.insert(step.id) }
-      if let output = step.deliveryName { expiredOutputs.insert(output) }
+      if let output = step.deliveryName { expiredDeliveries.insert(output) }
       expire(step.action.children)
     }
   }

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -61,34 +61,34 @@ nonisolated public enum WorkflowValidator {
 
 // MARK: - Walker
 
-nonisolated private enum OutputConsumer {
+nonisolated private enum DeliveryConsumer {
   case template
   case until
   case requiredActionInput
   case optionalActionInput
 }
 
-/// Where an output is read or skipped: the step's walk ordinal and the loop body it sits in.
-nonisolated private struct OutputUse {
-  let consumer: OutputConsumer
+/// Where a delivery is read or skipped: the step's walk ordinal and the loop body it sits in.
+nonisolated private struct DeliveryUse {
+  let consumer: DeliveryConsumer
   let ordinal: Int
   let loopID: String?
 }
 
 nonisolated private struct SkipRecord {
   let name: String
-  let use: OutputUse
+  let use: DeliveryUse
   let location: WorkflowSourceLocation?
 }
 
-nonisolated private struct OutputProducer {
+nonisolated private struct DeliveryProducer {
   let verdicts: Set<String>?
   /// The `repeat` step whose body holds the producer; nil at the top level.
   let loopID: String?
 }
 
-nonisolated private struct OutputInfo {
-  var producers: [OutputProducer] = []
+nonisolated private struct DeliveryInfo {
+  var producers: [DeliveryProducer] = []
   /// Verdict set of the producer whose delivery is the latest at this point of the walk; nil
   /// when it declares none, or when a skippable loop leaves the latest producer ambiguous.
   var latestVerdicts: Set<String>?
@@ -102,18 +102,18 @@ nonisolated private final class Walker {
   private var stepIDs: Set<String> = []
   private var launchedRoles: Set<String> = []
   private var possiblyLaunchedRoles: Set<String> = []
-  private var deliveries: [String: OutputInfo] = [:]
-  private var consumers: [String: [OutputUse]] = [:]
+  private var deliveries: [String: DeliveryInfo] = [:]
+  private var consumers: [String: [DeliveryUse]] = [:]
   /// Walk position of the step being checked; 0 before the first step.
   private var ordinal = 0
   /// Action steps visible to the step being validated: outer sequences first, current last.
   private var actionScopes: [[String: WorkflowActionSchema]] = [[:]]
   private var checkingActionInputs = false
   private var currentLoopID: String?
-  private var outerOutputNames: Set<String> = []
+  private var outerDeliveryNames: Set<String> = []
   /// `on_timeout: skip` expectations, kept apart from `deliveries` so folding a skippable loop
   /// cannot lose them before the consumers are reported.
-  private var skipOutputs: [SkipRecord] = []
+  private var skippedDeliveries: [SkipRecord] = []
 
   init(definition: WorkflowDefinition, context: WorkflowValidationContext) {
     self.definition = definition
@@ -408,10 +408,10 @@ nonisolated private final class Walker {
         }
       } catch { collector.error("expression_syntax", "\(error)", at: step.location) }
     }
-    let previousOutputs = deliveries
-    let previousOuterNames = outerOutputNames
-    outerOutputNames.formUnion(deliveries.keys)
-    defer { outerOutputNames = previousOuterNames }
+    let previousDeliveries = deliveries
+    let previousOuterNames = outerDeliveryNames
+    outerDeliveryNames.formUnion(deliveries.keys)
+    defer { outerDeliveryNames = previousOuterNames }
     let previousRoles = launchedRoles
     let previousPossibleRoles = possiblyLaunchedRoles
     var branchRoles: [Set<String>] = []
@@ -428,7 +428,7 @@ nonisolated private final class Walker {
       branchRoles.append(launchedRoles)
       possibleRoles.formUnion(possiblyLaunchedRoles)
       actionScopes.removeLast()
-      deliveries = previousOutputs
+      deliveries = previousDeliveries
       launchedRoles = previousRoles
       possiblyLaunchedRoles = previousPossibleRoles
     }
@@ -442,15 +442,15 @@ nonisolated private final class Walker {
 
   private func checkExpect(_ expect: WorkflowExpectation?, step: WorkflowStepDefinition) {
     guard let expect, let name = step.deliveryName else { return }
-    if outerOutputNames.contains(name) {
+    if outerDeliveryNames.contains(name) {
       collector.error(
-        "output_shadowing",
-        "Output '\(name)' would overwrite an outer scope. Use a distinct output name and retain values in state.",
+        "delivery_shadowing",
+        "Delivery '\(name)' would overwrite an outer scope. Use a distinct delivery name and retain values in state.",
         at: step.location)
     }
     let location = expect.location ?? step.location
     if !WorkflowSchema.isSlug(name) {
-      collector.error("output_name_slug", "Output name '\(name)' is not a valid slug.", at: location)
+      collector.error("delivery_name_slug", "Delivery name '\(name)' is not a valid slug.", at: location)
     }
     if expect.sections.contains(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty }) {
       collector.error("section_empty", "'sections' entries must not be empty.", at: location)
@@ -461,14 +461,15 @@ nonisolated private final class Walker {
     if let timeout = expect.timeoutSeconds, timeout > WorkflowValidator.longTimeoutSeconds {
       collector.warning("timeout_long", "'timeout' above 2h; the watchdog already supervises waiting.", at: location)
     }
-    var info = deliveries[name] ?? OutputInfo()
+    var info = deliveries[name] ?? DeliveryInfo()
     let verdicts = expect.verdicts.map(Set.init)
-    info.producers.append(OutputProducer(verdicts: verdicts, loopID: currentLoopID))
+    info.producers.append(DeliveryProducer(verdicts: verdicts, loopID: currentLoopID))
     info.latestVerdicts = verdicts
     if expect.onTimeout == .skip {
-      skipOutputs.append(
+      skippedDeliveries.append(
         SkipRecord(
-          name: name, use: OutputUse(consumer: .template, ordinal: ordinal, loopID: currentLoopID), location: location))
+          name: name, use: DeliveryUse(consumer: .template, ordinal: ordinal, loopID: currentLoopID), location: location
+        ))
     }
     deliveries[name] = info
   }
@@ -488,7 +489,7 @@ nonisolated private final class Walker {
   /// A skipped delivery ends the run only when a non-optional reader comes after it — later in
   /// document order, or anywhere in the same loop body, which the next iteration reads again.
   private func reportSkipConsumers() {
-    for record in skipOutputs {
+    for record in skippedDeliveries {
       let (name, skip, location) = (record.name, record.use, record.location)
       let blocking = (consumers[name] ?? []).contains { use in
         use.consumer != .optionalActionInput
@@ -497,14 +498,14 @@ nonisolated private final class Walker {
       guard blocking else { continue }
       collector.warning(
         "skip_ends_run",
-        "'on_timeout: skip' on output '\(name)' would end the run: a later step depends on it.",
+        "'on_timeout: skip' on delivery '\(name)' would end the run: a later step depends on it.",
         at: location)
     }
   }
 
   // MARK: Templates
 
-  private func checkTemplate(_ text: String, at location: WorkflowSourceLocation?, consumer: OutputConsumer) {
+  private func checkTemplate(_ text: String, at location: WorkflowSourceLocation?, consumer: DeliveryConsumer) {
     var remaining = text[...]
     while let start = remaining.range(of: "{{") {
       remaining = remaining[start.upperBound...]
@@ -518,7 +519,7 @@ nonisolated private final class Walker {
     if remaining.contains("}}") { collector.error("template_syntax", "Unexpected expression delimiter.", at: location) }
   }
 
-  private func checkExpression(_ expression: String, at location: WorkflowSourceLocation?, consumer: OutputConsumer) {
+  private func checkExpression(_ expression: String, at location: WorkflowSourceLocation?, consumer: DeliveryConsumer) {
     do {
       var parser = try WorkflowExpressionParser(expression)
       let node = try parser.parse()
@@ -548,7 +549,7 @@ nonisolated private final class Walker {
   }
 
   private func checkReference(
-    _ reference: WorkflowTemplate.Reference, at location: WorkflowSourceLocation?, consumer: OutputConsumer
+    _ reference: WorkflowTemplate.Reference, at location: WorkflowSourceLocation?, consumer: DeliveryConsumer
   ) {
     let parts = reference.components
     let valid: Bool
@@ -557,7 +558,7 @@ nonisolated private final class Walker {
       valid = checkContextReference(parts)
     case "inputs": valid = parts.count >= 2 && definition.input(named: parts[1]) != nil
     case "state": valid = parts.count >= 2 && definition.state[parts[1]] != nil
-    case "deliveries": valid = parts.count == 3 && checkOutputReference(parts, at: location, consumer: consumer)
+    case "deliveries": valid = parts.count == 3 && checkDeliveryReference(parts, at: location, consumer: consumer)
     case "actions": valid = parts.count >= 3 && checkActionReference(parts)
     default: valid = false
     }
@@ -587,14 +588,14 @@ nonisolated private final class Walker {
     return parts.count == 2 || (parts.count == 3 && allowed.contains(parts[2]))
   }
 
-  private func checkOutputReference(
-    _ parts: [String], at location: WorkflowSourceLocation?, consumer: OutputConsumer
+  private func checkDeliveryReference(
+    _ parts: [String], at location: WorkflowSourceLocation?, consumer: DeliveryConsumer
   ) -> Bool {
     guard let info = deliveries[parts[1]], ["path", "verdict"].contains(parts[2]) else { return false }
     if parts[2] == "verdict", info.latestVerdicts == nil {
       return false
     }
-    consumers[parts[1], default: []].append(OutputUse(consumer: consumer, ordinal: ordinal, loopID: currentLoopID))
+    consumers[parts[1], default: []].append(DeliveryUse(consumer: consumer, ordinal: ordinal, loopID: currentLoopID))
     return true
   }
 

--- a/supacode/CLIService/WorkflowRunPayload+App.swift
+++ b/supacode/CLIService/WorkflowRunPayload+App.swift
@@ -138,7 +138,7 @@ extension WorkflowActivationPayload {
       role: activation.role,
       state: activation.state.rawValue,
       dispatchID: activation.dispatchID,
-      output: activation.deliveryName,
+      delivery: activation.deliveryName,
       expect: WorkflowExpectationPayload(
         format: activation.expect.format,
         sections: activation.expect.sections,
@@ -170,7 +170,7 @@ extension WorkflowDeliveryPayload {
       ordinal: receipt.ordinal,
       step: receipt.stepID,
       role: role,
-      output: WorkflowDeliveryRecordPayload(receipt.output, formatter: WorkflowRunPayload.makeDateFormatter()),
+      record: WorkflowDeliveryRecordPayload(receipt.record, formatter: WorkflowRunPayload.makeDateFormatter()),
       warnings: receipt.issues.map {
         WorkflowDeliveryWarningPayload(code: $0.code, message: $0.message)
       }

--- a/supacode/Clients/Workflow/WorkflowCLIResponderClient.swift
+++ b/supacode/Clients/Workflow/WorkflowCLIResponderClient.swift
@@ -1,6 +1,6 @@
 // supacode/Clients/Workflow/WorkflowCLIResponderClient.swift
 // The reducer's side of the CLI rendezvous (docs-ai 063 B3, decision W1): a `done` request is
-// answered when its activation leaves `persisting`, never on the `.outputPersisted` event alone;
+// answered when its activation leaves `persisting`, never on the `.deliveryPersisted` event alone;
 // a self-initiated `run` is answered once its first activation is open. The composition root
 // turns the resolution into a wire response and resumes the socket handler.
 

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -394,8 +394,8 @@ nonisolated struct WorkflowRun: Equatable, Sendable {
   var observations: [String: WorkflowJSONValue] = [:]
   var actionExecutionID: String?
   var actionAttempts: [String: Int] = [:]
-  /// Output name → the step whose skip made it missing.
-  var skippedOutputs: [String: String] = [:]
+  /// Delivery name → the step whose skip made it missing.
+  var skippedDeliveries: [String: String] = [:]
   /// Steps skipped at start (`--skip` / the start sheet).
   let preSkippedSteps: Set<String>
   var stepRecords: [WorkflowStepRecord] = []

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -61,10 +61,10 @@ nonisolated enum WorkflowRunEvent: Equatable, Sendable {
   case actionCompleted(stepID: String, outputs: [String: WorkflowJSONValue], executionID: String = "")
   case actionFailed(stepID: String, reason: String, executionID: String = "", retryAllowed: Bool = true)
   case continueControlFlow
-  /// The `.persistOutput` effect of a delivery succeeded / failed (dsl-spec §5: validate,
+  /// The `.persistDelivery` effect of a delivery succeeded / failed (dsl-spec §5: validate,
   /// persist, then complete the record).
-  case outputPersisted(ordinal: Int)
-  case outputPersistFailed(ordinal: Int, reason: String)
+  case deliveryPersisted(ordinal: Int)
+  case deliveryPersistFailed(ordinal: Int, reason: String)
   case watchdog(ordinal: Int, WorkflowWatchdogVerdict)
   case user(WorkflowUserAction)
 }
@@ -109,7 +109,7 @@ nonisolated enum WorkflowRunEffect: Equatable, Sendable {
   case completeActivation(dispatchID: String, summary: String)
   case armWatchdog(WorkflowWatchdogRequest)
   case disarmWatchdog(ordinal: Int)
-  case persistOutput(name: String, ordinal: Int, body: String)
+  case persistDelivery(name: String, ordinal: Int, body: String)
   case persist
   case log(String)
   case finished(WorkflowRunStatus)
@@ -127,17 +127,17 @@ nonisolated enum WorkflowDeliverySelector: Equatable, Sendable {
 nonisolated struct WorkflowDeliveryReceipt: Equatable, Sendable {
   let ordinal: Int
   let stepID: String
-  let output: WorkflowDeliveryRecord
+  let record: WorkflowDeliveryRecord
   /// Non-empty when the delivery was accepted provisionally; the CLI reports them as warnings.
   let issues: [WorkflowDeliveryIssue]
 }
 
 nonisolated enum WorkflowSkipConsequence: Equatable, Sendable {
-  /// The step delivers no output; skipping it affects nothing else.
-  case noOutput
-  /// Only optional action inputs read the output; those actions run without the key.
+  /// The step produces no delivery; skipping it affects nothing else.
+  case noDelivery
+  /// Only optional action inputs read the delivery; those actions run without the key.
   case continues(optionalInputs: [String])
-  /// A template, condition, or required action input reads the output: the run ends `skipped`.
+  /// A template, condition, or required action input reads the delivery: the run ends `skipped`.
   case endsRun(dependent: String)
 }
 
@@ -315,10 +315,10 @@ nonisolated struct WorkflowRunMachine {
         stepID: stepID, reason: reason, executionID: executionID, retryAllowed: retryAllowed, effects: &effects)
     case .continueControlFlow:
       continueControlFlow(effects: &effects)
-    case .outputPersisted(let ordinal):
-      applyOutputPersisted(ordinal: ordinal, effects: &effects)
-    case .outputPersistFailed(let ordinal, let reason):
-      applyOutputPersistFailed(ordinal: ordinal, reason: reason, effects: &effects)
+    case .deliveryPersisted(let ordinal):
+      applyDeliveryPersisted(ordinal: ordinal, effects: &effects)
+    case .deliveryPersistFailed(let ordinal, let reason):
+      applyDeliveryPersistFailed(ordinal: ordinal, reason: reason, effects: &effects)
     case .watchdog(let ordinal, let verdict):
       applyWatchdog(ordinal: ordinal, verdict: verdict, effects: &effects)
     case .user(let action):
@@ -427,7 +427,7 @@ nonisolated struct WorkflowRunMachine {
     case .success(let delivery):
       validated = delivery
     }
-    let record = outputRecord(for: activation, verdict: validated.verdict)
+    let record = deliveryRecord(for: activation, verdict: validated.verdict)
     updateActivation(ordinal: activation.ordinal) {
       $0.state = .persisting
       $0.pendingDelivery = validated
@@ -437,23 +437,23 @@ nonisolated struct WorkflowRunMachine {
     run.status = .running
     run.updatedAt = now()
     // The watchdog supervises a *waiting* delivery: an accepted one is no longer its business,
-    // so it is disarmed before the output is even written and queued verdicts are ignored.
+    // so it is disarmed before the delivery is even written and queued verdicts are ignored.
     let effects: [WorkflowRunEffect] = [
       .disarmWatchdog(ordinal: activation.ordinal),
       .log(
-        "Step '\(activation.stepID)': output '\(activation.deliveryName)' accepted "
+        "Step '\(activation.stepID)': delivery '\(activation.deliveryName)' accepted "
           + "(invocation \(activation.ordinal))\(issueNote); persisting."),
-      .persistOutput(name: activation.deliveryName, ordinal: activation.ordinal, body: validated.body),
+      .persistDelivery(name: activation.deliveryName, ordinal: activation.ordinal, body: validated.body),
     ]
     return (
       .success(
         WorkflowDeliveryReceipt(
-          ordinal: activation.ordinal, stepID: activation.stepID, output: record, issues: validated.issues)),
+          ordinal: activation.ordinal, stepID: activation.stepID, record: record, issues: validated.issues)),
       effects
     )
   }
 
-  private func outputRecord(for activation: WorkflowActivation, verdict: String?) -> WorkflowDeliveryRecord {
+  private func deliveryRecord(for activation: WorkflowActivation, verdict: String?) -> WorkflowDeliveryRecord {
     WorkflowDeliveryRecord(
       name: activation.deliveryName,
       ordinal: activation.ordinal,
@@ -467,16 +467,16 @@ nonisolated struct WorkflowRunMachine {
     )
   }
 
-  private mutating func applyOutputPersistFailed(ordinal: Int, reason: String, effects: inout [WorkflowRunEffect]) {
+  private mutating func applyDeliveryPersistFailed(ordinal: Int, reason: String, effects: inout [WorkflowRunEffect]) {
     guard let activation = run.activeActivation, activation.ordinal == ordinal, activation.state == .persisting
     else { return }
     raiseAttention(
       .persistFailed(reason), stepID: activation.stepID, role: activation.role, ordinal: ordinal, effects: &effects)
   }
 
-  /// The output is on disk: a clean delivery completes the dispatch record and advances; one
+  /// The delivery is on disk: a clean delivery completes the dispatch record and advances; one
   /// with issues stays provisional and asks the user (Accept / Accept with verdict / Ask again).
-  private mutating func applyOutputPersisted(ordinal: Int, effects: inout [WorkflowRunEffect]) {
+  private mutating func applyDeliveryPersisted(ordinal: Int, effects: inout [WorkflowRunEffect]) {
     guard case .waitingForDelivery(ordinal) = run.phase, let activation = run.activeActivation,
       activation.state == .persisting, let delivery = activation.pendingDelivery
     else { return }
@@ -496,9 +496,9 @@ nonisolated struct WorkflowRunMachine {
     effects: inout [WorkflowRunEffect]
   ) {
     let ordinal = activation.ordinal
-    let record = outputRecord(for: activation, verdict: verdict)
+    let record = deliveryRecord(for: activation, verdict: verdict)
     run.deliveries[activation.deliveryName] = record
-    run.skippedOutputs[activation.deliveryName] = nil
+    run.skippedDeliveries[activation.deliveryName] = nil
     updateActivation(ordinal: ordinal) {
       $0.state = .delivered
       $0.pendingDelivery = nil
@@ -509,11 +509,11 @@ nonisolated struct WorkflowRunMachine {
         .completeActivation(
           dispatchID: dispatchID,
           summary:
-            "Delivered output '\(activation.deliveryName)' for workflow step '\(activation.stepID)'\(verdictNote)."
+            "Received delivery '\(activation.deliveryName)' for workflow step '\(activation.stepID)'\(verdictNote)."
         ))
     }
     effects.append(
-      .log("Step '\(activation.stepID)': output '\(activation.deliveryName)' delivered (invocation \(ordinal))."))
+      .log("Step '\(activation.stepID)': delivery '\(activation.deliveryName)' delivered (invocation \(ordinal))."))
     run.status = .running
     completeCurrentStep(effects: &effects)
     advance(effects: &effects)
@@ -537,12 +537,12 @@ nonisolated struct WorkflowRunMachine {
     return startConsequence(forStep: stepID, definition: definition, preSkipped: alreadySkipped)
   }
 
-  /// Before execution, conservatively inspect every branch that could consume a skipped output.
+  /// Before execution, conservatively inspect every branch that could consume a skipped delivery.
   private static func startConsequence(
     forStep stepID: String, definition: WorkflowDefinition, preSkipped: Set<String>
   ) -> WorkflowSkipConsequence {
     guard let name = definition.flattenedSteps.first(where: { $0.id == stepID })?.deliveryName else {
-      return .noOutput
+      return .noDelivery
     }
     let remaining = definition.steps
     return consequence(of: name, forStep: stepID, remaining: remaining, preSkipped: preSkipped)
@@ -553,7 +553,7 @@ nonisolated struct WorkflowRunMachine {
     -> WorkflowSkipConsequence
   {
     guard let name = run.definition.flattenedSteps.first(where: { $0.id == stepID })?.deliveryName else {
-      return .noOutput
+      return .noDelivery
     }
     return consequence(
       of: name, forStep: stepID,
@@ -671,7 +671,7 @@ nonisolated struct WorkflowRunMachine {
   private mutating func skipAtStart(_ step: WorkflowStepDefinition, effects: inout [WorkflowRunEffect]) {
     recordStep(step, state: .skipped, ordinal: nil)
     if let name = step.deliveryName {
-      run.skippedOutputs[name] = step.id
+      run.skippedDeliveries[name] = step.id
     }
     effects.append(.log("Step '\(step.id)': skipped at start."))
     moveNext()
@@ -974,7 +974,7 @@ nonisolated struct WorkflowRunMachine {
             stepID: evaluation.stepID, iteration: evaluation.iteration,
             state: evaluation.skipped ? .skipped : .completed, ordinal: nil))
       }
-      for name in cursor.expiredOutputs { run.deliveries.removeValue(forKey: name) }
+      for name in cursor.expiredDeliveries { run.deliveries.removeValue(forKey: name) }
       for name in cursor.expiredActions { run.actionOutputs.removeValue(forKey: name) }
       switch outcome {
       case .step: return true
@@ -1013,7 +1013,8 @@ nonisolated struct WorkflowRunMachine {
     effects.append(.persist)
     effects.append(
       .log(
-        "Step '\(invocation.stepID)': waiting for output '\(activation.deliveryName)' from role '\(invocation.role)'.")
+        "Step '\(invocation.stepID)': waiting for delivery '\(activation.deliveryName)' from role '\(invocation.role)'."
+      )
     )
     armWatchdog(ordinal: ordinal, nudgedAlready: false, effects: &effects)
   }
@@ -1099,8 +1100,9 @@ nonisolated struct WorkflowRunMachine {
         let delivery = activation.pendingDelivery
       {
         run.status = .running
-        effects.append(.log("Step '\(activation.stepID)': retrying to persist output '\(activation.deliveryName)'."))
-        effects.append(.persistOutput(name: activation.deliveryName, ordinal: activation.ordinal, body: delivery.body))
+        effects.append(.log("Step '\(activation.stepID)': retrying to persist delivery '\(activation.deliveryName)'."))
+        effects.append(
+          .persistDelivery(name: activation.deliveryName, ordinal: activation.ordinal, body: delivery.body))
         return
       }
       retryCurrentStep(effects: &effects)
@@ -1134,7 +1136,7 @@ nonisolated struct WorkflowRunMachine {
   }
 
   /// "Accept as delivered" / "Accept with verdict": a declared verdict must be supplied when the
-  /// delivery lacked one, otherwise the accepted output could not drive conditions or templates.
+  /// delivery lacked one, otherwise the accepted delivery could not drive conditions or templates.
   private mutating func acceptProvisionalDelivery(verdict: String?, effects: inout [WorkflowRunEffect]) {
     guard let attention = run.status.attention, let activation = run.activeActivation,
       activation.state == .provisional, let delivery = activation.pendingDelivery
@@ -1207,14 +1209,14 @@ nonisolated struct WorkflowRunMachine {
       run.stepRecords[index].state = .skipped
     }
     if let name = step.deliveryName {
-      run.skippedOutputs[name] = step.id
+      run.skippedDeliveries[name] = step.id
     }
     run.status = .running
     effects.append(.log("Step '\(step.id)': skipped."))
     switch skipConsequence(forStep: step.id) {
     case .endsRun(let dependent):
       finish(.skipped(step: step.id, dependent: dependent), effects: &effects)
-    case .noOutput, .continues:
+    case .noDelivery, .continues:
       moveNext()
       advance(effects: &effects)
     }
@@ -1326,7 +1328,7 @@ nonisolated struct WorkflowRunMachine {
     } else {
       subject = role ?? "the step"
     }
-    let deliveryName = run.currentActivation?.deliveryName ?? "its output"
+    let deliveryName = run.currentActivation?.deliveryName ?? "its delivery"
     switch reason {
     case .needsInput:
       return "\(subject) is waiting for input in its pane."
@@ -1362,7 +1364,7 @@ nonisolated struct WorkflowRunMachine {
     case .actionFailed(let detail):
       return "Step '\(stepID)' failed: \(detail)"
     case .persistFailed(let detail):
-      return "The delivered output of step '\(stepID)' could not be saved to the run directory: \(detail)"
+      return "The delivery from step '\(stepID)' could not be saved to the run directory: \(detail)"
     case .deliveryIssues(let issues):
       return "\(subject) delivered \(deliveryName), but: \(issues.map(\.message).joined(separator: "; "))."
         + " Accept it, ask again, or skip."
@@ -1396,7 +1398,7 @@ nonisolated struct WorkflowRunMachine {
     case .completed: "completed"
     case .cancelled: "cancelled"
     case .skipped(let step, let dependent):
-      "skipped (step '\(step)' was skipped but '\(dependent)' depends on its output)"
+      "skipped (step '\(step)' was skipped but '\(dependent)' depends on its delivery)"
     case .iterationLimitReached: "iteration limit reached"
     case .interrupted: "interrupted"
     }

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -41,12 +41,12 @@ nonisolated struct WorkflowRunRecordInvocation: Codable, Equatable, Sendable {
 nonisolated struct WorkflowRunRecordActivation: Codable, Equatable, Sendable {
   let dispatchID: String?
   let state: WorkflowActivationState
-  let output: String
+  let delivery: String
 
   enum CodingKeys: String, CodingKey {
     case dispatchID = "dispatch_id"
     case state
-    case output
+    case delivery
   }
 }
 
@@ -123,7 +123,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
   let actions: [String: [String: WorkflowJSONValue]]
   let state: [String: WorkflowJSONValue]?
   let actionAttempts: [String: Int]?
-  let skippedOutputs: [String: String]
+  let skippedDeliveries: [String: String]
   let steps: [Step]
 
   enum CodingKeys: String, CodingKey {
@@ -137,7 +137,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
     case actions
     case state
     case actionAttempts = "action_attempts"
-    case skippedOutputs = "skipped_outputs"
+    case skippedDeliveries = "skipped_deliveries"
     case steps
   }
 
@@ -168,7 +168,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
         resources: invocation.content?.resources.mapValues { String($0.dropFirst(run.runDirectory.path.count + 1)) },
         skill: invocation.content?.skill,
         activation: invocation.activation.map {
-          WorkflowRunRecordActivation(dispatchID: $0.dispatchID, state: $0.state, output: $0.deliveryName)
+          WorkflowRunRecordActivation(dispatchID: $0.dispatchID, state: $0.state, delivery: $0.deliveryName)
         },
         startedAt: invocation.startedAt,
         endedAt: invocation.endedAt
@@ -178,7 +178,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
     actions = run.actionOutputs
     state = run.controlCursor?.state.values
     actionAttempts = run.actionAttempts
-    skippedOutputs = run.skippedOutputs
+    skippedDeliveries = run.skippedDeliveries
     steps = run.stepRecords.map { Step(id: $0.stepID, iteration: $0.iteration, state: $0.state, ordinal: $0.ordinal) }
   }
 
@@ -203,7 +203,7 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
     actions = record.actions
     state = record.state
     actionAttempts = record.actionAttempts
-    skippedOutputs = record.skippedOutputs
+    skippedDeliveries = record.skippedDeliveries
     steps = record.steps
   }
 
@@ -441,7 +441,7 @@ nonisolated struct WorkflowRunStore: Sendable {
   /// Writes `deliveries/<name>.<ordinal>.md` and replaces `deliveries/<name>.md` atomically
   /// (temp file + rename), so a reader never sees a partially written latest view.
   @discardableResult
-  func writeOutput(runID: UUID, name: String, ordinal: Int, body: String) throws -> (versioned: URL, latest: URL) {
+  func writeDelivery(runID: UUID, name: String, ordinal: Int, body: String) throws -> (versioned: URL, latest: URL) {
     let runDirectory = try containedRunDirectory(runID: runID)
     guard WorkflowSchema.isSlug(name), ordinal > 0 else { throw WorkflowRunStoreError.unsafePath(name) }
     let versioned = WorkflowRunPaths.deliveryURL(runDirectory: runDirectory, name: name, ordinal: ordinal)

--- a/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
@@ -418,11 +418,11 @@ nonisolated struct WorkflowAttentionControl: Equatable, Sendable, Identifiable {
     consequence: WorkflowSkipConsequence
   ) -> String {
     switch consequence {
-    case .noOutput:
+    case .noDelivery:
       "Skip step '\(stepID)'? The workflow continues without an output from this step."
     case .continues(let optionalInputs):
       if optionalInputs.isEmpty {
-        "Skip step '\(stepID)'? The workflow continues without this output."
+        "Skip step '\(stepID)'? The workflow continues without this delivery."
       } else {
         "Skip step '\(stepID)'? The workflow continues without the optional input used by "
           + optionalInputs.joined(separator: ", ") + "."

--- a/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
@@ -767,12 +767,12 @@ struct WorkflowRunsFeature {
     case .completeActivation(let dispatchID, let summary):
       activation.complete(dispatchID, summary)
 
-    case .persistOutput(let name, let ordinal, let body):
+    case .persistDelivery(let name, let ordinal, let body):
       do {
-        _ = try store.writeOutput(runID: runID, name: name, ordinal: ordinal, body: body)
-        await send(.event(runID: runID, .outputPersisted(ordinal: ordinal)))
+        _ = try store.writeDelivery(runID: runID, name: name, ordinal: ordinal, body: body)
+        await send(.event(runID: runID, .deliveryPersisted(ordinal: ordinal)))
       } catch {
-        await send(.event(runID: runID, .outputPersistFailed(ordinal: ordinal, reason: "\(error)")))
+        await send(.event(runID: runID, .deliveryPersistFailed(ordinal: ordinal, reason: "\(error)")))
       }
 
     case .persist:
@@ -821,7 +821,7 @@ extension WorkflowRunEffect {
     switch self {
     case .openActivation, .inject, .typeLine, .launch, .runAction, .close: true
     case .awaitRoleIdle, .cancelRoleWait, .materializeInstruction, .materializeSkill, .notify,
-      .abandonActivation, .completeActivation, .armWatchdog, .disarmWatchdog, .persistOutput, .persist, .log,
+      .abandonActivation, .completeActivation, .armWatchdog, .disarmWatchdog, .persistDelivery, .persist, .log,
       .finished, .yieldControl:
       false
     }

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -347,10 +347,10 @@ private struct WorkflowStartCard: View {
   private func consequenceText(_ consequence: WorkflowSkipConsequence?) -> String? {
     switch consequence {
     case .endsRun(let dependent):
-      return "Cannot skip: step '\(dependent)' needs its output."
+      return "Cannot skip: step '\(dependent)' needs its delivery."
     case .continues(let optional) where !optional.isEmpty:
-      return "The run continues; \(optional.joined(separator: ", ")) proceeds without this output."
-    case .continues, .noOutput, nil:
+      return "The run continues; \(optional.joined(separator: ", ")) proceeds without this delivery."
+    case .continues, .noDelivery, nil:
       return nil
     }
   }

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -166,14 +166,14 @@ final class WorkflowRunHarness {
         watchdogs.append(request)
       case .disarmWatchdog(let ordinal):
         disarmed.append(ordinal)
-      case .persistOutput(let name, let ordinal, let body):
+      case .persistDelivery(let name, let ordinal, let body):
         do {
-          try store.writeOutput(runID: runID, name: name, ordinal: ordinal, body: body)
+          try store.writeDelivery(runID: runID, name: name, ordinal: ordinal, body: body)
         } catch {
-          try await apply(.outputPersistFailed(ordinal: ordinal, reason: "\(error)"))
+          try await apply(.deliveryPersistFailed(ordinal: ordinal, reason: "\(error)"))
           continue
         }
-        try await apply(.outputPersisted(ordinal: ordinal))
+        try await apply(.deliveryPersisted(ordinal: ordinal))
       case .persist:
         try store.writeRecord(WorkflowRunRecord(run: machine.run))
       case .log(let line):
@@ -366,7 +366,7 @@ struct WorkflowRunHarnessTests {
     #expect(try harness.store.readRecord(runID: harness.run.id).deliveries["brief"]?.ordinal == 1)
   }
 
-  @Test func cancelAbandonsThePendingActivationAndKeepsDeliveredOutputs() async throws {
+  @Test func cancelAbandonsThePendingActivationAndKeepsDeliveries() async throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }
     let harness = try await makeHarness(root: root)
@@ -429,7 +429,7 @@ struct WorkflowRunHarnessTests {
     #expect(!harness.launches[0].expectsDelivery)
     #expect(harness.notifications == ["Handed off to Pi Reviewer"])
     let record = try harness.store.readRecord(runID: harness.run.id)
-    #expect(record.skippedOutputs == ["brief": "brief"])
+    #expect(record.skippedDeliveries == ["brief": "brief"])
     #expect(record.actions["transition"]?["output"] != nil)
   }
 }

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -190,7 +190,7 @@ struct WorkflowRunMachineTests {
   ) throws -> [WorkflowRunEffect] {
     let (result, effects) = machine.deliver(ordinal: ordinal, selector: .token(token), body: body, verdict: verdict)
     _ = try result.get()
-    return effects + machine.apply(.outputPersisted(ordinal: ordinal))
+    return effects + machine.apply(.deliveryPersisted(ordinal: ordinal))
   }
 
   /// Drives the fixture through `brief` → `launch` → findings delivery and returns the machine.
@@ -277,14 +277,14 @@ struct WorkflowRunMachineTests {
     let (result, effects) = machine.deliver(
       ordinal: 1, selector: .token("TOKEN-1"), body: "```md\n# Brief\n## Scope\nx\n## Claims\ny\n```", verdict: nil)
     let receipt = try result.get()
-    #expect(receipt.output.name == "brief")
-    #expect(receipt.output.path == "\(runDir)/deliveries/brief.1.md")
-    #expect(receipt.output.latestPath == "\(runDir)/deliveries/brief.md")
+    #expect(receipt.record.name == "brief")
+    #expect(receipt.record.path == "\(runDir)/deliveries/brief.1.md")
+    #expect(receipt.record.latestPath == "\(runDir)/deliveries/brief.md")
     #expect(
       effects == [
         .disarmWatchdog(ordinal: 1),
-        .log("Step 'brief': output 'brief' accepted (invocation 1); persisting."),
-        .persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n"),
+        .log("Step 'brief': delivery 'brief' accepted (invocation 1); persisting."),
+        .persistDelivery(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n"),
       ])
     // Nothing advances until the output is on disk (dsl-spec §5: validate, persist, complete).
     #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
@@ -295,18 +295,18 @@ struct WorkflowRunMachineTests {
         == .failure(.stepNotExpecting))
   }
 
-  @Test func persistedOutputCompletesTheActivationAndAdvancesToTheLaunch() throws {
+  @Test func persistedDeliveryCompletesTheActivationAndAdvancesToTheLaunch() throws {
     var (machine, _) = try makeMachine()
     _ = machine.apply(.roleIdle(ordinal: 1))
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
     _ = machine.deliver(
       ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
-    #expect(machine.apply(.outputPersisted(ordinal: 7)).isEmpty)
-    let effects = machine.apply(.outputPersisted(ordinal: 1))
+    #expect(machine.apply(.deliveryPersisted(ordinal: 7)).isEmpty)
+    let effects = machine.apply(.deliveryPersisted(ordinal: 1))
     #expect(!effects.contains(.disarmWatchdog(ordinal: 1)))
     #expect(
       effects.contains(
-        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+        .completeActivation(dispatchID: "d1", summary: "Received delivery 'brief' for workflow step 'brief'.")))
     #expect(effects.contains(.materializeSkill(id: "prowl.adversarial-reviewer")))
     guard
       case .launch(let request)? = effects.first(where: { if case .launch = $0 { return true } else { return false } })
@@ -357,10 +357,10 @@ struct WorkflowRunMachineTests {
     #expect(machine.apply(.watchdog(ordinal: 1, .nudge)).isEmpty)
     #expect(machine.run.status == .running)
     #expect(machine.run.invocations[0].activation?.state == .persisting)
-    let persisted = machine.apply(.outputPersisted(ordinal: 1))
+    let persisted = machine.apply(.deliveryPersisted(ordinal: 1))
     #expect(
       persisted.contains(
-        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+        .completeActivation(dispatchID: "d1", summary: "Received delivery 'brief' for workflow step 'brief'.")))
     #expect(!persisted.contains(.disarmWatchdog(ordinal: 1)))
     #expect(machine.run.phase == .runningAction(stepID: "transition"))
   }
@@ -371,13 +371,13 @@ struct WorkflowRunMachineTests {
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
     _ = machine.deliver(
       ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil)
-    _ = machine.apply(.outputPersistFailed(ordinal: 1, reason: "disk full"))
+    _ = machine.apply(.deliveryPersistFailed(ordinal: 1, reason: "disk full"))
     let attention = try #require(machine.run.status.attention)
     #expect(attention.reason == .persistFailed("disk full"))
     #expect(attention.actions == [.retry, .cancel])
     #expect(machine.run.phase == .waitingForDelivery(ordinal: 1))
     let retry = machine.apply(.user(.retry))
-    #expect(retry.contains(.persistOutput(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n")))
+    #expect(retry.contains(.persistDelivery(name: "brief", ordinal: 1, body: "# Brief\n## Scope\nx\n## Claims\ny\n")))
     #expect(machine.run.status == .running)
     #expect(machine.run.invocations[0].activation?.state == .persisting)
     let cancel = machine.apply(.user(.cancel))
@@ -439,7 +439,7 @@ struct WorkflowRunMachineTests {
       ordinal: 1, selector: .token("TOKEN-1"), body: "# Brief\n## Scope\nx", verdict: nil)
     let receipt = try result.get()
     #expect(receipt.issues == [.missingSections(["## Claims"])])
-    let persisted = machine.apply(.outputPersisted(ordinal: 1))
+    let persisted = machine.apply(.deliveryPersisted(ordinal: 1))
     #expect(!persisted.contains { if case .completeActivation = $0 { return true } else { return false } })
     #expect(machine.run.invocations[0].activation?.state == .provisional)
     let attention = try #require(machine.run.status.attention)
@@ -457,7 +457,7 @@ struct WorkflowRunMachineTests {
     let accepted = machine.apply(.user(.acceptDelivery(verdict: nil)))
     #expect(
       accepted.contains(
-        .completeActivation(dispatchID: "d1", summary: "Delivered output 'brief' for workflow step 'brief'.")))
+        .completeActivation(dispatchID: "d1", summary: "Received delivery 'brief' for workflow step 'brief'.")))
     #expect(machine.run.status == .running)
     #expect(machine.run.deliveries["brief"]?.ordinal == 1)
     #expect(machine.run.invocations[0].activation?.state == .delivered)
@@ -525,7 +525,7 @@ struct WorkflowRunMachineTests {
       effects.contains(
         .abandonActivation(dispatchID: "d1", reason: "Workflow run \(Self.runID.uuidString): step 'brief' skipped.")))
     #expect(machine.run.invocations[0].activation?.state == .skipped)
-    #expect(machine.run.skippedOutputs == ["brief": "brief"])
+    #expect(machine.run.skippedDeliveries == ["brief": "brief"])
     #expect(machine.run.phase == .runningAction(stepID: "transition"))
   }
 
@@ -546,7 +546,7 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.actionOutputs["context"]?["branch"] == "feat/x")
   }
 
-  @Test func issuesVerdictRunsRoundsUntilCleanWithLatestWinsOutputs() throws {
+  @Test func issuesVerdictRunsRoundsUntilCleanWithLatestWinsDeliveries() throws {
     var machine = try machineAfterFindings(verdict: "issues", inputs: ["max_rounds": "3"])
     #expect(machine.run.currentIteration == 1)
     #expect(machine.run.phase == .waitingForRole(role: "author", ordinal: 3))
@@ -569,7 +569,7 @@ struct WorkflowRunMachineTests {
     _ = machine.apply(.injectionSucceeded(ordinal: 4, dispatchID: "d4"))
     let round1 = try deliverPersisted(
       &machine, ordinal: 4, token: "TOKEN-4", body: "# Findings\nstill", verdict: "issues")
-    #expect(round1.contains(.persistOutput(name: "round_findings", ordinal: 4, body: "# Findings\nstill\n")))
+    #expect(round1.contains(.persistDelivery(name: "round_findings", ordinal: 4, body: "# Findings\nstill\n")))
     #expect(machine.run.deliveries["round_findings"] == nil)
     #expect(machine.run.controlCursor?.state.values["path"] == .string("\(runDir)/deliveries/round_findings.md"))
     #expect(machine.run.controlCursor?.state.values["rounds"] == .integer(1))
@@ -692,7 +692,7 @@ struct WorkflowRunMachineTests {
         == .failure(.stepNotExpecting))
   }
 
-  @Test func skipInsideTheLoopEndsTheRunBecauseUntilReadsTheOutput() throws {
+  @Test func skipInsideTheLoopEndsTheRunBecauseUntilReadsTheDelivery() throws {
     var machine = try machineAfterFindings(verdict: "issues")
     _ = machine.apply(.roleIdle(ordinal: 3))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))
@@ -758,7 +758,7 @@ struct WorkflowRunMachineTests {
     _ = machine.apply(.injectionSucceeded(ordinal: 1, dispatchID: "d1"))
     let effects = machine.apply(.user(.skip))
     #expect(machine.run.status == .running)
-    #expect(machine.run.skippedOutputs == ["brief": "brief"])
+    #expect(machine.run.skippedDeliveries == ["brief": "brief"])
     #expect(
       effects.contains(
         .runAction(
@@ -922,7 +922,7 @@ struct WorkflowRunMachineTests {
     let late = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
     #expect((try? late.result.get()) != nil)
     #expect(machine.run.status == .running)
-    _ = machine.apply(.outputPersisted(ordinal: 1))
+    _ = machine.apply(.deliveryPersisted(ordinal: 1))
     #expect(machine.run.phase == .launching(ordinal: 2))
   }
 
@@ -1022,7 +1022,7 @@ struct WorkflowRunMachineTests {
     #expect(cancelling.run.status == .cancelled)
   }
 
-  @Test func cancelAbandonsTheActivationNamingRunAndStepAndKeepsOutputs() throws {
+  @Test func cancelAbandonsTheActivationNamingRunAndStepAndKeepsDeliveries() throws {
     var machine = try machineAfterFindings(verdict: "issues")
     _ = machine.apply(.roleIdle(ordinal: 3))
     _ = machine.apply(.injectionSucceeded(ordinal: 3, dispatchID: "d3"))

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -95,6 +95,14 @@ struct WorkflowRunStoreTests {
 
     let url = store.directory(for: run.id).appending(path: "run.json")
     let json = try String(contentsOf: url, encoding: .utf8)
+    #expect(json.contains("\"skipped_deliveries\""))
+    #expect(!json.contains("\"skipped_outputs\""))
+    let retiredRecord = json.replacing("\"skipped_deliveries\"", with: "\"skipped_outputs\"")
+    #expect(throws: (any Error).self) {
+      try WorkflowRunRecord.makeDecoder().decode(WorkflowRunRecord.self, from: Data(retiredRecord.utf8))
+    }
+    #expect(json.contains("\"delivery\" : \"brief\""))
+    #expect(!json.contains("\"output\""))
     #expect(!json.contains("SECRET-TOKEN"))
     #expect(json.contains("\"dispatch_id\" : \"dispatch-1\""))
     #expect(json.contains("\"version\" : 1"))
@@ -109,7 +117,7 @@ struct WorkflowRunStoreTests {
     #expect(decoded.inputs == [])
     #expect(decoded.bindings["receiver"]?.profile == WorkflowRunMachineTests.reviewerProfile)
     #expect(decoded.bindings["source"]?.pane == WorkflowRunMachineTests.authorPane)
-    #expect(decoded.invocations.first?.activation?.output == "brief")
+    #expect(decoded.invocations.first?.activation?.delivery == "brief")
     #expect(decoded.run.status.attention?.actions == [.nudge, .keepWaiting, .skip, .cancel])
     #expect(decoded.run.status.attention?.issues == nil)
   }
@@ -208,14 +216,14 @@ struct WorkflowRunStoreTests {
     #expect(try store.readRecord(runID: run.id).run.id == run.id)
   }
 
-  @Test func outputsAreVersionedAndTheLatestViewIsReplacedAtomically() throws {
+  @Test func deliveriesAreVersionedAndTheLatestViewIsReplacedAtomically() throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }
     let store = WorkflowRunStore(rootURL: root)
     let runID = UUID()
     try store.ensureLayout(runID: runID)
-    let first = try store.writeOutput(runID: runID, name: "findings", ordinal: 2, body: "round 1\n")
-    let second = try store.writeOutput(runID: runID, name: "findings", ordinal: 4, body: "round 2\n")
+    let first = try store.writeDelivery(runID: runID, name: "findings", ordinal: 2, body: "round 1\n")
+    let second = try store.writeDelivery(runID: runID, name: "findings", ordinal: 4, body: "round 2\n")
     #expect(first.versioned.lastPathComponent == "findings.2.md")
     #expect(second.versioned.lastPathComponent == "findings.4.md")
     #expect(first.latest == second.latest)
@@ -253,7 +261,7 @@ struct WorkflowRunStoreTests {
       try store.writeInstruction(runID: runID, stepID: "../escape", ordinal: 1, text: "x")
     }
     #expect(throws: WorkflowRunStoreError.unsafePath("Bad Name")) {
-      try store.writeOutput(runID: runID, name: "Bad Name", ordinal: 1, body: "x")
+      try store.writeDelivery(runID: runID, name: "Bad Name", ordinal: 1, body: "x")
     }
     #expect(throws: WorkflowRunStoreError.unsafePath("brief")) {
       try store.writeInstruction(runID: runID, stepID: "brief", ordinal: 0, text: "x")
@@ -323,7 +331,7 @@ struct WorkflowRunStoreTests {
     #expect(try store.markInterruptedRuns(now: { Self.now }).unreadable.count == 1)
   }
 
-  @Test func symlinkedOutputsDirectoryIsRejected() throws {
+  @Test func symlinkedDeliveriesDirectoryIsRejected() throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }
     let store = WorkflowRunStore(rootURL: root)
@@ -335,7 +343,7 @@ struct WorkflowRunStoreTests {
     try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
     try FileManager.default.createSymbolicLink(at: deliveries, withDestinationURL: elsewhere)
     #expect(throws: WorkflowRunStoreError.self) {
-      try store.writeOutput(runID: runID, name: "findings", ordinal: 1, body: "x")
+      try store.writeDelivery(runID: runID, name: "findings", ordinal: 1, body: "x")
     }
     #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path(percentEncoded: false)).isEmpty)
   }

--- a/supacodeTests/WorkflowRunsFeatureTests.swift
+++ b/supacodeTests/WorkflowRunsFeatureTests.swift
@@ -1,6 +1,6 @@
 // supacodeTests/WorkflowRunsFeatureTests.swift
 // The reducer that wires B2's machine to the boundaries (docs-ai 063 B3): ordered effect
-// execution, the two-phase `done` rendezvous, late launches, and the restart scan.
+// execution, the two-phase `deliver` rendezvous, late launches, and the restart scan.
 
 import ComposableArchitecture
 import DependenciesTestSupport
@@ -336,7 +336,7 @@ struct WorkflowRunsFeatureTests {
 
   // MARK: - Ordered execution
 
-  @Test(.dependencies) func aRunPerformsItsEffectsInMachineOrderAndAnswersDoneAfterPersistence()
+  @Test(.dependencies) func aRunPerformsItsEffectsInMachineOrderAndAnswersDeliverAfterPersistence()
     async throws
   {
     let fixture = try Fixture()
@@ -369,7 +369,7 @@ struct WorkflowRunsFeatureTests {
           body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil, source: "pane"))
     )
     #expect(store.state.pendingDeliveries[requestID]?.ordinal == 1)
-    await store.receive(.event(runID: runID, .outputPersisted(ordinal: 1)), timeout: Self.timeout)
+    await store.receive(.event(runID: runID, .deliveryPersisted(ordinal: 1)), timeout: Self.timeout)
     #expect(fixture.responses.count == 1)
     guard case .delivered(let run, let receipt) = fixture.responses[0].resolution else {
       Issue.record("expected a delivered resolution, got \(fixture.responses[0].resolution)")
@@ -442,7 +442,7 @@ struct WorkflowRunsFeatureTests {
 
   // MARK: - Rendezvous (decision W1)
 
-  @Test(.dependencies) func cancelWhileTheOutputIsPersistingFailsThePendingDone() async throws {
+  @Test(.dependencies) func cancelWhileTheOutputIsPersistingFailsThePendingDeliver() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let queue = RecordingQueue()
@@ -462,7 +462,7 @@ struct WorkflowRunsFeatureTests {
     #expect(store.state.sessions[runID]?.run.activeActivation?.state == .persisting)
     #expect(fixture.responses.isEmpty)
     #expect(
-      queue.effects.contains { if case .persistOutput = $0 { return true } else { return false } })
+      queue.effects.contains { if case .persistDelivery = $0 { return true } else { return false } })
 
     await store.send(.userAction(runID: runID, .cancel))
     await store.finish(timeout: Self.timeout)
@@ -476,12 +476,12 @@ struct WorkflowRunsFeatureTests {
           message: "The step stopped waiting for this delivery before the output was saved."))
     #expect(queue.effects.contains(.finished(.cancelled)))
 
-    // The queued `.outputPersisted` of the abandoned write is stale: ignored, nothing answered twice.
-    await store.send(.event(runID: runID, .outputPersisted(ordinal: 1)))
+    // The queued `.deliveryPersisted` of the abandoned write is stale: ignored, nothing answered twice.
+    await store.send(.event(runID: runID, .deliveryPersisted(ordinal: 1)))
     #expect(fixture.responses.count == 1)
   }
 
-  @Test(.dependencies) func aPersistenceFailureFailsThePendingDoneWithWorkflowFailed() async throws {
+  @Test(.dependencies) func aPersistenceFailureFailsThePendingDeliverWithWorkflowFailed() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let queue = RecordingQueue()
@@ -498,7 +498,7 @@ struct WorkflowRunsFeatureTests {
           body: "## Scope\nx\n## Claims\ny", verdict: nil, source: "manual")))
     #expect(queue.effects.first == .log("Step 'brief': delivery received (source=manual)."))
 
-    await store.send(.event(runID: runID, .outputPersistFailed(ordinal: 1, reason: "disk full")))
+    await store.send(.event(runID: runID, .deliveryPersistFailed(ordinal: 1, reason: "disk full")))
     #expect(store.state.sessions[runID]?.run.status.attention?.reason.code == "persist_failed")
     #expect(store.state.pendingDeliveries.isEmpty)
     #expect(fixture.responses.count == 1)
@@ -527,7 +527,7 @@ struct WorkflowRunsFeatureTests {
         WorkflowDeliveryRequest(
           requestID: requestID, runID: runID, ordinal: 1, selector: .token("TOKEN-1"),
           body: "## Scope\nonly", verdict: nil, source: "pane")))
-    await store.send(.event(runID: runID, .outputPersisted(ordinal: 1)))
+    await store.send(.event(runID: runID, .deliveryPersisted(ordinal: 1)))
     #expect(store.state.sessions[runID]?.run.status.attention?.reason.code == "delivery_issues")
     #expect(fixture.responses.count == 1)
     guard case .provisional(_, let receipt) = fixture.responses[0].resolution else {
@@ -853,7 +853,7 @@ struct WorkflowRunsFeatureTests {
         WorkflowDeliveryRequest(
           requestID: UUID(), runID: runID, ordinal: 1, selector: .token(Self.firstToken),
           body: "# Brief\n## Scope\nx\n## Claims\ny", verdict: nil, source: "pane")))
-    await store.receive(.event(runID: runID, .outputPersisted(ordinal: 1)), timeout: Self.timeout)
+    await store.receive(.event(runID: runID, .deliveryPersisted(ordinal: 1)), timeout: Self.timeout)
     await store.receive(\.event, timeout: Self.timeout)
     let first = try #require(store.state.sessions[runID]?.run.bindings["reviewer"]?.pane)
     #expect(store.state.paneOwners[first.surfaceID] == runID)
@@ -916,7 +916,7 @@ struct WorkflowRunsFeatureTests {
         WorkflowDeliveryRequest(
           requestID: UUID(), runID: runID, ordinal: 1, selector: .token(Self.firstToken), body: "brief",
           verdict: nil, source: "pane")))
-    await store.receive(.event(runID: runID, .outputPersisted(ordinal: 1)), timeout: Self.timeout)
+    await store.receive(.event(runID: runID, .deliveryPersisted(ordinal: 1)), timeout: Self.timeout)
     await store.receive(\.event, timeout: Self.timeout)
     let reviewer = try #require(store.state.sessions[runID]?.run.bindings["reviewer"]?.pane)
     await store.send(
@@ -924,7 +924,7 @@ struct WorkflowRunsFeatureTests {
         WorkflowDeliveryRequest(
           requestID: UUID(), runID: runID, ordinal: 2, selector: .token(Self.secondToken), body: "findings",
           verdict: nil, source: "pane")))
-    await store.receive(.event(runID: runID, .outputPersisted(ordinal: 2)), timeout: Self.timeout)
+    await store.receive(.event(runID: runID, .deliveryPersisted(ordinal: 2)), timeout: Self.timeout)
     return reviewer
   }
 
@@ -945,7 +945,7 @@ struct WorkflowRunsFeatureTests {
     #expect(!WorkflowRunEffect.completeActivation(dispatchID: "d", summary: "s").isRevocable)
     #expect(!WorkflowRunEffect.abandonActivation(dispatchID: "d", reason: "r").isRevocable)
     #expect(!WorkflowRunEffect.persist.isRevocable)
-    #expect(!WorkflowRunEffect.persistOutput(name: "o", ordinal: 1, body: "b").isRevocable)
+    #expect(!WorkflowRunEffect.persistDelivery(name: "o", ordinal: 1, body: "b").isRevocable)
     #expect(!WorkflowRunEffect.log("l").isRevocable)
     #expect(WorkflowRunEffect.close(role: "r", surfaceID: pane).isRevocable, "cancel never closes panes")
     #expect(!WorkflowRunEffect.notify("n").isRevocable)

--- a/supacodeTests/WorkflowRuntimeCoordinatorTests.swift
+++ b/supacodeTests/WorkflowRuntimeCoordinatorTests.swift
@@ -208,7 +208,7 @@ struct WorkflowRuntimeCoordinatorTests {
     var machine = session.machine(now: { Self.now }, makeToken: { "T" })
     let (result, _) = machine.deliver(
       ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
-    _ = machine.apply(.outputPersisted(ordinal: 1))
+    _ = machine.apply(.deliveryPersisted(ordinal: 1))
     return .delivered(run: machine.run, receipt: try result.get())
   }
 
@@ -218,7 +218,7 @@ struct WorkflowRuntimeCoordinatorTests {
 
   // MARK: - deliver attribution (decision W3)
 
-  @Test func doneFromTheRolePaneIsAttributedByItsPendingDispatch() async throws {
+  @Test func deliverFromTheRolePaneIsAttributedByItsPendingDispatch() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let session = try fixture.waitingSession()
@@ -245,12 +245,12 @@ struct WorkflowRuntimeCoordinatorTests {
     }
     #expect(deliver.delivery.state == .delivered)
     #expect(deliver.delivery.role == "author")
-    #expect(deliver.delivery.output.name == "brief")
+    #expect(deliver.delivery.record.name == "brief")
     #expect(deliver.run.role == "author")
     #expect(fixture.rendezvous.pendingRequestIDs.isEmpty)
   }
 
-  @Test func doneWithoutABodyOrHalfAManualTargetIsInvalid() async throws {
+  @Test func deliverWithoutABodyOrHalfAManualTargetIsInvalid() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let noBody = await fixture.coordinator.deliver(WorkflowInput(action: .deliver), callerPane: Self.authorCaller)
@@ -264,7 +264,7 @@ struct WorkflowRuntimeCoordinatorTests {
     #expect(fixture.sent.isEmpty)
   }
 
-  @Test func doneOutsideAnyPaneNeedsAnExplicitTargetAndThenIsManual() async throws {
+  @Test func deliverOutsideAnyPaneNeedsAnExplicitTargetAndThenIsManual() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let session = try fixture.waitingSession()
@@ -348,7 +348,7 @@ struct WorkflowRuntimeCoordinatorTests {
     #expect(forced.selector == .manual(stepID: "launch"))
   }
 
-  @Test func doneAwaitsTheReducerAndAProvisionalAnswerIsReportedAsProvisional() async throws {
+  @Test func deliverAwaitsTheReducerAndAProvisionalAnswerIsReportedAsProvisional() async throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }
     let session = try fixture.waitingSession()
@@ -362,7 +362,7 @@ struct WorkflowRuntimeCoordinatorTests {
     #expect(fixture.rendezvous.pendingRequestIDs == [fixture.requestID])
     var machine = session.machine(now: { Self.now }, makeToken: { "T" })
     let (result, _) = machine.deliver(ordinal: 1, selector: .token("TOKEN-1"), body: "## Scope\nonly", verdict: nil)
-    _ = machine.apply(.outputPersisted(ordinal: 1))
+    _ = machine.apply(.deliveryPersisted(ordinal: 1))
     fixture.coordinator.resolve(fixture.requestID, .provisional(run: machine.run, receipt: try result.get()))
     let response = await task.value
     #expect(response.ok)
@@ -438,7 +438,7 @@ struct WorkflowRuntimeCoordinatorTests {
     var machine = session.machine(now: { Self.now }, makeToken: { "TOKEN-2" })
     let (result, _) = machine.deliver(
       ordinal: nil, selector: .manual(stepID: "brief"), body: "## Scope\nx\n## Claims\ny", verdict: nil)
-    _ = machine.apply(.outputPersisted(ordinal: 1))
+    _ = machine.apply(.deliveryPersisted(ordinal: 1))
     #expect(machine.run.phase == .launching(ordinal: 2))
     let reviewerPane = WorkflowPaneIdentity(surfaceID: UUID(), tabID: nil, handle: "p9", displayName: "Pi", agent: "pi")
     _ = machine.apply(.launched(ordinal: 2, pane: reviewerPane, dispatchID: "dispatch-2"))


### PR DESCRIPTION
Workflow submissions use delivery terminology in the DSL, but activation fields, receipt records, skipped-dependency metadata, diagnostics, and internal persistence helpers still used output names.

This completes the contract with `activation.delivery`, `delivery.record`, `skipped_deliveries`, and the `workflowDeliveryRecord` schema definition. Delivery-specific diagnostics, helpers, logs, and tests now use the same terms. CLI reference examples use `.pwlworkflow` bundle paths, and the manual and shipped skill describe the new fields. Action `output` and `output_path` retain their existing meaning.

Serialization tests assert the emitted keys and reject the retired payload/record shapes. No compatibility aliases or migration are added for this unreleased contract.

Validation: CLI build and smoke checks, 291 CLI unit tests, 112 CLI integration tests, 3147 App tests, and make check (152 script tests) passed.
The final make build-app also passed.
