### PR TITLE
Accept a session title chip on the Claude composer border

### DIFF
--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -150,3 +150,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-09-05: captured Pi and Codex live footers gained explicit rules, while
   the time-based Working hold was retired in favor of deterministic screen state — see
   [015-deterministic-live-footer-coverage.md](015-deterministic-live-footer-coverage.md)
+- Updated 2026-09-09: Claude Code paints the session title as a chip on the composer's
+  top border; the border predicate rejected it and a working agent read as idle — see
+  [016-claude-titled-composer-border.md](016-claude-titled-composer-border.md)

--- a/docs-ai/030-agent-status-detection/012-claude-screen-profile.md
+++ b/docs-ai/030-agent-status-detection/012-claude-screen-profile.md
@@ -5,6 +5,10 @@
 > row shape instead of `suffix(3)`; the canonical-tail contract and the Debug
 > canonical-tail assert described below no longer apply to Claude.
 
+> Amended by [016-claude-titled-composer-border.md](016-claude-titled-composer-border.md):
+> the composer border may carry a session title chip; the idle composer rule and the
+> live block anchor accept it.
+
 | | |
 | --- | --- |
 | **Status** | Implemented |

--- a/docs-ai/030-agent-status-detection/016-claude-titled-composer-border.md
+++ b/docs-ai/030-agent-status-detection/016-claude-titled-composer-border.md
@@ -1,0 +1,68 @@
+# 016 — Claude composer border with a session title chip
+
+Amends [012-claude-screen-profile.md](012-claude-screen-profile.md) and
+[014-claude-full-screen-live-block.md](014-claude-full-screen-live-block.md): the composer
+border that anchors both the live status block and the `claude.idleComposer` rule is no
+longer required to be rule characters only.
+
+| | |
+| --- | --- |
+| **Status** | Implemented |
+| **Date** | 2026-09-09 |
+| **Branch** | `fix/claude-titled-composer-border` |
+
+## Problem
+
+Claude Code paints a named session's title as a chip on the composer's top border:
+
+```text
+✢ Crafting… (19s · still thinking with xhigh effort)
+  ⎿  Tip: Did you know you can drag and drop image files into your terminal?
+
+──────────────────────────────────── Titled composer border probe ─
+❯
+────────────────────────────────────────────────────────────────────
+```
+
+The chip has existed for named sessions (`/rename`, `--name`, hook-set titles) since
+2.1.129 and was realigned in 2.1.236; the reported 2.1.266 screen carried one with an
+auto-generated-looking title. `isBoxBorderLine` accepted only lines made entirely of
+`─`/`-`, so a titled border was not a border:
+
+- `contentAbovePrompt` found no border and kept the titled row inside the region above
+  the prompt.
+- `liveStatusBlock` walked bottom-up, met that row first, and stopped: it is not live
+  chrome and has no queued `❯` head above it. The live block was empty, so the spinner,
+  elapsed-status, and background-work rules never saw the spinner row.
+- `hasIdleComposer` failed for the same reason, so the screen fell through to
+  `fallback.noRuleMatched` — idle — while the agent was working.
+
+`prowl agents --json` on the live pane reported `idle / fallback.noRuleMatched` for both
+the spinner screen and the empty composer.
+
+## Fix
+
+`isBoxBorderLine` now accepts a run of at least three rule characters followed by an
+optional title chip: a space-led segment that ends with a rule character. A plain rule
+line still matches. Nothing else in the profile changed; the shape-bounded live block and
+the idle composer rule work as before once the border is recognized.
+
+A false positive here costs little: `contentAbovePrompt` uses the *last* border above the
+prompt, which is the composer's own, and `hasIdleComposer` only inspects the rows adjacent
+to the prompt.
+
+## Evidence
+
+Two captures from a scripted probe session on Claude Code 2.1.266 (179×58), titled via
+`/rename`, redacted with `scripts/make-detection-fixture.py`:
+
+- `claude/2.1.266/working/titled-border-spinner.txt` → `working / claude.spinner`
+- `claude/2.1.266/idle/titled-composer.txt` → `idle / claude.idleComposer`
+
+Both failed against the previous detector (working read as idle; idle matched no rule)
+and pass after the change.
+
+## Non-goals
+
+- Reading the title out of the chip. Tab titles already come from the terminal title.
+- Treating chips on other rows as borders; only the composer frame is affected.

