### PR TITLE
Keep Canvas completion reminders until the pane is visible

### DIFF
--- a/docs-ai/066-agent-island/000-plan.md
+++ b/docs-ai/066-agent-island/000-plan.md
@@ -149,3 +149,6 @@ until it reconnects. The picker matches by UUID only (`AgentIslandDisplaySelecti
 
 - Updated 2026-09-08: preserve completion acknowledgements across session lookup suspension — see
   [005-completion-acknowledgement.md](005-completion-acknowledgement.md).
+
+- Updated 2026-09-08: continue Canvas completion viewing with viewport coverage — see
+  [006-canvas-completion-visibility.md](006-canvas-completion-visibility.md).

--- a/docs-ai/066-agent-island/000-plan.md
+++ b/docs-ai/066-agent-island/000-plan.md
@@ -146,3 +146,6 @@ until it reconnects. The picker matches by UUID only (`AgentIslandDisplaySelecti
 
 - Updated 2026-09-05: consolidated agent presentation settings and refined the floating grip — see
   [004-agent-display-settings.md](004-agent-display-settings.md).
+
+- Updated 2026-09-08: preserve completion acknowledgements across session lookup suspension — see
+  [005-completion-acknowledgement.md](005-completion-acknowledgement.md).

--- a/docs-ai/066-agent-island/005-completion-acknowledgement.md
+++ b/docs-ai/066-agent-island/005-completion-acknowledgement.md
@@ -1,0 +1,33 @@
+# 066.005 — Completion acknowledgement across session resolution
+
+## Context
+
+PR #781 and the original #778, resubmitted as #782 by @SunChJ, route automatic
+acknowledgement through the viewed-surface predicate. A session lookup can suspend
+while the user acknowledges a completion and then leaves the window. Deriving read
+state from the pre-lookup snapshot can restore Done when session metadata changes.
+
+## Change
+
+After session resolution, merge the current acknowledgement for the same observed
+state into the polling result. Preserve its change timestamp. A new working/blocked
+to idle transition must still become unread when unviewed; do not treat an earlier
+acknowledgement as permission to read future completions. Keep the read policy private.
+
+The implementation uses a per-call session resolver seam and controlled suspension
+in behavior tests. Tests cover changed and unchanged session metadata, a new
+completion after acknowledgement, and state changes during suspension.
+
+If state other than acknowledgement or its timestamp changed during suspension,
+discard the stale poll. The next scheduled poll observes the new state.
+
+## Validation
+
+The controlled suspension test failed on #781 before the fix: Done reappeared and
+the acknowledgement timestamp was replaced. It passes with the fix, with and without
+new session metadata. Related local tests passed; no live-agent GUI reproduction
+was performed for this polling-state change.
+
+## Refs
+
+PR #781; related original implementation #778 and resubmission #782.

--- a/docs-ai/066-agent-island/006-canvas-completion-visibility.md
+++ b/docs-ai/066-agent-island/006-canvas-completion-visibility.md
@@ -1,0 +1,36 @@
+# 066.006 — Canvas completion visibility
+
+## Context and approach
+
+Continue @SunChJ's original commit from #780, resubmitted unchanged as #783.
+Keep that commit in the branch history and use #781 as the acknowledgement prerequisite.
+
+The Canvas predicate checks actual keyboard focus and window visibility. A card can
+keep those properties while panning moves it completely outside the viewport.
+Reproduce that case through AppKit geometry and the completion polling path. If it
+fails, require a nonempty visible area before acknowledging a completion. Partial
+visibility remains sufficient; no percentage, center-point, or animation gate is added.
+
+Preserve navigation, broadcast input, and worktree-scoped notification semantics.
+Test offscreen, partially visible, scaled, and returned panes along with logical-only
+focus and inactive-window cases. Verify the combined implementation with #781.
+
+## Outcome
+
+The combined polling test reproduced the report: an offscreen first responder changed
+from Working to Idle instead of Done. Its AppKit `visibleRect` was nonempty but entirely
+outside its bounds, so checking `visibleRect.isEmpty` alone would not fix the issue.
+The predicate now computes the intersection of `bounds` and `visibleRect` and
+requires a nonempty result. `CGRect.intersects` alone accepts a zero-area surface
+in this environment, so it does not enforce the intended positive-area boundary.
+
+The tests use positive terminal frames, real first-responder transitions, and native
+view geometry. Coverage includes clipped ancestor coordinates at 0.5x, 1x, and 2x,
+partial intersection, zero area, and leaving/returning to the viewport. Completion
+polling and automatic acknowledgement run against the #781 implementation.
+
+## Validation
+
+The final combined Xcode run passed 83 test methods with zero failures and warnings.
+`make check` passed, including 146 script tests. The offscreen test failed before
+this change and passed afterward. No live-agent GUI session was manually exercised.

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -55,7 +55,8 @@ A row whose pane is bound to an active workflow run replaces its subtitle with
 ## Interactions
 
 - **Click a row** → focuses that worktree + tab + pane and brings Prowl forward. A
-  **Done** row downgrades to **Idle** once focused.
+  **Done** row downgrades to **Idle** once viewed in the active, visible Prowl window.
+  Internal focus changes while the window is inactive do not clear the completion.
 - **Right-click a row** for the context menu:
   - **Hand Off…** — opens the Hand Off HUD for that agent's pane
     (selecting and focusing it first), regardless of which pane currently has

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -118,7 +118,9 @@ frames keep the last trusted state instead of forcing Idle.
 A **Done** pane becomes **Idle** when it is actually viewed: its worktree and tab are selected,
 its pane is focused, and the Prowl window is key and visible. Keeping a pane selected while
 Prowl is inactive, hidden, or minimized does not mark its completion as read. Unknown window
-state is conservatively treated as not viewed. See [Canvas](canvas.md) for Canvas-specific behavior.
+state is conservatively treated as not viewed. An acknowledged completion stays read when
+a pending session lookup finishes; a later unviewed completion still becomes **Done**.
+See [Canvas](canvas.md) for Canvas-specific behavior.
 
 ## Cooperative signal bus
 

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -115,7 +115,10 @@ frames keep the last trusted state instead of forcing Idle.
 | **Done**    | raw `idle` + **unseen** | just finished; you haven't looked yet |
 | **Idle**    | raw `idle` + **seen**   | nothing running                       |
 
-A **Done** pane becomes **Idle** the moment you focus it.
+A **Done** pane becomes **Idle** when it is actually viewed: its worktree and tab are selected,
+its pane is focused, and the Prowl window is key and visible. Keeping a pane selected while
+Prowl is inactive, hidden, or minimized does not mark its completion as read. Unknown window
+state is conservatively treated as not viewed. See [Canvas](canvas.md) for Canvas-specific behavior.
 
 ## Cooperative signal bus
 

--- a/docs/components/agent-island.md
+++ b/docs/components/agent-island.md
@@ -61,7 +61,10 @@ badge takes the subtitle position, as in the sidebar. The displayed priority ord
 first, then unviewed Done, newest first within each state. Cells
 cannot be dismissed from the island. A
 Blocked cell clears when the agent leaves that state, a Done cell clears once the entry is viewed,
-and a removed entry disappears with the roster.
+and a removed entry disappears with the roster. A selected pane is not considered viewed while
+Prowl's window is inactive, hidden, or minimized, so its Done reminder remains. Unknown window
+state also retains reminders rather than automatically marking them read. See [Canvas](canvas.md)
+for Canvas-specific behavior.
 
 ## Interactions
 

--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -96,7 +96,10 @@ or the repository page otherwise.
 
 Clicking an Agent Island **Done** reminder keeps the existing Canvas navigation: Prowl comes
 forward and focuses the target card and pane. The completion becomes read once that terminal
-is the actual keyboard responder in its key, visible window. A logical focus request alone,
+is the actual keyboard responder in its key, visible window and some of the terminal intersects
+its visible viewport. A focused pane completely outside the viewport stays unread until navigation
+brings it back. Partial visibility is sufficient; no minimum visible percentage is required.
+A logical focus request alone,
 an inactive window, or a hidden/detached terminal does not count as viewing it. Other cards
 and splits are not acknowledged merely because they are selected or receive broadcast input.
 **Blocked** reminders remain until the agent leaves the blocked state.

--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -92,6 +92,15 @@ or the repository page otherwise.
 - The left nav band is tinted with the focused card's repository color
   (`windowTintMode`).
 
+### Agent Island completion reminders
+
+Clicking an Agent Island **Done** reminder keeps the existing Canvas navigation: Prowl comes
+forward and focuses the target card and pane. The completion becomes read once that terminal
+is the actual keyboard responder in its key, visible window. A logical focus request alone,
+an inactive window, or a hidden/detached terminal does not count as viewing it. Other cards
+and splits are not acknowledged merely because they are selected or receive broadcast input.
+**Blocked** reminders remain until the agent leaves the blocked state.
+
 ## Layout & sizing
 
 - Default card size adapts to screen width (roughly 800×550 on a 14", larger on a

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,7 +65,7 @@ user-visible states:
 - **Blocked** — waiting for you (a confirmation/permission prompt). This is the
   one that needs your attention.
 - **Done** — finished and you haven't looked yet (an unseen completion). Becomes
-  **Idle** once you focus it.
+  **Idle** once you view the focused pane in the active, visible Prowl window.
 - **Idle** — nothing running / seen.
 
 How this is detected (process inspection + on-screen heuristics) and the full

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -56,7 +56,16 @@ extension WorktreeTerminalState {
     }
   }
 
-  func detectAgentState(for view: GhosttySurfaceView, tabId: TerminalTabID) async -> Bool {
+  typealias RetainedSessionResolver =
+    @MainActor (
+      IdentifiedAgentProcess?, PaneAgentState, URL?, String, URL?
+    ) async -> (session: AgentSession?, missStreak: Int)
+
+  func detectAgentState(
+    for view: GhosttySurfaceView,
+    tabId: TerminalTabID,
+    resolveSession: RetainedSessionResolver? = nil
+  ) async -> Bool {
     let surfaceID = view.id
     let childPID = view.bridge.childPID()
     let processGroupID = view.bridge.foregroundProcessGroupID()
@@ -94,7 +103,7 @@ extension WorktreeTerminalState {
     }
 
     let now = Date()
-    let previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
+    var previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
     let activeText = view.bridge.readActiveText() ?? ""
     // Reuse the previous scan while the screen and detected agent are unchanged.
     // A live-but-idle agent is polled every 300 ms and `detectState` re-splits,
@@ -112,17 +121,20 @@ extension WorktreeTerminalState {
 
     let iconLookupToken = identified?.iconLookupToken ?? previous.iconLookupToken ?? agent.iconLookupToken
     let workingDirectory = activeAgentWorkingDirectory(surfaceID: surfaceID)
-    let (session, sessionMissStreak) = await resolveRetainedSession(
-      identified: identified,
-      previous: previous,
-      workingDirectory: workingDirectory,
-      activeText: activeText,
-      configRoot: launchProfilesBySurface[surfaceID]?.configRoot(forDetected: agent)
+    let (session, sessionMissStreak) = await (resolveSession ?? Self.resolveRetainedSession)(
+      identified, previous, workingDirectory, activeText,
+      launchProfilesBySurface[surfaceID]?.configRoot(forDetected: agent)
     )
     // Re-check after the suspension: the pane may have been closed and its
     // agent state cleaned up while the resolver was doing file inspection;
     // writing below would resurrect a ghost Active Agents entry.
     guard surfaces[surfaceID] != nil else { return false }
+    // Acknowledgement can change while session inspection is suspended. Preserve it,
+    // but discard this observation if any other state changed in the meantime.
+    guard let current = surfaceAgentStates[surfaceID] else { return false }
+    previous.seen = current.seen
+    previous.lastChangedAt = current.lastChangedAt
+    guard previous == current else { return true }
     let launchObservation = resolvedLaunchObservation(identified: identified, previous: previous)
     let lastChangedAt = (previous.detectedAgent != agent || previous.state != stabilized) ? now : previous.lastChangedAt
     var next = PaneAgentState(
@@ -263,7 +275,7 @@ extension WorktreeTerminalState {
     )
   }
 
-  private func resolveRetainedSession(
+  private static func resolveRetainedSession(
     identified: IdentifiedAgentProcess?,
     previous: PaneAgentState,
     workingDirectory: URL?,

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -110,11 +110,6 @@ extension WorktreeTerminalState {
       raw: raw
     )
 
-    let seen = Self.resolvedSeen(
-      previous: previous,
-      stabilized: stabilized,
-      isForeground: isSelected() && isFocusedSurface(surfaceID)
-    )
     let iconLookupToken = identified?.iconLookupToken ?? previous.iconLookupToken ?? agent.iconLookupToken
     let workingDirectory = activeAgentWorkingDirectory(surfaceID: surfaceID)
     let (session, sessionMissStreak) = await resolveRetainedSession(
@@ -141,7 +136,7 @@ extension WorktreeTerminalState {
       iconLookupToken: iconLookupToken,
       fallbackState: raw,
       state: stabilized,
-      seen: seen,
+      seen: resolvedSeen(previous: previous, stabilized: stabilized, surfaceID: surfaceID),
       lastChangedAt: lastChangedAt
     )
     next.sessionMissStreak = sessionMissStreak
@@ -209,12 +204,12 @@ extension WorktreeTerminalState {
     return detection
   }
 
-  private static func resolvedSeen(
+  private func resolvedSeen(
     previous: PaneAgentState,
     stabilized: AgentRawState,
-    isForeground: Bool
+    surfaceID: UUID
   ) -> Bool {
-    if isForeground || stabilized == .blocked {
+    if isViewedSurface(surfaceID) {
       return true
     }
     if (previous.state == .working || previous.state == .blocked) && stabilized == .idle {
@@ -293,7 +288,8 @@ extension WorktreeTerminalState {
   }
 
   func markAgentSeen(surfaceID: UUID) {
-    guard var state = surfaceAgentStates[surfaceID], !state.seen else { return }
+    // Focus bookkeeping can run while the window is inactive or before a tab is selected.
+    guard isViewedSurface(surfaceID), var state = surfaceAgentStates[surfaceID], !state.seen else { return }
     state.seen = true
     state.lastChangedAt = Date()
     surfaceAgentStates[surfaceID] = state

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -701,11 +701,14 @@ extension WorktreeTerminalState {
     if isCanvasManaged {
       // Canvas owns focus separately from normal-mode selection and window observers.
       // Its logical focus callback runs before requestFocus actually installs the responder.
+      // Panning preserves focus. visibleRect can extend outside bounds on non-clipping views.
       guard isFocusedSurface(surfaceId), let view = surfaces[surfaceId],
         view.focused, !view.isHiddenOrHasHiddenAncestor,
         let window = view.window
       else { return false }
-      return window.isKeyWindow && window.occlusionState.contains(.visible) && window.firstResponder === view
+      let visibleBounds = view.bounds.intersection(view.visibleRect)
+      return !visibleBounds.isEmpty && window.isKeyWindow && window.occlusionState.contains(.visible)
+        && window.firstResponder === view
     }
     return isViewingWorktree() && isFocusedSurface(surfaceId)
   }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -696,10 +696,18 @@ extension WorktreeTerminalState {
     return isSelected() && lastWindowIsKey == true && lastWindowIsVisible == true
   }
 
-  /// Whether the user is actively looking at `surfaceId` right now: its worktree
-  /// is visible and it is the focused pane of the selected tab.
+  /// Whether the user is actively looking at `surfaceId` right now.
   func isViewedSurface(_ surfaceId: UUID) -> Bool {
-    isViewingWorktree() && isFocusedSurface(surfaceId)
+    if isCanvasManaged {
+      // Canvas owns focus separately from normal-mode selection and window observers.
+      // Its logical focus callback runs before requestFocus actually installs the responder.
+      guard isFocusedSurface(surfaceId), let view = surfaces[surfaceId],
+        view.focused, !view.isHiddenOrHasHiddenAncestor,
+        let window = view.window
+      else { return false }
+      return window.isKeyWindow && window.occlusionState.contains(.visible) && window.firstResponder === view
+    }
+    return isViewingWorktree() && isFocusedSurface(surfaceId)
   }
 
   func updateRunningState(for tabId: TerminalTabID) {

--- a/supacodeTests/CanvasViewedSurfaceTests.swift
+++ b/supacodeTests/CanvasViewedSurfaceTests.swift
@@ -70,6 +70,91 @@ struct CanvasViewedSurfaceTests {
     #expect(fixture.state.isViewedSurface(fixture.surface.id))
   }
 
+  @Test func offscreenFocusedCompletionRemainsUnreadUntilItReturns() async {
+    let fixture = Fixture()
+    fixture.surface.setFrameOrigin(NSPoint(x: 2000, y: 2000))
+    #expect(fixture.window.firstResponder === fixture.surface)
+    #expect(!fixture.surface.isHiddenOrHasHiddenAncestor)
+    #expect(!fixture.surface.bounds.intersects(fixture.surface.visibleRect))
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude, state: .working, seen: true
+    )
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(currentAgent: .claude)
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude, text: "", detection: AgentScreenDetection(state: .idle, reason: .legacyDetector)
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+
+    fixture.surface.setFrameOrigin(NSPoint(x: 20, y: 20))
+    #expect(fixture.window.firstResponder === fixture.surface)
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+  }
+
+  @Test(arguments: [0.5, 1.0, 2.0])
+  func scaledViewportRequiresIntersection(scale: Double) {
+    let fixture = Fixture()
+    let viewport = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+    viewport.clipsToBounds = true
+    viewport.bounds = NSRect(x: 0, y: 0, width: 600 / scale, height: 400 / scale)
+    fixture.window.contentView?.addSubview(viewport)
+    viewport.addSubview(fixture.surface)
+    #expect(fixture.window.makeFirstResponder(fixture.surface))
+    fixture.surface.focused = true
+
+    fixture.surface.setFrameOrigin(NSPoint(x: viewport.bounds.maxX + 10, y: 20))
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.surface.setFrameOrigin(NSPoint(x: viewport.bounds.maxX, y: 20))
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.surface.setFrameOrigin(NSPoint(x: viewport.bounds.maxX - 20, y: 20))
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.surface.setFrameOrigin(NSPoint(x: 20, y: 20))
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func zeroAreaSurfaceDoesNotCountAsViewed() {
+    let fixture = Fixture()
+    fixture.surface.setFrameSize(.zero)
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func logicalFocusAndInactiveWindowDoNotReadCompletion() async {
+    let fixture = Fixture()
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude, state: .idle, seen: false
+    )
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(currentAgent: .claude)
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude, text: "", detection: AgentScreenDetection(state: .idle, reason: .legacyDetector)
+    )
+    fixture.window.makeFirstResponder(nil)
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+
+    #expect(fixture.window.makeFirstResponder(fixture.surface))
+    fixture.window.reportsKey = false
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+
+    fixture.window.reportsKey = true
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude, state: .blocked, seen: false
+    )
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .blocked)
+  }
+
   private struct Fixture {
     let state: WorktreeTerminalState
     let surface: GhosttySurfaceView
@@ -98,6 +183,7 @@ struct CanvasViewedSurfaceTests {
       tabID = state.tabManager.createTab(title: "Canvas", icon: nil)
       state.tabManager.selectTab(tabID)
       state.surfaces[surface.id] = surface
+      state.trees[tabID] = SplitTree<GhosttySurfaceView>(view: surface)
       state.focusedSurfaceIdByTab[tabID] = surface.id
       state.isCanvasManaged = true
       state.isSelected = { false }
@@ -110,6 +196,7 @@ struct CanvasViewedSurfaceTests {
         backing: .buffered,
         defer: true
       )
+      surface.frame = NSRect(x: 20, y: 20, width: 400, height: 300)
       window.contentView?.addSubview(surface)
       #expect(window.makeFirstResponder(surface))
       // No Ghostty C surface is created in these tests, so its focus callback is skipped.

--- a/supacodeTests/CanvasViewedSurfaceTests.swift
+++ b/supacodeTests/CanvasViewedSurfaceTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CanvasViewedSurfaceTests {
+  @Test func actualCanvasFocusDoesNotDependOnNormalModeSelectionOrWindowCache() {
+    let fixture = Fixture()
+
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+    #expect(!fixture.state.isViewingWorktree())
+  }
+
+  enum UnviewedCondition: CaseIterable {
+    case inactiveWindow, occludedWindow, detached, hidden, hiddenAncestor
+    case logicalFocusOnly, clearedFocus, otherPane, otherTab
+  }
+
+  @Test(arguments: UnviewedCondition.allCases)
+  func canvasDoesNotTreatUnviewedSurfacesAsRead(condition: UnviewedCondition) {
+    let fixture = Fixture()
+    // Stale normal-mode flags must never override the live Canvas window.
+    fixture.state.lastWindowIsKey = true
+    fixture.state.lastWindowIsVisible = true
+    fixture.state.isSelected = { true }
+
+    switch condition {
+    case .inactiveWindow: fixture.window.reportsKey = false
+    case .occludedWindow: fixture.window.reportsVisible = false
+    case .detached: fixture.surface.removeFromSuperview()
+    case .hidden: fixture.surface.isHidden = true
+    case .hiddenAncestor: fixture.window.contentView?.isHidden = true
+    case .logicalFocusOnly: fixture.window.makeFirstResponder(nil)
+    case .clearedFocus: fixture.surface.focused = false
+    case .otherPane:
+      fixture.state.focusedSurfaceIdByTab[fixture.tabID] = UUID()
+    case .otherTab:
+      let other = fixture.state.tabManager.createTab(title: "Other", icon: nil)
+      fixture.state.tabManager.selectTab(other)
+    }
+
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func becomingTheActualResponderCompletesTheViewingTransition() {
+    let fixture = Fixture()
+    fixture.window.makeFirstResponder(nil)
+    fixture.surface.focused = true
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    #expect(fixture.window.makeFirstResponder(fixture.surface))
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.window.reportsKey = false
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+    fixture.window.reportsKey = true
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  @Test func leavingCanvasRestoresTheNormalViewingPolicy() {
+    let fixture = Fixture()
+    fixture.state.isCanvasManaged = false
+    #expect(!fixture.state.isViewedSurface(fixture.surface.id))
+
+    fixture.state.isSelected = { true }
+    fixture.state.lastWindowIsKey = true
+    fixture.state.lastWindowIsVisible = true
+    #expect(fixture.state.isViewedSurface(fixture.surface.id))
+  }
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let surface: GhosttySurfaceView
+    let window: CanvasTestWindow
+    let tabID: TerminalTabID
+
+    init() {
+      let runtime = GhosttyRuntime()
+      state = WorktreeTerminalState(
+        runtime: runtime,
+        worktree: Worktree(
+          id: "/tmp/repo/canvas",
+          name: "canvas",
+          detail: "",
+          workingDirectory: URL(fileURLWithPath: "/tmp/repo/canvas"),
+          repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+        ),
+        skipsSurfaceCreationForTesting: true
+      )
+      surface = GhosttySurfaceView(
+        runtime: runtime,
+        workingDirectory: nil,
+        context: GHOSTTY_SURFACE_CONTEXT_TAB,
+        skipsSurfaceCreationForTesting: true
+      )
+      tabID = state.tabManager.createTab(title: "Canvas", icon: nil)
+      state.tabManager.selectTab(tabID)
+      state.surfaces[surface.id] = surface
+      state.focusedSurfaceIdByTab[tabID] = surface.id
+      state.isCanvasManaged = true
+      state.isSelected = { false }
+      state.lastWindowIsKey = nil
+      state.lastWindowIsVisible = nil
+
+      window = CanvasTestWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+        styleMask: [.titled],
+        backing: .buffered,
+        defer: true
+      )
+      window.contentView?.addSubview(surface)
+      #expect(window.makeFirstResponder(surface))
+      // No Ghostty C surface is created in these tests, so its focus callback is skipped.
+      surface.focused = true
+    }
+  }
+}
+
+@MainActor
+private final class CanvasTestWindow: NSWindow {
+  var reportsKey = true
+  var reportsVisible = true
+
+  override var isKeyWindow: Bool { reportsKey }
+  override var occlusionState: NSWindow.OcclusionState { reportsVisible ? [.visible] : [] }
+}

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyKit
 import Testing
 
 @testable import supacode
@@ -42,6 +43,41 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(!state.isViewedSurface(UUID()))
   }
 
+  @Test func inactiveFocusedCompletionPollRemainsUnread() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .working,
+      seen: true
+    )
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(
+      currentAgent: .claude
+    )
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude,
+      text: "",
+      detection: AgentScreenDetection(state: .idle, reason: .legacyDetector)
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func inactiveFocusBookkeepingDoesNotAcknowledgeCompletion() {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+
+    fixture.state.recordActiveSurface(fixture.surface, in: fixture.tabID)
+
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -61,5 +97,40 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     state.lastWindowIsKey = true
     state.lastWindowIsVisible = true
     return (state, surfaceId)
+  }
+
+  private struct DetectionFixture {
+    let state: WorktreeTerminalState
+    let tabID: TerminalTabID
+    let surface: GhosttySurfaceView
+  }
+
+  private func makeDetectionFixture() -> DetectionFixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/wt-1",
+        name: "wt-1",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let surface = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: state.worktree.workingDirectory,
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabID = state.tabManager.createTab(title: "tab", icon: nil)
+    state.tabManager.selectTab(tabID)
+    state.surfaces[surface.id] = surface
+    state.trees[tabID] = SplitTree<GhosttySurfaceView>(view: surface)
+    state.focusedSurfaceIdByTab[tabID] = surface.id
+    state.isSelected = { true }
+    state.lastWindowIsKey = true
+    state.lastWindowIsVisible = true
+    return DetectionFixture(state: state, tabID: tabID, surface: surface)
   }
 }

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -78,6 +78,94 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
   }
 
+  enum ViewingCondition: CaseIterable {
+    case viewed, inactive, hidden, unknown, canvas, otherWorktree, otherPane, otherTab
+  }
+
+  @Test(arguments: ViewingCondition.allCases, [AgentRawState.working, .blocked])
+  func completionPollingRequiresViewedSurface(
+    condition: ViewingCondition,
+    previousState: AgentRawState
+  ) async {
+    let fixture = makeDetectionFixture()
+    apply(condition, to: fixture.state)
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: previousState, seen: true),
+      detected: .idle
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(
+      fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState
+        == (condition == .viewed ? .idle : .done)
+    )
+  }
+
+  @Test(arguments: ViewingCondition.allCases)
+  func automaticAcknowledgementRequiresViewedSurface(condition: ViewingCondition) {
+    let fixture = makeDetectionFixture()
+    apply(condition, to: fixture.state)
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+
+    #expect(
+      fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState
+        == (condition == .viewed ? .idle : .done)
+    )
+  }
+
+  @Test func inactiveStableIdlePollDoesNotCreateCompletion() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: true),
+      detected: .idle
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+  }
+
+  @Test func inactiveUnreadStateSurvivesBlockedRoundTrip() async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: false),
+      detected: .blocked
+    )
+
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.seen == false)
+
+    prepareDetection(fixture, detected: .idle)
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func returningToViewedSurfaceAcknowledgesCompletion() {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    fixture.state.surfaceAgentStates[fixture.surface.id] = PaneAgentState(
+      detectedAgent: .claude,
+      state: .idle,
+      seen: false
+    )
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+
+    fixture.state.lastWindowIsKey = true
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -132,5 +220,50 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     state.lastWindowIsKey = true
     state.lastWindowIsVisible = true
     return DetectionFixture(state: state, tabID: tabID, surface: surface)
+  }
+
+  private func apply(_ condition: ViewingCondition, to state: WorktreeTerminalState) {
+    switch condition {
+    case .viewed:
+      break
+    case .inactive:
+      state.lastWindowIsKey = false
+    case .hidden:
+      state.lastWindowIsVisible = false
+    case .unknown:
+      state.lastWindowIsKey = nil
+      state.lastWindowIsVisible = nil
+    case .canvas:
+      state.isCanvasManaged = true
+    case .otherWorktree:
+      state.isSelected = { false }
+    case .otherPane:
+      if let tabID = state.tabManager.selectedTabId {
+        state.focusedSurfaceIdByTab[tabID] = UUID()
+      }
+    case .otherTab:
+      let tabID = state.tabManager.createTab(title: "other", icon: nil)
+      state.tabManager.selectTab(tabID)
+    }
+  }
+
+  private func preparePoll(
+    _ fixture: DetectionFixture,
+    previous: PaneAgentState,
+    detected: AgentRawState
+  ) {
+    fixture.state.surfaceAgentStates[fixture.surface.id] = previous
+    fixture.state.agentDetectionPresenceBySurface[fixture.surface.id] = AgentDetectionPresence(
+      currentAgent: .claude
+    )
+    prepareDetection(fixture, detected: detected)
+  }
+
+  private func prepareDetection(_ fixture: DetectionFixture, detected: AgentRawState) {
+    fixture.state.lastAgentScreenScanBySurface[fixture.surface.id] = WorktreeTerminalState.AgentScreenScan(
+      agent: .claude,
+      text: "",
+      detection: AgentScreenDetection(state: detected, reason: .legacyDetector)
+    )
   }
 }

