### PR TITLE
Add built-in handoff workflow with optional receiver

### DIFF
--- a/ProwlCLITests/WorkflowRoleRequirementsTests.swift
+++ b/ProwlCLITests/WorkflowRoleRequirementsTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import ProwlCLIShared
+
+struct WorkflowRoleRequirementsTests {
+  @Test func shippedHandoffIsAValidBuiltInBundle() throws {
+    let root = URL(filePath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+    let file = WorkflowDiscovery.load(
+      url: root.appending(path: "Resources/workflows/handoff.pwlworkflow"),
+      scope: .bundle, context: .init(scope: .bundle))
+    #expect(file.isValid)
+    #expect(file.definition?.id == "prowl.handoff")
+  }
+
+  private func definition(condition: String = "inputs.next == 'launch'") throws -> WorkflowDefinition {
+    try #require(
+      WorkflowDocumentParser.parse(
+        """
+        schema: prowl.workflow/v1
+        id: example
+        name: Example
+        inputs:
+          next: {type: enum, values: [save, launch], default: launch}
+        roles:
+          receiver: {source: launch}
+        steps:
+          - id: choose
+            if: "\(condition)"
+            then:
+              - id: receive
+                launch: receiver
+                prompt: Continue.
+                expect: {delivery: accepted}
+        """
+      ).definition)
+  }
+
+  @Test func saveOnlyDoesNotRequireAReceiver() throws {
+    #expect(WorkflowRoleRequirements.launchRoles(in: try definition(), inputs: ["next": "save"]).isEmpty)
+    #expect(WorkflowRoleRequirements.launchRoles(in: try definition(), inputs: [:]) == ["receiver"])
+    #expect(WorkflowRoleRequirements.launchRoles(in: try definition(), inputs: ["next": "launch"]) == ["receiver"])
+  }
+
+  @Test func skippedLaunchDoesNotRequireAReceiver() throws {
+    #expect(WorkflowRoleRequirements.launchRoles(in: try definition(), inputs: [:], skipped: ["receive"]).isEmpty)
+  }
+
+  @Test func optionalRuntimeReferencesDoNotPredictTheBranch() throws {
+    let definition = try definition(condition: "!exists(state.ready)")
+    #expect(WorkflowRoleRequirements.launchRoles(in: definition, inputs: [:]) == ["receiver"])
+  }
+}

--- a/Resources/workflows/handoff.pwlworkflow/workflow.yaml
+++ b/Resources/workflows/handoff.pwlworkflow/workflow.yaml
@@ -1,0 +1,58 @@
+schema: prowl.workflow/v1
+id: prowl.handoff
+name: Handoff
+description: Save the current task and context, then optionally start a receiving agent.
+icon: arrow.triangle.branch
+inputs:
+  next:
+    type: enum
+    values: [launch, save]
+    default: launch
+    prompt: After saving (launch a receiver or save only)
+roles:
+  author:
+    source: current
+  receiver:
+    source: launch
+    placement: tab
+    background: true
+steps:
+  - id: briefing
+    title: Prepare handoff briefing
+    message: author
+    instruction: |
+      Prepare a concise handoff of the task in this conversation. Include these headings:
+      ## Objective
+      ## Current State
+      ## What Has Been Done
+      ## Open Questions
+      ## Risks / Watch Out
+      ## Next Steps
+      Record the user's constraints, decisions, relevant files, completed verification,
+      unresolved issues, and a concrete next action. Distinguish tested facts from assumptions.
+      Do not perform new task work or write shared handoff files; submit the briefing itself.
+      Prowl will save it with generated repository and session context.
+    expect:
+      delivery: briefing
+      sections: ['## Objective', '## Current State', '## Next Steps']
+      strict: true
+  - id: save
+    title: Save handoff packet
+    action: builtin:save-handoff
+    with:
+      briefing: '{{ deliveries.briefing.path }}'
+  - id: next
+    if: inputs.next == 'launch'
+    then:
+      - id: receive
+        title: Start receiving agent
+        launch: receiver
+        prompt: |
+          Continue the task described in this handoff packet:
+          {{ actions.save.output.path }}
+          Read the entire packet before acting. Its instructions, constraints, completed work,
+          open questions, and next steps define the task. Read any referenced session excerpt
+          when needed. Verify the current files before changing them; do not repeat completed work.
+          Continue the task directly unless a material ambiguity prevents safe progress.
+  - id: saved
+    notify: 'Handoff saved: {{ actions.save.output.path }}'

--- a/Resources/workflows/handoff.pwlworkflow/workflow.yaml
+++ b/Resources/workflows/handoff.pwlworkflow/workflow.yaml
@@ -15,7 +15,7 @@ roles:
   receiver:
     source: launch
     placement: tab
-    background: true
+    background: false
 steps:
   - id: briefing
     title: Prepare handoff briefing

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -695,3 +695,5 @@ attaches hooks through A2's launch boundary.
 - Updated 2026-09-07: Normalize workflow naming before D3; no aliases or migration — see [019](019-workflow-naming.md).
 
 - Updated 2026-09-08: Complete delivery naming in CLI/persisted records, diagnostics, helpers, and active examples — see [019](019-workflow-naming.md).
+
+- Updated 2026-09-08: add only `prowl.handoff`, keep existing handoff entry points, and make receiver launch optional — see [020](020-handoff-workflow.md). This supersedes D3's two-workflow and legacy-retirement scope for this slice.

--- a/docs-ai/063-agent-workflows/020-handoff-workflow.md
+++ b/docs-ai/063-agent-workflows/020-handoff-workflow.md
@@ -107,3 +107,11 @@ used the matching Debug CLI; AX key delivery could not raise the window, while s
 Agents-menu/start-sheet actions worked. After all test tabs closed, AX window re-discovery
 failed. All created panes were closed and the isolated process was stopped; local evidence
 and its temporary directory entry were retained. No UI metadata repair was warranted.
+
+## Receiver focus amendment
+
+The owner requested `receiver.background: false` after initial acceptance. The receiver now
+opens in a new tab and takes focus; the source remains open. The earlier Debug evidence above
+records the original background behavior, not a live verification of this amendment. Both
+launch and save-only still require a detected source agent to author the briefing. Admission
+rejects a missing source pane or bare shell before the run starts.

--- a/docs-ai/063-agent-workflows/020-handoff-workflow.md
+++ b/docs-ai/063-agent-workflows/020-handoff-workflow.md
@@ -1,6 +1,6 @@
 # 063.020 — Additive Handoff Workflow
 
-Status: Implemented; external review and Debug acceptance pending, 2026-09-08.
+Status: Implemented, reviewed, and accepted in Debug; PR #786, 2026-09-08.
 
 ## Scope and authority
 
@@ -77,3 +77,33 @@ Before PR: CLI build, smoke, unit (225 XCTest plus 69 Swift Testing), and integr
 (112 tests) passed. The initial app core run passed 137 tests; focused follow-ups passed
 25 and 53 tests. Bundle/role tests passed four tests. `make check` passed. External review
 and live acceptance are tracked separately below when complete.