--- a/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/ClaudeScreenProfile.swift
@@ -402,8 +402,20 @@ nonisolated private func isClaudeWorkspaceTrustChoiceLine(_ line: String) -> Boo
   return option == "no, exit" || option == "yes, i trust this folder"
 }
 
+// A named session paints its title as a chip on the composer's top border:
+// "──────── Titled composer border probe ─". The rule run before the chip and the
+// single rule character after it are structural; the title is free text. Requiring
+// rule characters only made a titled border invisible, which emptied the live status
+// block above it and reported a working agent as idle.
 nonisolated private func isBoxBorderLine(_ line: String) -> Bool {
   let trimmed = line.trimmingCharacters(in: .whitespaces)
-  guard trimmed.count >= 3 else { return false }
-  return trimmed.allSatisfy { $0 == "─" || $0 == "-" }
+  let rule = trimmed.prefix(while: isBorderRuleCharacter)
+  guard rule.count >= 3 else { return false }
+  let titleChip = trimmed[rule.endIndex...]
+  guard !titleChip.isEmpty else { return true }
+  return titleChip.hasPrefix(" ") && titleChip.last.map(isBorderRuleCharacter) == true
+}
+
+nonisolated private func isBorderRuleCharacter(_ character: Character) -> Bool {
+  character == "─" || character == "-"
 }

--- a/supacodeTests/ClaudeScreenProfileTests.swift
+++ b/supacodeTests/ClaudeScreenProfileTests.swift
@@ -43,6 +43,10 @@ struct ClaudeScreenProfileTests {
       "claude/2.1.226/working/676-wrapped-background-agent-wait.txt": .matched(
         ClaudeScreenProfile.RuleID.backgroundWork
       ),
+      "claude/2.1.266/idle/titled-composer.txt": .matched(ClaudeScreenProfile.RuleID.idleComposer),
+      "claude/2.1.266/working/titled-border-spinner.txt": .matched(
+        ClaudeScreenProfile.RuleID.spinner
+      ),
     ]
     let fixtures = try AgentScreenFixtureCorpus.load().filter { $0.agent == .claude }
 
@@ -52,6 +56,50 @@ struct ClaudeScreenProfileTests {
       #expect(detection.state == fixture.expectedState)
       #expect(detection.reason == expectedReasons[fixture.relativePath])
     }
+  }
+
+  @Test func titledComposerBorderStillFramesTheComposer() {
+    let working = ClaudeScreenProfile.detect(
+      in: AgentScreenSnapshot(
+        text: """
+            ✢ Crafting… (19s · still thinking with xhigh effort)
+              ⎿  Tip: Use /permissions to pre-approve tools
+
+            ──────────────────── Titled composer border probe ─
+            ❯
+            ───────────────────────────────────────────────────
+          """
+      )
+    )
+    #expect(working.state == .working)
+    #expect(working.reason == .matched(ClaudeScreenProfile.RuleID.spinner))
+
+    let idle = ClaudeScreenProfile.detect(
+      in: AgentScreenSnapshot(
+        text: """
+            ⏺ Done.
+
+            ──────────────────── Titled composer border probe ─
+            ❯
+            ───────────────────────────────────────────────────
+          """
+      )
+    )
+    #expect(idle.state == .idle)
+    #expect(idle.reason == .matched(ClaudeScreenProfile.RuleID.idleComposer))
+
+    // A chip without its closing rule character is prose, not a border.
+    let unterminated = ClaudeScreenProfile.detect(
+      in: AgentScreenSnapshot(
+        text: """
+            ✢ Crafting… (19s · still thinking with xhigh effort)
+            ──────────────────── Titled composer border probe
+            ❯
+            ───────────────────────────────────────────────────
+          """
+      )
+    )
+    #expect(unterminated.reason == .noRuleMatched)
   }
 
   @Test func elapsedAndBackgroundWorkHaveDistinctReasons() {

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/idle/titled-composer.metadata.json
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/idle/titled-composer.metadata.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-09-09T04:54:12Z",
+  "cli_version": "2.1.266",
+  "capture_source": "prowl-read-detection",
+  "terminal": {
+    "columns": 179,
+    "rows": 58
+  },
+  "redactions": [
+    "workspace path replaced with /…/prowl-fixture-workspace-live-00001/claude-main",
+    "account plan name replaced with XXX in the banner and status line",
+    "status line context percentage replaced with X%",
+    "status line quota percentages and elapsed windows replaced with X placeholders"
+  ],
+  "issue": null
+}

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/idle/titled-composer.txt
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/idle/titled-composer.txt
@@ -1,0 +1,58 @@
+
+ ▐▛███▛█   Claude Code v2.1.266
+▝▜██████▀  Fable 5.1 with xhigh effort · Claude XXX
+  ▝▝ ▝▝    /…/prowl-fixture-workspace-live-00001/claude-main
+
+
+❯ /rename Titled composer border probe
+  ⎿  Session renamed to: Titled composer border probe
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Titled composer border probe ─
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [Fable 5.1 | XXX       ] ░░░░░░░░░░ X% | claude-main | 1 CLAUDE.md | 2 hooks | ███░░░░░░░ XX% (Xh XXm / 5h) | █░░░░░░░░░ X% (Xd XXh / 7d)
+  ⏸ manual mode on · ← for agents

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/working/titled-border-spinner.metadata.json
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/working/titled-border-spinner.metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-09-09T04:54:12Z",
+  "cli_version": "2.1.266",
+  "capture_source": "prowl-read-detection",
+  "terminal": {
+    "columns": 179,
+    "rows": 58
+  },
+  "redactions": [
+    "workspace path replaced with /…/prowl-fixture-workspace-live-00001/claude-main",
+    "account plan name replaced with XXX in the banner and status line",
+    "model output paragraphs replaced with <MODEL_OUTPUT>",
+    "status line context percentage replaced with X%",
+    "status line quota percentages and elapsed windows replaced with X placeholders"
+  ],
+  "issue": null
+}