--- a/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
+++ b/supacodeTests/WorktreeTerminalStateViewedSurfaceTests.swift
@@ -166,6 +166,79 @@ struct WorktreeTerminalStateViewedSurfaceTests {
     #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
   }
 
+  @Test(arguments: [false, true])
+  func acknowledgementDuringSessionLookupIsPreserved(metadataChanges: Bool) async {
+    let fixture = makeDetectionFixture()
+    fixture.state.lastWindowIsKey = false
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(
+        detectedAgent: .claude, fallbackState: .idle, state: .idle, seen: false),
+      detected: .idle
+    )
+    let session =
+      metadataChanges ? AgentSession(id: "resolved", transcriptPath: nil, source: .recentFile) : nil
+    let (started, signalStarted) = AsyncStream<Void>.makeStream()
+    let (resume, signalResume) = AsyncStream<Void>.makeStream()
+    let poll = Task {
+      await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID) {
+        _, _, _, _, _ in
+        signalStarted.yield(())
+        signalStarted.finish()
+        for await _ in resume { break }
+        return (session, 0)
+      }
+    }
+    for await _ in started { break }
+    fixture.state.lastWindowIsKey = true
+    fixture.state.markAgentSeen(surfaceID: fixture.surface.id)
+    let acknowledgedAt = fixture.state.surfaceAgentStates[fixture.surface.id]?.lastChangedAt
+    fixture.state.lastWindowIsKey = false
+    signalResume.yield(())
+    signalResume.finish()
+
+    #expect(await poll.value)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .idle)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.lastChangedAt == acknowledgedAt)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.session == session)
+
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .working, seen: true),
+      detected: .idle
+    )
+    #expect(await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID))
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id]?.displayState == .done)
+  }
+
+  @Test func stateChangedDuringSessionLookupIsNotOverwritten() async {
+    let fixture = makeDetectionFixture()
+    preparePoll(
+      fixture,
+      previous: PaneAgentState(detectedAgent: .claude, state: .idle, seen: false),
+      detected: .idle
+    )
+    let (started, signalStarted) = AsyncStream<Void>.makeStream()
+    let (resume, signalResume) = AsyncStream<Void>.makeStream()
+    let poll = Task {
+      await fixture.state.detectAgentState(for: fixture.surface, tabId: fixture.tabID) {
+        _, _, _, _, _ in
+        signalStarted.yield(())
+        signalStarted.finish()
+        for await _ in resume { break }
+        return (nil, 0)
+      }
+    }
+    for await _ in started { break }
+    let newer = PaneAgentState(detectedAgent: .claude, state: .working, seen: true)
+    fixture.state.surfaceAgentStates[fixture.surface.id] = newer
+    signalResume.yield(())
+    signalResume.finish()
+
+    #expect(await poll.value)
+    #expect(fixture.state.surfaceAgentStates[fixture.surface.id] == newer)
+  }
+
   private func makeViewedState() -> (WorktreeTerminalState, UUID) {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),