+
+## Adversarial review
+
+PR #786 received two reviews from the neighboring Pi session. Round 1 confirmed one P2:
+the CLI guide section was accidentally placed inside a delivery heredoc. A focused Markdown
+boundary check reproduced the failure; 58c29416 corrected it and the same check passed.
+Round 2 verified the fix and found no new issues. The P0/P1/major-UX P2 gate is clean.
+No runtime code changed during review. Both rounds are recorded on the PR.
+
+## Debug acceptance and documentation
+
+The isolated Debug instance used the matching checkout CLI and `/tmp/prowl-self-verify.sock`.
+Native AX inspection showed that selecting `save` hides the Receiver picker and keeps Run
+enabled. A GUI-started Codex save-only run completed with only an author binding, no new
+pane, and a durable briefing/session packet. A self-initiated Codex-to-Pi run then completed;
+its log confirms that the first instruction returned to the caller instead of being typed.
+Pi read the packet, created the exact requested receipt, and preserved the input file. The
+source pane stayed open and the receiver launched in the background. The previous packet
+remained byte-for-byte unchanged.
+
+A third live run submitted a briefing without required sections. It returned `OUTPUT_INVALID`;
+cancellation produced no delivery/action output, no new receiver, and no changes to the shared
+handoff files (verified by hashes). Component, CLI, and shipped skill documentation now
+reflect these observed paths and distinguish workflow completion from receiver task completion.
+
+Verification friction was environmental: the installed CLI lacked `workflow read`, so agents
+used the matching Debug CLI; AX key delivery could not raise the window, while semantic
+Agents-menu/start-sheet actions worked. After all test tabs closed, AX window re-discovery
+failed. All created panes were closed and the isolated process was stopped; local evidence
+and its temporary directory entry were retained. No UI metadata repair was warranted.

--- a/docs-ai/063-agent-workflows/020-handoff-workflow.md
+++ b/docs-ai/063-agent-workflows/020-handoff-workflow.md
@@ -1,0 +1,79 @@
+# 063.020 — Additive Handoff Workflow
+
+Status: Implemented; external review and Debug acceptance pending, 2026-09-08.
+
+## Scope and authority
+
+Add one built-in, `prowl.handoff`. Keep the existing handoff HUD, CLI, and execution
+path. Do not add `prowl.handoff-checkpoint`, retire legacy commands, or publish a
+release. This owner decision supersedes the migration scope of the earlier D3 plan.
+
+## Infrastructure assessment
+
+The runner already provides explicit deliveries, self-initiated first messages,
+profile launch, scoped content access, action records, and retry/cancel attention.
+HandoffStore and HandoffCoordinator already preserve briefing, generated context,
+archives, and session excerpts across Git worktrees, workspaces, and plain directories.
+Reuse these boundaries instead of adding a file-operation library or another launcher.
+
+Two small gaps remain: a reusable action to persist a workflow briefing, and profile
+admission for a launch branch disabled by immutable start inputs. The latter must agree
+between the CLI, start sheet, and machine. Unknown/runtime-dependent conditions remain
+conservative; do not predict runtime state or execute actions during admission.
+
+## Workflow
+
+1. The current agent writes a briefing with Objective, Current State, and Next Steps.
+   This is the first step so self-initiated runs receive the delivery contract directly.
+2. A native `builtin:save-handoff` action validates the briefing and saves it with
+   repository/session context under `.prowl/handoff/`, using the existing storage core.
+   Keep an immutable, run-specific handoff copy for the receiver, separate from mutable
+   `current.md` and expiring workflow history. Validate inputs before writing shared state.
+3. An input selects saving only or launching a receiver (default). Launch uses the normal
+   profile picker and workflow launch path, without runtime restrictions or pane closure.
+   The receiver reads the saved packet and continues the recorded task. Workflow completion
+   means the packet was saved and the optional receiver launched, not that its task is done.
+4. Report the saved artifact through the workflow result/notification.
+
+Do not require a receiver profile in save-only mode. Preserve unrelated role constraints;
+prune only launch roles proven unused by immutable inputs or explicit step skips.
+Use the existing surface-specific session capture through dependency injection.
+
+## Validation and review gates
+
+Use failing behavior tests before fixes: artifact validation/archiving, immutable packet,
+non-Git/workspace roots, save-only profile admission, launch selection, self-initiated
+briefing, and action failure/cancel boundaries. Run CLI build/smoke/unit/integration,
+relevant App tests, make check, and make build-app.
+
+Self-review plan coverage and unnecessary complexity before opening a non-draft PR.
+Then request at least two adversarial review rounds from the neighboring Pi pane. Verify
+findings, reproduce real issues, and add regression tests before fixes. Record each round
+on the PR; continue while P0/P1 or major-UX P2 issues remain.
+
+After the review gate, use an isolated Debug instance for actual Codex/Pi scenarios:
+self-initiated and GUI starts, save-only, receiver continuation, and relevant failure
+handling. Check the packet, receipt, run state, and receiver behavior. Finally reconcile
+component/CLI documentation and the shipped workflow skill with the observed behavior.
+
+## Implementation and self-review
+
+The shipped bundle uses the existing delivery and launch steps. `WorkflowHandoffAction`
+reuses `HandoffCoordinator.makeCheckpoint`; its receiver packet is built from the save's
+own values rather than mutable shared files. The generic role requirement calculation is
+shared by admission, machine startup, and the native start sheet. Runtime expressions keep
+both branches eligible. No profile/runtime allow-list, new launcher, or legacy migration was
+introduced.
+
+Self-review checked the approved additive scope, first-step self-initiation, archive lifetime,
+source-session capture, optional profile selection, and failure-before-write boundaries.
+Focused tests cover Git/plain storage, preserved old briefings, immutable packets, rejected
+external/invalid/symlink inputs, both admitted paths, and reducer session capture. Existing
+HandoffStore tests cover workspace collection; existing runner tests cover cancellation.
+The normal local `workflow validate` command treats files as user scope and correctly rejects
+reserved IDs; the shipped bundle is tested with bundle-scope discovery instead.
+
+Before PR: CLI build, smoke, unit (225 XCTest plus 69 Swift Testing), and integration
+(112 tests) passed. The initial app core run passed 137 tests; focused follow-ups passed
+25 and 53 tests. Bundle/role tests passed four tests. `make check` passed. External review
+and live acceptance are tracked separately below when complete.

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -67,7 +67,7 @@ say when each is cut:
 | D1 (rest) | Merged | #761: Settings › Agents › Workflows page, `docs/components/workflows.md`, CLI reachability status (deferred from C0); [063.013](013-d1-workflows-settings.md) |
 | D1 (UI refinement) | Merged | #763: post-merge native list/detail refinement, repository-local workflow Settings, Run Setup copy, explicit run targets, file opening, and capsule YAML icons; [063.014](014-workflow-settings-ui-refinement.md) |
 | #726 T1 | Implemented and verified — #767 merged; closure [#769](https://github.com/onevcat/Prowl/pull/769) merged | [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md): zero-inference inventory and production configuration preflight verified; [runbook](../064-agent-completion-signals/agent-contracts-runbook.md). Eight-runtime headless checks pass; T1 verification and scoped publication are complete; R2b GUI/workflow acceptance belongs to D3. |
-| D3 | In progress | Add `prowl.handoff` with optional receiver launch, retain legacy handoff; self-review, Pi review, and Debug E2E required. See [020](020-handoff-workflow.md). |
+| D3 | Implemented and Debug-accepted; PR #786 | Added `prowl.handoff` with optional receiver launch; legacy handoff retained. Self-review, two Pi review rounds, and live Codex/Pi E2E complete. See [020](020-handoff-workflow.md). |
 | D2 | Deferred to R3 | `prowl.adversarial-review` built-in + reviewer skill + loop-specific E2E — after the handoff-first R2b release |
 
 #### R1 PR ledger