--- a/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/working/titled-border-spinner.txt
+++ b/supacodeTests/Fixtures/AgentScreenDetection/claude/2.1.266/working/titled-border-spinner.txt
@@ -1,0 +1,58 @@
+
+ ▐▛███▛█   Claude Code v2.1.266
+▝▜██████▀  Fable 5.1 with xhigh effort · Claude XXX
+  ▝▝ ▝▝    /…/prowl-fixture-workspace-live-00001/claude-main
+
+
+❯ /rename Titled composer border probe
+  ⎿  Session renamed to: Titled composer border probe
+
+❯ Run the shell command sleep 45 and then reply with exactly: probe done
+
+⏺ <MODEL_OUTPUT>
+
+  Ran 1 shell command
+
+⏺ <MODEL_OUTPUT>
+
+  Ran 1 shell command
+
+⏺ <MODEL_OUTPUT>
+
+✻ Churned for 19s · done 1:48 PM
+
+❯ Without using any tools, write a 300-word story about a lighthouse keeper.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+✢ Crafting… (19s · still thinking with xhigh effort)
+  ⎿  Tip: Did you know you can drag and drop image files into your terminal?
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Titled composer border probe ─
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [Fable 5.1 | XXX       ] ░░░░░░░░░░ X% | claude-main | 1 CLAUDE.md | 2 hooks | ███░░░░░░░ XX% (Xh XXm / 5h) | █░░░░░░░░░ X% (Xd XXh / 7d) | ⏱️  <1m
+  ✓ Bash ×2
+  ⏸ manual mode on · ← for agents


### PR DESCRIPTION
## Summary

Prowl reported a working Claude Code pane as idle whenever the session had a title. Claude Code paints the title as a chip on the composer's top border (`──── Titled composer border probe ─`), and `isBoxBorderLine` accepted only lines made entirely of rule characters. With the border unrecognized, the live status block above it came back empty, the spinner row was never evaluated, and the screen fell through to `fallback.noRuleMatched`.

## Change

- `isBoxBorderLine` accepts a run of at least three rule characters followed by an optional space-led title chip that ends with a rule character. Plain borders behave as before.
- Two captured 2.1.266 fixtures (spinner and empty composer behind a titled border) plus an inline profile test. Both fixtures failed against the previous detector.
- docs-ai 030 amendment `016-claude-titled-composer-border.md`, linked from `000-plan.md` and `012`.

## Verification

- `ClaudeScreenProfileTests`, `AgentScreenFixtureCorpusTests`, `AgentScreenRuleCoverageTests`, `ClaudeBackgroundAgentDetectionTests`, `ScreenHeuristicsTests`: red on the new fixtures before the change, all passing after.
- `make check` and `make build-app` pass.
- Live check on the running app before the fix: `prowl agents --json` reported `idle / fallback.noRuleMatched` for the probe pane while its spinner was visible.