### PR DESCRIPTION
## Summary

A Canvas pane can keep keyboard focus after panning moves its card completely outside the viewport. Such a pane must retain its unread Done state until it returns to view.

Continue the Canvas acknowledgement implementation from #783, with its original commit preserved. Require the focused terminal's bounds to intersect its AppKit visible rectangle, in addition to the original key/visible-window and actual-responder checks. Partial visibility is sufficient. Keep navigation, broadcast input, and worktree-scoped notification behavior unchanged.

The completion-read prerequisite #781 is merged. This branch includes that implementation, and the combined behavior was tested locally.

Fixes #779.

## Validation

- Reproduced the bug against the original #783 implementation combined with #781: moving the focused pane outside the viewport changed Working to Idle instead of Done.
- Confirmed that `visibleRect` can be nonempty but outside the terminal bounds; the predicate uses rectangle intersection.
- Final combined Xcode tests passed (83 test methods), including offscreen/returned panes, partial intersection, 0.5x/1x/2x ancestor scaling, zero area, logical-only focus, inactive windows, Blocked state, normal-mode viewing, Active Agents, and Island.
- `make check` passed, including 146 script tests.
- `make build-app` passed.
- `git diff --check` passed.
- Native AppKit tests use actual first-responder transitions and view geometry; no live-agent GUI session was manually exercised.

## Original contribution

Thanks to @SunChJ (SamsonCJ) for the Canvas implementation in #780, resubmitted as #783. Original commit `3635ff56d1f001e70fc7422ab8666da8523b6883` is retained unchanged as an ancestor of this branch. This follow-up adds viewport coverage and combined behavior tests. Thanks to @onevtail for reporting the offscreen case.

Use a merge commit to retain the original contribution in repository history.