--- a/docs-ai/063-agent-workflows/release-plan.md
+++ b/docs-ai/063-agent-workflows/release-plan.md
@@ -1,3 +1,7 @@
+> **2026-09-08 D3 scope:** Add only `prowl.handoff`, with optional receiver launch.
+> Keep the existing handoff HUD and CLI. No checkpoint built-in or legacy retirement
+> in this slice. See [020](020-handoff-workflow.md); this overrides the older D3 scope below.
+
 > **2026-09-07 naming slice:** Action bundles (#774) and personal history (#775) are
 > merged. Normalize the unreleased contract before D3; see [019](019-workflow-naming.md).
 > This slice does not implement handoff or adversarial review and does not publish a release.
@@ -63,7 +67,7 @@ say when each is cut:
 | D1 (rest) | Merged | #761: Settings › Agents › Workflows page, `docs/components/workflows.md`, CLI reachability status (deferred from C0); [063.013](013-d1-workflows-settings.md) |
 | D1 (UI refinement) | Merged | #763: post-merge native list/detail refinement, repository-local workflow Settings, Run Setup copy, explicit run targets, file opening, and capsule YAML icons; [063.014](014-workflow-settings-ui-refinement.md) |
 | #726 T1 | Implemented and verified — #767 merged; closure [#769](https://github.com/onevcat/Prowl/pull/769) merged | [064.016](../064-agent-completion-signals/016-t1-contract-test-plan.md): zero-inference inventory and production configuration preflight verified; [runbook](../064-agent-completion-signals/agent-contracts-runbook.md). Eight-runtime headless checks pass; T1 verification and scoped publication are complete; R2b GUI/workflow acceptance belongs to D3. |
-| D3 | Next | `prowl.handoff` and `prowl.handoff-checkpoint`, legacy retirement, first built-in workflow E2E; R2b release candidate after acceptance |
+| D3 | In progress | Add `prowl.handoff` with optional receiver launch, retain legacy handoff; self-review, Pi review, and Debug E2E required. See [020](020-handoff-workflow.md). |
 | D2 | Deferred to R3 | `prowl.adversarial-review` built-in + reviewer skill + loop-specific E2E — after the handoff-first R2b release |
 
 #### R1 PR ledger
@@ -150,7 +154,7 @@ touch B1's files); #733 must merge before B3 starts. Docs: `workflows.md` (CLI p
 | 1 | **C2** start sheet + entry points (capsule popover, palette, Active Agents) | 063 | B3 | GUI-initiated runs |
 | 2 | **D1** `prowl-workflow` authoring skill (shipped early in #754; skills embedding from 065), `docs/components/workflows.md`, Settings › Workflows page, CLI reachability status (deferred from C0) | 063 | B1, C2, 065-K1 | custom workflows, agent-assisted authoring |
 | 3 | **#726 T1** headless contract tests against the real tier-A binaries through the production renderers/decoder (`make test-agent-contracts`, passing runs update T0) | 064 | #726 T0, S3 wave 1 | hook contracts fail loudly on binary drift before D3's E2E leans on them |
-| 4 | **D3** `prowl.handoff` + `prowl.handoff-checkpoint`, native actions, legacy retirement, docs/skill migration, and Debug E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | handoff is the first built-in workflow; assess R2b release after acceptance |
+| 4 | **D3** additive `prowl.handoff`, save action, optional receiver, docs/skill updates, and Debug E2E | 063 | A2, C2, D1, S3 wave 1, #733, #726 T1 | handoff is the first built-in workflow; assess R2b release after acceptance |
 
 The owner revised the order on 2026-09-05: handoff is simpler than adversarial review and
 will provide the first built-in workflow validation. Keep slice IDs stable (D3 remains handoff,

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -591,6 +591,21 @@ run="$(prowl workflow run review --role reviewer=Codex --input max_rounds=3 --js
 printf '%s\n' "$run" | jq -r '.data.self_initiated.line'      # what to do now, when this pane is the current role
 prowl workflow status --json | jq '.data.activation'           # what this pane owes, and how to deliver it
 PROWL_WORKFLOW_TOKEN=… prowl workflow deliver - <<'EOF'
+### Built-in handoff workflow
+
+`prowl workflow run prowl.handoff --role receiver=Codex --json` asks the calling agent for
+a briefing, saves a durable packet, and launches the selected Profile in a background tab.
+Use `--input next=save` to save only; no receiver binding or installed receiver Profile is
+required. Launch roles proven unused by start inputs or skipped steps are not bound. Roles
+in runtime-dependent branches remain required. The existing `prowl handoff` commands remain
+available.
+
+For self-initiated runs, follow `data.self_initiated.line` and its exact delivery command.
+Inspect `actions.save.output.path` in the run's action results for the saved packet.
+Workflow completion confirms saving and optional launch, not completion of the receiver's
+continued task. See [Built-in Handoff](workflows.md#built-in-handoff).
+
+
 ## Scope
 …
 EOF

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -591,21 +591,6 @@ run="$(prowl workflow run review --role reviewer=Codex --input max_rounds=3 --js
 printf '%s\n' "$run" | jq -r '.data.self_initiated.line'      # what to do now, when this pane is the current role
 prowl workflow status --json | jq '.data.activation'           # what this pane owes, and how to deliver it
 PROWL_WORKFLOW_TOKEN=… prowl workflow deliver - <<'EOF'
-### Built-in handoff workflow
-
-`prowl workflow run prowl.handoff --role receiver=Codex --json` asks the calling agent for
-a briefing, saves a durable packet, and launches the selected Profile in a background tab.
-Use `--input next=save` to save only; no receiver binding or installed receiver Profile is
-required. Launch roles proven unused by start inputs or skipped steps are not bound. Roles
-in runtime-dependent branches remain required. The existing `prowl handoff` commands remain
-available.
-
-For self-initiated runs, follow `data.self_initiated.line` and its exact delivery command.
-Inspect `actions.save.output.path` in the run's action results for the saved packet.
-Workflow completion confirms saving and optional launch, not completion of the receiver's
-continued task. See [Built-in Handoff](workflows.md#built-in-handoff).
-
-
 ## Scope
 …
 EOF
@@ -626,6 +611,20 @@ It uses the same worktree, fixed bundle copy, process limits, cancellation, and 
 as a workflow run. Poll the returned run ID with `workflow status` and inspect its run directory.
 
 `validate` accepts the bundle directory, not its `workflow.yaml`. Loose YAML files are not workflow bundles. See [Workflows](workflows.md#script-actions-and-bundles) for approval and results.
+
+### Built-in handoff workflow
+
+`prowl workflow run prowl.handoff --role receiver=Codex --json` asks the calling agent for
+a briefing, saves a durable packet, and launches the selected Profile in a background tab.
+Use `--input next=save` to save only; no receiver binding or installed receiver Profile is
+required. Launch roles proven unused by start inputs or skipped steps are not bound. Roles
+in runtime-dependent branches remain required. The existing `prowl handoff` commands remain
+available.
+
+For self-initiated runs, follow `data.self_initiated.line` and its exact delivery command.
+Inspect `actions.save.output.path` in the run's action results for the saved packet.
+Workflow completion confirms saving and optional launch, not completion of the receiver's
+continued task. See [Built-in Handoff](workflows.md#built-in-handoff).
 
 ### `prowl read [target]`
 Read a pane's content.

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -622,7 +622,9 @@ in runtime-dependent branches remain required. The existing `prowl handoff` comm
 available.
 
 For self-initiated runs, follow `data.self_initiated.line` and its exact delivery command.
-Inspect `actions.save.output.path` in the run's action results for the saved packet.
+The workflow expression `actions.save.output.path` names the saved packet. For CLI inspection,
+read `actions/save/<execution UUID>/result.json` under the reported `run_directory`; its
+`path` field is the packet path.
 Workflow completion confirms saving and optional launch, not completion of the receiver's
 continued task. See [Built-in Handoff](workflows.md#built-in-handoff).
 

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -615,7 +615,7 @@ as a workflow run. Poll the returned run ID with `workflow status` and inspect i
 ### Built-in handoff workflow
 
 `prowl workflow run prowl.handoff --role receiver=Codex --json` asks the calling agent for
-a briefing, saves a durable packet, and launches the selected Profile in a background tab.
+a briefing, saves a durable packet, and launches the selected Profile in a new tab with focus.
 Use `--input next=save` to save only; no receiver binding or installed receiver Profile is
 required. Launch roles proven unused by start inputs or skipped steps are not bound. Roles
 in runtime-dependent branches remain required. The existing `prowl handoff` commands remain

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -36,7 +36,7 @@ shared root — but works for any runnable target.
 
 ## The transition
 
-Every handoff runs one pure sequence, no matter which entry point started it:
+The legacy HUD and `prowl handoff` CLI share this transition sequence:
 
 ```text
 collect briefing → archive outgoing state → install fresh current.md

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -11,6 +11,16 @@
 
 **Related:** [workspaces](workspaces.md) · [cli](cli.md) · [agent-detection](agent-detection.md) · [command-palette](command-palette.md)
 
+## Workflow entry point
+
+The built-in `prowl.handoff` adds an agent-authored workflow entry point alongside the
+existing HUD and commands described below. It asks the current agent for a briefing,
+saves it with generated context, then launches a receiving Profile unless `next=save`.
+The receiver reads an independent packet in `archive/workflow-<run UUID>.md`, so later
+handoffs cannot replace its instructions. Workflow history cleanup does not delete these
+handoff packets. See [Built-in Handoff](workflows.md#built-in-handoff) for commands and
+completion semantics. The legacy transition sequence below is unchanged.
+
 ## Why
 
 Coding agents are independent processes; each keeps its own conversation

--- a/docs/components/workflows.md
+++ b/docs/components/workflows.md
@@ -57,7 +57,7 @@ Three sources, later ones winning for the same `id`:
 
 | Source | Location | Notes |
 |---|---|---|
-| Built-in | `Prowl.app/Contents/Resources/workflows/` | ids `prowl.*` are reserved for it. Includes Repository Context (`builtin:collect-worktree-context`). |
+| Built-in | `Prowl.app/Contents/Resources/workflows/` | ids `prowl.*` are reserved for it. Includes Repository Context and Handoff (`prowl.handoff`). |
 | Your workflows | `~/.prowl/workflows/*.pwlworkflow` | personal; not tied to a repository |
 | Repository | `<repo root>/.prowl/workflows/*.pwlworkflow` | travels with the repo; seen only from that repository's worktrees |
 
@@ -236,11 +236,11 @@ is not listening on its socket. The same status appears under Settings → Agent
 ## Script actions and bundles
 
 Local actions live under `actions/<id>/action.yaml` in a `.pwlworkflow` bundle, with scripts,
-helpers, and assets beside them. Steps reference `local:<id>` or `builtin:collect-worktree-context`.
+helpers, and assets beside them. Steps reference `local:<id>` or a registered `builtin:<id>`.
 Action inputs and results are typed JSON; validated results appear at
 `actions.<step>.output` and `actions.<step>.output_path`. The built-in repository context
-writes per-invocation artifacts, not shared handoff files. Legacy `prowl handoff` remains a
-separate CLI feature. These actions are also distinct from shell-command Custom Actions.
+writes per-invocation artifacts. `builtin:save-handoff` saves a briefing and generated context
+under `.prowl/handoff/`. The existing `prowl handoff` CLI remains available. These actions are also distinct from shell-command Custom Actions.
 
 Scripts have your local user permissions. In Settings > Agents > Workflows, open the bundle's
 script review, inspect the source location, interpreter, entrypoint, and changed files, then
@@ -306,3 +306,27 @@ metadata. History scans check the record's file identity without decoding its
 contents. Missing metadata or a changed record protects the run from cleanup and
 export until it can be inspected. Record replacement invalidates the old metadata
 before publishing the new pair. No old-history migration or fallback is performed.
+
+## Built-in Handoff
+
+`prowl.handoff` asks the current agent to summarize its task, saves the briefing with
+repository and available session context, and optionally launches a receiver in a background
+tab. Select `next=save` to save only; the receiver Profile is then unnecessary and hidden in
+the start sheet. The default `next=launch` uses the normal Profile picker without a runtime
+restriction. Both source and receiver panes stay open.
+
+```bash
+prowl workflow run prowl.handoff --role receiver=Codex --json
+prowl workflow run prowl.handoff --input next=save --json
+```
+
+When an agent starts the workflow itself, it must follow `self_initiated.line` in the response
+and deliver its briefing with the supplied token. The run saves nothing until that delivery
+passes its required sections. The receiver reads an independent packet under
+`.prowl/handoff/archive/workflow-<run UUID>.md`; later handoffs do not change that packet.
+`current.md` and `context.md` retain the latest handoff for the existing HUD and CLI.
+
+A completed workflow means the packet was saved and the selected receiver was launched.
+It does not certify that the receiver finished the task. A failed launch keeps the packet;
+retry the failed step or use the packet manually. Cancelling keeps saved material and panes.
+See [Handoff](handoff.md) for storage and session context details.

--- a/docs/components/workflows.md
+++ b/docs/components/workflows.md
@@ -310,10 +310,16 @@ before publishing the new pair. No old-history migration or fallback is performe
 ## Built-in Handoff
 
 `prowl.handoff` asks the current agent to summarize its task, saves the briefing with
-repository and available session context, and optionally launches a receiver in a background
-tab. Select `next=save` to save only; the receiver Profile is then unnecessary and hidden in
-the start sheet. The default `next=launch` uses the normal Profile picker without a runtime
+repository and available session context, and optionally launches a receiver in a new tab
+and switches focus to it. Select `next=save` to save only; the receiver Profile is then
+unnecessary and hidden in the start sheet. The default `next=launch` uses the normal Profile picker without a runtime
 restriction. Both source and receiver panes stay open.
+
+Both modes require a source pane with a detected agent to write the briefing. A selected bare
+shell cannot start the run; choose another agent pane in the same worktree. With no available
+agent pane, start an agent first. The workflow does not create its own author. CLI admission
+returns `AGENT_NOT_FOUND` for a bare shell or `SOURCE_REQUIRED` for a missing source pane,
+before saving or launching anything.
 
 ```bash
 prowl workflow run prowl.handoff --role receiver=Codex --json

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -310,6 +310,11 @@ printf '%s\n' "$result" | jq '.data.observation, .data.screen'
 
 ## Handing Off Your Task
 
+The built-in `prowl.handoff` workflow is also available: it requests a briefing and saves
+context before optionally launching a receiver. See the `prowl-workflow` skill for that
+flow. The direct commands below remain available.
+
+
 `prowl handoff to <agent> --brief -` hands your task to another agent. Run it from your own pane (the calling pane is the source — no selector needed) and pipe your briefing on stdin. Prowl finds the calling pane through process ancestry, so any descendant of the pane's shell (an agent, its tool shell) works; under tmux/screen or a detached wrapper that resolution fails with `SOURCE_REQUIRED`, and in exactly those setups `$PROWL_PANE_ID` is not trustworthy either (it names the pane the tmux server started in, which may still exist) — identify your pane by other means (`prowl agents --json`, a unique `pane.cwd`) and pass it with `--pane` explicitly.
 
 ```bash

--- a/skills/prowl-workflow/SKILL.md
+++ b/skills/prowl-workflow/SKILL.md
@@ -56,6 +56,15 @@ steps, and output contracts the task needs; add loops, deadlines, and automatic 
 only when their behavior serves the requested outcome. The authoring reference explains
 data dependencies, loop exits, and typed state and result scopes.
 
+## Built-in handoff
+
+Use `prowl workflow run prowl.handoff --role receiver=<Profile> --json` to prepare and save
+this conversation's task context, then start a receiver. Use `--input next=save` instead to
+save without a receiver. Follow the returned `self_initiated.line` and deliver the briefing
+with its exact command; do not wait for Prowl to message you again. The receiver reads the
+saved packet and continues the task. A completed run confirms save/launch, not task completion.
+The existing `prowl handoff` CLI and HUD remain available.
+
 ## Running a workflow
 
 ```bash

--- a/skills/prowl-workflow/SKILL.md
+++ b/skills/prowl-workflow/SKILL.md
@@ -59,7 +59,8 @@ data dependencies, loop exits, and typed state and result scopes.
 ## Built-in handoff
 
 Use `prowl workflow run prowl.handoff --role receiver=<Profile> --json` to prepare and save
-this conversation's task context, then start a receiver. Use `--input next=save` instead to
+this conversation's task context, then start and focus a receiver in a new tab. Both modes
+require a source pane with a detected agent. Use `--input next=save` instead to
 save without a receiver. Follow the returned `self_initiated.line` and deliver the briefing
 with its exact command; do not wait for Prowl to message you again. The receiver reads the
 saved packet and continues the task. A completed run confirms save/launch, not task completion.

--- a/skills/prowl-workflow/references/actions.md
+++ b/skills/prowl-workflow/references/actions.md
@@ -159,3 +159,17 @@ worktree-oriented name describes the workflow target; multi-repository workspace
 plain-directory collection are future work. `builtin:collect-agent-context` is planned,
 not registered. Use verb-first kebab-case names for local actions, such as
 `local:write-report`; the runner does not infer behavior or permissions from the name.
+
+## Save handoff
+
+`builtin:save-handoff` takes a required `briefing` path to a UTF-8 briefing file within the
+current run directory, normally `{{ deliveries.briefing.path }}`. It validates the briefing
+before updating shared handoff state. It supports the existing handoff storage targets:
+Git worktrees, workspaces, and plain directories. Available source session context is included.
+
+The action returns `output.path` (an independent briefing/context packet),
+`output.current_path`, and `output.context_path`. Packets live under
+`.prowl/handoff/archive/` and survive workflow history cleanup. The action never launches an
+agent. The built-in `prowl.handoff` combines this action with a current-agent briefing and
+an optional receiver launch. Retrying a save creates a new packet and may archive shared
+state again; cancellation does not roll back completed writes.

--- a/supacode/CLIService/Shared/WorkflowActionRegistry.swift
+++ b/supacode/CLIService/Shared/WorkflowActionRegistry.swift
@@ -94,7 +94,20 @@ nonisolated public enum WorkflowActionRegistry {
       outputs: [
         WorkflowActionOutput(name: "output", description: "JSON object containing path and branch"),
         WorkflowActionOutput(name: "output_path", description: "Path to this invocation's result.json"),
-      ])
+      ]),
+    WorkflowActionSchema(
+      id: "builtin:save-handoff",
+      description: "Save a validated briefing and generated context, with an immutable handoff packet.",
+      inputs: [
+        WorkflowActionInput(
+          name: "briefing", required: true, kind: .path,
+          description: "UTF-8 briefing file in this workflow run, with Objective, Current State, and Next Steps")
+      ],
+      outputs: [
+        WorkflowActionOutput(
+          name: "output", description: "JSON object containing path, current_path, and context_path"),
+        WorkflowActionOutput(name: "output_path", description: "Path to this invocation's result.json"),
+      ]),
   ]
 
   public static func schema(for id: String, in actions: [WorkflowActionSchema] = all) -> WorkflowActionSchema? {

--- a/supacode/CLIService/Shared/WorkflowRoleRequirements.swift
+++ b/supacode/CLIService/Shared/WorkflowRoleRequirements.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Launch roles required by the start inputs. Runtime-dependent branches remain eligible.
+nonisolated public enum WorkflowRoleRequirements {
+  public static func launchRoles(
+    in definition: WorkflowDefinition, inputs: [String: String], skipped: Set<String> = []
+  ) -> Set<String> {
+    let launchNames = Set(definition.roles.filter { $0.source == .launch }.map(\.name))
+    var values: [String: WorkflowJSONValue] = [:]
+    for input in definition.inputs {
+      guard let value = inputs[input.name] ?? input.defaultValue?.stringValue else { continue }
+      values[input.name] = input.type == .integer ? Int(value).map(WorkflowJSONValue.integer) : .string(value)
+    }
+    var required: Set<String> = []
+
+    func expression(_ source: String) -> WorkflowExpressionNode? {
+      var parser = try? WorkflowExpressionParser(source)
+      return try? parser?.parse()
+    }
+    func recordReferences(_ node: WorkflowExpressionNode) {
+      for path in node.references where path.first == "context" {
+        if path.count == 1 || (path.count == 2 && path[1] == "roles") {
+          required.formUnion(launchNames)
+        } else if path.count > 2, path[1] == "roles" {
+          required.insert(path[2])
+        }
+      }
+    }
+    func inputCondition(_ source: String) -> Bool? {
+      guard let node = expression(source) else { return nil }
+      recordReferences(node)
+      guard node.references.allSatisfy({ $0.first == "inputs" }),
+        case .boolean(let result) = try? node.evaluate(["inputs": .object(values)])
+      else { return nil }
+      return result
+    }
+    func templates(_ text: String) {
+      var remaining = text[...]
+      while let start = remaining.range(of: "{{") {
+        remaining = remaining[start.upperBound...]
+        guard let end = remaining.range(of: "}}") else { return }
+        if let node = expression(String(remaining[..<end.lowerBound])) { recordReferences(node) }
+        remaining = remaining[end.upperBound...]
+      }
+    }
+    func json(_ value: WorkflowJSONValue) {
+      switch value {
+      case .string(let text): templates(text)
+      case .array(let values): values.forEach(json)
+      case .object(let values): values.values.forEach(json)
+      default: break
+      }
+    }
+    func actionInputs(_ id: String, _ inputs: [String: WorkflowJSONValue]) {
+      inputs.values.forEach(json)
+      for input in WorkflowActionRegistry.schema(for: id)?.inputs ?? [] where input.kind == .role {
+        if case .string(let role) = inputs[input.name] { required.insert(role) }
+      }
+    }
+    func visit(_ steps: [WorkflowStepDefinition]) {
+      for step in steps where !skipped.contains(step.id) {
+        if let title = step.title { templates(title) }
+        switch step.action {
+        case .launch(let role, let prompt, _, _):
+          required.insert(role)
+          templates(prompt)
+        case .message(let role, let content, _):
+          required.insert(role)
+          templates(content.body)
+        case .close(let role): required.insert(role)
+        case .notify(let text): templates(text)
+        case .action(let id, let inputs):
+          actionInputs(id, inputs)
+        case .control(.conditional(let condition, let thenSteps, let elseSteps)):
+          if let result = inputCondition(condition) {
+            visit(result ? thenSteps : elseSteps)
+          } else {
+            visit(thenSteps)
+            visit(elseSteps)
+          }
+        case .control(.loop(let condition, _, let body)):
+          if inputCondition(condition) != false { visit(body) }
+        case .control(.set(let fields)):
+          for source in fields.values {
+            if let node = expression(source) { recordReferences(node) }
+          }
+        case .control(.breakLoop), .control(.continueLoop): break
+        }
+      }
+    }
+    visit(definition.steps)
+    return required.intersection(launchNames)
+  }
+}

--- a/supacode/CLIService/WorkflowRunAdmission.swift
+++ b/supacode/CLIService/WorkflowRunAdmission.swift
@@ -132,7 +132,7 @@ enum WorkflowRunAdmission {
     }
     if let actionID = input.testAction {
       let localID = actionID.hasPrefix("local:") ? String(actionID.dropFirst(6)) : ""
-      guard actionID == "builtin:collect-worktree-context" || entry.file.actions[localID] != nil else {
+      guard WorkflowActionRegistry.schema(for: actionID) != nil || entry.file.actions[localID] != nil else {
         return .failure(.init(code: CLIErrorCode.invalidArgument, message: "Unknown bundle action '\(actionID)'."))
       }
       definition = WorkflowDefinition(
@@ -174,7 +174,9 @@ enum WorkflowRunAdmission {
       overrides: arguments.overrides,
       scope: runScope(entry.file.scope, worktree: worktree),
       deliversToCurrent: deliversToCurrentRole(definition, skipped: arguments.skipped))
-    for role in definition.roles {
+    let launchRoles = WorkflowRoleRequirements.launchRoles(
+      in: definition, inputs: arguments.inputs, skipped: arguments.skipped)
+    for role in definition.roles where role.source != .launch || launchRoles.contains(role.name) {
       if let failure = binder.bind(role) {
         return .failure(failure)
       }

--- a/supacode/Domain/Workflow/WorkflowHandoffAction.swift
+++ b/supacode/Domain/Workflow/WorkflowHandoffAction.swift
@@ -1,0 +1,66 @@
+import Foundation
+import ProwlCLIShared
+
+nonisolated enum WorkflowHandoffAction {
+  static func save(inputs: [String: WorkflowJSONValue], context: WorkflowActionContext) async throws
+    -> WorkflowJSONValue
+  {
+    guard Set(inputs.keys) == ["briefing"], case .string(let path) = inputs["briefing"] else {
+      throw WorkflowActionError.missingInput("briefing")
+    }
+    let runDirectory =
+      context.runDirectory
+      ?? WorkflowRunPaths.runDirectory(root: context.rootURL, runID: context.runID)
+    let source = URL(filePath: path).standardizedFileURL
+    let canonicalRun = WorkflowHistoryStorage.canonicalURL(runDirectory)
+    let canonicalSource = WorkflowHistoryStorage.canonicalURL(source)
+    guard canonicalSource.path.hasPrefix(canonicalRun.path + "/"),
+      try FileManager.default.attributesOfItem(atPath: source.path)[.type] as? FileAttributeType == .typeRegular
+    else { throw WorkflowActionError.unsafePath(path) }
+    let handle = try FileHandle(forReadingFrom: source)
+    defer { try? handle.close() }
+    let data = try handle.read(upToCount: WorkflowSizeLimits.payload + 1) ?? Data()
+    guard data.count <= WorkflowSizeLimits.payload, let text = String(data: data, encoding: .utf8),
+      let briefing = HandoffStore.validatedBriefing(from: text)
+    else { throw WorkflowActionError.invalidBriefing(path: path) }
+
+    let store = HandoffStore(rootURL: context.rootURL)
+    try validateDestinations(store)
+    try Task.checkCancellation()
+    let result = try await HandoffCoordinator(store: store).makeCheckpoint(
+      outgoingAgent: context.outgoingAgent, sessionContext: context.sessionContext,
+      note: "workflow=\(context.runID.uuidString)", briefingSource: .inline(briefing), now: context.now)
+    // Build this packet from this save's values, not the shared current/context files:
+    // another handoff may already have replaced those while the receiver is starting.
+    let appendix = store.buildAppendix(
+      outgoingAgent: context.outgoingAgent, sessionContext: result.save.sessionContext,
+      repos: result.save.repos, changedFiles: result.save.changedFiles, now: context.now)
+    let packet = try HandoffStore.reserveFileURL(
+      in: store.archiveDirectory, stem: "workflow-\(context.runID.uuidString)", fileExtension: "md")
+    try (briefing + "\n" + appendix + "\n").write(to: packet, atomically: true, encoding: .utf8)
+    return .object([
+      "path": .string(packet.path), "current_path": .string(store.currentURL.path),
+      "context_path": .string(store.contextURL.path),
+    ])
+  }
+
+  private static func validateDestinations(_ store: HandoffStore) throws {
+    for directory in [
+      store.rootURL.appending(path: ".prowl"), store.handoffDirectory,
+      store.archiveDirectory, store.sessionDirectory,
+    ] {
+      if let attributes = try? FileManager.default.attributesOfItem(atPath: directory.path),
+        attributes[.type] as? FileAttributeType != .typeDirectory
+      {
+        throw WorkflowActionError.unsafePath(directory.path)
+      }
+    }
+    for file in [store.currentURL, store.contextURL, store.logURL, store.ignoreURL] {
+      if let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
+        attributes[.type] as? FileAttributeType != .typeRegular
+      {
+        throw WorkflowActionError.unsafePath(file.path)
+      }
+    }
+  }
+}

--- a/supacode/Domain/Workflow/WorkflowNativeActions.swift
+++ b/supacode/Domain/Workflow/WorkflowNativeActions.swift
@@ -99,6 +99,8 @@ nonisolated struct WorkflowNativeActionRunner: WorkflowActionExecuting {
         try WorkflowActionRegistry.worktreeContextInput.validate(.object(inputs))
         output = try await collectWorktreeContext(inputs: inputs, context: context, artifacts: artifacts)
         try WorkflowActionRegistry.worktreeContextOutput.validate(output)
+      } else if actionID == "builtin:save-handoff" {
+        output = try await WorkflowHandoffAction.save(inputs: inputs, context: context)
       } else {
         output = try await script(actionID: actionID, inputs: inputs, context: context, request: requestData)
       }

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -211,7 +211,9 @@ nonisolated struct WorkflowRunMachine {
     guard WorkflowRenderedText.isSingleLine(context.worktree.path) else {
       throw .unsafePath(context.worktree.path)
     }
-    for role in definition.roles where bindings[role.name] == nil {
+    let launchRoles = WorkflowRoleRequirements.launchRoles(in: definition, inputs: inputs, skipped: skippedSteps)
+    for role in definition.roles
+    where bindings[role.name] == nil && (role.source != .launch || launchRoles.contains(role.name)) {
       throw .missingBinding(role: role.name)
     }
     let startedAt = now()

--- a/supacode/Features/Workflow/Models/WorkflowStartContext.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStartContext.swift
@@ -166,7 +166,10 @@ nonisolated struct WorkflowStartContext: Equatable, Sendable {
     guard !requiresBundleApproval, item.isRunnable, cliInstalled, cliServiceFailure == nil, pickRoles.isEmpty else {
       return false
     }
-    guard launchRoles.allSatisfy({ $0.effectiveBind == .auto && $0.resolvedProfileID != nil })
+    let required = WorkflowRoleRequirements.launchRoles(in: definition, inputs: [:])
+    guard
+      launchRoles.filter({ required.contains($0.name) })
+        .allSatisfy({ $0.effectiveBind == .auto && $0.resolvedProfileID != nil })
     else { return false }
     guard definition.inputs.allSatisfy({ $0.defaultValue != nil }) else { return false }
     guard let source else { return true }

--- a/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
@@ -115,6 +115,7 @@ struct WorkflowRunsFeature {
     case notice(WorkflowRunNotice)
   }
 
+  @Dependency(TerminalClient.self) var terminal
   @Dependency(WorkflowHistoryStorageKey.self) var historyStorage
   @Dependency(WorkflowRuntimeClient.self) var runtime
   @Dependency(WorkflowActivationClient.self) var activation
@@ -539,9 +540,17 @@ struct WorkflowRunsFeature {
   ) -> Effect<Action> {
     let run = session.run
     let timestamp = now
+    let sourcePane = run.context.sourcePaneID ?? run.bindings.values.first { $0.source == .current }?.pane?.surfaceID
+    let sourceContext =
+      actionID == "builtin:save-handoff"
+      ? sourcePane.flatMap {
+        terminal.handoffSourceContextForSurface(session.worktree.id, $0)?.sessionContext
+      } : nil
     let context = WorkflowActionContext(
       runID: run.id, rootURL: run.context.worktree.rootURL,
-      roleAgents: run.bindings.mapValues { $0.agent }, outgoingAgent: nil, now: timestamp,
+      roleAgents: run.bindings.mapValues { $0.agent },
+      outgoingAgent: sourceContext?.agent ?? run.bindings.values.first { $0.source == .current }?.agent,
+      sessionContext: sourceContext, now: timestamp,
       stepID: stepID, executionID: executionID, attempt: run.actionAttempts[stepID] ?? 1,
       bundle: run.context.bundle, values: run.stepValues, runDirectory: run.runDirectory)
     run.context.occupancy?.beginActivity()

--- a/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowStartFeature.swift
@@ -85,6 +85,12 @@ struct WorkflowStartFeature {
         alreadySkipped: skippedSteps.subtracting([stepID]))
     }
 
+    var requiredLaunchRoles: [WorkflowStartLaunchRole] {
+      let names = WorkflowRoleRequirements.launchRoles(
+        in: context.definition, inputs: inputValues, skipped: skippedSteps)
+      return context.launchRoles.filter { names.contains($0.name) }
+    }
+
     var canRun: Bool {
       guard !requiresBundleApproval, !isSubmitting, cliInstalled, context.cliServiceFailure == nil,
         context.item.isRunnable
@@ -97,7 +103,7 @@ struct WorkflowStartFeature {
         else { return false }
         if sourceRequiresAgent, candidate.agentToken == nil { return false }
       }
-      for role in context.launchRoles {
+      for role in requiredLaunchRoles {
         guard let chosen = launchSelections[role.name],
           let candidate = candidates(for: role).first(where: { $0.profileID == chosen }),
           candidate.unavailableReason == nil
@@ -124,7 +130,7 @@ struct WorkflowStartFeature {
         workflowID: context.item.workflowID,
         worktreeID: context.worktreeID,
         sourceSurfaceID: context.source != nil ? selectedSourceSurfaceID : nil,
-        roleBindings: context.launchRoles.compactMap { role in
+        roleBindings: requiredLaunchRoles.compactMap { role in
           launchSelections[role.name].map { "\(role.name)=\($0.uuidString)" }
         }
           + context.pickRoles.compactMap { role in

--- a/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStartOverlayView.swift
@@ -67,7 +67,7 @@ private struct WorkflowStartCard: View {
           if let source = store.context.source {
             sourceSection(source)
           }
-          ForEach(store.context.launchRoles) { role in
+          ForEach(store.requiredLaunchRoles) { role in
             launchRoleSection(role)
           }
           ForEach(store.context.pickRoles) { role in
@@ -410,7 +410,7 @@ private struct WorkflowStartCard: View {
 extension WorkflowStartFeature.State {
   /// The toggle appears exactly when a launch role would ask again next time (011 decision 5).
   var showsDontAskAgain: Bool {
-    context.launchRoles.contains { $0.effectiveBind == .ask } || dontAskAgain
+    requiredLaunchRoles.contains { $0.effectiveBind == .ask } || dontAskAgain
   }
 
   var selectedSourceIsBareShell: Bool {

--- a/supacodeTests/WorkflowNativeActionsTests.swift
+++ b/supacodeTests/WorkflowNativeActionsTests.swift
@@ -45,6 +45,65 @@ struct WorkflowNativeActionsTests {
       now: Self.now)
   }
 
+  @Test(arguments: [true, false])
+  func handoffSavesAnImmutablePacketAndPreservesThePreviousBriefing(git: Bool) async throws {
+    let root = try makeRepo()
+    if !git { try FileManager.default.removeItem(at: root.appending(path: ".git")) }
+    defer { try? FileManager.default.removeItem(at: root) }
+    let invocation = context(root: root)
+    let runDirectory = invocation.directory.deletingLastPathComponent().deletingLastPathComponent()
+      .deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+    let briefing = "# Handoff\n## Objective\nFinish task.\n## Current State\nReady.\n## Next Steps\nVerify receipt.\n"
+    let source = runDirectory.appending(path: "briefing.md")
+    try briefing.write(to: source, atomically: true, encoding: .utf8)
+    let store = HandoffStore(rootURL: root)
+    try store.writeBriefing("Previous briefing", archivingPrevious: false, now: Self.now)
+
+    let result = try await WorkflowNativeActionRunner().execute(
+      actionID: "builtin:save-handoff", inputs: ["briefing": .string(source.path)], context: invocation)
+    guard case .object(let output) = result["output"], case .string(let path) = output["path"] else {
+      Issue.record("Missing handoff packet")
+      return
+    }
+    let packet = try String(contentsOf: URL(filePath: path), encoding: .utf8)
+    #expect(packet.contains("Finish task."))
+    #expect(packet.contains("# Handoff Context"))
+    #expect(path.hasPrefix(store.archiveDirectory.path + "/"))
+    #expect(try String(contentsOf: store.currentURL, encoding: .utf8).contains("Finish task."))
+    let archives = try FileManager.default.contentsOfDirectory(
+      at: store.archiveDirectory, includingPropertiesForKeys: nil)
+    #expect(try archives.contains { try String(contentsOf: $0, encoding: .utf8).contains("Previous briefing") })
+    try store.writeBriefing("Later briefing", archivingPrevious: true, now: Self.now)
+    #expect(try String(contentsOf: URL(filePath: path), encoding: .utf8) == packet)
+  }
+
+  @Test(arguments: ["outside", "invalid", "symlink"])
+  func handoffRejectsUnsafeBriefingsBeforeWritingSharedState(kind: String) async throws {
+    let root = try makeRepo()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let invocation = context(root: root)
+    let runDirectory = WorkflowRunPaths.runDirectory(root: root, runID: invocation.runID)
+    try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+    let source = (kind == "outside" ? root : runDirectory).appending(path: "briefing.md")
+    let briefing = "# Handoff\n## Objective\nFinish.\n## Current State\nReady.\n## Next Steps\nVerify."
+    try (kind == "invalid" ? "" : briefing).write(to: source, atomically: true, encoding: .utf8)
+    let handoff = root.appending(path: ".prowl/handoff")
+    let external = root.appending(path: "external")
+    if kind == "symlink" {
+      try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(
+        at: handoff.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try FileManager.default.createSymbolicLink(at: handoff, withDestinationURL: external)
+    }
+    await #expect(throws: (any Error).self) {
+      try await WorkflowNativeActionRunner().execute(
+        actionID: "builtin:save-handoff", inputs: ["briefing": .string(source.path)], context: invocation)
+    }
+    #expect(!FileManager.default.fileExists(atPath: handoff.appending(path: "current.md").path))
+    #expect(!FileManager.default.fileExists(atPath: handoff.appending(path: "context.md").path))
+  }
+
   @Test func worktreeContextWritesInvocationArtifactsAndRecords() async throws {
     let root = try makeRepo()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/supacodeTests/WorkflowRunAdmissionTests.swift
+++ b/supacodeTests/WorkflowRunAdmissionTests.swift
@@ -219,6 +219,25 @@ struct WorkflowRunAdmissionTests {
     return nil
   }
 
+  @Test(arguments: ["save", "launch"])
+  func shippedHandoffResolvesOnlyTheSelectedPath(next: String) throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let root = URL(filePath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+    let yaml = try String(
+      contentsOf: root.appending(path: "Resources/workflows/handoff.pwlworkflow/workflow.yaml"), encoding: .utf8
+    )
+    .replacing("id: prowl.handoff", with: "id: handoff")
+    try fixture.write(yaml, to: "handoff")
+    let admitted = try admit(
+      fixture, workflow: "handoff", pane: fixture.authorPane,
+      roles: next == "launch" ? ["receiver=Codex"] : [], inputs: ["next=\(next)"]
+    ).get()
+    #expect(admitted.session.run.selfInitiatedLine?.contains("prowl workflow deliver -") == true)
+    #expect((admitted.session.run.bindings["receiver"] != nil) == (next == "launch"))
+    #expect(fixture.plannedProfiles.isEmpty == (next == "save"))
+  }
+
   @Test func testActionTreatsJSONInputAsLiteralData() throws {
     let fixture = try Fixture()
     defer { fixture.cleanUp() }

--- a/supacodeTests/WorkflowRunsFeatureTests.swift
+++ b/supacodeTests/WorkflowRunsFeatureTests.swift
@@ -233,7 +233,8 @@ struct WorkflowRunsFeatureTests {
   private func makeStore(
     _ fixture: Fixture, queue: WorkflowEffectQueueClient,
     storage: SettingsTestStorage = SettingsTestStorage(),
-    actionExecutor: (any WorkflowActionExecuting)? = nil
+    actionExecutor: (any WorkflowActionExecuting)? = nil,
+    handoffSource: HandoffSourceContext? = nil
   ) -> TestStoreOf<WorkflowRunsFeature> {
     let store = TestStore(initialState: WorkflowRunsFeature.State()) {
       WorkflowRunsFeature()
@@ -241,6 +242,7 @@ struct WorkflowRunsFeatureTests {
       if let actionExecutor {
         $0.workflowActionExecutor = actionExecutor
       }
+      $0[TerminalClient.self].handoffSourceContextForSurface = { _, _ in handoffSource }
       $0.workflowRuntimeClient = fixture.runtime
       $0.workflowActivationClient = fixture.activation
       $0.workflowWatchdogClient = fixture.watchdog
@@ -309,12 +311,14 @@ struct WorkflowRunsFeatureTests {
 
   /// A native action that reports when it started and finishes only once released.
   nonisolated final class GatedActionExecutor: WorkflowActionExecuting, Sendable {
+    let receivedContext = LockIsolated<WorkflowActionContext?>(nil)
     private let startedStream = AsyncStream<Void>.makeStream()
     private let releaseStream = AsyncStream<Void>.makeStream()
 
     func execute(actionID: String, inputs: [String: WorkflowJSONValue], context: WorkflowActionContext) async throws
       -> [String: WorkflowJSONValue]
     {
+      receivedContext.setValue(context)
       startedStream.continuation.yield()
       for await _ in releaseStream.stream { break }
       return ["summary": "done"]
@@ -714,6 +718,27 @@ struct WorkflowRunsFeatureTests {
     #expect(fixture.guardAnswers.isEmpty)
     #expect(store.state.sessions[runID]?.run.phase == .injecting(ordinal: 1))
     await store.send(.userAction(runID: runID, .cancel))
+    await store.finish(timeout: Self.timeout)
+  }
+
+  @Test(.dependencies) func handoffActionCapturesTheSourceSession() async throws {
+    let fixture = try Fixture()
+    defer { fixture.cleanUp() }
+    let gate = GatedActionExecutor()
+    let source = HandoffSourceContext(
+      sessionContext: .init(
+        agent: "pi", sessionID: "handoff-session", paneID: "source-pane", paneTitle: nil, source: "test",
+        confidence: "exact", excerptText: nil), observation: nil)
+    let store = makeStore(fixture, queue: WorkflowEffectQueue().client, actionExecutor: gate, handoffSource: source)
+    let (session, effects) = try fixture.session(
+      Self.actionFirst
+        .replacing("builtin:collect-worktree-context", with: "builtin:save-handoff")
+        .replacing("root:", with: "briefing:"))
+    await store.send(.started(session, effects: effects))
+    await gate.started()
+    #expect(gate.receivedContext.value?.sessionContext?.sessionID == "handoff-session")
+    #expect(gate.receivedContext.value?.outgoingAgent == "pi")
+    gate.release()
     await store.finish(timeout: Self.timeout)
   }
 

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -8,6 +8,21 @@ import Testing
 
 @MainActor
 struct WorkflowStartFeatureTests {
+  @Test func shippedHandoffSaveOnlyNeedsNoReceiverProfile() throws {
+    let root = URL(filePath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+    let yaml = try String(
+      contentsOf: root.appending(path: "Resources/workflows/handoff.pwlworkflow/workflow.yaml"), encoding: .utf8)
+    let context = try makeContext(yaml: yaml, includeCandidates: false)
+    var state = WorkflowStartFeature.State(context: context)
+    #expect(!state.canRun)
+    #expect(state.requiredLaunchRoles.map(\.name) == ["receiver"])
+    state.inputValues["next"] = "save"
+    #expect(state.requiredLaunchRoles.isEmpty)
+    #expect(state.canRun)
+    state.inputValues["next"] = "launch"
+    #expect(!state.canRun)
+  }
+
   static let review = """
     schema: prowl.workflow/v1
     id: review


### PR DESCRIPTION
Add the built-in `prowl.handoff` workflow. The current agent delivers a task briefing, Prowl saves it with repository/session context, and the workflow optionally starts a receiving Profile in a new tab and switches focus to it. The existing handoff HUD and CLI stay available.

- Save an independent packet under `.prowl/handoff/archive/` so later handoffs and workflow history cleanup cannot replace the receiver's instructions.
- Share input-aware launch-role requirements across admission, startup, and the start sheet. Save-only mode does not require a receiver Profile; runtime-dependent branches remain conservative.
- Update component/CLI documentation and the shipped skills.

Validation: relevant app tests, CLI build/smoke/unit/integration, bundle discovery and role tests, `make check`, and `make build-app`. Self-review and two adversarial review rounds completed; one documentation issue was reproduced and fixed. Isolated Debug acceptance passed for the native picker, save-only, self-initiated transfer with verified receiver output, immutable packets, and strict rejection/cancellation. Review and acceptance details are recorded in comments and docs-ai/063-agent-workflows/020-handoff-workflow.md.


Receiver focus was changed to foreground launch at the owner's request after the initial Debug acceptance. Bundle/source-admission/start-sheet tests and local checks/build cover the amendment; the earlier live E2E recorded background behavior.
