### PR TITLE
Unify workflow prompts and polish execution history

### DIFF
--- a/ProwlCLIContracts/Resources/cli-output-schema.json
+++ b/ProwlCLIContracts/Resources/cli-output-schema.json
@@ -4638,7 +4638,7 @@
         "line": {
           "type": "string"
         },
-        "instruction_path": {
+        "prompt_path": {
           "type": "string"
         },
         "completion": {

--- a/ProwlCLIContracts/Resources/workflow-definition-schema.json
+++ b/ProwlCLIContracts/Resources/workflow-definition-schema.json
@@ -313,7 +313,8 @@
       "additionalProperties": false,
       "required": [
         "id",
-        "message"
+        "message",
+        "prompt"
       ],
       "properties": {
         "id": {
@@ -325,28 +326,13 @@
         "message": {
           "$ref": "#/$defs/slug"
         },
-        "text": {
-          "$ref": "#/$defs/template"
-        },
-        "instruction": {
+        "prompt": {
           "$ref": "#/$defs/template"
         },
         "expect": {
           "$ref": "#/$defs/expect"
         }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "text"
-          ]
-        },
-        {
-          "required": [
-            "instruction"
-          ]
-        }
-      ]
+      }
     },
     "launchStep": {
       "type": "object",

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1365,8 +1365,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       updatedAt: "2026-08-30T01:00:00.000Z",
       finishedAt: nil,
       selfInitiated: WorkflowSelfInitiatedPayload(
-        line: "[Prowl] Read /Projects/App/.prowl/workflow-runs/R/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -",
-        instructionPath: "/Projects/App/.prowl/workflow-runs/R/instructions/brief.1.md",
+        line: "[Prowl] Read /Projects/App/.prowl/workflow-runs/R/prompts/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -",
+        promptPath: "/Projects/App/.prowl/workflow-runs/R/prompts/brief.1.md",
         completion: ["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]))
     let runResponse = try CommandResponse(
       ok: true, command: "workflow", schemaVersion: "prowl.cli.workflow.v1",
@@ -1393,8 +1393,8 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(actionInput.actionInputs, ["count": .integer(3)])
     XCTAssertEqual(actionInput.target, .auto("p3"))
     let runOutput = try jsonObject(from: runResult.stdout)
-    XCTAssertEqual(((runOutput["data"] as? [String: Any])?["self_initiated"] as? [String: Any])?["instruction_path"] as? String,
-      "/Projects/App/.prowl/workflow-runs/R/instructions/brief.1.md")
+    XCTAssertEqual(((runOutput["data"] as? [String: Any])?["self_initiated"] as? [String: Any])?["prompt_path"] as? String,
+      "/Projects/App/.prowl/workflow-runs/R/prompts/brief.1.md")
     let runText = try runWithMockServer(
       socketPath: temporarySocketPath(suffix: "workflow-run-text"), response: runResponse,
       args: ["workflow", "run", "review", "--no-color"]).1

--- a/ProwlCLITests/WorkflowBundleValidatorTests.swift
+++ b/ProwlCLITests/WorkflowBundleValidatorTests.swift
@@ -24,7 +24,7 @@ struct WorkflowBundleValidatorTests {
         then: [{id: strict, launch: helper, prompt: Review strictly.}]
         else: [{id: normal, launch: helper, prompt: Review normally.}]
       """
-    #expect(codes(choice + "\n- id: work\n  message: helper\n  text: Review.", state: header).isEmpty)
+    #expect(codes(choice + "\n- id: work\n  message: helper\n  prompt: Review.", state: header).isEmpty)
     #expect(codes(choice + "\n- id: again\n  launch: helper\n  prompt: Review.", state: header)
       .contains("launch_twice"))
     let partial = """
@@ -32,7 +32,7 @@ struct WorkflowBundleValidatorTests {
         if: 'true'
         then: [{id: strict, launch: helper, prompt: Review strictly.}]
       """
-    #expect(codes(partial + "\n- id: work\n  message: helper\n  text: Review.", state: header)
+    #expect(codes(partial + "\n- id: work\n  message: helper\n  prompt: Review.", state: header)
       .contains("message_before_launch"))
     #expect(codes(partial + "\n- id: again\n  launch: helper\n  prompt: Review.", state: header)
       .contains("launch_twice"))
@@ -136,14 +136,14 @@ struct WorkflowBundleValidatorTests {
     let diagnostics = codes("""
       - id: outer
         message: author
-        text: Write.
+        prompt: Write.
         expect: {delivery: report}
       - id: branch
         if: 'true'
         then:
           - id: inner
             message: author
-            text: Write again.
+            prompt: Write again.
             expect: {delivery: report}
       - id: after
         notify: '{{ deliveries.report.path }}'

--- a/ProwlCLITests/WorkflowContentTests.swift
+++ b/ProwlCLITests/WorkflowContentTests.swift
@@ -21,7 +21,7 @@ struct WorkflowContentTests {
 
   @Test func taskInputsCannotGrantMetadataOrAnotherRolesInstructions() {
     let root = URL(filePath: "/history/run")
-    let paths = [root.appending(path: "run.json").path, root.appending(path: "instructions/private.2.md").path]
+    let paths = [root.appending(path: "run.json").path, root.appending(path: "prompts/private.2.md").path]
     let content = WorkflowTaskContent.make(
       text: paths.joined(separator: " "), task: (UUID(), 1), runDirectory: root, knownPaths: paths, skill: nil)
     #expect(content.resources.isEmpty)

--- a/ProwlCLITests/WorkflowDocumentParserTests.swift
+++ b/ProwlCLITests/WorkflowDocumentParserTests.swift
@@ -7,15 +7,15 @@ final class WorkflowDocumentParserTests: XCTestCase {
 
   func testExpectStrictParsesAndDefaultsToFalse() throws {
     let yaml = WorkflowFixtures.minimal(
-      extraSteps: "  - id: a\n    message: author\n    text: x\n    expect: { delivery: a, strict: true }\n"
-        + "  - id: b\n    message: author\n    text: y\n    expect: { delivery: b }")
+      extraSteps: "  - id: a\n    message: author\n    prompt: x\n    expect: { delivery: a, strict: true }\n"
+        + "  - id: b\n    message: author\n    prompt: y\n    expect: { delivery: b }")
     let workflow = try WorkflowFixtures.parse(yaml)
     XCTAssertEqual(workflow.steps[1].action.expect?.strict, true)
     XCTAssertEqual(workflow.steps[2].action.expect?.strict, false)
     XCTAssertEqual(
       WorkflowFixtures.codes(
         WorkflowFixtures.minimal(
-          extraSteps: "  - id: a\n    message: author\n    text: x\n    expect: { strict: yes please }")),
+          extraSteps: "  - id: a\n    message: author\n    prompt: x\n    expect: { strict: yes please }")),
       ["type_mismatch"])
   }
 
@@ -56,11 +56,11 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertEqual(workflow.steps.map(\.id), ["brief", "launch", "remember", "rounds", "context", "done", "cleanup"])
     XCTAssertEqual(workflow.flattenedSteps.map(\.id), ["brief", "launch", "remember", "rounds", "fix", "rereview", "retain", "context", "done", "cleanup"])
 
-    guard case .message(let role, .instruction(let instruction), let briefExpect) = workflow.steps[0].action else {
+    guard case .message(let role, let prompt, let briefExpect) = workflow.steps[0].action else {
       return XCTFail("brief should be an instruction message")
     }
     XCTAssertEqual(role, "author")
-    XCTAssertTrue(instruction.hasPrefix("Write a short brief"))
+    XCTAssertTrue(prompt.hasPrefix("Write a short brief"))
     XCTAssertEqual(briefExpect?.delivery, "brief")
     XCTAssertEqual(briefExpect?.sections, ["## Scope", "## Claims"])
     XCTAssertEqual(briefExpect?.timeoutSeconds, 600)
@@ -171,11 +171,9 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertEqual(WorkflowFixtures.parseCodes(two), ["step_verb"])
   }
 
-  func testMessageNeedsExactlyOneOfTextOrInstruction() {
-    let neither = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    message: author")
-    XCTAssertEqual(WorkflowFixtures.parseCodes(neither), ["message_content"])
-    let both = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    message: author\n    text: a\n    instruction: b")
-    XCTAssertEqual(WorkflowFixtures.parseCodes(both), ["message_content"])
+  func testMessageRequiresPrompt() {
+    let missing = WorkflowFixtures.minimal(extraSteps: "  - id: b\n    message: author")
+    XCTAssertEqual(WorkflowFixtures.parseCodes(missing), ["missing_key"])
   }
 
   func testExpectIsRejectedOnActionNotifyAndClose() {
@@ -194,10 +192,10 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertNil(WorkflowDocumentParser.parseDuration("10"))
     XCTAssertNil(WorkflowDocumentParser.parseDuration("1d"))
     let badTimeout = WorkflowFixtures.minimal(
-      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 1d }")
+      extraSteps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { timeout: 1d }")
     XCTAssertEqual(WorkflowFixtures.parseCodes(badTimeout), ["timeout_syntax"])
     let orphanPolicy = WorkflowFixtures.minimal(
-      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { on_timeout: skip }")
+      extraSteps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { on_timeout: skip }")
     XCTAssertEqual(WorkflowFixtures.parseCodes(orphanPolicy), ["on_timeout_requires_timeout"])
   }
 
@@ -218,7 +216,7 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertNil(WorkflowDocumentParser.parseDuration("99999999999999999999s"))
     XCTAssertEqual(WorkflowDocumentParser.parseDuration("2562047788015215h"), 2562047788015215 * 3600)
     let overflow = WorkflowFixtures.minimal(
-      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 9223372036854775807h }")
+      extraSteps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { timeout: 9223372036854775807h }")
     XCTAssertEqual(WorkflowFixtures.parseCodes(overflow), ["timeout_syntax"])
   }
 
@@ -245,7 +243,7 @@ final class WorkflowDocumentParserTests: XCTestCase {
     XCTAssertNil(WorkflowDocumentParser.parseDuration(" 10m"))
     XCTAssertNil(WorkflowDocumentParser.parseDuration("10m "))
     let paddedTimeout = WorkflowFixtures.minimal(
-      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: \" 10m\" }")
+      extraSteps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { timeout: \" 10m\" }")
     XCTAssertEqual(WorkflowFixtures.parseCodes(paddedTimeout), ["timeout_syntax"])
     let legacy = WorkflowFixtures.minimal(extraSteps: "  - id: loop\n    repeat: {max: 2}\n    steps: [{id: x, notify: hi}]")
     XCTAssertEqual(WorkflowFixtures.parseCodes(legacy), ["step_verb"])

--- a/ProwlCLITests/WorkflowFixtures.swift
+++ b/ProwlCLITests/WorkflowFixtures.swift
@@ -40,7 +40,7 @@ enum WorkflowFixtures {
       - id: brief
         title: "Author writing the brief"
         message: author
-        instruction: |
+        prompt: |
           Write a short brief for an adversarial reviewer: ## Scope, ## Claims, ## How to verify.
           Deliver it with the generated completion command.
         expect: { delivery: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
@@ -64,11 +64,11 @@ enum WorkflowFixtures {
           - id: fix
             title: "Round {{ context.step.iteration }}: author addressing findings"
             message: author
-            text: "Findings: {{ state.findings_path }}. Fix or rebut each item."
+            prompt: "Findings: {{ state.findings_path }}. Fix or rebut each item."
             expect: { delivery: disposition, timeout: 30m }
           - id: rereview
             message: reviewer
-            text: "Disposition: {{ deliveries.disposition.path }}. Re-review."
+            prompt: "Disposition: {{ deliveries.disposition.path }}. Re-review."
             expect: { delivery: round_findings, verdicts: [clean, issues], timeout: 30m }
           - id: retain
             set:
@@ -99,7 +99,7 @@ enum WorkflowFixtures {
     steps:
       - id: ask
         message: author
-        text: "Say hello."
+        prompt: "Say hello."
     \(extraSteps)
 
     """

--- a/ProwlCLITests/WorkflowNamingTests.swift
+++ b/ProwlCLITests/WorkflowNamingTests.swift
@@ -30,7 +30,7 @@ struct WorkflowNamingTests {
         id: naming
         name: Naming
         roles: {author: {source: current}}
-        steps: [{id: report, message: author, text: Review., expect: {delivery: report, verdicts: \(values)}}]
+        steps: [{id: report, message: author, prompt: Review., expect: {delivery: report, verdicts: \(values)}}]
         """)
       let definition = try #require(parsed.definition)
       let diagnostics = WorkflowValidator.validate(definition, context: .init(scope: .user))
@@ -56,7 +56,7 @@ struct WorkflowNamingTests {
         id: naming
         name: Naming
         roles: {author: {source: current}}
-        steps: [{id: brief, message: author, text: Write., expect: {\(fields)}}]
+        steps: [{id: brief, message: author, prompt: Write., expect: {\(fields)}}]
         """)
       #expect(parsed.definition == nil)
       #expect(parsed.diagnostics.contains { $0.code == "unknown_key" })
@@ -111,7 +111,7 @@ struct WorkflowNamingTests {
       steps:
         - id: brief
           message: author
-          text: Write a briefing.
+          prompt: Write a briefing.
           expect: {delivery: briefing, verdicts: [ready, blocked]}
       """)
     #expect(parsed.diagnostics.isEmpty)

--- a/ProwlCLITests/WorkflowPromptContractTests.swift
+++ b/ProwlCLITests/WorkflowPromptContractTests.swift
@@ -1,0 +1,37 @@
+import ProwlCLIShared
+import XCTest
+
+final class WorkflowPromptContractTests: XCTestCase {
+  func testMessageAcceptsSingleLineAndMultilinePrompts() throws {
+    for prompt in ["prompt: Review this", "prompt: |\n      Review this\n      Report findings"] {
+      let result = WorkflowDocumentParser.parse(document("message: author\n    \(prompt)"))
+      XCTAssertEqual(result.diagnostics, [])
+      let definition = try XCTUnwrap(result.definition)
+      XCTAssertEqual(WorkflowValidator.validate(definition, context: .init(scope: .user)).filter { $0.severity == .error }, [])
+    }
+  }
+
+  func testMessageRequiresPromptAndRejectsRetiredFields() {
+    for field in ["text", "instruction"] {
+      let result = WorkflowDocumentParser.parse(document("message: author\n    \(field): Review this"))
+      XCTAssertNil(result.definition)
+      XCTAssertEqual(Set(result.diagnostics.map(\.code)), ["unknown_key", "missing_key"])
+      let mixed = WorkflowDocumentParser.parse(document("message: author\n    prompt: Review\n    \(field): Other"))
+      XCTAssertEqual(mixed.diagnostics.map(\.code), ["unknown_key"])
+    }
+    XCTAssertEqual(WorkflowDocumentParser.parse(document("message: author")).diagnostics.map(\.code), ["missing_key"])
+  }
+
+  private func document(_ step: String) -> String {
+    """
+    schema: prowl.workflow/v1
+    id: prompt-contract
+    name: Prompt contract
+    roles:
+      author: { source: current }
+    steps:
+      - id: review
+        \(step)
+    """
+  }
+}

--- a/ProwlCLITests/WorkflowSchemaTests.swift
+++ b/ProwlCLITests/WorkflowSchemaTests.swift
@@ -32,7 +32,7 @@ final class WorkflowSchemaTests: XCTestCase {
     let deliver =
       ###"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"deliver","run":{\###(Self.runFields)},"delivery":{"state":"provisional","ordinal":1,"step":"brief","role":"author","record":\###(Self.output),"warnings":[{"code":"missing_sections","message":"missing ## Claims"}]}}}"###
     let read =
-      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"read","run":"0BADCAFE-0000-4000-8000-000000000042","invocation":1,"role":"author","step":"brief","resource":"instruction","body":"Read","encoding":"utf-8","resources":[],"offset":0,"next_offset":4,"total_bytes":8}}"#
+      #"{"ok":true,"command":"workflow","schema_version":"prowl.cli.workflow.v1","data":{"action":"read","run":"0BADCAFE-0000-4000-8000-000000000042","invocation":1,"role":"author","step":"brief","resource":"prompt","body":"Read","encoding":"utf-8","resources":[],"offset":0,"next_offset":4,"total_bytes":8}}"#
     for instance in [list, listWithoutWorktree, validate, schema, error, run, status, cancel, deliver, read] {
       try assertValidity(instance, expected: true)
     }
@@ -112,8 +112,8 @@ final class WorkflowSchemaTests: XCTestCase {
       updatedAt: "2026-08-30T01:02:03Z",
       finishedAt: nil,
       selfInitiated: WorkflowSelfInitiatedPayload(
-        line: "[Prowl] Read /r/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -",
-        instructionPath: "/r/instructions/brief.1.md",
+        line: "[Prowl] Read /r/prompts/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -",
+        promptPath: "/r/prompts/brief.1.md",
         completion: ["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]))
     let runObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(run)) as? [String: Any])
     let activationObject = try XCTUnwrap(runObject["activation"] as? [String: Any])
@@ -163,7 +163,7 @@ final class WorkflowSchemaTests: XCTestCase {
     #"{"name":"brief","ordinal":1,"path":"/r/deliveries/brief.1.md","latest_path":"/r/deliveries/brief.md","delivered_at":"2026-08-30T01:02:03Z"}"#
 
   private static let runFields =
-    ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.adversarial-review","name":"Adversarial Review"},"scope":"repo","definition_path":"/Projects/App/.prowl/workflows/review.pwlworkflow","source":"live","status":{"state":"running"},"step":"brief","role":"author","worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"author":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","tab_id":"00000000-0000-0000-0000-000000000011","handle":"p1","display_name":"Claude Code","agent":"claude"}},"reviewer":{"source":"launch","profile":{"id":"00000000-0000-0000-0000-000000000009","name":"Pi Reviewer","agent":"pi"}}},"activation":{"ordinal":1,"step":"brief","role":"author","state":"waiting","dispatch_id":"dispatch-1","delivery":"brief","expect":{"format":"markdown","sections":["## Scope","## Claims"],"strict":false,"completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]},"deadline":"2026-08-30T01:10:00Z"},"deliveries":{},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:00:00Z","self_initiated":{"line":"[Prowl] Read /r/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -","instruction_path":"/r/instructions/brief.1.md","completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]}"###
+    ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.adversarial-review","name":"Adversarial Review"},"scope":"repo","definition_path":"/Projects/App/.prowl/workflows/review.pwlworkflow","source":"live","status":{"state":"running"},"step":"brief","role":"author","worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"author":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","tab_id":"00000000-0000-0000-0000-000000000011","handle":"p1","display_name":"Claude Code","agent":"claude"}},"reviewer":{"source":"launch","profile":{"id":"00000000-0000-0000-0000-000000000009","name":"Pi Reviewer","agent":"pi"}}},"activation":{"ordinal":1,"step":"brief","role":"author","state":"waiting","dispatch_id":"dispatch-1","delivery":"brief","expect":{"format":"markdown","sections":["## Scope","## Claims"],"strict":false,"completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]},"deadline":"2026-08-30T01:10:00Z"},"deliveries":{},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:00:00Z","self_initiated":{"line":"[Prowl] Read /r/prompts/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -","prompt_path":"/r/prompts/brief.1.md","completion":["PROWL_WORKFLOW_TOKEN=T prowl workflow deliver -"]}"###
 
   private static let recordFields =
     ###""id":"0BADCAFE-0000-4000-8000-000000000042","workflow":{"id":"prowl.handoff","name":"Hand Off"},"scope":"bundle","source":"record","status":{"state":"interrupted"},"worktree":{"id":"wt","name":"feature","branch":"feat/x","path":"/Projects/App"},"run_directory":"/Projects/App/.prowl/workflow-runs/0BADCAFE-0000-4000-8000-000000000042","bindings":{"source":{"source":"current","pane":{"id":"00000000-0000-0000-0000-000000000001","handle":"p1","display_name":"shell"}}},"deliveries":{"brief":\###(WorkflowSchemaTests.output)},"started_at":"2026-08-30T01:00:00Z","updated_at":"2026-08-30T01:05:00Z","finished_at":"2026-08-30T01:05:00Z""###
@@ -228,7 +228,7 @@ final class WorkflowSchemaTests: XCTestCase {
       extraSteps: "  - id: loop\n    repeat: { max: 2 }\n    steps:\n      - id: l\n        launch: r\n        prompt: go",
       extraRoles: "  r:\n    source: launch")
     let orphanPolicy = WorkflowFixtures.minimal(
-      extraSteps: "  - id: b\n    message: author\n    text: hi\n    expect: { on_timeout: skip }")
+      extraSteps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { on_timeout: skip }")
     for (name, yaml) in [
       ("unknownKey", unknownKey), ("twoVerbs", twoVerbs), ("headless", headless), ("badMax", badMax),
       ("launchInLoop", launchInLoop), ("orphanPolicy", orphanPolicy),

--- a/ProwlCLITests/WorkflowValidatorTests.swift
+++ b/ProwlCLITests/WorkflowValidatorTests.swift
@@ -49,7 +49,7 @@ final class WorkflowValidatorTests: XCTestCase {
       WorkflowFixtures.codes(minimal(steps: "  - id: Fix It\n    notify: hi")), ["step_id_slug"])
     XCTAssertEqual(
       WorkflowFixtures.codes(
-        minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { delivery: Bad.Name }")),
+        minimal(steps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { delivery: Bad.Name }")),
       ["delivery_name_slug"])
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal() + "inputs:\n  Max: { type: integer }\n"), ["input_name_slug"])
@@ -61,7 +61,7 @@ final class WorkflowValidatorTests: XCTestCase {
   }
 
   func testUndefinedRolesAndRoleSources() {
-    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: ghost\n    text: hi")), ["undefined_role"])
+    XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: ghost\n    prompt: hi")), ["undefined_role"])
     XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    close: ghost")), ["undefined_role"])
     XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: "  - id: b\n    close: author")), ["close_role_source"])
     XCTAssertEqual(
@@ -71,11 +71,11 @@ final class WorkflowValidatorTests: XCTestCase {
   func testLaunchOrderingRules() {
     let role = "  r:\n    source: launch"
     XCTAssertEqual(
-      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: r\n    text: hi", roles: role)),
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: r\n    prompt: hi", roles: role)),
       ["message_before_launch"])
     let twice = "  - id: l1\n    launch: r\n    prompt: go\n  - id: l2\n    launch: r\n    prompt: again"
     XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: twice, roles: role)), ["launch_twice"])
-    let ordered = "  - id: l1\n    launch: r\n    prompt: go\n  - id: m\n    message: r\n    text: \"pane {{ context.roles.r.pane_id }}\""
+    let ordered = "  - id: l1\n    launch: r\n    prompt: go\n  - id: m\n    message: r\n    prompt: \"pane {{ context.roles.r.pane_id }}\""
     XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: ordered, roles: role)), [])
   }
 
@@ -134,7 +134,7 @@ final class WorkflowValidatorTests: XCTestCase {
     let steps = """
         - id: b
           message: author
-          text: hi
+          prompt: hi
           expect: { delivery: brief }
         - id: ctx
           action: builtin:collect-worktree-context
@@ -182,7 +182,7 @@ final class WorkflowValidatorTests: XCTestCase {
 
   func testVerdictRules() {
     func expect(_ verdict: String) -> String {
-      minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { verdicts: \(verdict) }")
+      minimal(steps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { verdicts: \(verdict) }")
     }
     XCTAssertEqual(WorkflowFixtures.codes(expect("[clean]")), ["verdict_count"])
     XCTAssertEqual(WorkflowFixtures.codes(expect("[a, b, c, d, e]")), ["verdict_count"])
@@ -191,19 +191,19 @@ final class WorkflowValidatorTests: XCTestCase {
     XCTAssertEqual(WorkflowFixtures.codes(expect("[clean, issues]")), [])
   }
 
-  func testTextMustBeOneLineButInstructionsMayNot() {
-    let text = minimal(steps: "  - id: b\n    message: author\n    text: \"two\\nlines\"")
-    XCTAssertEqual(WorkflowFixtures.codes(text), ["text_multiline"])
-    let instruction = minimal(steps: "  - id: b\n    message: author\n    instruction: |\n      two\n      lines")
+  func testPromptsAcceptQuotedNewlinesAndBlockScalars() {
+    let text = minimal(steps: "  - id: b\n    message: author\n    prompt: \"two\\nlines\"")
+    XCTAssertEqual(WorkflowFixtures.codes(text), [])
+    let instruction = minimal(steps: "  - id: b\n    message: author\n    prompt: |\n      two\n      lines")
     XCTAssertEqual(WorkflowFixtures.codes(instruction), [])
   }
 
   // MARK: - Warnings
 
   func testWarnings() {
-    let long = minimal(steps: "  - id: b\n    message: author\n    text: hi\n    expect: { timeout: 3h }")
+    let long = minimal(steps: "  - id: b\n    message: author\n    prompt: hi\n    expect: { timeout: 3h }")
     XCTAssertEqual(WorkflowFixtures.codes(long), ["timeout_long"])
-    let spelled = minimal(steps: "  - id: b\n    message: author\n    text: \"finish with prowl workflow deliver -\"")
+    let spelled = minimal(steps: "  - id: b\n    message: author\n    prompt: \"finish with prowl workflow deliver -\"")
     XCTAssertEqual(WorkflowFixtures.codes(spelled), ["spells_completion_command"])
     XCTAssertEqual(WorkflowFixtures.diagnostics(spelled).first?.severity, .warning)
   }
@@ -212,7 +212,7 @@ final class WorkflowValidatorTests: XCTestCase {
     let blocking = """
         - id: b
           message: author
-          text: hi
+          prompt: hi
           expect: { delivery: brief, timeout: 5m, on_timeout: skip }
         - id: n
           notify: "{{ deliveries.brief.path }}"
@@ -221,7 +221,7 @@ final class WorkflowValidatorTests: XCTestCase {
     let optional = """
         - id: b
           message: author
-          text: hi
+          prompt: hi
           expect: { delivery: brief, timeout: 5m, on_timeout: skip }
         - id: t
           action: builtin:collect-worktree-context
@@ -242,12 +242,12 @@ final class WorkflowValidatorTests: XCTestCase {
 
   // MARK: - Round 1 review findings
 
-  func testControlCharactersIncludingTabsAreRejectedInTypedText() {
+  func testInputDefaultsRemainSingleLineButPromptsAllowTabs() {
     XCTAssertEqual(
       WorkflowFixtures.codes(minimal() + "inputs:\n  s: { type: string, default: \"has\\ttab\" }\n"),
       ["input_default_multiline"])
     XCTAssertEqual(
-      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: author\n    text: \"a\\tb\"")), ["text_multiline"])
+      WorkflowFixtures.codes(minimal(steps: "  - id: b\n    message: author\n    prompt: \"a\\tb\"")), [])
   }
 
 
@@ -255,11 +255,11 @@ final class WorkflowValidatorTests: XCTestCase {
     let stale = """
         - id: first
           message: author
-          text: First
+          prompt: First
           expect: { delivery: result, verdicts: [clean, issues] }
         - id: second
           message: author
-          text: Second
+          prompt: Second
           expect: { delivery: result }
         - id: report
           notify: "{{ deliveries.result.verdict }}"
@@ -268,11 +268,11 @@ final class WorkflowValidatorTests: XCTestCase {
     let refreshed = """
         - id: first
           message: author
-          text: First
+          prompt: First
           expect: { delivery: result }
         - id: second
           message: author
-          text: Second
+          prompt: Second
           expect: { delivery: result, verdicts: [clean, issues] }
         - id: report
           notify: "{{ deliveries.result.verdict }}"
@@ -311,13 +311,13 @@ final class WorkflowValidatorTests: XCTestCase {
     let consumedBefore = """
         - id: first
           message: author
-          text: First
+          prompt: First
           expect: { delivery: brief }
         - id: use
           notify: "{{ deliveries.brief.path }}"
         - id: second
           message: author
-          text: Second
+          prompt: Second
           expect: { delivery: brief, timeout: 5m, on_timeout: skip }
       """
     XCTAssertEqual(WorkflowFixtures.codes(minimal(steps: consumedBefore)), [], "nothing after the skip depends on it")

--- a/Resources/workflows/handoff.pwlworkflow/workflow.yaml
+++ b/Resources/workflows/handoff.pwlworkflow/workflow.yaml
@@ -20,7 +20,7 @@ steps:
   - id: briefing
     title: Prepare handoff briefing
     message: author
-    instruction: |
+    prompt: |
       Prepare a concise handoff of the task in this conversation. Include these headings:
       ## Objective
       ## Current State

--- a/docs-ai/013-prowl-cli/contracts/workflow.md
+++ b/docs-ai/013-prowl-cli/contracts/workflow.md
@@ -36,7 +36,7 @@ Wire request: `command: "workflow"` with `action` (`list` | `run` | `status` | `
 ### `read` assigned content
 
 The socket request uses `action: "read"`, `runID` (UUID), `invocation` (positive
-ordinal), optional `contentResource` (default `instruction`), and `contentOffset`
+ordinal), optional `contentResource` (default `prompt`), and `contentOffset`
 (default 0). The caller is resolved from socket peer ancestry. There is no read token
 and no arbitrary path argument. The pane must own this run and the invocation must
 be its role's last assigned task. Skipped/revoked activations and cancelled runs are
@@ -237,8 +237,8 @@ valid; the app-side `list` always has the bundle.
     "started_at": "2026-08-30T01:00:00.000Z",
     "updated_at": "2026-08-30T01:00:00.000Z",
     "self_initiated": {
-      "line": "[Prowl] Read …/instructions/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=… prowl workflow deliver -",
-      "instruction_path": "…/instructions/brief.1.md",
+      "line": "[Prowl] Read …/prompts/brief.1.md and follow it — finish with: PROWL_WORKFLOW_TOKEN=… prowl workflow deliver -",
+      "prompt_path": "…/prompts/brief.1.md",
       "completion": ["PROWL_WORKFLOW_TOKEN=… prowl workflow deliver -"]
     }
   }

--- a/docs-ai/061-native-toolbar-controls/toolbar-controls.md
+++ b/docs-ai/061-native-toolbar-controls/toolbar-controls.md
@@ -52,6 +52,9 @@ exposes `ToolbarContent.sharedBackgroundVisibility(_:)` only on macOS 26+. The a
 - Bell and update form a second capsule immediately after it.
 - The two capsules are separate.
 - Bell retains its `.orange` unread state and `.secondary` idle state.
+- Workflow History uses `checklist` with the same `.secondary` idle tint.
+- Bell and History share a window-local `ToolbarPopoverCoordinator`. Only one owns
+  presentation; late hover/dismiss callbacks from a replaced panel are ignored.
 - Update retains `Color("ProwlAccent")`.
 
 ### Why it is an exception

--- a/docs-ai/063-agent-workflows/000-plan.md
+++ b/docs-ai/063-agent-workflows/000-plan.md
@@ -138,10 +138,10 @@ that advances one step at a time through existing terminal boundaries:
   command is the only spelling agents ever see**: one completion-command renderer produces
   the initial hint, every nudge, and every re-delivery (token always present; for verdict
   steps one complete executable command per allowed value on every transport — typed
-  line, materialized instruction, and `prowl workflow status` — never a placeholder);
+  line, scoped-read response, and `prowl workflow status` — never a placeholder);
   built-ins and examples say
   "finish with the generated completion command"; the validator warns when
-  `text`/`instruction` spells out `prowl workflow deliver`. `expect` is valid only on
+  `prompt` spells out `prowl workflow deliver`. `expect` is valid only on
   `message` and `launch` (their target role delivers); native actions return typed
   outputs synchronously. Skipping a step whose expected output is referenced by a later
   template ends the run as `skipped` (the panel says which step depends on it) — V1 has
@@ -152,11 +152,11 @@ that advances one step at a time through existing terminal boundaries:
 - `action` → native or bundle-local actions (`builtin:collect-worktree-context`, `local:<verb-object>`).
 - `notify`/`close` → the existing bell pipeline and protected close path.
 
-**Data channels.** Inbound to an agent is always *file + short pointer*: long
-`instruction` text is materialized (one file per invocation, named by the run-global
-invocation ordinal — the DSL spec §§5/8 are normative for run-directory layout) and one
-line is typed (or passed as the kickoff prompt); short `text` is typed verbatim (single
-line).
+**Data channels.** Both `message` and `launch` author their task as `prompt`.
+The runner saves a task-only body for each invocation. After rendering, short safe
+messages are typed directly; multiline or longer messages use pane-scoped read.
+Launch uses its kickoff carrier. The DSL spec §§4/5/8 define transport and storage.
+Completion guidance is generated separately from the saved task body.
 Outbound is `prowl workflow deliver [--verdict v] -` (stdin): the caller pane identifies the
 run/role, the delivery token identifies the awaited step — the YAML itself carries nothing
 machine-specific. Transcript observation (`agents read`) and headless adapter capture are
@@ -199,7 +199,7 @@ schedules cancellable grace deadlines on the injected clock; it never relies on 
 event alone.
 
 **Data bus.** `<root>/.prowl/workflow-runs/<run-id>/` holds `run.json`, `log.md`,
-`instructions/` and `deliveries/` (both versioned by the run-global invocation ordinal, latest
+`prompts/` and `deliveries/` (both versioned by the run-global invocation ordinal, latest
 output view replaced atomically — layout normative in the DSL spec §8), `skills/`
 (materialized from the embedded skill registry only — `skill:` ids are safe slugs that must
 resolve to a bundled skill).
@@ -569,7 +569,7 @@ attaches hooks through A2's launch boundary.
 - **Review round 4 (2026-08-22; verified item by item before adopting)** — the renderer
   now emits one complete executable command per verdict value on every transport (no
   placeholders); run-global monotonic activation ordinals make `deliveries/<name>.<ordinal>.md`
-  and `instructions/<step>.<ordinal>.md` collision-free, with atomic "latest" replacement;
+  and `prompts/<step>.<ordinal>.md` collision-free, with atomic "latest" replacement;
   native actions declare typed input/output schemas and `actions.<step>.<key>` is validated
   like `deliveries.*` (known action, declared key, producer dominates consumer); `repeat.max`
   is a positive integer literal or exactly one integer-input template, resolved at start,

--- a/docs-ai/063-agent-workflows/007-b2-runner-core.md
+++ b/docs-ai/063-agent-workflows/007-b2-runner-core.md
@@ -63,7 +63,7 @@ All new types are `nonisolated` where the app target's MainActor default would o
   `iterationLimitReached`, `interrupted`).
 - `WorkflowRunMachine.swift` — `WorkflowRunEvent` (`roleIdle`, `injectionSucceeded/Failed`,
   `launched/launchFailed`, `actionCompleted/Failed`, `watchdog(ordinal, verdict)`,
-  `timeout`, `user(action)`), `WorkflowRunEffect` (`awaitRoleIdle`, `materializeInstruction`,
+  `timeout`, `user(action)`), `WorkflowRunEffect` (`awaitRoleIdle`, `materializePrompt`,
   `inject`, `launch`, `runAction`, `notify`, `close`, `abandonActivation`, `completeActivation`,
   `armWatchdog`, `disarmWatchdog`, `persistOutput`, `persist`, `log`, `finished`), `start(...)`,
   `apply(_:)`, `deliver(...) -> Result<WorkflowDeliveryReceipt, WorkflowDeliveryError>`,
@@ -82,7 +82,7 @@ All new types are `nonisolated` where the app target's MainActor default would o
   `OUTPUT_TOO_LARGE`).
 - `WorkflowRunStore.swift` — `<root>/.prowl/workflow-runs/<run-id>/` layout, self-ignoring
   `.gitignore`, `WorkflowRunRecord` (Codable, `version` 1), append-only `log.md`,
-  `instructions/<step>.<ordinal>.md`, `deliveries/<name>.<ordinal>.md` + atomically replaced
+  `prompts/<step>.<ordinal>.md`, `deliveries/<name>.<ordinal>.md` + atomically replaced
   `deliveries/<name>.md`, `skills/<id>/` copied from the bundle, every path from validated slugs and
   the run UUID under `AgentProfileHomeProvisioner.validatePhysicalContainment`, and
   `markInterruptedRuns()` for launch.
@@ -236,7 +236,7 @@ Everything lives in `supacode/Domain/Workflow/` (app target) plus three Shared t
 `inject` → `openMessageActivation` (issue + bind) then `insertCommittedText` + `submitLine`,
 `.injectionSucceeded(dispatchID)` or `.injectionFailed` (cancelling the issuance);
 `openActivation` → issue + bind only (self-initiated first step; the line is in
-`run.selfInitiatedLine`); `materializeInstruction` before the inject that names it;
+`run.selfInitiatedLine`); `materializePrompt` before the inject that names it;
 `launch` → plan the frozen profile with `.prompt`, attach the environment values as child-only
 carriers (like `attachingDispatch`), issue the dispatch when `expectsDelivery`, then `.launched`;
 `runAction` → `WorkflowNativeActionRunner`; `armWatchdog` → one `WorkflowWatchdog` per request,

--- a/docs-ai/063-agent-workflows/019-workflow-naming.md
+++ b/docs-ai/063-agent-workflows/019-workflow-naming.md
@@ -32,6 +32,24 @@ This change does not implement handoff migration, new context collectors, or rev
 - Delivery diagnostics use `delivery_shadowing` and `delivery_name_slug`.
 - The terminal loop-limit state is `iteration_limit_reached`.
 
+## Prompt contract follow-up (2026-09-09)
+
+Implemented: `message` and `launch` both require `prompt`. Remove `message.text`,
+`message.instruction`, and `WorkflowMessageContent`; reject the retired YAML fields.
+There are no aliases, migrations, or old-record compatibility requirements.
+
+The runner chooses transport after rendering: short, safe single-line messages may be
+injected directly; other messages use the pane-scoped read command. Launch keeps its
+kickoff transport. `expect` alone determines whether the runner waits for a delivery.
+Persist task-only bodies under `prompts/<step>.<ordinal>.md`; expose `prompt_path`
+and the `prompt` read resource. Completion guidance stays in the transport protocol,
+not in the saved task body. Update schemas, bundles, templates, tests, authoring skills,
+and maintained design references together.
+
+History details use execution-time target snapshots, rendered notification bodies,
+condition outcomes, and each action execution's saved request. They never reconstruct
+past inputs from current variables or associate an old attempt with a relaunched pane.
+
 ## Verification
 
 Add parser, expression/runtime, command/schema, and retired-name rejection coverage.

--- a/docs-ai/063-agent-workflows/021-step-history-ui.md
+++ b/docs-ai/063-agent-workflows/021-step-history-ui.md
@@ -74,8 +74,9 @@ invocation numbers; retain loop paths and retry counts next to the step title. F
 steps initially collapse. Do not override a user's expansion choices on routine updates.
 
 - Text/Markdown deliveries: name, verdict when present, a 200-character preview, exact
-  remaining-character count, and icon-only Copy/Open/Reveal actions. Read at most the
-  delivery protocol limit (16 MiB) on a utility task; retain only the preview in view state.
+  remaining-character count, and icon-only Copy/Open/Reveal actions. Preview and Copy
+  read at most 64 MiB on a utility task; retain only the text preview in view state.
+  Open/Reveal remain available when preview loading fails or exceeds its bound.
 - JSON action output: expandable fields with 32 children per level and five levels of
   disclosure. Values stay on one line with middle truncation. Open/Copy always use the
   complete result, not the preview.
@@ -83,7 +84,7 @@ steps initially collapse. Do not override a user's expansion choices on routine 
   File operations retain the history containment gate; the only external artifact location
   is the worktree's `.prowl/handoff/`, with its own link and containment checks. Arbitrary
   strings are never interpreted as paths. Missing files report an explicit action error.
-- Steps with no output: a short No output message only when expanded.
+- Pure operations show their recorded execution summary, not an empty Output section.
 - Errors: show recorded error details and any partial output. Offer existing permitted
   attention actions only while the run remains active; history is read-only.
 - Technical details: step ID, role, attempt, and available invocation times. Do not invent
@@ -138,8 +139,8 @@ Before implementation, audit `supacode/Domain/Workflow/WorkflowRunStore.swift` a
 3. Resolve historical titles from a retained execution definition where available, not a
    subsequently edited source workflow. Fall back to recorded IDs when unavailable.
 4. Distinguish branch exclusion, skip, and terminal non-execution from absence of a record.
-5. Preserve existing privacy and path-containment rules. Old records with missing fields
-   remain readable in broader scopes and explicitly lack unavailable detail.
+5. Preserve existing privacy and path-containment rules. No aliases, data migration,
+   log parsing, or old-result recovery is required; unsupported records are unavailable.
 
 The exact pane/session identity mapping, historical attempt coverage, and viewing-file
 lifecycle require a focused code audit before implementation. These are implementation
@@ -158,6 +159,46 @@ constraints, not authorization for name-based matching or synthetic history.
   and update the user manual and toolbar guide with the shipped behavior.
 - Implementation now includes the shared step panel, pane/session navigation index,
   persisted step attempts, and terminal history. Live UI acceptance is still pending.
+
+## Execution-summary follow-up plan (2026-09-09)
+
+- Prefer the execution-time rendered title, then the frozen static title or verb summary.
+  Never evaluate an old title against current variables.
+- Message and launch details show their exact invocation target, a 200-character Markdown
+  prompt preview, and full-body Open/Copy/Reveal. A successful launch reports that the
+  agent started; it does not imply the agent's task finished.
+- Capture target profile/pane identity per attempt, including relaunch results. Keep
+  historical identity after closure but show a focus link only for a live surface.
+- Action details show the action identifier and typed inputs from that execution's
+  `request.json`, loaded lazily through the same bounded containment gate as outputs.
+- Notify details show the rendered message and say it was sent to Prowl Notifications.
+  Use the declared title or a fixed notification title, not an empty Output section.
+- Record condition outcomes and state/control summaries when executed. Pure operations
+  show those facts rather than an empty output placeholder. Skipped branches do not claim
+  to have evaluated or delivered anything.
+- Unify all agent task content as `prompt`, including saved paths and CLI fields. This is
+  a clean contract, without aliases, migration, log parsing, or old-content recovery.
+- Verify parser/serialization rejection, transport choice, immutable attempt identity,
+  recorded inputs/conditions/notifications, bounded previews, file safety, and Debug UI.
+
+### Execution-summary result
+
+Implemented the prompt-only contract and per-invocation target snapshots. History now
+shows task-only prompt files with inline Markdown, actual action inputs, rendered notices,
+and condition outcomes. Loop rechecks are recorded as checks rather than retry attempts;
+failed controls keep their rendered titles. File readers reload when an active attempt
+changes or finishes. No legacy result reconstruction remains in step grouping.
+
+Focused regressions first reproduced missing target/condition/title records. Review also
+identified initial file-publication races and the 16 MiB preview mismatch; bounded readers
+now accept 64 MiB while Open/Reveal do not depend on preview success. The full App suite
+passed 3,203 main tests and two process tests. CLI build/smoke, 297 unit tests and 112
+integration tests passed, as did `make check` (153 script tests) and the Debug build.
+
+An isolated Debug workflow completed a real launch, multiline scoped-read message,
+context action, branch, and notifications. Native checks verified prompt Markdown and
+remaining counts, full 386-byte prompt copy, external opening in Typora, action-input copy
+against `request.json`, and closed-pane identity without stale focus links.
 
 ## UI refinement plan (2026-09-09)
 

--- a/docs-ai/063-agent-workflows/021-step-history-ui.md
+++ b/docs-ai/063-agent-workflows/021-step-history-ui.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Implemented; five review rounds converged; native UI acceptance pending |
+| **Status** | Implemented; UI refinement and hover switching verified in Debug |
 | **Anchor date** | 2026-09-08 |
 | **Related** | [Status center](010-c1-workflow-status-center.md), [history storage](018-history-storage-plan.md), [toolbar rules](../061-native-toolbar-controls/toolbar-controls.md) |
 
@@ -43,12 +43,13 @@ a completed review step with an `issues` verdict still receives a completion che
 Use two columns: a compact run list and a wider step detail pane. Each column scrolls
 independently; header and footer stay visible. Bound panel size to the available screen.
 
-The list puts active runs first, then history by descending time. Rows show name, state,
-and time, plus attribution when needed. Initially load about ten recent records and offer
+The list puts active runs first, then history by descending time. Rows show name, a
+baseline-aligned state symbol, and attribution when needed; no repeated state/time text. Initially load about ten recent records and offer
 Load More. This is a presentation limit, not a retention change. First opening selects an
 attention run, otherwise an active run, otherwise the latest historical run.
 
-The detail header shows name, overall state, start/end time, and elapsed duration. The
+The detail header shows name and overall state on one line, then a clock symbol,
+local `yyyy-MM-dd HH:mm` start time, and elapsed duration on one line. The
 step list is the main content; do not place a large result dashboard above it. While open,
 keep the selected run, expanded steps, and reading position stable across status changes,
 new runs, and list reorderings. A pane/scope change must not silently replace an open detail;
@@ -68,15 +69,20 @@ keep the selected record until the user selects another run or reopens the panel
 
 Use the declared step title or a generic action title. A collapsed row can show role,
 output count, or a short error reason. Expand a row to show error/wait reason first, then
-outputs, then collapsed technical details. Failed/attention steps initially expand; successful
+outputs, then an action diagnostics menu when available. Remove duplicate step IDs and
+invocation numbers; retain loop paths and retry counts next to the step title. Failed/attention steps initially expand; successful
 steps initially collapse. Do not override a user's expansion choices on routine updates.
 
-- Text/Markdown deliveries: name, verdict when present, bounded readable preview, Copy,
-  and Open Full Output. Preview limits must bound both loaded content and visual height.
-- JSON action output: bounded field preview with depth/item limits, Copy, and Open Full
-  Output. Long strings wrap or truncate; no unbounded trees or horizontal layout expansion.
-- Known file artifacts: name, Open, and Reveal in Finder. Do not infer files from arbitrary
-  string fields. Missing files keep their record and an unavailable explanation.
+- Text/Markdown deliveries: name, verdict when present, a 200-character preview, exact
+  remaining-character count, and icon-only Copy/Open/Reveal actions. Read at most the
+  delivery protocol limit (16 MiB) on a utility task; retain only the preview in view state.
+- JSON action output: expandable fields with 32 children per level and five levels of
+  disclosure. Values stay on one line with middle truncation. Open/Copy always use the
+  complete result, not the preview.
+- Known file artifacts: named absolute `path`/`*_path` fields offer Open/Reveal/Copy.
+  File operations retain the history containment gate; the only external artifact location
+  is the worktree's `.prowl/handoff/`, with its own link and containment checks. Arbitrary
+  strings are never interpreted as paths. Missing files report an explicit action error.
 - Steps with no output: a short No output message only when expanded.
 - Errors: show recorded error details and any partial output. Offer existing permitted
   attention actions only while the run remains active; history is read-only.
@@ -105,8 +111,8 @@ outputs. A successful retry shows a checkmark plus its attempt count.
 On completion, update the same panel in place and freeze elapsed time. Do not close it,
 switch runs, expand every output, or reset scroll position. On cancellation/interruption,
 stop progress indicators and distinguish interrupted work from steps never reached.
-Role information remains visible after a pane closes, but unavailable focus actions are
-disabled. Workflow completion never implies completion of a launched agent's later work.
+Role information and recorded agent icons remain visible after a pane closes. Only live
+terminal surfaces get `@pN` focus links; agent detection is not the pane-liveness test. Workflow completion never implies completion of a launched agent's later work.
 
 Footer actions are Run Folder, Log, and a menu for Keep Run and Export. Storage budgets and
 cleanup stay in Settings. Retention policy is unchanged. A removed/corrupt record gets an
@@ -152,6 +158,50 @@ constraints, not authorization for name-based matching or synthetic history.
   and update the user manual and toolbar guide with the shipped behavior.
 - Implementation now includes the shared step panel, pane/session navigation index,
   persisted step attempts, and terminal history. Live UI acceptance is still pending.
+
+## UI refinement plan (2026-09-09)
+
+- Keep the native two-column popover. Use baseline-aligned, semantically tinted status
+  symbols; remove list status/time text and put run status beside its title.
+- Put the local start timestamp and duration on one line. Show step durations only from
+  recorded invocation or action timestamps; never infer control-step timing.
+- Keep historical role/runtime identity visible. Only a live pane gets an actionable handle.
+- Use whole-row step disclosure with hover feedback, trailing duration, and compact output
+  actions. Keep retries, loop paths, verdicts, and errors distinct from execution success.
+- Replace flattened JSON with bounded nested fields. Use aligned, single-line values with
+  middle truncation and explicit file actions for named paths. Preserve file validation.
+- Limit delivery previews to 200 characters with an exact remaining-character count.
+  Move action diagnostics to a menu; remove redundant execution metadata. Use neutral
+  empty-output text rather than claiming old control steps lost output.
+- Verify projection boundaries with tests, then inspect the Debug popover and toolbar at
+  normal and constrained widths. Update the user manual, run checks/build, and submit a PR.
+
+### UI refinement result
+
+The detail surface now uses compact step rows, typed output fields, and icon-only file
+controls. Older records without an associated saved result use `No saved output` rather
+than alleging a recording failure. Recorded invocation/action times supply durations;
+unknown control-step timing remains a dash.
+
+The additional History-to-Bell hover regression was reproduced in an isolated Debug app:
+after switching to Bell and holding the pointer still, History reopened. A window-local
+`ToolbarPopoverCoordinator` now owns both presentations, the pin, and the close timer.
+Replacing a panel invalidates its ownership, so its late hover/dismiss callbacks cannot
+reopen it or dismiss the new panel. TestClock cases cover stale callbacks, close timers,
+reverse switching, panel entry, and pinning. Live replay held Notifications open after
+more than one second without pointer movement.
+
+File-action acceptance also caught a macOS path-alias mismatch: standardizing a worktree
+could turn `/private/tmp` into `/tmp` while its recorded artifact kept the physical path.
+The gate now accepts the recorded root or its canonical alias, then validates every
+remaining path component without resolving artifact links. `current.md` opened in Typora;
+full Markdown copy matched all 3,479 characters rather than the 200-character preview.
+
+Verification: `make check`, 3,198 main tests plus two process tests, and `make build-app`
+passed. Debug checks covered the real retained Handoff/Repository Context records in a
+separate data directory, compact output layout, live and closed role presentation,
+History/Bell hover switching, and Normal/Shelf/Canvas toolbar grouping at a 1,000-point
+window width. The final path-alias cases also run in the focused presentation suite.
 
 ## Implementation notes (2026-09-09)
 

--- a/docs-ai/063-agent-workflows/dsl-spec.md
+++ b/docs-ai/063-agent-workflows/dsl-spec.md
@@ -169,7 +169,7 @@ kebab-case names for actions; dot-separated expressions address data, not action
 
 | Verb | Payload and behavior |
 | --- | --- |
-| `message: role` | `text` (one line) or `instruction` (file-backed multiline); waits for the role to be idle before injection; optional `expect` |
+| `message: role` | required `prompt` (single-line or multiline); waits for the role to be idle before delivery; optional `expect` |
 | `launch: role` | `prompt`, optional bundled `skill`, optional `expect`; at most once per persistent role |
 | `action: builtin:collect-worktree-context` or `local:id` | typed `with` object; awaits validated result; no `expect`; see [actions](../../skills/prowl-workflow/references/actions.md) |
 | `notify: text` | notification |
@@ -179,6 +179,14 @@ kebab-case names for actions; dot-separated expressions address data, not action
 | `while` | boolean expression, `steps`, optional `max_iterations` |
 | `break: true` / `continue: true` | innermost loop control |
 
+
+The runner chooses message transport after rendering. A safe single-line prompt whose
+complete typed line is at most 4 KiB is injected directly; otherwise Prowl injects a
+pane-scoped `workflow read` command. Launch uses the kickoff carrier (128 KiB cap).
+Both verbs save only the rendered task body under `prompts/<step>.<ordinal>.md`,
+with granted resource references. `prompt_path` identifies that file. Completion
+commands are added by the transport and scoped-read response, not stored in the body.
+The default read resource is `prompt`. There are no alternate content keys or aliases.
 
 ## 5. `expect`
 
@@ -225,7 +233,7 @@ expect:
   — once for a plain step, once per iteration inside a loop, again after Relaunch —
   mints a run-global, monotonic **invocation ordinal** (1, 2, 3, … across all steps and
   iterations) on entry, whether or not the step waits; it names the step's artifacts
-  (`instructions/<step>.<ordinal>.md`). When the step has an `expect`, the same invocation
+  (`prompts/<step>.<ordinal>.md`). When the step has an `expect`, the same invocation
   is also its *activation* `(run id, step id, ordinal, delivery role)`: the runner mints a
   fresh delivery token for it, and the previous activation of the same step (if any) is
   terminal. Exactly one successful `deliver` is accepted per activation, identified by its
@@ -300,7 +308,7 @@ handoff.
 
 **Self-initiated runs.** When `run` is invoked from the pane that becomes the `current`
 role and the first step is a `message` to that role, the response carries that step's
-rendered instruction (or scoped `workflow read` command) and its completion command, and the runner does **not**
+rendered prompt (or scoped `workflow read` command) and its completion command, and the runner does **not**
 also type them into the caller's pane — the caller already has them. For an agent this
 makes a self-handoff two commands: `prowl workflow run prowl.handoff`, then the returned
 `… prowl workflow deliver -` with its briefing on stdin.
@@ -310,7 +318,7 @@ Error codes: `WORKFLOW_NOT_FOUND`, `WORKFLOW_INVALID`, `RUN_NOT_FOUND`, `PANE_BU
 `OUTPUT_INVALID` (empty body; sections/format/verdict only under `strict: true`), `OUTPUT_TOO_LARGE`,
 `VERDICT_REQUIRED` (`strict: true` only),
 `PROFILE_NOT_FOUND`, `PROFILE_NOT_UNIQUE`, `SKILL_NOT_FOUND`, `RENDERED_TEXT_INVALID`
-(a rendered `text`/pointer/`--input` value would not survive as one terminal line),
+(a generated protocol line or `--input` value would not survive as one terminal line),
 `UNSAFE_PATH`, `PROMPT_TOO_LARGE` (a rendered `launch` prompt above 128 KiB),
 `WORKFLOW_DELIVERY_REQUIRED` (`agents dispatch-complete` from a pane whose pending record is a
 workflow activation; the message carries the exact `prowl workflow deliver` replacement).
@@ -368,7 +376,7 @@ A run directory is `~/.prowl/logs/workflow-runs/<root-name>-<root-hash>/YYYY-MM/
 definition/                         Fixed bundle copy
 run.json                            Status, bindings, typed state, attempts, output references
 log.md                              Timeline
-instructions/<step>.<ordinal>.md   Materialized agent instructions
+prompts/<step>.<ordinal>.md   Rendered task body without completion protocol
 deliveries/<name>.<ordinal>.md         Accepted/provisional agent delivery
 deliveries/<name>.md                   Latest file view
 skills/<skill>/                     Materialized bundled skill
@@ -385,7 +393,7 @@ The canonical execution root identifies its history bucket; the UTC month is fix
 creation. Global UUID lookup does not depend on open projects. See
 [personal history and retention](018-history-storage-plan.md) for the fixed 30-day
 policy, 5 GiB soft budget, 24-hour protection, Keep Run, and complete ZIP export.
-Agents use `workflow read` with pane/task attribution for instructions and explicitly
+Agents use `workflow read` with pane/task attribution for prompts and explicitly
 granted output/action resources; ordinary delivery remains `workflow deliver -` on stdin.
 
 Only the current execution UUID may publish an action result. Cancel terminates the owned

--- a/docs/components/workflows.md
+++ b/docs/components/workflows.md
@@ -41,8 +41,7 @@ capability. `agents: []` allows none; `any` and `*` are not wildcard tokens. Lea
 unset unless there is a specific preference to express; profile selection normally belongs
 to the user's saved preferences and the start-sheet picker.
 
-Steps are `message` (type one line or provide scoped CLI access to persisted
-instructions), `launch` (start a launch role with a kickoff prompt),
+Steps are `message` (send a prompt to an idle role), `launch` (start a launch role with a kickoff prompt),
 `set`, nested `if`/`else`, `while`, `break`/`continue`,
 `action` (built-in or local script), `notify`, and `close`. A `message` or
 `launch` step may `expect` an output: the role finishes by running the exact
@@ -158,22 +157,34 @@ termination have separate states. Nested rounds show their complete loop path.
 Rounds and retry attempts retain their own
 recorded outputs and errors. Provisional and corrected submissions keep separate
 body snapshots. Failed action attempts link to their own stdout, stderr, and
-execution record. Older records can lack some details.
+execution record. Step titles come from the execution, not from later YAML edits.
 
-Text/Markdown previews show the first 200 characters and the remaining character
-count. JSON output uses nested, expandable fields, with single-line values and
+Message and launch steps show the target role, recorded profile or agent, and the
+saved prompt. A launch reports **Agent started** only after startup succeeds;
+without `expect`, this does not mean the agent finished its task. Targets are recorded
+per attempt, so a relaunch cannot change an earlier attempt's identity.
+
+Action steps show their action ID and resolved **Input** from that execution's saved
+request, separate from **Output**. Conditions show the selected branch and recorded
+boolean result. Notifications show the text sent to Prowl Notifications; a declared
+step title takes precedence over the default notification label. Pure operations do
+not show an empty Output section.
+
+Prompt and delivery previews show the first 200 characters with inline Markdown
+formatting and the remaining character count. JSON output uses nested, expandable fields, with single-line values and
 middle-truncated paths. Each level shows at most 32 fields, up to five levels deep;
 the complete JSON remains available externally. `output` is the action's returned
 JSON value; `output_path` is the saved `result.json` file containing that value,
 not a second result.
 
+Preview and Copy read files up to 64 MiB. Open and Reveal remain available if a
+preview is unavailable or a file exceeds that reader bound.
+
 Compact icon buttons open full output, copy full content, or reveal files in Finder;
 hover a button for its label. Named absolute path fields also offer file actions.
 Opening is limited to retained workflow storage and the worktree's `.prowl/handoff/`
 artifacts, with link and containment checks. **Diagnostics** holds action stdout,
-stderr, and execution metadata. Empty steps show **No output**; older runs with no
-saved detail show **No saved output**, without claiming that recording failed.
-Missing or unreadable files get a separate message. **Keep Run** and **Export** are
+stderr, and execution metadata. Missing or unreadable files get a separate message. **Keep Run** and **Export** are
 in the run's More menu; usage and cleanup remain in Settings.
 
 A selected run stays open when it completes, without switching to another run or
@@ -194,7 +205,7 @@ The creation month stays fixed. No project-local runtime files or Git-ignore rul
 are created. Personal and team workflow definitions keep their existing locations.
 
 Each run contains `run.json`, `log.md`, its frozen bundle in `definition/`,
-`instructions/`, `skills/`, `deliveries/`, and `actions/`. Metadata records the original
+`prompts/`, `skills/`, `deliveries/`, and `actions/`. Metadata records the original
 execution root. `prowl workflow status <run-id>` finds saved history even after that
 root is closed, moved, or deleted. A moved folder does not inherit the old history.
 
@@ -215,7 +226,13 @@ Manual cleanup shows candidate runs and estimated reclaimed space, then requires
 confirmation. It uses the same protections and checks eligibility again before
 deleting each complete run. Old project-local data is neither migrated nor deleted.
 
-Agents retrieve assigned instructions and explicit input resources with
+Both `message` and `launch` require `prompt`; the retired `text` and `instruction`
+fields are not accepted. A message waits for an idle agent, then Prowl chooses direct
+single-line delivery or scoped read after rendering. Launch uses a kickoff prompt.
+`expect` controls whether either step waits for an agent delivery. Saved files in
+`prompts/` contain the task body, without generated completion commands.
+
+Agents retrieve assigned prompts and explicit input resources with
 `prowl workflow read`, using the run ID, invocation number, and assigned pane. Prowl owns
 persistence; deliver text or JSON through `prowl workflow deliver -` on stdin. Run
 paths are temporary artifact locations, not durable downstream references.

--- a/docs/components/workflows.md
+++ b/docs/components/workflows.md
@@ -145,24 +145,46 @@ Hover to preview; click or interact with its contents to keep it open. The defau
 its identified agent session participated as a role. **This Worktree** and **All
 Runs** include broader history and records whose pane identity is unavailable.
 
-Select a run on the left, then expand its steps on the right. Checkmarks indicate
-completed execution; a delivery verdict such as `issues` does not mean execution
-failed. Branches not selected, skipped steps, and steps not reached before
+The muted checklist button opens Workflow History. The run list shows each name,
+a tinted state icon, and project or pane attribution; completed runs use a green
+checkmark. The detail header puts status beside the title and start time beside
+elapsed time.
+
+Select a run on the left, then click anywhere on a step row to expand it. Hover
+highlights the row. Recorded step duration appears at the right; a dash means no
+duration was saved. Checkmarks indicate completed execution; a delivery verdict
+such as `issues` does not mean execution failed. Branches not selected, skipped steps, and steps not reached before
 termination have separate states. Nested rounds show their complete loop path.
 Rounds and retry attempts retain their own
 recorded outputs and errors. Provisional and corrected submissions keep separate
 body snapshots. Failed action attempts link to their own stdout, stderr, and
 execution record. Older records can lack some details.
 
-Text and JSON previews have fixed limits. **Open Full Output** opens the complete
-file in its default external application; **Copy Full Output** copies the complete
-content. No full-text expansion changes the panel layout. Missing files remain
-visible as unavailable. **Keep Run** and **Export** are in the run's More menu;
-usage and cleanup remain in Settings.
+Text/Markdown previews show the first 200 characters and the remaining character
+count. JSON output uses nested, expandable fields, with single-line values and
+middle-truncated paths. Each level shows at most 32 fields, up to five levels deep;
+the complete JSON remains available externally. `output` is the action's returned
+JSON value; `output_path` is the saved `result.json` file containing that value,
+not a second result.
+
+Compact icon buttons open full output, copy full content, or reveal files in Finder;
+hover a button for its label. Named absolute path fields also offer file actions.
+Opening is limited to retained workflow storage and the worktree's `.prowl/handoff/`
+artifacts, with link and containment checks. **Diagnostics** holds action stdout,
+stderr, and execution metadata. Empty steps show **No output**; older runs with no
+saved detail show **No saved output**, without claiming that recording failed.
+Missing or unreadable files get a separate message. **Keep Run** and **Export** are
+in the run's More menu; usage and cleanup remain in Settings.
 
 A selected run stays open when it completes, without switching to another run or
 resetting the reading position. Only active runs offer recovery and cancellation.
-Role focus is available only for panes still present in the agent list.
+Roles retain their recorded agent icon after execution. An `@pN` link appears only
+while that terminal pane exists, even if its agent has exited back to the shell.
+Closed panes keep their role and agent icon without an inactive link.
+
+Hovering from History to the bell switches the preview without reopening the old
+panel. A click pins the panel; click the other button to switch a pinned panel.
+Escape or an outside click dismisses it.
 
 Every run, including `workflow test-action`, stores its runtime data in
 `~/.prowl/logs/workflow-runs/<root-name>-<root-hash>/YYYY-MM/<run-id>/`.

--- a/scripts/check_workflow_naming.py
+++ b/scripts/check_workflow_naming.py
@@ -9,6 +9,9 @@ import sys
 
 
 RULES = (
+    (r"\bWorkflowMessageContent\b", "Use a single prompt string."),
+    (r"\binstruction_path\b", "Use prompt_path."),
+    (r"^\s*(?:-\s*)?instruction\s*:", "Use prompt for agent task content."),
     (r"\bworkflow\s+done\b", "Use workflow deliver."),
     (r"\bWorkflowDone\w*\b", "Use WorkflowDeliver types."),
     (r"builtin:(?:git\.context|worktree\.context|agent\.context)\b", "Use a verb-first action ID."),
@@ -36,6 +39,10 @@ REFERENCES = (
 
 def violations(text: str, *, swift: bool = False) -> list[tuple[int, str]]:
     findings = []
+    try:
+        structured_json = isinstance(json.loads(text), (dict, list))
+    except (ValueError, TypeError):
+        structured_json = False
     if re.search(r"\bworkflow\s+done\b", text):
         findings.append((1, "Use workflow deliver."))
     block = None
@@ -58,12 +65,14 @@ def violations(text: str, *, swift: bool = False) -> list[tuple[int, str]]:
             if line.lstrip().startswith("//"):
                 public_text = line
         for pattern, message in RULES:
+            if pattern == r"\binstruction_path\b" and (custom_data or structured_json):
+                continue
             if pattern.startswith(r"^\s*(?:-\s*)?"):
                 if custom_data:
                     continue
                 candidate = yaml_line
             else:
-                candidate = line if pattern.startswith(r"\bWorkflowDone") else public_text
+                candidate = line if pattern.startswith((r"\bWorkflowDone", r"\bWorkflowMessageContent")) else public_text
             candidate = candidate.replace("\\", "")
             candidate = re.sub(r"""\[\s*['"]([a-zA-Z_][\w-]*)['"]\s*\]""", r".\1", candidate)
             candidate = re.sub(
@@ -92,6 +101,13 @@ def violations(text: str, *, swift: bool = False) -> list[tuple[int, str]]:
                     for item in node:
                         check_declarations(item)
                 elif isinstance(node, dict):
+                    if node.get("command") == "workflow":
+                        check_declarations(node.get("data"))
+                    task = node.get("self_initiated")
+                    if isinstance(task, dict) and "instruction_path" in task:
+                        findings.append((1, "Use prompt_path."))
+                    if "message" in node and set(node) & {"text", "instruction"}:
+                        findings.append((1, "Use prompt for agent task content."))
                     expect = node.get("expect")
                     if isinstance(expect, dict) and set(expect) & {"output", "verdict"}:
                         findings.append((1, "Use delivery and verdicts in expect."))

--- a/scripts/test_workflow_naming.py
+++ b/scripts/test_workflow_naming.py
@@ -19,6 +19,24 @@ class WorkflowNamingTests(unittest.TestCase):
             with self.subTest(text=text):
                 self.assertTrue(violations(text))
 
+    def test_prompt_names_reject_retired_contracts_but_allow_custom_data(self):
+        for text in (
+            '"instruction_path": "/run/instructions/task.1.md"',
+            "WorkflowMessageContent", "instruction: Review this.",
+            '{"steps":[{"id":"task","message":"author","text":"Review"}]}',
+            '{"command":"workflow","data":{"self_initiated":{"instruction_path":"/run/task.md"}}}',
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(violations(text))
+        for text in (
+            '"prompt_path": "/run/prompts/task.1.md"',
+            "with:\n  instruction: user-defined\n  text: custom\n  instruction_path: custom",
+            '{"steps":[{"id":"task","action":"local:write","with":{"instruction_path":"custom"}}]}',
+            '{"steps":[{"id":"task","action":"local:write","with":{"text":"custom"}}]}',
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(violations(text))
+
     def test_alternative_protocol_syntax(self):
         for text in (
             '{"steps":[{"id":"review","expect":{"output":"findings","verdict":["clean","issues"]}}]}',

--- a/skills/prowl-workflow/SKILL.md
+++ b/skills/prowl-workflow/SKILL.md
@@ -84,7 +84,7 @@ prowl workflow cancel <run-id> [--json]
   `--input k=v`.
 - When starting from the `current` role's own pane, inspect the `run` response for
   `self_initiated` (`.data.self_initiated` with `--json`). If present, follow its `line` or
-  `instruction_path` and completion command yourself; Prowl does not type that first task
+  `prompt_path` and completion command yourself; Prowl does not type that first task
   back into the same pane. Waiting for another message would leave your own step unfinished.
 - The run is asynchronous: `run` returns the run id and frozen bindings; poll
   `prowl workflow status <run-id> --json` (`.data.status.state` is `running`,
@@ -104,10 +104,10 @@ An active task delivered by Prowl in this pane, a launched role's kickoff protoc
 looks like this:
 
 ```
-[Prowl] <instruction…> — finish with: PROWL_WORKFLOW_TOKEN=<token> prowl workflow deliver [--verdict <v>] -
+[Prowl] <prompt or scoped-read command…> — finish with: PROWL_WORKFLOW_TOKEN=<token> prowl workflow deliver [--verdict <v>] -
 ```
 
-1. Do the work the instruction asks for, completely, before delivering.
+1. Do the work the prompt asks for, completely, before delivering.
 2. Deliver by running the **exact rendered command** with the body on stdin as markdown
    (`printf '…' | PROWL_WORKFLOW_TOKEN=… prowl workflow deliver -`). When verdict variants are
    offered, pick exactly one and run that variant.
@@ -133,7 +133,7 @@ the companion skill for driving individual panes outside a workflow.
 ## Assigned content and retention
 
 Use the scoped `prowl workflow read` command supplied with the task to retrieve
-instructions. Read returned resource IDs with the same run ID and invocation number;
+the prompt. Read returned resource IDs with the same run ID and invocation number;
 `workflow-resource:` references are handles, not filesystem paths. Use `--json`
 for byte-preserving reads, decode each chunk by its `encoding`, and continue with
 `--offset <next_offset>` until `next_offset` is absent. Only the assigned pane can read this content; reads do not require a token.

--- a/skills/prowl-workflow/references/authoring.md
+++ b/skills/prowl-workflow/references/authoring.md
@@ -17,7 +17,7 @@ roles:
 steps:
   - id: summary
     message: author
-    instruction: |
+    prompt: |
       Inspect the current changes and write a concise summary.
     expect: {delivery: summary, sections: ["## Summary"]}
   - id: done
@@ -123,7 +123,7 @@ kebab-case names for actions; dot-separated expressions address data, not action
 
 | Verb | Payload and behavior |
 | --- | --- |
-| `message: role` | `text` (one line) or `instruction` (file-backed multiline); waits for the role to be idle before injection; optional `expect` |
+| `message: role` | required `prompt` (single-line or multiline); Prowl selects direct delivery or scoped read after rendering; waits for idle; optional `expect` |
 | `launch: role` | `prompt`, optional bundled `skill`, optional `expect`; at most once per persistent role |
 | `action: builtin:collect-worktree-context` or `local:id` | typed `with` object; awaits validated result; no `expect`; see [actions](actions.md) |
 | `notify: text` | notification |
@@ -200,7 +200,7 @@ expect:
 
 Prowl appends the completion command itself — the typed line or kickoff prompt ends with
 the exact `PROWL_WORKFLOW_TOKEN=… prowl workflow deliver [--verdict v] -` to run. **Never
-write `prowl workflow deliver` into your own `text`/`instruction`/`prompt`** (the validator
+write `prowl workflow deliver` into your own `prompt`** (the validator
 warns); the runner's renderer is the only source of that command.
 
 

--- a/skills/prowl-workflow/references/runbook.md
+++ b/skills/prowl-workflow/references/runbook.md
@@ -26,7 +26,7 @@ or the CLI cannot reach the intended Prowl instance.
 
 When the caller is the `current` role and the first step messages that role, the `run`
 response returns the task directly in `self_initiated` (`.data.self_initiated` in JSON):
-`line`, optional `instruction_path`, and `completion`. The agent that invoked `run` must
+`line`, optional `prompt_path`, and `completion`. The agent that invoked `run` must
 perform it and deliver; there is no separate injected first message to wait for.
 
 ## While it runs
@@ -97,8 +97,8 @@ Runtime data lives in personal history, outside the execution root:
 │   └── <name>.md                # "latest" view, replaced atomically on each delivery
 ├── definition/                  # frozen workflow bundle
 ├── actions/                     # action results and artifacts
-├── instructions/
-│   └── <step>.<ordinal>.md      # task instructions and granted resource references
+├── prompts/
+│   └── <step>.<ordinal>.md      # task-only prompts and granted resource references
 └── skills/
     └── <id>/SKILL.md            # bundled skills named by `launch … skill:` (empty otherwise)
 ```
@@ -147,7 +147,7 @@ Every awaited step mints a fresh token for its activation; Skip/Cancel/Relaunch 
 | `TOKEN_REQUIRED` / `TOKEN_INVALID` / `STEP_NOT_EXPECTING` | delivering without/with a stale token, or the step has moved on — check `prowl workflow status` |
 | `OUTPUT_INVALID` / `VERDICT_REQUIRED` / `OUTPUT_TOO_LARGE` | empty body / missing mandatory verdict under `strict` / body over the cap |
 | `WORKFLOW_DELIVERY_REQUIRED` | `dispatch-complete` was used inside a workflow activation — run the `prowl workflow deliver` command the error echoes |
-| `PROMPT_TOO_LARGE` / `RENDERED_TEXT_INVALID` | a rendered launch prompt over 128 KiB / a rendered line that isn't one clean terminal line — shorten, or move content into an `instruction` |
+| `PROMPT_TOO_LARGE` / `RENDERED_TEXT_INVALID` | a rendered launch prompt over 128 KiB / a rendered line that isn't one clean terminal line — shorten the kickoff prompt or inspect the generated protocol line; multiline message prompts automatically use scoped read |
 
 The `workflow deliver --json` receipt exposes its delivery record at
 `.data.delivery.record`; `.data.activation.delivery` in a status response is the expected delivery name.

--- a/supacode/CLIService/Shared/WorkflowCommandPayload.swift
+++ b/supacode/CLIService/Shared/WorkflowCommandPayload.swift
@@ -491,20 +491,20 @@ nonisolated public struct WorkflowDeliveryRecordPayload: Codable, Equatable, Sen
 nonisolated public struct WorkflowSelfInitiatedPayload: Codable, Equatable, Sendable {
   /// The line the runner would have typed, completion command included.
   public let line: String
-  /// The materialized instruction file the line points at, for `instruction` steps.
-  public let instructionPath: String?
+  /// The saved task-only prompt for this invocation.
+  public let promptPath: String?
   /// The `prowl workflow deliver` commands that complete the step, one per allowed verdict.
   public let completion: [String]
 
   enum CodingKeys: String, CodingKey {
     case line
-    case instructionPath = "instruction_path"
+    case promptPath = "prompt_path"
     case completion
   }
 
-  public init(line: String, instructionPath: String?, completion: [String]) {
+  public init(line: String, promptPath: String?, completion: [String]) {
     self.line = line
-    self.instructionPath = instructionPath
+    self.promptPath = promptPath
     self.completion = completion
   }
 }

--- a/supacode/CLIService/Shared/WorkflowControlCursor.swift
+++ b/supacode/CLIService/Shared/WorkflowControlCursor.swift
@@ -24,6 +24,8 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
     public let iteration: Int?
     public let skipped: Bool
     public var path: [String] = []
+    public var title: String?
+    public var summary: String?
   }
 
   public private(set) var evaluations: [Evaluation] = []
@@ -82,9 +84,12 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
       }
       let position = if case .loop = control { 0 } else { iteration }
       let stepContext = Self.positioned(context, stepID: step.id, iteration: position)
-      let positionRecord = Evaluation(stepID: step.id, iteration: iteration, skipped: false, path: iterationPath)
+      var positionRecord = Evaluation(stepID: step.id, iteration: iteration, skipped: false, path: iterationPath)
+      positionRecord.title = step.title.flatMap {
+        try? WorkflowExpression.renderText($0, values: values(over: stepContext))
+      }
       failedPosition = positionRecord
-      try execute(control, step: step, context: stepContext)
+      positionRecord.summary = try execute(control, step: step, context: stepContext)
       evaluations.append(positionRecord)
       failedPosition = nil
     }
@@ -101,11 +106,12 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
 
   private mutating func execute(
     _ control: WorkflowControlStep, step: WorkflowStepDefinition, context: [String: WorkflowJSONValue]
-  ) throws {
+  ) throws -> String {
     switch control {
     case .set(let assignments):
       try state.assign(assignments, values: values(over: context))
       frames[frames.count - 1].index += 1
+      return "Updated state: " + assignments.keys.sorted().joined(separator: ", ")
     case .conditional(let condition, let yes, let otherwise):
       let selected = try conditionValue(condition, context: context)
       let branch = selected ? yes : otherwise
@@ -113,15 +119,18 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
       frames[frames.count - 1].index += 1
       expire(step.action.children)
       frames.append(Frame(steps: branch))
+      return "\(selected ? "Then" : "Else") branch selected\n\(condition) = \(selected)"
     case .loop(let condition, let maximum, let body):
       frames[frames.count - 1].index += 1
       expire(body)
-      if try conditionValue(condition, context: context) {
+      let entered = try conditionValue(condition, context: context)
+      if entered {
         if let maximum, maximum <= 0 { throw WorkflowLoopLimit(stepID: step.id) }
         frames.append(Frame(steps: body, loop: step, iteration: 1))
       } else {
         recordSkipped(body)
       }
+      return "\(entered ? "Entered loop" : "Loop not entered")\n\(condition) = \(entered)"
     case .breakLoop, .continueLoop:
       guard let loopIndex = frames.lastIndex(where: { $0.loop != nil }) else {
         throw WorkflowExpressionError.type("Loop control requires an enclosing loop.")
@@ -129,8 +138,10 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
       while frames.count - 1 > loopIndex { expire(frames.removeLast().steps) }
       if case .breakLoop = control {
         expire(frames.removeLast().steps)
+        return "Exited the loop."
       } else {
         frames[loopIndex].index = frames[loopIndex].steps.count
+        return "Continued to the next loop iteration."
       }
     }
   }
@@ -140,7 +151,17 @@ nonisolated public struct WorkflowControlCursor: Equatable, Sendable {
     if let loop = frame.loop, case .control(.loop(let condition, let maximum, _)) = loop.action {
       expire(frame.steps)
       let loopContext = Self.positioned(context, stepID: loop.id, iteration: frame.iteration)
-      if try conditionValue(condition, context: loopContext) {
+      var evaluation = Evaluation(
+        stepID: loop.id, iteration: frames.dropLast().last(where: { $0.loop != nil })?.iteration,
+        skipped: false, path: Array(iterationPath.dropLast()))
+      evaluation.title = loop.title.flatMap {
+        try? WorkflowExpression.renderText($0, values: values(over: loopContext))
+      }
+      failedPosition = evaluation
+      let matched = try conditionValue(condition, context: loopContext)
+      evaluation.summary = "Loop condition \(matched ? "matched" : "ended the loop")\n\(condition) = \(matched)"
+      evaluations.append(evaluation)
+      if matched {
         if let maximum, frame.iteration >= maximum {
           throw WorkflowLoopLimit(stepID: loop.id)
         }

--- a/supacode/CLIService/Shared/WorkflowDefinition.swift
+++ b/supacode/CLIService/Shared/WorkflowDefinition.swift
@@ -335,21 +335,8 @@ nonisolated public struct WorkflowExpectation: Equatable, Sendable {
   }
 }
 
-nonisolated public enum WorkflowMessageContent: Equatable, Sendable {
-  /// One line, typed verbatim.
-  case text(String)
-  /// Multi-line, materialized to a run file; one pointer line is typed.
-  case instruction(String)
-
-  public var body: String {
-    switch self {
-    case .text(let value), .instruction(let value): value
-    }
-  }
-}
-
 nonisolated public enum WorkflowStepAction: Equatable, Sendable {
-  case message(role: String, content: WorkflowMessageContent, expect: WorkflowExpectation?)
+  case message(role: String, prompt: String, expect: WorkflowExpectation?)
   case launch(role: String, prompt: String, skill: String?, expect: WorkflowExpectation?)
   /// `with` preserves JSON values and evaluates embedded expressions.
   case action(id: String, inputs: [String: WorkflowJSONValue])

--- a/supacode/CLIService/Shared/WorkflowDocumentParser.swift
+++ b/supacode/CLIService/Shared/WorkflowDocumentParser.swift
@@ -233,22 +233,12 @@ nonisolated public enum WorkflowDocumentParser {
   }
 
   private static func parseMessage(_ step: MappingReader) -> WorkflowStepAction? {
-    step.checkKeys(["id", "title", "message", "text", "instruction", "expect"])
+    step.checkKeys(["id", "title", "message", "prompt", "expect"])
     let role = step.requiredString("message")
-    let text = step.string("text")
-    let instruction = step.string("instruction")
-    let content: WorkflowMessageContent?
-    switch (text, instruction) {
-    case (let text?, nil): content = .text(text)
-    case (nil, let instruction?): content = .instruction(instruction)
-    default:
-      step.collector.error(
-        "message_content", "A message step needs exactly one of 'text' or 'instruction'.", at: step.location)
-      content = nil
-    }
+    let prompt = step.requiredString("prompt")
     let expect = parseExpect(step)
-    guard let role, let content else { return nil }
-    return .message(role: role, content: content, expect: expect)
+    guard let role, let prompt else { return nil }
+    return .message(role: role, prompt: prompt, expect: expect)
   }
 
   private static func parseLaunch(_ step: MappingReader, insideLoop: Bool) -> WorkflowStepAction? {

--- a/supacode/CLIService/Shared/WorkflowJSONSchema.swift
+++ b/supacode/CLIService/Shared/WorkflowJSONSchema.swift
@@ -332,7 +332,8 @@ nonisolated public enum WorkflowJSONSchema {
           "additionalProperties": false,
           "required": [
             "id",
-            "message"
+            "message",
+            "prompt"
           ],
           "properties": {
             "id": {
@@ -344,28 +345,13 @@ nonisolated public enum WorkflowJSONSchema {
             "message": {
               "$ref": "#/$defs/slug"
             },
-            "text": {
-              "$ref": "#/$defs/template"
-            },
-            "instruction": {
+            "prompt": {
               "$ref": "#/$defs/template"
             },
             "expect": {
               "$ref": "#/$defs/expect"
             }
-          },
-          "oneOf": [
-            {
-              "required": [
-                "text"
-              ]
-            },
-            {
-              "required": [
-                "instruction"
-              ]
-            }
-          ]
+          }
         },
         "launchStep": {
           "type": "object",

--- a/supacode/CLIService/Shared/WorkflowRoleRequirements.swift
+++ b/supacode/CLIService/Shared/WorkflowRoleRequirements.swift
@@ -64,9 +64,9 @@ nonisolated public enum WorkflowRoleRequirements {
         case .launch(let role, let prompt, _, _):
           required.insert(role)
           templates(prompt)
-        case .message(let role, let content, _):
+        case .message(let role, let prompt, _):
           required.insert(role)
-          templates(content.body)
+          templates(prompt)
         case .close(let role): required.insert(role)
         case .notify(let text): templates(text)
         case .action(let id, let inputs):

--- a/supacode/CLIService/Shared/WorkflowValidator.swift
+++ b/supacode/CLIService/Shared/WorkflowValidator.swift
@@ -258,8 +258,8 @@ nonisolated private final class Walker {
       checkTemplate(title, at: step.location, consumer: .template)
     }
     switch step.action {
-    case .message(let role, let content, let expect):
-      checkMessage(step, role: role, content: content, expect: expect)
+    case .message(let role, let prompt, let expect):
+      checkMessage(step, role: role, prompt: prompt, expect: expect)
     case .launch(let role, let prompt, let skill, let expect):
       checkLaunch(step, role: role, prompt: prompt, skill: skill, expect: expect)
     case .action(let id, let inputs):
@@ -276,7 +276,7 @@ nonisolated private final class Walker {
   }
 
   private func checkMessage(
-    _ step: WorkflowStepDefinition, role: String, content: WorkflowMessageContent, expect: WorkflowExpectation?
+    _ step: WorkflowStepDefinition, role: String, prompt: String, expect: WorkflowExpectation?
   ) {
     if let definitionRole = requireRole(role, at: step.location), definitionRole.source == .launch,
       !launchedRoles.contains(role)
@@ -285,12 +285,8 @@ nonisolated private final class Walker {
         "message_before_launch", "Step '\(step.id)' messages launch role '\(role)' before its launch step.",
         at: step.location)
     }
-    if case .text(let text) = content, !WorkflowValidator.isSingleLine(text) {
-      collector.error(
-        "text_multiline", "'text' must be one line; use 'instruction' for multi-line content.", at: step.location)
-    }
-    checkTemplate(content.body, at: step.location, consumer: .template)
-    warnIfSpellingCompletion(content.body, at: step.location)
+    checkTemplate(prompt, at: step.location, consumer: .template)
+    warnIfSpellingCompletion(prompt, at: step.location)
     checkExpect(expect, step: step)
   }
 

--- a/supacode/CLIService/WorkflowRunPayload+App.swift
+++ b/supacode/CLIService/WorkflowRunPayload+App.swift
@@ -26,7 +26,7 @@ extension WorkflowRunPayload {
       if includeSelfInitiated, let line = run.selfInitiatedLine {
         WorkflowSelfInitiatedPayload(
           line: line,
-          instructionPath: run.invocations.first?.instructionPath,
+          promptPath: run.invocations.first?.promptPath,
           completion: run.invocations.first?.activation?.completion.messageCommands ?? [])
       } else {
         nil

--- a/supacode/CLIService/WorkflowRuntimeCoordinator.swift
+++ b/supacode/CLIService/WorkflowRuntimeCoordinator.swift
@@ -171,14 +171,14 @@ final class WorkflowRuntimeCoordinator {
             listings[id] = try JSONEncoder().encode(names)
           }
         }
-        let resource = requestResource ?? "instruction"
+        let resource = requestResource ?? "prompt"
         let data: Data
         let total: Int64
         let next: Int64?
-        if resource == "instruction" || listings[resource] != nil {
+        if resource == "prompt" || listings[resource] != nil {
           let full =
             listings[resource]
-            ?? Data((grant.text + (invocation.activation?.completion.instructionTrailer() ?? "")).utf8)
+            ?? Data((grant.text + (invocation.activation?.completion.completionTrailer() ?? "")).utf8)
           guard offset >= 0, offset <= full.count else { throw WorkflowHistoryError.protectedRun }
           let end = min(Int(offset) + WorkflowSizeLimits.contentPage, full.count)
           data = full.subdata(in: Int(offset)..<end)

--- a/supacode/Domain/Workflow/WorkflowHistoryIndex.swift
+++ b/supacode/Domain/Workflow/WorkflowHistoryIndex.swift
@@ -71,10 +71,15 @@ nonisolated struct WorkflowHistoryStepDefinition: Codable, Equatable, Sendable {
   let id: String
   let title: String
   let loop: String?
+  var kind: String = ""
+  var actionID: String?
 
   static func flatten(_ steps: [WorkflowStepDefinition], loop: String? = nil) -> [Self] {
     steps.flatMap { step in
-      let current = Self(id: step.id, title: step.title ?? step.historyTitle, loop: loop)
+      // Dynamic titles are captured at execution, not evaluated later against changed state.
+      let title = step.title.flatMap { $0.contains("{{") ? nil : $0 } ?? step.historyTitle
+      var current = Self(id: step.id, title: title, loop: loop, kind: step.action.verb)
+      if case .action(let id, _) = step.action { current.actionID = id }
       let nestedLoop: String?
       if case .control(.loop) = step.action { nestedLoop = step.id } else { nestedLoop = loop }
       return [current] + flatten(step.action.children, loop: nestedLoop)
@@ -88,9 +93,16 @@ nonisolated extension WorkflowStepDefinition {
     case .message(let role, _, _): "Message \(role)"
     case .launch(let role, _, _, _): "Launch \(role)"
     case .action(let id, _): "Run \(id)"
-    case .notify: "Send notification"
+    case .notify: "Send to Prowl Notifications"
     case .close(let role): "Close \(role)"
-    case .control: id
+    case .control(let control):
+      switch control {
+      case .conditional: "Choose a branch"
+      case .loop: "Loop \(id)"
+      case .set: "Update workflow state"
+      case .breakLoop: "Exit loop"
+      case .continueLoop: "Continue loop"
+      }
     }
   }
 }

--- a/supacode/Domain/Workflow/WorkflowLineRenderer.swift
+++ b/supacode/Domain/Workflow/WorkflowLineRenderer.swift
@@ -29,7 +29,7 @@ nonisolated enum WorkflowRenderedText {
 }
 
 /// The completion command of one activation. This is the only place that spells
-/// `prowl workflow deliver`: the typed hint, the materialized instruction trailer, the launch
+/// `prowl workflow deliver`: the typed hint, the scoped-read completion trailer, the launch
 /// protocol block, the watchdog nudge, every re-delivery, and the `WORKFLOW_DELIVERY_REQUIRED`
 /// message all read from it, so no path can show a token-less or verdict-less command.
 nonisolated struct WorkflowCompletionCommand: Equatable, Sendable {
@@ -57,13 +57,13 @@ nonisolated struct WorkflowCompletionCommand: Equatable, Sendable {
     return verdicts.map { "\(Self.executable) --verdict \($0) -" }
   }
 
-  /// Appended to a typed `text` or pointer line.
+  /// Appended to a typed prompt or scoped-read line.
   var typedSuffix: String {
     " — finish with: " + messageCommands.joined(separator: Self.commandSeparator)
   }
 
-  /// The trailer of a materialized instruction file; lists the same commands as the typed line.
-  func instructionTrailer() -> String {
+  /// Added to the scoped-read response, not to the saved prompt body.
+  func completionTrailer() -> String {
     var lines = ["", "---", "When this step is fully complete, finish with"]
     if messageCommands.count > 1 {
       lines[lines.count - 1] += " exactly one of:"
@@ -144,11 +144,14 @@ nonisolated enum WorkflowTypedLine {
     try validated(prefix + text + (completion?.typedSuffix ?? ""))
   }
 
-  /// `instruction` → `[Prowl] Read <absolute path> and follow it[ — finish with: …]`.
-  static func pointer(to path: String, completion: WorkflowCompletionCommand?) throws(WorkflowRenderedTextError)
-    -> String
+  /// Transport is chosen after template rendering, never by an authored DSL field.
+  static func prompt(_ grant: WorkflowTaskContent, completion: WorkflowCompletionCommand?)
+    throws(WorkflowRenderedTextError) -> String
   {
-    try validated(prefix + "Read \(path) and follow it" + (completion?.typedSuffix ?? ""))
+    let inline = grant.text + (grant.resources.isEmpty ? "" : " " + grant.guidance)
+    let line = prefix + inline + (completion?.typedSuffix ?? "")
+    if line.utf8.count <= 4096 && WorkflowRenderedText.isSingleLine(line) { return line }
+    return try text(grant.guidance, completion: completion)
   }
 
   /// The panel's "Ask again" after a provisional delivery: what was missing, and the command.

--- a/supacode/Domain/Workflow/WorkflowRun.swift
+++ b/supacode/Domain/Workflow/WorkflowRun.swift
@@ -168,8 +168,8 @@ nonisolated enum WorkflowRunPaths {
     return storage.directory(root: root, createdAt: createdAt ?? Date(), runID: runID)
   }
 
-  static func instructionURL(runDirectory: URL, stepID: String, ordinal: Int) -> URL {
-    runDirectory.appending(path: "instructions", directoryHint: .isDirectory)
+  static func promptURL(runDirectory: URL, stepID: String, ordinal: Int) -> URL {
+    runDirectory.appending(path: "prompts", directoryHint: .isDirectory)
       .appending(path: "\(stepID).\(ordinal).md", directoryHint: .notDirectory)
   }
 
@@ -243,7 +243,8 @@ nonisolated struct WorkflowInvocation: Equatable, Sendable {
   let role: String
   let kind: WorkflowInvocationKind
   let startedAt: Date
-  var instructionPath: String?
+  var promptPath: String?
+  var target: WorkflowRunRecord.Binding?
   var content: WorkflowTaskContent?
   var activation: WorkflowActivation?
   var endedAt: Date?
@@ -298,6 +299,7 @@ nonisolated struct WorkflowStepRecord: Equatable, Sendable {
   var delivery: WorkflowDeliveryRecord?
   var submissions: [WorkflowHistorySubmission]?
   var actionExecutionID: String?
+  var summary: String?
 }
 
 // MARK: - Attention and status

--- a/supacode/Domain/Workflow/WorkflowRunMachine.swift
+++ b/supacode/Domain/Workflow/WorkflowRunMachine.swift
@@ -94,7 +94,7 @@ nonisolated enum WorkflowRunEffect: Equatable, Sendable {
   case cancelRoleWait(ordinal: Int)
   /// Self-initiated first step: open the activation record without typing anything.
   case openActivation(role: String, surfaceID: UUID, ordinal: Int)
-  case materializeInstruction(ordinal: Int, stepID: String, text: String)
+  case materializePrompt(ordinal: Int, stepID: String, text: String)
   case materializeSkill(id: String)
   /// Issue + bind the activation (when `opensActivation`) and type the line as one operation.
   case inject(role: String, surfaceID: UUID, ordinal: Int, line: String, opensActivation: Bool)
@@ -397,6 +397,9 @@ nonisolated struct WorkflowRunMachine {
     }
     run.participants[invocation.role, default: []].append(pane)
     run.bindings[invocation.role] = binding.binding(pane: pane)
+    updateInvocation(ordinal: ordinal) {
+      $0.target = .init(source: binding.source, profile: binding.profile, pane: pane)
+    }
     effects.append(.log("Step '\(invocation.stepID)': role '\(invocation.role)' launched in \(pane.handle)."))
     openWaiting(ordinal: ordinal, dispatchID: dispatchID, effects: &effects)
   }
@@ -645,8 +648,8 @@ nonisolated struct WorkflowRunMachine {
   ) -> String? {
     if let title = step.title, references(name, in: title) { return step.id }
     switch step.action {
-    case .message(_, let content, _):
-      if references(name, in: content.body) { return step.id }
+    case .message(_, let prompt, _):
+      if references(name, in: prompt) { return step.id }
     case .launch(_, let prompt, _, _):
       if references(name, in: prompt) { return step.id }
     case .notify(let text):
@@ -749,6 +752,7 @@ nonisolated struct WorkflowRunMachine {
   {
     guard let rendered = render(text, step: step, effects: &effects) else { return false }
     recordStep(step, state: .completed, ordinal: nil)
+    run.stepRecords[run.stepRecords.count - 1].summary = rendered
     effects.append(.notify(rendered))
     effects.append(.log("Step '\(step.id)': notified \"\(rendered)\"."))
     moveNext()
@@ -758,9 +762,11 @@ nonisolated struct WorkflowRunMachine {
   private mutating func enterClose(_ step: WorkflowStepDefinition, role: String, effects: inout [WorkflowRunEffect]) {
     recordStep(step, state: .completed, ordinal: nil)
     if let surfaceID = run.bindings[role]?.pane?.surfaceID {
+      run.stepRecords[run.stepRecords.count - 1].summary = "Requested closure of role '\(role)'."
       effects.append(.close(role: role, surfaceID: surfaceID))
       effects.append(.log("Step '\(step.id)': close requested for role '\(role)'."))
     } else {
+      run.stepRecords[run.stepRecords.count - 1].summary = "Role '\(role)' has no pane to close."
       effects.append(.log("Step '\(step.id)': role '\(role)' has no pane to close."))
     }
     moveNext()
@@ -775,7 +781,7 @@ nonisolated struct WorkflowRunMachine {
   private mutating func enterMessage(
     _ step: WorkflowStepDefinition, selfInitiated: Bool, effects: inout [WorkflowRunEffect]
   ) {
-    guard case .message(let role, let content, let expect) = step.action else { return }
+    guard case .message(let role, let prompt, let expect) = step.action else { return }
     let ordinal = mintOrdinal()
     run.invocations.append(
       WorkflowInvocation(
@@ -790,7 +796,7 @@ nonisolated struct WorkflowRunMachine {
     let isCurrentRole = run.definition.role(named: role)?.source == .current
     if selfInitiated, isCurrentRole {
       guard
-        let line = renderMessageLine(ordinal: ordinal, step: step, content: content, expect: expect, effects: &effects)
+        let line = renderMessageLine(ordinal: ordinal, step: step, prompt: prompt, expect: expect, effects: &effects)
       else { return }
       run.selfInitiatedLine = line
       effects.append(.log("Step '\(step.id)': returned to the caller's own pane instead of being typed."))
@@ -810,28 +816,28 @@ nonisolated struct WorkflowRunMachine {
   }
 
   private mutating func injectCurrentMessage(ordinal: Int, effects: inout [WorkflowRunEffect]) {
-    guard let step = run.currentStep, case .message(let role, let content, let expect) = step.action,
+    guard let step = run.currentStep, case .message(let role, let prompt, let expect) = step.action,
       let pane = run.bindings[role]?.pane
     else { return }
     guard
-      let line = renderMessageLine(ordinal: ordinal, step: step, content: content, expect: expect, effects: &effects)
+      let line = renderMessageLine(ordinal: ordinal, step: step, prompt: prompt, expect: expect, effects: &effects)
     else { return }
     run.phase = .injecting(ordinal: ordinal)
     effects.append(
       .inject(role: role, surfaceID: pane.surfaceID, ordinal: ordinal, line: line, opensActivation: expect != nil))
   }
 
-  /// Renders the typed line (materializing an instruction first) and opens the activation
+  /// Renders the typed line (saving the prompt first) and opens the activation
   /// token; nil when rendering failed, in which case the run is already in attention or ended.
   private mutating func renderMessageLine(
     ordinal: Int,
     step: WorkflowStepDefinition,
-    content: WorkflowMessageContent,
+    prompt: String,
     expect: WorkflowExpectation?,
     effects: inout [WorkflowRunEffect]
   ) -> String? {
     guard let invocation = invocation(ordinal) else { return nil }
-    guard let rendered = render(content.body, step: step, effects: &effects) else { return nil }
+    guard let rendered = render(prompt, step: step, effects: &effects) else { return nil }
     var completion: WorkflowCompletionCommand?
     if let expect, let deliveryName = step.deliveryName {
       // A `roleBusy` refusal returns the same invocation to its idle wait: the activation and its
@@ -850,26 +856,11 @@ nonisolated struct WorkflowRunMachine {
     let grant = taskContent(
       text: rendered, ordinal: ordinal, skill: nil)
     updateInvocation(ordinal: ordinal) { $0.content = grant }
+    let url = WorkflowRunPaths.promptURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
+    updateInvocation(ordinal: ordinal) { $0.promptPath = WorkflowRunPaths.path(url) }
+    effects.append(.materializePrompt(ordinal: ordinal, stepID: step.id, text: grant.text))
     do {
-      switch content {
-      case .text:
-        let path = WorkflowRunPaths.instructionURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
-        updateInvocation(ordinal: ordinal) { $0.instructionPath = WorkflowRunPaths.path(path) }
-        effects.append(
-          .materializeInstruction(
-            ordinal: ordinal, stepID: step.id, text: grant.text + (completion?.instructionTrailer() ?? "")))
-        return try WorkflowTypedLine.text(
-          grant.text + (grant.resources.isEmpty ? "" : " " + grant.guidance), completion: completion)
-      case .instruction:
-        let url = WorkflowRunPaths.instructionURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
-        let path = WorkflowRunPaths.path(url)
-        var text = grant.text
-        if !text.hasSuffix("\n") { text += "\n" }
-        if let completion { text += completion.instructionTrailer() }
-        updateInvocation(ordinal: ordinal) { $0.instructionPath = path }
-        effects.append(.materializeInstruction(ordinal: ordinal, stepID: step.id, text: text))
-        return try WorkflowTypedLine.text(grant.guidance, completion: completion)
-      }
+      return try WorkflowTypedLine.prompt(grant, completion: completion)
     } catch {
       run.phase = .injecting(ordinal: ordinal)
       updateActivation(ordinal: ordinal) { $0.state = .revoked }
@@ -935,14 +926,12 @@ nonisolated struct WorkflowRunMachine {
         runID: run.id.uuidString, workflowName: run.definition.name, role: role, stepTitle: title, expect: expect)
     }
     let grant = taskContent(text: userPrompt, ordinal: ordinal, skill: skill)
-    let instruction = WorkflowRunPaths.instructionURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
+    let promptURL = WorkflowRunPaths.promptURL(runDirectory: run.runDirectory, stepID: step.id, ordinal: ordinal)
     updateInvocation(ordinal: ordinal) {
       $0.content = grant
-      $0.instructionPath = WorkflowRunPaths.path(instruction)
+      $0.promptPath = WorkflowRunPaths.path(promptURL)
     }
-    effects.append(
-      .materializeInstruction(
-        ordinal: ordinal, stepID: step.id, text: grant.text + "\n\n" + (protocolBlock ?? "")))
+    effects.append(.materializePrompt(ordinal: ordinal, stepID: step.id, text: grant.text))
     let prompt = WorkflowLaunchPrompt.render(
       userPrompt: grant.text + "\n\n" + grant.guidance, protocolBlock: protocolBlock)
     do {
@@ -1051,7 +1040,7 @@ nonisolated struct WorkflowRunMachine {
         run.stepRecords.append(
           .init(
             stepID: position.stepID, iteration: position.iteration, state: .active,
-            ordinal: nil, iterationPath: position.path))
+            ordinal: nil, iterationPath: position.path, title: position.title))
       }
       raiseAttention(
         .actionFailed("Control evaluation failed: \(error)"), stepID: cursor.failedPosition?.stepID ?? "control",
@@ -1070,7 +1059,8 @@ nonisolated struct WorkflowRunMachine {
         .init(
           stepID: evaluation.stepID, iteration: evaluation.iteration,
           state: evaluation.skipped ? .skipped : .completed, ordinal: nil,
-          iterationPath: evaluation.path, branchExcluded: evaluation.skipped))
+          iterationPath: evaluation.path, branchExcluded: evaluation.skipped,
+          title: evaluation.title, summary: evaluation.summary))
     }
     for name in cursor.expiredDeliveries { run.deliveries.removeValue(forKey: name) }
     for name in cursor.expiredActions { run.actionOutputs.removeValue(forKey: name) }
@@ -1331,14 +1321,14 @@ nonisolated struct WorkflowRunMachine {
     switch step.action {
     case .launch:
       advance(effects: &effects)
-    case .message(_, let content, let expect):
+    case .message(_, let prompt, let expect):
       let ordinal = mintOrdinal()
       run.invocations.append(
         WorkflowInvocation(
           ordinal: ordinal, stepID: step.id, iteration: run.currentIteration, role: role, kind: .launch,
           startedAt: now()))
       recordStep(step, state: .active, ordinal: ordinal)
-      guard let rendered = render(content.body, step: step, effects: &effects) else { return }
+      guard let rendered = render(prompt, step: step, effects: &effects) else { return }
       launch(
         LaunchPlan(
           step: step, ordinal: ordinal, role: role, userPrompt: rendered, skill: nil, expect: expect, redelivery: true),
@@ -1508,6 +1498,11 @@ nonisolated struct WorkflowRunMachine {
   }
 
   private mutating func recordStep(_ step: WorkflowStepDefinition, state: WorkflowStepState, ordinal: Int?) {
+    if let ordinal, let role = step.action.targetRole, let binding = run.bindings[role] {
+      updateInvocation(ordinal: ordinal) {
+        $0.target = .init(source: binding.source, profile: binding.profile, pane: binding.pane)
+      }
+    }
     run.stepRecords.append(
       WorkflowStepRecord(
         stepID: step.id, iteration: run.currentIteration, state: state, ordinal: ordinal,

--- a/supacode/Domain/Workflow/WorkflowRunStore.swift
+++ b/supacode/Domain/Workflow/WorkflowRunStore.swift
@@ -1,6 +1,6 @@
 // supacode/Domain/Workflow/WorkflowRunStore.swift
 // Personal run directories contain `run.json`,
-// an append-only `log.md`, materialized instructions and skills, and versioned deliveries with an
+// an append-only `log.md`, saved prompts and skills, and versioned deliveries with an
 // atomically replaced latest view. Every path is built from validated slugs and the run UUID
 // under the same physical containment gate as profile homes.
 
@@ -16,20 +16,22 @@ nonisolated struct WorkflowRunRecordInvocation: Codable, Equatable, Sendable {
   let iteration: Int?
   let role: String
   let kind: WorkflowInvocationKind
-  let instructionPath: String?
+  let promptPath: String?
   let resources: [String: String]?
   let skill: String?
   let activation: WorkflowRunRecordActivation?
   let startedAt: Date
   let endedAt: Date?
+  var target: WorkflowRunRecord.Binding?
 
   enum CodingKeys: String, CodingKey {
+    case target
     case ordinal
     case step
     case iteration
     case role
     case kind
-    case instructionPath = "instruction_path"
+    case promptPath = "prompt_path"
     case resources
     case skill
     case activation
@@ -118,13 +120,14 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
     var delivery: WorkflowDeliveryRecord?
     var submissions: [WorkflowHistorySubmission]?
     var actionExecutionID: String?
+    var summary: String?
   }
 
   var historyIsPartial: Bool?
   var sourcePaneID: UUID?
   var sourceSessionIdentity: String?
   var participants: [String: [WorkflowPaneIdentity]]?
-  var stepDefinitions: [WorkflowHistoryStepDefinition]?
+  var stepDefinitions: [WorkflowHistoryStepDefinition]
   let version: Int
   let run: WorkflowRunRecordInfo
   let worktree: WorkflowRunWorktree
@@ -187,14 +190,15 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
         iteration: invocation.iteration,
         role: invocation.role,
         kind: invocation.kind,
-        instructionPath: invocation.instructionPath,
+        promptPath: invocation.promptPath,
         resources: invocation.content?.resources.mapValues { String($0.dropFirst(run.runDirectory.path.count + 1)) },
         skill: invocation.content?.skill,
         activation: invocation.activation.map {
           WorkflowRunRecordActivation(dispatchID: $0.dispatchID, state: $0.state, delivery: $0.deliveryName)
         },
         startedAt: invocation.startedAt,
-        endedAt: invocation.endedAt
+        endedAt: invocation.endedAt,
+        target: invocation.target
       )
     }
     deliveries = run.deliveries
@@ -206,7 +210,8 @@ nonisolated struct WorkflowRunRecord: Codable, Equatable, Sendable {
       Step(
         id: $0.stepID, iteration: $0.iteration, state: $0.state, ordinal: $0.ordinal,
         iterationPath: $0.iterationPath, branchExcluded: $0.branchExcluded, title: $0.title, error: $0.error,
-        outputs: $0.outputs, delivery: $0.delivery, submissions: $0.submissions, actionExecutionID: $0.actionExecutionID
+        outputs: $0.outputs, delivery: $0.delivery, submissions: $0.submissions,
+        actionExecutionID: $0.actionExecutionID, summary: $0.summary
       )
     }
   }
@@ -381,7 +386,7 @@ nonisolated struct WorkflowRunStore: Sendable {
   func ensureLayout(runID: UUID) throws {
     let runDirectory = directory(for: runID)
     try storage.prepare(runDirectory)
-    for name in ["instructions", "deliveries", "skills"] {
+    for name in ["prompts", "deliveries", "skills"] {
       try storage.prepare(runDirectory.appending(path: name))
     }
   }
@@ -467,13 +472,13 @@ nonisolated struct WorkflowRunStore: Sendable {
     try handle.write(contentsOf: Data(entry.utf8))
   }
 
-  // MARK: Instructions and deliveries
+  // MARK: Prompts and deliveries
 
   @discardableResult
-  func writeInstruction(runID: UUID, stepID: String, ordinal: Int, text: String) throws -> URL {
+  func writePrompt(runID: UUID, stepID: String, ordinal: Int, text: String) throws -> URL {
     let runDirectory = try containedRunDirectory(runID: runID)
     guard WorkflowSchema.isSlug(stepID), ordinal > 0 else { throw WorkflowRunStoreError.unsafePath(stepID) }
-    let url = WorkflowRunPaths.instructionURL(runDirectory: runDirectory, stepID: stepID, ordinal: ordinal)
+    let url = WorkflowRunPaths.promptURL(runDirectory: runDirectory, stepID: stepID, ordinal: ordinal)
     try requireNotSymbolicLink(url.deletingLastPathComponent())
     try requireNotSymbolicLink(url)
     try text.write(to: url, atomically: true, encoding: .utf8)

--- a/supacode/Domain/Workflow/WorkflowStarterTemplate.swift
+++ b/supacode/Domain/Workflow/WorkflowStarterTemplate.swift
@@ -41,7 +41,7 @@ nonisolated enum WorkflowStarterTemplate {
       - id: brief
         title: Author writing the brief
         message: author
-        instruction: |
+        prompt: |
           Write a short brief for a reviewer: what changed, what you are unsure about, and how
           to verify it. Focus: {{ inputs.focus }}
           Deliver the brief with the generated completion command.

--- a/supacode/Features/Repositories/Models/ToolbarPopoverCoordinator.swift
+++ b/supacode/Features/Repositories/Models/ToolbarPopoverCoordinator.swift
@@ -1,0 +1,79 @@
+import Clocks
+import Observation
+
+/// One owner for adjacent hover popovers. Callbacks from a replaced panel cannot reopen it.
+@MainActor @Observable
+final class ToolbarPopoverCoordinator {
+  enum Destination { case notifications, history }
+
+  private(set) var presented: Destination?
+  private var pinned: Destination?
+  private var hoveredButton: Destination?
+  private var hoveredPopover: Destination?
+  @ObservationIgnored private var closeTask: Task<Void, Never>?
+  @ObservationIgnored private let clock: any Clock<Duration>
+
+  init(clock: any Clock<Duration> = ContinuousClock()) {
+    self.clock = clock
+  }
+
+  func hoverButton(_ destination: Destination, hovering: Bool) {
+    if hovering {
+      hoveredButton = destination
+      closeTask?.cancel()
+      guard pinned == nil else { return }
+      if presented != destination { hoveredPopover = nil }
+      presented = destination
+    } else if hoveredButton == destination {
+      hoveredButton = nil
+      scheduleClose()
+    }
+  }
+
+  func hoverPopover(_ destination: Destination, hovering: Bool) {
+    guard presented == destination else { return }
+    hoveredPopover = hovering ? destination : nil
+    scheduleClose()
+  }
+
+  func toggle(_ destination: Destination) {
+    if pinned == destination {
+      dismiss(destination)
+    } else {
+      showPinned(destination)
+    }
+  }
+
+  func showPinned(_ destination: Destination) {
+    closeTask?.cancel()
+    if presented != destination { hoveredPopover = nil }
+    presented = destination
+    pinned = destination
+  }
+
+  func pin(_ destination: Destination) {
+    guard presented == destination else { return }
+    showPinned(destination)
+  }
+
+  func dismiss(_ destination: Destination) {
+    guard presented == destination else { return }
+    closeTask?.cancel()
+    presented = nil
+    pinned = nil
+    hoveredPopover = nil
+    hoveredButton = nil
+  }
+
+  private func scheduleClose() {
+    closeTask?.cancel()
+    guard let destination = presented, pinned == nil, hoveredButton != destination, hoveredPopover != destination else {
+      return
+    }
+    closeTask = Task { [weak self, clock] in
+      do { try await clock.sleep(for: .milliseconds(180)) } catch { return }
+      guard !Task.isCancelled else { return }
+      self?.dismiss(destination)
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift
+++ b/supacode/Features/Repositories/Views/ToolbarNotificationsPopoverButton.swift
@@ -1,15 +1,11 @@
 import SwiftUI
 
 struct ToolbarNotificationsPopoverButton: View {
+  @Environment(ToolbarPopoverCoordinator.self) private var popovers
   let groups: [ToolbarNotificationRepositoryGroup]
   let unseenWorktreeCount: Int
   let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
   let onDismissAll: () -> Void
-  @State private var isPresented = false
-  @State private var isPinnedOpen = false
-  @State private var isHoveringButton = false
-  @State private var isHoveringPopover = false
-  @State private var closeTask: Task<Void, Never>?
 
   private var notificationCount: Int {
     groups.reduce(0) { count, repository in
@@ -22,7 +18,7 @@ struct ToolbarNotificationsPopoverButton: View {
 
   var body: some View {
     Button {
-      togglePresentation()
+      popovers.toggle(.notifications)
     } label: {
       HStack(spacing: 6) {
         Image(systemName: unseenWorktreeCount > 0 ? "bell.badge.fill" : "bell.fill")
@@ -36,69 +32,29 @@ struct ToolbarNotificationsPopoverButton: View {
     }
     .help("Notifications. Hover or click to show all notifications.")
     .accessibilityLabel("Notifications")
-    .onHover { hovering in
-      isHoveringButton = hovering
-      updatePresentation()
-    }
-    .popover(isPresented: $isPresented) {
+    .onHover { popovers.hoverButton(.notifications, hovering: $0) }
+    .popover(
+      isPresented: Binding(
+        get: { popovers.presented == .notifications },
+        set: { if !$0 { popovers.dismiss(.notifications) } }
+      )
+    ) {
       ToolbarNotificationsPopoverView(
         groups: groups,
         onSelectNotification: { worktreeID, notification in
           onSelectNotification(worktreeID, notification)
-          closePopover()
+          popovers.dismiss(.notifications)
         },
         onDismissAll: {
           onDismissAll()
-          closePopover()
+          popovers.dismiss(.notifications)
         }
       )
-      .onHover { hovering in
-        isHoveringPopover = hovering
-        updatePresentation()
-      }
-      .onDisappear {
-        isHoveringPopover = false
-        isPinnedOpen = false
-      }
+      .onHover { popovers.hoverPopover(.notifications, hovering: $0) }
     }
     .onChange(of: groups) { _, newValue in
-      if newValue.isEmpty {
-        closePopover()
-      }
+      if newValue.isEmpty { popovers.dismiss(.notifications) }
     }
-    .onDisappear {
-      closeTask?.cancel()
-    }
-  }
-
-  private func togglePresentation() {
-    if isPinnedOpen {
-      closePopover()
-      return
-    }
-    closeTask?.cancel()
-    isPinnedOpen = true
-    isPresented = true
-  }
-
-  private func updatePresentation() {
-    if isPinnedOpen || isHoveringButton || isHoveringPopover {
-      closeTask?.cancel()
-      isPresented = true
-      return
-    }
-    closeTask?.cancel()
-    closeTask = Task { @MainActor in
-      try? await ContinuousClock().sleep(for: .milliseconds(150))
-      if !Task.isCancelled {
-        isPresented = false
-      }
-    }
-  }
-
-  private func closePopover() {
-    closeTask?.cancel()
-    isPinnedOpen = false
-    isPresented = false
+    .onDisappear { popovers.dismiss(.notifications) }
   }
 }

--- a/supacode/Features/Repositories/Views/WorkflowHistoryPopoverButton.swift
+++ b/supacode/Features/Repositories/Views/WorkflowHistoryPopoverButton.swift
@@ -3,61 +3,32 @@ import SwiftUI
 
 struct WorkflowHistoryPopoverButton: View {
   @Bindable var store: StoreOf<WorkflowStepHistoryFeature>
+  @Environment(ToolbarPopoverCoordinator.self) private var popovers
   let onIntent: (WorkflowRunPanelIntent) -> Void
-  @State private var presented = false
-  @State private var pinned = false
-  @State private var hoveringButton = false
-  @State private var hoveringPanel = false
-  @State private var closeTask: Task<Void, Never>?
 
   var body: some View {
     Button {
-      if pinned {
-        presented = false
-      } else {
-        pinned = true
-        presented = true
-      }
+      popovers.toggle(.history)
     } label: {
-      Image(systemName: "clock.arrow.circlepath")
+      Image(systemName: "checklist")
+        .foregroundStyle(.secondary)
     }
     .help("Workflow History. Hover to preview or click to keep open.")
     .accessibilityLabel("Workflow History")
-    .onHover {
-      hoveringButton = $0
-      updateHover()
+    .onHover { popovers.hoverButton(.history, hovering: $0) }
+    .popover(
+      isPresented: Binding(
+        get: { popovers.presented == .history },
+        set: { if !$0 { popovers.dismiss(.history) } }
+      )
+    ) {
+      WorkflowStepHistoryView(store: store, onIntent: onIntent, onInteraction: { popovers.pin(.history) })
+        .onHover { popovers.hoverPopover(.history, hovering: $0) }
     }
-    .popover(isPresented: $presented) {
-      WorkflowStepHistoryView(store: store, onIntent: onIntent, onInteraction: { pinned = true })
-        .onHover {
-          hoveringPanel = $0
-          updateHover()
-        }
-    }
-    .onChange(of: presented) { _, visible in
+    .onChange(of: popovers.presented == .history) { _, visible in
       store.send(.setPresented(visible))
-      if !visible {
-        pinned = false
-        hoveringPanel = false
-      }
     }
-    .onChange(of: store.openRequest) { _, _ in
-      pinned = true
-      presented = true
-    }
-    .onDisappear { closeTask?.cancel() }
-  }
-
-  private func updateHover() {
-    closeTask?.cancel()
-    if hoveringButton || hoveringPanel {
-      presented = true
-      return
-    }
-    guard !pinned else { return }
-    closeTask = Task { @MainActor in
-      try? await ContinuousClock().sleep(for: .milliseconds(180))
-      if !Task.isCancelled && !pinned { presented = false }
-    }
+    .onChange(of: store.openRequest) { _, _ in popovers.showPinned(.history) }
+    .onDisappear { popovers.dismiss(.history) }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -29,6 +29,7 @@ struct WorktreeDetailView: View {
   /// True while a Canvas card is expanded in place, so the otherwise-transparent
   /// Canvas toolbar gets a matching material scrim instead of showing through.
   @State private var isCanvasCardExpanded = false
+  @State private var toolbarPopovers = ToolbarPopoverCoordinator()
   @State private var historyStore = Store(initialState: WorkflowStepHistoryFeature.State()) {
     WorkflowStepHistoryFeature()
   }
@@ -114,6 +115,7 @@ struct WorktreeDetailView: View {
       }
     }
     .environment(historyStore)
+    .environment(toolbarPopovers)
     .task { loadWorkflowHistory(context: historyContext, runs: state.workflowRuns.sessions.values.map(\.run)) }
     .onChange(of: historyContext) { _, context in historyStore.send(.context(context)) }
     .onChange(of: state.workflowRuns.sessions) { _, sessions in
@@ -209,7 +211,8 @@ struct WorktreeDetailView: View {
           currentSignal: terminalManager.currentAgentSignalEvidenceSnapshot(surfaceID: entry.surfaceID)
             .latestManagedHook)
       },
-      worktreeID: worktree?.id, livePaneIDs: Set(repositories.activeAgents.entries.map(\.surfaceID)))
+      worktreeID: worktree?.id,
+      livePaneIDs: Set(terminalManager.activeWorktreeStates.flatMap { $0.surfaces.keys }))
   }
 
   private func toolbarSharedState(

--- a/supacode/Features/Workflow/Models/WorkflowHistoryDetailPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryDetailPresentation.swift
@@ -1,0 +1,147 @@
+import Foundation
+import ProwlCLIShared
+
+nonisolated struct WorkflowHistoryRole {
+  let role: String
+  let agent: String?
+  let livePane: WorkflowPaneIdentity?
+
+  init(role: String, binding: WorkflowRunRecord.Binding, livePaneIDs: Set<UUID>) {
+    self.role = role
+    agent = binding.pane?.agent ?? binding.profile?.agent
+    livePane = binding.pane.flatMap { livePaneIDs.contains($0.surfaceID) ? $0 : nil }
+  }
+}
+
+nonisolated struct WorkflowHistoryTextPreview {
+  let text: String
+  let remainingCharacters: Int
+
+  init(_ body: String) {
+    text = String(body.prefix(200))
+    remainingCharacters = max(0, body.count - text.count)
+  }
+}
+
+nonisolated struct WorkflowHistoryOutputField: Identifiable {
+  let key: String
+  let value: WorkflowJSONValue
+  var depth = 0
+  var id: String { key }
+  var displayKey: String { String(key.prefix(100)) }
+
+  static func fields(_ values: [String: WorkflowJSONValue], depth: Int = 0) -> [Self] {
+    values.keys.sorted().prefix(32).map { Self(key: $0, value: values[$0]!, depth: depth) }
+  }
+
+  var children: [Self]? {
+    guard depth < 5 else { return nil }
+    switch value {
+    case .object(let values): return Self.fields(values, depth: depth + 1)
+    case .array(let values):
+      return values.prefix(32).enumerated().map { Self(key: "[\($0.offset)]", value: $0.element, depth: depth + 1) }
+    default: return nil
+    }
+  }
+
+  var childCount: Int {
+    switch value {
+    case .object(let values): values.count
+    case .array(let values): values.count
+    default: 0
+    }
+  }
+
+  var summary: String {
+    switch value {
+    case .object(let values): "\(values.count) fields"
+    case .array(let values): "\(values.count) items"
+    case .string(let text): String(text.prefix(200)) + (text.dropFirst(200).isEmpty ? "" : "…")
+    default: (try? String(bytes: JSONEncoder().encode(value), encoding: .utf8)) ?? "null"
+    }
+  }
+
+  var fileURL: URL? {
+    guard key == "path" || key.hasSuffix("_path"), case .string(let path) = value,
+      path.hasPrefix("/"), !path.contains("\n"), !path.contains("\0")
+    else { return nil }
+    return URL(filePath: path)
+  }
+}
+
+nonisolated enum WorkflowHistoryTiming {
+  static func duration(_ interval: TimeInterval) -> String {
+    guard interval.isFinite, interval >= 1 else { return "<1s" }
+    let seconds = Int(min(interval, Double(Int.max / 2)))
+    var parts: [String] = []
+    if seconds >= 3600 { parts.append("\(seconds / 3600)h") }
+    if seconds >= 60 { parts.append("\(seconds % 3600 / 60)m") }
+    parts.append("\(seconds % 60)s")
+    return parts.joined(separator: " ")
+  }
+
+  static func timestamp(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd HH:mm"
+    return formatter.string(from: date)
+  }
+
+  static func actionDuration(_ data: Data) -> TimeInterval? {
+    guard let value = try? JSONDecoder().decode(WorkflowJSONValue.self, from: data),
+      case .object(let fields) = value,
+      case .string(let start) = fields["started_at"], case .string(let end) = fields["finished_at"]
+    else { return nil }
+    let formatter = ISO8601DateFormatter()
+    guard let start = formatter.date(from: start), let end = formatter.date(from: end), end >= start else { return nil }
+    return end.timeIntervalSince(start)
+  }
+
+  static func durations(
+    _ groups: [WorkflowHistoryStepGroup], record: WorkflowRunRecord, directory: URL?, storage: WorkflowHistoryStorage
+  ) -> [String: TimeInterval] {
+    let invocations = Dictionary(record.invocations.map { ($0.ordinal, $0) }, uniquingKeysWith: { first, _ in first })
+    var result: [String: TimeInterval] = [:]
+    for group in groups {
+      let durations: [TimeInterval] = group.attempts.compactMap { attempt in
+        if let ordinal = attempt.ordinal, let invocation = invocations[ordinal], let end = invocation.endedAt,
+          end >= invocation.startedAt
+        {
+          return end.timeIntervalSince(invocation.startedAt)
+        }
+        guard let directory, let path = diagnosticDirectory(attempt, directory: directory),
+          let data = try? storage.read(path.appending(path: "execution.json"), limit: 64 * 1024)
+        else { return nil }
+        return actionDuration(data)
+      }
+      if !durations.isEmpty, durations.count == group.attempts.count {
+        result[group.id] = durations.reduce(0, +)
+      }
+    }
+    return result
+  }
+
+  static func diagnosticDirectory(_ attempt: WorkflowRunRecord.Step, directory: URL) -> URL? {
+    guard WorkflowSchema.isSlug(attempt.id), let execution = attempt.actionExecutionID,
+      UUID(uuidString: execution) != nil
+    else { return nil }
+    return directory.appending(path: "actions/\(attempt.id)/\(execution)")
+  }
+}
+
+nonisolated enum WorkflowHistoryArtifact {
+  static func validate(_ url: URL, worktree: URL, storage: WorkflowHistoryStorage) throws {
+    if url.path.hasPrefix(storage.baseURL.path + "/") {
+      try storage.validate(url)
+    } else {
+      // Resolve the worktree alias, but never resolve links within the artifact path.
+      let files = WorkflowHistoryStorage(baseURL: worktree)
+      let roots = [worktree.path, files.baseURL.path]
+      guard let root = roots.first(where: { url.path.hasPrefix($0 + "/.prowl/handoff/") }) else {
+        throw WorkflowHistoryError.unsafePath(url.path)
+      }
+      let relative = String(url.path.dropFirst(root.count + 1))
+      try files.validate(files.baseURL.appending(path: relative))
+    }
+  }
+}

--- a/supacode/Features/Workflow/Models/WorkflowHistoryDetailPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryDetailPresentation.swift
@@ -14,6 +14,7 @@ nonisolated struct WorkflowHistoryRole {
 }
 
 nonisolated struct WorkflowHistoryTextPreview {
+  static let maximumBytes = 64 * 1024 * 1024
   let text: String
   let remainingCharacters: Int
 
@@ -21,6 +22,22 @@ nonisolated struct WorkflowHistoryTextPreview {
     text = String(body.prefix(200))
     remainingCharacters = max(0, body.count - text.count)
   }
+
+  static func read(_ url: URL, storage: WorkflowHistoryStorage) throws -> Self {
+    let data = try storage.read(url, limit: maximumBytes)
+    guard let text = String(data: data, encoding: .utf8) else { throw CocoaError(.fileReadInapplicableStringEncoding) }
+    return Self(text)
+  }
+}
+
+nonisolated struct WorkflowHistoryFileRevision: Hashable {
+  var updatedAt: Date?
+  var state: String?
+}
+
+nonisolated struct WorkflowHistoryFileLoadKey: Hashable {
+  let url: URL
+  let revision: WorkflowHistoryFileRevision
 }
 
 nonisolated struct WorkflowHistoryOutputField: Identifiable {

--- a/supacode/Features/Workflow/Models/WorkflowHistoryExecutionPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryExecutionPresentation.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ProwlCLIShared
+
+nonisolated enum WorkflowHistoryExecution {
+  static func promptURL(_ invocation: WorkflowRunRecordInvocation, directory: URL) -> URL? {
+    guard WorkflowSchema.isSlug(invocation.step), invocation.ordinal > 0, let path = invocation.promptPath else {
+      return nil
+    }
+    let expected = WorkflowRunPaths.promptURL(
+      runDirectory: directory, stepID: invocation.step, ordinal: invocation.ordinal)
+    let recorded = path.hasPrefix("/") ? URL(filePath: path) : directory.appending(path: path)
+    guard recorded.standardizedFileURL == expected.standardizedFileURL else { return nil }
+    return expected
+  }
+
+  static func agentStatus(_ invocation: WorkflowRunRecordInvocation) -> String? {
+    if invocation.kind == .launch {
+      guard invocation.target?.pane != nil else { return "Agent has not started." }
+      return "Agent started."
+    }
+    return nil
+  }
+
+  static func actionInput(_ data: Data) throws -> [String: WorkflowJSONValue] {
+    struct Request: Decodable { let input: [String: WorkflowJSONValue] }
+    let input = try JSONDecoder().decode(Request.self, from: data).input
+    try WorkflowJSON.validate(.object(input))
+    return input
+  }
+}

--- a/supacode/Features/Workflow/Models/WorkflowHistoryOutput.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryOutput.swift
@@ -23,6 +23,13 @@ enum WorkflowHistoryOutput {
         throw CocoaError(.fileReadInapplicableStringEncoding)
       }
       copy(text)
+    case .copyText(let text): copy(text)
+    case .openArtifact(let url, let worktree):
+      try WorkflowHistoryArtifact.validate(url, worktree: worktree, storage: storage)
+      guard NSWorkspace.shared.open(url) else { throw CocoaError(.fileReadUnknown) }
+    case .revealArtifact(let url, let worktree):
+      try WorkflowHistoryArtifact.validate(url, worktree: worktree, storage: storage)
+      NSWorkspace.shared.activateFileViewerSelecting([url])
     case .openText(let text, let name):
       try await openData(Data(text.utf8), name: name)
     case .openJSON(let output):

--- a/supacode/Features/Workflow/Models/WorkflowHistoryOutput.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryOutput.swift
@@ -18,7 +18,9 @@ enum WorkflowHistoryOutput {
       try storage.validate(url)
       NSWorkspace.shared.activateFileViewerSelecting([url])
     case .copyFile(let url):
-      let data = try await Task.detached(priority: .utility) { try storage.read(url, limit: 64 * 1024 * 1024) }.value
+      let data = try await Task.detached(priority: .utility) {
+        try storage.read(url, limit: WorkflowHistoryTextPreview.maximumBytes)
+      }.value
       guard let text = String(bytes: data, encoding: .utf8) else {
         throw CocoaError(.fileReadInapplicableStringEncoding)
       }

--- a/supacode/Features/Workflow/Models/WorkflowHistoryPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryPresentation.swift
@@ -49,9 +49,12 @@ nonisolated enum WorkflowHistoryStatus {
     switch state {
     case "completed": "checkmark.circle.fill"
     case "active", "running": "play.circle"
-    case "needs_attention", "failed": "exclamationmark.circle.fill"
-    case "skipped", "branch_not_selected": "forward.end.circle"
-    case "cancelled", "interrupted": "stop.circle"
+    case "needs_attention", "failed", "iteration_limit_reached": "exclamationmark.circle.fill"
+    case "skipped": "forward.end.circle"
+    case "branch_not_selected": "arrow.triangle.branch"
+    case "cancelled": "stop.circle"
+    case "interrupted": "pause.circle"
+    case "not_run": "minus.circle"
     default: "circle"
     }
   }
@@ -67,7 +70,11 @@ nonisolated struct WorkflowHistoryStepGroup: Identifiable, Sendable {
   var iterationLabel: String?
 
   var subtitle: String {
-    var parts = [WorkflowHistoryStatus.label(state)]
+    [WorkflowHistoryStatus.label(state), contextLabel].filter { !$0.isEmpty }.joined(separator: " · ")
+  }
+
+  var contextLabel: String {
+    var parts: [String] = []
     if let iterationLabel { parts.append(iterationLabel) } else if let iteration { parts.append("Round \(iteration)") }
     if attempts.count > 1 { parts.append("\(attempts.count) attempts") }
     return parts.joined(separator: " · ")
@@ -130,62 +137,12 @@ nonisolated struct WorkflowHistoryStepGroup: Identifiable, Sendable {
   }
 }
 
-nonisolated enum WorkflowHistoryOutputPreview {
-  static func json(_ outputs: [String: WorkflowJSONValue]) -> String {
-    let text = outputs.keys.sorted().prefix(8).map { key in
-      "\(bounded(key, limit: 100)): \(preview(outputs[key]!, depth: 0))"
-    }.joined(separator: "\n")
-    return bounded(text, limit: 4096)
-  }
-
-  static func text(_ data: Data, limit: Int = 4096) -> String? {
-    let prefix = data.prefix(limit)
-    if let value = String(bytes: prefix, encoding: .utf8) { return value }
-    guard data.count > limit else { return nil }
-    for count in 1...min(3, prefix.count) {
-      let suffix = Array(prefix.suffix(count))
-      let lead = suffix[0]
-      let length =
-        (0xC2...0xDF).contains(lead) ? 2 : (0xE0...0xEF).contains(lead) ? 3 : (0xF0...0xF4).contains(lead) ? 4 : 0
-      guard count < length, suffix.dropFirst().allSatisfy({ (0x80...0xBF).contains($0) }) else { continue }
-      if count > 1 {
-        let second = suffix[1]
-        if (lead == 0xE0 && second < 0xA0) || (lead == 0xED && second >= 0xA0)
-          || (lead == 0xF0 && second < 0x90) || (lead == 0xF4 && second >= 0x90)
-        {
-          continue
-        }
-      }
-      if let value = String(bytes: prefix.dropLast(count), encoding: .utf8) { return value }
-    }
-    return nil
-  }
-
-  private static func bounded(_ value: String, limit: Int) -> String {
-    let data = Data(value.utf8.prefix(limit + 4))
-    return text(data, limit: limit) ?? ""
-  }
-
-  private static func preview(_ value: WorkflowJSONValue, depth: Int) -> String {
-    switch value {
-    case .string(let value): bounded(value, limit: 300)
-    case .object(let fields):
-      depth >= 2
-        ? "{…}"
-        : "{"
-          + fields.keys.sorted().prefix(6).map {
-            "\(bounded($0, limit: 100)): \(preview(fields[$0]!, depth: depth + 1))"
-          }.joined(separator: ", ") + "}"
-    case .array(let values):
-      depth >= 2 ? "[…]" : "[" + values.prefix(6).map { preview($0, depth: depth + 1) }.joined(separator: ", ") + "]"
-    default: (try? String(bytes: JSONEncoder().encode(value), encoding: .utf8)) ?? "null"
-    }
-  }
-}
-
 nonisolated enum WorkflowHistoryOutputIntent: Equatable, Sendable {
   case openFile(URL)
   case copyFile(URL)
+  case copyText(String)
+  case openArtifact(URL, worktree: URL)
+  case revealArtifact(URL, worktree: URL)
   case reveal(URL)
   case openText(String, String)
   case openJSON([String: WorkflowJSONValue])

--- a/supacode/Features/Workflow/Models/WorkflowHistoryPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowHistoryPresentation.swift
@@ -66,47 +66,38 @@ nonisolated struct WorkflowHistoryStepGroup: Identifiable, Sendable {
   let state: String
   let iteration: Int?
   let attempts: [WorkflowRunRecord.Step]
-  var legacyDetailsUnavailable = false
+  let definition: WorkflowHistoryStepDefinition
+  let invocations: [Int: WorkflowRunRecordInvocation]
   var iterationLabel: String?
 
   var subtitle: String {
     [WorkflowHistoryStatus.label(state), contextLabel].filter { !$0.isEmpty }.joined(separator: " · ")
   }
 
+  var attemptLabel: String { definition.kind == "while" ? "Check" : "Attempt" }
+
   var contextLabel: String {
     var parts: [String] = []
     if let iterationLabel { parts.append(iterationLabel) } else if let iteration { parts.append("Round \(iteration)") }
-    if attempts.count > 1 { parts.append("\(attempts.count) attempts") }
+    if attempts.count > 1 { parts.append("\(attempts.count) \(attemptLabel.lowercased())s") }
     return parts.joined(separator: " · ")
   }
 
   static func groups(_ record: WorkflowRunRecord) -> [Self] {
-    var definitions = record.stepDefinitions ?? []
-    let known = Set(definitions.map(\.id))
-    var added: Set<String> = []
-    for step in record.steps where !known.contains(step.id) && added.insert(step.id).inserted {
-      definitions.append(.init(id: step.id, title: step.title ?? step.id, loop: nil))
-    }
+    let definitions = record.stepDefinitions
     let positions = Dictionary(
       definitions.enumerated().map { ($0.element.id, $0.offset) }, uniquingKeysWith: { first, _ in first })
-    let deliveries = Dictionary(
-      record.deliveries.values.map { ($0.ordinal, $0) }, uniquingKeysWith: { first, _ in first })
+    let invocations = Dictionary(
+      record.invocations.map { ($0.ordinal, $0) }, uniquingKeysWith: { first, _ in first })
     let titles = Dictionary(definitions.map { ($0.id, $0.title) }, uniquingKeysWith: { first, _ in first })
     let byStep = Dictionary(grouping: record.steps, by: \.id)
     var result: [(group: Self, order: [Int])] = []
     for definition in definitions {
       let records = byStep[definition.id] ?? []
-      let byPath = Dictionary(grouping: records) { $0.iterationPath ?? $0.iteration.map { ["legacy:\($0)"] } ?? [] }
+      let byPath = Dictionary(grouping: records) { $0.iterationPath ?? [] }
       let paths = byPath.isEmpty ? [[]] : Array(byPath.keys)
       for path in paths {
-        let attempts = (byPath[path] ?? []).map { step in
-          var step = step
-          if step.delivery == nil, let ordinal = step.ordinal { step.delivery = deliveries[ordinal] }
-          if record.stepDefinitions == nil, records.count == 1, step.state == .completed, step.outputs == nil {
-            step.outputs = record.actions[step.id]
-          }
-          return step
-        }
+        let attempts = byPath[path] ?? []
         let latest = attempts.last
         var state = latest?.state.rawValue ?? (record.run.status.isTerminal ? "not_run" : "pending")
         if latest?.state == .active && record.run.status.isTerminal { state = "interrupted" }
@@ -115,8 +106,8 @@ nonisolated struct WorkflowHistoryStepGroup: Identifiable, Sendable {
         let group = Self(
           id: "\(definition.id):\(path.joined(separator: "/"))",
           title: latest?.title ?? definition.title, state: state, iteration: latest?.iteration, attempts: attempts,
-          legacyDetailsUnavailable: record.stepDefinitions == nil,
-          iterationLabel: path.isEmpty || path.first?.hasPrefix("legacy:") == true
+          definition: definition, invocations: invocations,
+          iterationLabel: path.isEmpty
             ? nil
             : path.map { component in
               let parts = component.split(separator: ":")

--- a/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
+++ b/supacode/Features/Workflow/Models/WorkflowStatusCenterPresentation.swift
@@ -46,7 +46,7 @@ nonisolated struct WorkflowRunPresentation: Equatable, Sendable, Identifiable {
   let elapsedText: String
   let status: Status
   let currentStepTitle: String
-  let currentInstruction: String?
+  let currentPrompt: String?
   let roles: [WorkflowRolePresentation]
   let stepItems: [WorkflowStepListItem]
   let attentionControls: [WorkflowAttentionControl]
@@ -64,7 +64,7 @@ nonisolated struct WorkflowRunPresentation: Equatable, Sendable, Identifiable {
     status = run.status.attention.map { .needsAttention($0.message) } ?? .running
     let context = Self.templateContext(for: run, iteration: run.currentIteration)
     currentStepTitle = Self.title(for: run.currentStep, context: context) ?? "Finishing workflow"
-    currentInstruction = Self.instruction(for: run.currentStep, context: context)
+    currentPrompt = Self.prompt(for: run.currentStep, context: context)
     roles = run.definition.roles.map { role in
       WorkflowRolePresentation(role: role, binding: run.bindings[role.name])
     }
@@ -134,15 +134,15 @@ nonisolated struct WorkflowRunPresentation: Equatable, Sendable, Identifiable {
     step.historyTitle
   }
 
-  private static func instruction(
+  private static func prompt(
     for step: WorkflowStepDefinition?,
     context: [String: WorkflowJSONValue]
   ) -> String? {
     guard let step else { return nil }
     let source: String?
     switch step.action {
-    case .message(_, let content, _):
-      source = content.body
+    case .message(_, let prompt, _):
+      source = prompt
     case .launch(_, let prompt, _, _):
       source = prompt
     case .action(let id, _):

--- a/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
+++ b/supacode/Features/Workflow/Reducer/WorkflowRunsFeature.swift
@@ -670,10 +670,10 @@ struct WorkflowRunsFeature {
           .event(runID: runID, .injectionFailed(ordinal: ordinal, failure.injectionFailure)))
       }
 
-    case .materializeInstruction(let ordinal, let stepID, let text):
+    case .materializePrompt(let ordinal, let stepID, let text):
       do {
         try store.ensureLayout(runID: runID)
-        _ = try store.writeInstruction(runID: runID, stepID: stepID, ordinal: ordinal, text: text)
+        _ = try store.writePrompt(runID: runID, stepID: stepID, ordinal: ordinal, text: text)
       } catch {
         let reason = "The instruction could not be persisted: \(error)"
         let event: WorkflowRunEvent =
@@ -847,7 +847,7 @@ extension WorkflowRunEffect {
   nonisolated var isRevocable: Bool {
     switch self {
     case .openActivation, .inject, .typeLine, .launch, .runAction, .close: true
-    case .awaitRoleIdle, .cancelRoleWait, .materializeInstruction, .materializeSkill, .notify,
+    case .awaitRoleIdle, .cancelRoleWait, .materializePrompt, .materializeSkill, .notify,
       .abandonActivation, .completeActivation, .armWatchdog, .disarmWatchdog, .persistDelivery, .persist, .log,
       .finished, .yieldControl:
       false

--- a/supacode/Features/Workflow/Views/WorkflowHistoryControls.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryControls.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+extension WorkflowHistoryStatus {
+  static func tint(_ state: String) -> Color {
+    switch state {
+    case "completed": .green
+    case "active", "running": .blue
+    case "needs_attention", "interrupted", "iteration_limit_reached": .orange
+    case "failed": .red
+    default: .secondary
+    }
+  }
+}
+
+struct WorkflowHistoryStatusIcon: View {
+  let state: String
+
+  var body: some View {
+    Image(systemName: WorkflowHistoryStatus.symbol(state))
+      .foregroundStyle(WorkflowHistoryStatus.tint(state))
+      .accessibilityLabel(WorkflowHistoryStatus.label(state))
+      .help(WorkflowHistoryStatus.label(state))
+  }
+}
+
+struct WorkflowHistoryIconButton: View {
+  let label: String
+  let symbol: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(label, systemImage: symbol, action: action)
+      .labelStyle(.iconOnly)
+      .buttonStyle(.borderless)
+      .controlSize(.small)
+      .help(label)
+      .accessibilityLabel(label)
+  }
+}
+
+struct WorkflowHistoryDisclosureStyle: DisclosureGroupStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Button {
+        configuration.isExpanded.toggle()
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: configuration.isExpanded ? "chevron.down" : "chevron.right")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: 10)
+            .accessibilityHidden(true)
+          configuration.label
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 9)
+        .contentShape(.rect)
+      }
+      .buttonStyle(WorkflowHistoryRowButtonStyle(expanded: configuration.isExpanded))
+      .accessibilityValue(configuration.isExpanded ? "Expanded" : "Collapsed")
+      .accessibilityHint("Expand or collapse step details")
+      .help(configuration.isExpanded ? "Collapse step" : "Expand step")
+      if configuration.isExpanded {
+        configuration.content
+          .padding(.leading, 26)
+          .padding(.trailing, 8)
+          .padding(.vertical, 10)
+      }
+    }
+  }
+}
+
+private struct WorkflowHistoryRowButtonStyle: ButtonStyle {
+  let expanded: Bool
+
+  func makeBody(configuration: Configuration) -> some View {
+    Row(configuration: configuration, expanded: expanded)
+  }
+
+  private struct Row: View {
+    let configuration: ButtonStyleConfiguration
+    let expanded: Bool
+    @State private var hovering = false
+
+    var body: some View {
+      configuration.label
+        .background(
+          Color.primary.opacity(configuration.isPressed ? 0.12 : hovering ? 0.08 : expanded ? 0.04 : 0),
+          in: RoundedRectangle(cornerRadius: 6)
+        )
+        .onHover { hovering = $0 }
+    }
+  }
+}

--- a/supacode/Features/Workflow/Views/WorkflowHistoryExecutionView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryExecutionView.swift
@@ -1,0 +1,132 @@
+import ProwlCLIShared
+import SwiftUI
+
+struct WorkflowHistoryExecutionView: View {
+  let definition: WorkflowHistoryStepDefinition
+  let attempt: WorkflowRunRecord.Step
+  let invocation: WorkflowRunRecordInvocation?
+  let directory: URL?
+  let worktree: URL
+  let livePaneIDs: Set<UUID>
+  let revision: WorkflowHistoryFileRevision
+  let onFocus: (UUID) -> Void
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if let invocation {
+        if let target = invocation.target {
+          WorkflowHistoryRoleView(
+            role: invocation.role, binding: target, livePaneIDs: livePaneIDs, showsName: true, onFocus: onFocus)
+        }
+        if let status = WorkflowHistoryExecution.agentStatus(invocation) {
+          Text(status).font(.caption).foregroundStyle(.secondary)
+        }
+        if let directory, let url = WorkflowHistoryExecution.promptURL(invocation, directory: directory) {
+          WorkflowHistoryTextFileView(
+            label: "Prompt", contentName: "prompt", url: url, onOutput: onOutput, revision: revision)
+        }
+      }
+      if let action = definition.actionID {
+        LabeledContent("Action", value: action).font(.caption).textSelection(.enabled)
+        if let directory, let execution = WorkflowHistoryTiming.diagnosticDirectory(attempt, directory: directory) {
+          WorkflowHistoryActionInputView(
+            directory: execution, worktree: worktree, onOutput: onOutput, revision: revision)
+        }
+      }
+      if let summary = attempt.summary {
+        if definition.kind == "notify" {
+          Text("Sent to Prowl Notifications").font(.caption).foregroundStyle(.secondary)
+          WorkflowHistoryInlineTextView(text: summary, name: "notification", onOutput: onOutput)
+        } else {
+          Text(summary).font(.caption).textSelection(.enabled)
+        }
+      }
+    }
+  }
+}
+
+struct WorkflowHistoryRoleView: View {
+  let role: String
+  let binding: WorkflowRunRecord.Binding
+  let livePaneIDs: Set<UUID>
+  var showsName = false
+  let onFocus: (UUID) -> Void
+  @ScaledMetric(relativeTo: .caption) private var iconSize = 13
+
+  var body: some View {
+    let presentation = WorkflowHistoryRole(role: role, binding: binding, livePaneIDs: livePaneIDs)
+    HStack(spacing: 5) {
+      Text("\(role):").foregroundStyle(.secondary)
+      if let agent = presentation.agent {
+        let token = DetectedAgent(rawValue: agent)?.iconLookupToken ?? agent
+        TabIconImage(
+          rawName: (CommandIconMap.iconForFirstToken(token) ?? TabIconSource(systemSymbol: "terminal")).storageString,
+          pointSize: iconSize
+        ).accessibilityLabel(agent).help(agent)
+      }
+      if showsName, let name = binding.profile?.name ?? binding.pane?.displayName {
+        Text(name).lineLimit(1).truncationMode(.middle).help(name)
+      }
+      if let pane = presentation.livePane {
+        Button("@\(pane.handle)") { onFocus(pane.surfaceID) }
+          .buttonStyle(.link).help("Focus \(role) in @\(pane.handle)")
+      } else if presentation.agent == nil {
+        Text("Not bound").foregroundStyle(.secondary)
+      }
+    }.font(.caption)
+  }
+}
+
+private struct WorkflowHistoryActionInputView: View {
+  let directory: URL
+  let worktree: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  let revision: WorkflowHistoryFileRevision
+  @State private var inputs: [String: WorkflowJSONValue]?
+  @State private var unavailable = false
+
+  var body: some View {
+    Group {
+      if let inputs {
+        WorkflowHistoryJSONView(values: inputs, worktree: worktree, onOutput: onOutput, title: "Input")
+      } else {
+        Text(unavailable ? "No saved action input." : "Loading input…").font(.caption).foregroundStyle(.secondary)
+      }
+    }
+    .task(id: WorkflowHistoryFileLoadKey(url: directory, revision: revision)) {
+      inputs = nil
+      unavailable = false
+      let storage = WorkflowHistoryStorage.configured
+      let url = directory.appending(path: "request.json")
+      let result = await Task.detached(priority: .utility) {
+        guard let data = try? storage.read(url, limit: WorkflowSizeLimits.transportFrame) else {
+          return nil as [String: WorkflowJSONValue]?
+        }
+        return try? WorkflowHistoryExecution.actionInput(data)
+      }.value
+      guard !Task.isCancelled else { return }
+      inputs = result
+      unavailable = result == nil
+    }
+  }
+}
+
+private struct WorkflowHistoryInlineTextView: View {
+  let text: String
+  let name: String
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+
+  var body: some View {
+    let preview = WorkflowHistoryTextPreview(text)
+    HStack(alignment: .top) {
+      WorkflowHistoryMarkdownPreview(preview: preview, emptyText: "Empty message")
+      WorkflowHistoryIconButton(label: "Open full \(name)", symbol: "arrow.up.forward.square") {
+        onOutput(.openText(text, "\(name).md"))
+      }
+      WorkflowHistoryIconButton(label: "Copy full \(name)", symbol: "doc.on.doc") {
+        onOutput(.copyText(text))
+      }
+    }
+  }
+}

--- a/supacode/Features/Workflow/Views/WorkflowHistoryMarkdownPreview.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryMarkdownPreview.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct WorkflowHistoryMarkdownPreview: View {
+  let preview: WorkflowHistoryTextPreview
+  let emptyText: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(markdown)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      if preview.remainingCharacters > 0 {
+        Text("\(preview.remainingCharacters.formatted()) more characters…")
+          .font(.caption).foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  private var markdown: AttributedString {
+    let text = preview.text.isEmpty ? emptyText : preview.text
+    return (try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+      ?? AttributedString(text)
+  }
+}

--- a/supacode/Features/Workflow/Views/WorkflowHistoryOutputViews.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryOutputViews.swift
@@ -5,19 +5,21 @@ struct WorkflowHistoryJSONView: View {
   let values: [String: WorkflowJSONValue]
   let worktree: URL
   let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  var title = "Output"
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       HStack {
-        Text("Output").font(.caption).foregroundStyle(.secondary)
+        Text(title).font(.caption).foregroundStyle(.secondary)
         Spacer()
-        WorkflowHistoryIconButton(label: "Open full JSON output", symbol: "arrow.up.forward.square") {
+        WorkflowHistoryIconButton(label: "Open full JSON \(title.lowercased())", symbol: "arrow.up.forward.square") {
           onOutput(.openJSON(values))
         }
-        WorkflowHistoryIconButton(label: "Copy full JSON output", symbol: "doc.on.doc") {
+        WorkflowHistoryIconButton(label: "Copy full JSON \(title.lowercased())", symbol: "doc.on.doc") {
           onOutput(.copyJSON(values))
         }
       }
+      if values.isEmpty { Text("No fields").foregroundStyle(.secondary) }
       ForEach(WorkflowHistoryOutputField.fields(values)) { field in
         WorkflowHistoryOutputFieldView(field: field, worktree: worktree, onOutput: onOutput)
       }
@@ -100,59 +102,65 @@ struct WorkflowHistoryDeliveryView: View {
   let delivery: WorkflowDeliveryRecord
   let directory: URL
   let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  var revision = WorkflowHistoryFileRevision()
+
+  var body: some View {
+    if WorkflowSchema.isSlug(delivery.name), delivery.ordinal > 0 {
+      let url = delivery.path.hasPrefix("/") ? URL(filePath: delivery.path) : directory.appending(path: delivery.path)
+      WorkflowHistoryTextFileView(
+        label: delivery.name, contentName: "output", url: url, onOutput: onOutput,
+        verdict: delivery.verdict, revision: revision)
+    } else {
+      Text("Output reference is invalid.").foregroundStyle(.secondary)
+    }
+  }
+}
+
+struct WorkflowHistoryTextFileView: View {
+  let label: String
+  let contentName: String
+  let url: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  var verdict: String?
+  var revision = WorkflowHistoryFileRevision()
   @State private var preview: WorkflowHistoryTextPreview?
   @State private var error: String?
-
-  private var url: URL {
-    if delivery.path.hasPrefix("/") { return URL(filePath: delivery.path) }
-    return directory.appending(path: delivery.path)
-  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       HStack {
-        Text(delivery.name).font(.caption).foregroundStyle(.secondary).lineLimit(1)
-        if let verdict = delivery.verdict { Text(verdict).font(.caption.weight(.medium)).lineLimit(1) }
+        Text(label).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+        if let verdict { Text(verdict).font(.caption.weight(.medium)).lineLimit(1) }
         Spacer(minLength: 8)
         HStack(spacing: 8) {
-          WorkflowHistoryIconButton(label: "Open full output", symbol: "arrow.up.forward.square") {
+          WorkflowHistoryIconButton(label: "Open full \(contentName)", symbol: "arrow.up.forward.square") {
             onOutput(.openFile(url))
           }
-          WorkflowHistoryIconButton(label: "Copy full output", symbol: "doc.on.doc") { onOutput(.copyFile(url)) }
-          WorkflowHistoryIconButton(label: "Reveal output in Finder", symbol: "folder") { onOutput(.reveal(url)) }
-        }.disabled(preview == nil)
+          WorkflowHistoryIconButton(label: "Copy full \(contentName)", symbol: "doc.on.doc") {
+            onOutput(.copyFile(url))
+          }
+          WorkflowHistoryIconButton(label: "Reveal \(contentName) in Finder", symbol: "folder") {
+            onOutput(.reveal(url))
+          }
+        }
       }
       if let preview {
-        Text(preview.text.isEmpty ? "No output" : preview.text)
-          .lineLimit(6)
-          .textSelection(.enabled)
-          .frame(maxWidth: .infinity, alignment: .leading)
-        if preview.remainingCharacters > 0 {
-          Text("\(preview.remainingCharacters.formatted()) more characters…")
-            .font(.caption).foregroundStyle(.secondary)
-        }
+        WorkflowHistoryMarkdownPreview(preview: preview, emptyText: "Empty \(contentName)")
       } else {
-        Text(error ?? "Loading output…").foregroundStyle(.secondary)
+        Text(error ?? "Loading \(contentName)…").foregroundStyle(.secondary)
       }
     }
-    .task(id: url) {
+    .task(id: WorkflowHistoryFileLoadKey(url: url, revision: revision)) {
       preview = nil
       error = nil
-      guard WorkflowSchema.isSlug(delivery.name), delivery.ordinal > 0 else {
-        error = "Output reference is invalid."
-        return
-      }
       let storage = WorkflowHistoryStorage.configured
       let outputURL = url
       let result = await Task.detached(priority: .utility) { () -> WorkflowHistoryTextPreview? in
-        guard let data = try? storage.read(outputURL, limit: WorkflowSizeLimits.payload),
-          let text = String(data: data, encoding: .utf8)
-        else { return nil }
-        return WorkflowHistoryTextPreview(text)
+        try? WorkflowHistoryTextPreview.read(outputURL, storage: storage)
       }.value
       guard !Task.isCancelled else { return }
       preview = result
-      if result == nil { error = "Saved output could not be read." }
+      if result == nil { error = "Preview unavailable. Open the file to view its contents." }
     }
   }
 }

--- a/supacode/Features/Workflow/Views/WorkflowHistoryOutputViews.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryOutputViews.swift
@@ -1,0 +1,158 @@
+import ProwlCLIShared
+import SwiftUI
+
+struct WorkflowHistoryJSONView: View {
+  let values: [String: WorkflowJSONValue]
+  let worktree: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text("Output").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        WorkflowHistoryIconButton(label: "Open full JSON output", symbol: "arrow.up.forward.square") {
+          onOutput(.openJSON(values))
+        }
+        WorkflowHistoryIconButton(label: "Copy full JSON output", symbol: "doc.on.doc") {
+          onOutput(.copyJSON(values))
+        }
+      }
+      ForEach(WorkflowHistoryOutputField.fields(values)) { field in
+        WorkflowHistoryOutputFieldView(field: field, worktree: worktree, onOutput: onOutput)
+      }
+      if values.count > 32 { Text("\(values.count - 32) more fields in full output").foregroundStyle(.secondary) }
+    }
+    .font(.caption)
+  }
+}
+
+private struct WorkflowHistoryOutputFieldView: View {
+  let field: WorkflowHistoryOutputField
+  let worktree: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  @State private var expanded = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 6) {
+        if let children = field.children, !children.isEmpty {
+          Button {
+            expanded.toggle()
+          } label: {
+            HStack(spacing: 6) {
+              Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                .font(.caption2).frame(width: 10).accessibilityHidden(true)
+              valueRow
+            }.contentShape(.rect)
+          }
+          .buttonStyle(.plain)
+          .help("\(expanded ? "Collapse" : "Expand") \(field.key)")
+          .accessibilityValue(expanded ? "Expanded" : "Collapsed")
+        } else {
+          Color.clear.frame(width: 10, height: 1)
+          valueRow
+        }
+        if let url = field.fileURL {
+          WorkflowHistoryIconButton(label: "Open \(url.lastPathComponent)", symbol: "arrow.up.forward.square") {
+            onOutput(.openArtifact(url, worktree: worktree))
+          }
+          WorkflowHistoryIconButton(label: "Reveal \(url.lastPathComponent) in Finder", symbol: "folder") {
+            onOutput(.revealArtifact(url, worktree: worktree))
+          }
+        }
+        if case .string(let value) = field.value {
+          WorkflowHistoryIconButton(label: "Copy \(field.key)", symbol: "doc.on.doc") { onOutput(.copyText(value)) }
+        }
+      }
+      if expanded, let children = field.children {
+        ForEach(children) { child in
+          WorkflowHistoryOutputFieldView(field: child, worktree: worktree, onOutput: onOutput)
+        }
+        .padding(.leading, 14)
+        if field.childCount > children.count {
+          Text("\(field.childCount - children.count) more fields in full output")
+            .foregroundStyle(.secondary).padding(.leading, 30)
+        }
+      }
+    }
+  }
+
+  private var valueRow: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      Text(field.displayKey)
+        .foregroundStyle(.secondary)
+        .frame(width: 100, alignment: .leading)
+        .help(
+          field.key == "output_path"
+            ? "The saved JSON result file; output contains its fields" : String(field.key.prefix(300)))
+      Text(field.fileURL?.path ?? field.summary)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .font(.caption.monospaced())
+    .lineLimit(1)
+    .truncationMode(.middle)
+  }
+}
+
+struct WorkflowHistoryDeliveryView: View {
+  let delivery: WorkflowDeliveryRecord
+  let directory: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  @State private var preview: WorkflowHistoryTextPreview?
+  @State private var error: String?
+
+  private var url: URL {
+    if delivery.path.hasPrefix("/") { return URL(filePath: delivery.path) }
+    return directory.appending(path: delivery.path)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(delivery.name).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+        if let verdict = delivery.verdict { Text(verdict).font(.caption.weight(.medium)).lineLimit(1) }
+        Spacer(minLength: 8)
+        HStack(spacing: 8) {
+          WorkflowHistoryIconButton(label: "Open full output", symbol: "arrow.up.forward.square") {
+            onOutput(.openFile(url))
+          }
+          WorkflowHistoryIconButton(label: "Copy full output", symbol: "doc.on.doc") { onOutput(.copyFile(url)) }
+          WorkflowHistoryIconButton(label: "Reveal output in Finder", symbol: "folder") { onOutput(.reveal(url)) }
+        }.disabled(preview == nil)
+      }
+      if let preview {
+        Text(preview.text.isEmpty ? "No output" : preview.text)
+          .lineLimit(6)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        if preview.remainingCharacters > 0 {
+          Text("\(preview.remainingCharacters.formatted()) more characters…")
+            .font(.caption).foregroundStyle(.secondary)
+        }
+      } else {
+        Text(error ?? "Loading output…").foregroundStyle(.secondary)
+      }
+    }
+    .task(id: url) {
+      preview = nil
+      error = nil
+      guard WorkflowSchema.isSlug(delivery.name), delivery.ordinal > 0 else {
+        error = "Output reference is invalid."
+        return
+      }
+      let storage = WorkflowHistoryStorage.configured
+      let outputURL = url
+      let result = await Task.detached(priority: .utility) { () -> WorkflowHistoryTextPreview? in
+        guard let data = try? storage.read(outputURL, limit: WorkflowSizeLimits.payload),
+          let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        return WorkflowHistoryTextPreview(text)
+      }.value
+      guard !Task.isCancelled else { return }
+      preview = result
+      if result == nil { error = "Saved output could not be read." }
+    }
+  }
+}

--- a/supacode/Features/Workflow/Views/WorkflowHistoryStepRow.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryStepRow.swift
@@ -1,0 +1,127 @@
+import ProwlCLIShared
+import SwiftUI
+
+struct WorkflowHistoryStepRow: View {
+  let group: WorkflowHistoryStepGroup
+  let duration: TimeInterval?
+  let directory: URL?
+  let worktree: URL
+  let onOutput: (WorkflowHistoryOutputIntent) -> Void
+  let onInteraction: () -> Void
+  @State private var expanded: Bool
+
+  init(
+    group: WorkflowHistoryStepGroup, duration: TimeInterval?, directory: URL?, worktree: URL,
+    onOutput: @escaping (WorkflowHistoryOutputIntent) -> Void, onInteraction: @escaping () -> Void
+  ) {
+    self.group = group
+    self.duration = duration
+    self.directory = directory
+    self.worktree = worktree
+    self.onOutput = onOutput
+    self.onInteraction = onInteraction
+    _expanded = State(initialValue: group.state == "failed" || group.state == "needs_attention")
+  }
+
+  var body: some View {
+    DisclosureGroup(isExpanded: $expanded) {
+      VStack(alignment: .leading, spacing: 10) {
+        if group.attempts.isEmpty {
+          Text("This step did not run.").foregroundStyle(.secondary)
+        }
+        ForEach(Array(group.attempts.enumerated()), id: \.offset) { index, attempt in
+          if group.attempts.count > 1 {
+            if index == group.attempts.count - 1 {
+              Text("Attempt \(index + 1)").font(.caption).foregroundStyle(.secondary)
+              attemptContent(attempt)
+            } else {
+              DisclosureGroup("Attempt \(index + 1) · \(WorkflowHistoryStatus.label(attempt.state.rawValue))") {
+                attemptContent(attempt)
+              }.disclosureGroupStyle(.automatic)
+            }
+          } else {
+            attemptContent(attempt)
+          }
+        }
+      }
+      .font(.callout)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    } label: {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        WorkflowHistoryStatusIcon(state: group.state)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(group.title).lineLimit(2)
+          if !group.contextLabel.isEmpty {
+            Text(group.contextLabel).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+          }
+        }
+        Spacer(minLength: 8)
+        Text(duration.map(WorkflowHistoryTiming.duration) ?? "—")
+          .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+          .fixedSize()
+          .help(duration == nil ? "No duration recorded" : "Recorded step duration, including retries")
+      }.font(.subheadline)
+    }
+    .disclosureGroupStyle(WorkflowHistoryDisclosureStyle())
+    .onChange(of: expanded) { _, _ in onInteraction() }
+  }
+
+  @ViewBuilder
+  private func attemptContent(_ attempt: WorkflowRunRecord.Step) -> some View {
+    if let error = attempt.error {
+      HStack {
+        Text(attempt.state == .completed ? "Earlier issue" : "Error").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        WorkflowHistoryIconButton(label: "Open full error", symbol: "arrow.up.forward.square") {
+          onOutput(.openText(error, "error.txt"))
+        }
+        WorkflowHistoryIconButton(label: "Copy full error", symbol: "doc.on.doc") {
+          onOutput(.copyText(error))
+        }
+      }
+      Text(String(error.prefix(1000))).foregroundStyle(.orange).textSelection(.enabled).lineLimit(6)
+    }
+    if let submissions = attempt.submissions, !submissions.isEmpty, let directory {
+      ForEach(Array(submissions.enumerated()), id: \.offset) { index, submission in
+        if index == submissions.count - 1 {
+          if submissions.count > 1 || !submission.accepted {
+            Text("Submission \(index + 1) · \(submission.statusLabel)").font(.caption).foregroundStyle(.secondary)
+          }
+          ForEach(submission.issues, id: \.self) { Text($0).foregroundStyle(.orange).lineLimit(3) }
+          WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
+        } else {
+          DisclosureGroup("Submission \(index + 1) · \(submission.statusLabel)") {
+            ForEach(submission.issues, id: \.self) { Text($0).foregroundStyle(.orange).lineLimit(3) }
+            WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
+          }.disclosureGroupStyle(.automatic)
+        }
+      }
+    } else if let delivery = attempt.delivery, let directory {
+      WorkflowHistoryDeliveryView(delivery: delivery, directory: directory, onOutput: onOutput)
+    }
+    if let outputs = attempt.outputs, !outputs.isEmpty {
+      WorkflowHistoryJSONView(values: outputs, worktree: worktree, onOutput: onOutput)
+    }
+    if attempt.delivery == nil && (attempt.submissions ?? []).isEmpty && (attempt.outputs ?? [:]).isEmpty
+      && attempt.error == nil
+    {
+      Text(group.legacyDetailsUnavailable ? "No saved output" : "No output")
+        .foregroundStyle(.secondary)
+    }
+    if let directory, let diagnostics = WorkflowHistoryTiming.diagnosticDirectory(attempt, directory: directory) {
+      Menu {
+        ForEach(["stdout.log", "stderr.log", "execution.json"], id: \.self) { name in
+          Button(name, systemImage: "doc.text") { onOutput(.openFile(diagnostics.appending(path: name))) }
+            .help("Open \(name)")
+        }
+      } label: {
+        Label("Diagnostics", systemImage: "terminal")
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .help("Open action logs or the execution record")
+    }
+  }
+}

--- a/supacode/Features/Workflow/Views/WorkflowHistoryStepRow.swift
+++ b/supacode/Features/Workflow/Views/WorkflowHistoryStepRow.swift
@@ -6,18 +6,25 @@ struct WorkflowHistoryStepRow: View {
   let duration: TimeInterval?
   let directory: URL?
   let worktree: URL
+  let livePaneIDs: Set<UUID>
+  let updatedAt: Date
+  let onFocus: (UUID) -> Void
   let onOutput: (WorkflowHistoryOutputIntent) -> Void
   let onInteraction: () -> Void
   @State private var expanded: Bool
 
   init(
     group: WorkflowHistoryStepGroup, duration: TimeInterval?, directory: URL?, worktree: URL,
+    livePaneIDs: Set<UUID>, updatedAt: Date, onFocus: @escaping (UUID) -> Void,
     onOutput: @escaping (WorkflowHistoryOutputIntent) -> Void, onInteraction: @escaping () -> Void
   ) {
     self.group = group
     self.duration = duration
     self.directory = directory
     self.worktree = worktree
+    self.livePaneIDs = livePaneIDs
+    self.updatedAt = updatedAt
+    self.onFocus = onFocus
     self.onOutput = onOutput
     self.onInteraction = onInteraction
     _expanded = State(initialValue: group.state == "failed" || group.state == "needs_attention")
@@ -32,10 +39,12 @@ struct WorkflowHistoryStepRow: View {
         ForEach(Array(group.attempts.enumerated()), id: \.offset) { index, attempt in
           if group.attempts.count > 1 {
             if index == group.attempts.count - 1 {
-              Text("Attempt \(index + 1)").font(.caption).foregroundStyle(.secondary)
+              Text("\(group.attemptLabel) \(index + 1)").font(.caption).foregroundStyle(.secondary)
               attemptContent(attempt)
             } else {
-              DisclosureGroup("Attempt \(index + 1) · \(WorkflowHistoryStatus.label(attempt.state.rawValue))") {
+              DisclosureGroup(
+                "\(group.attemptLabel) \(index + 1) · \(WorkflowHistoryStatus.label(attempt.state.rawValue))"
+              ) {
                 attemptContent(attempt)
               }.disclosureGroupStyle(.automatic)
             }
@@ -68,6 +77,8 @@ struct WorkflowHistoryStepRow: View {
 
   @ViewBuilder
   private func attemptContent(_ attempt: WorkflowRunRecord.Step) -> some View {
+    let revision = WorkflowHistoryFileRevision(
+      updatedAt: attempt.state == .active ? updatedAt : nil, state: attempt.state.rawValue)
     if let error = attempt.error {
       HStack {
         Text(attempt.state == .completed ? "Earlier issue" : "Error").font(.caption).foregroundStyle(.secondary)
@@ -81,6 +92,14 @@ struct WorkflowHistoryStepRow: View {
       }
       Text(String(error.prefix(1000))).foregroundStyle(.orange).textSelection(.enabled).lineLimit(6)
     }
+    if attempt.state == .skipped {
+      Text(attempt.branchExcluded == true ? "This branch was not selected." : "This step was skipped.")
+        .font(.caption).foregroundStyle(.secondary)
+    }
+    WorkflowHistoryExecutionView(
+      definition: group.definition, attempt: attempt,
+      invocation: attempt.ordinal.flatMap { group.invocations[$0] }, directory: directory,
+      worktree: worktree, livePaneIDs: livePaneIDs, revision: revision, onFocus: onFocus, onOutput: onOutput)
     if let submissions = attempt.submissions, !submissions.isEmpty, let directory {
       ForEach(Array(submissions.enumerated()), id: \.offset) { index, submission in
         if index == submissions.count - 1 {
@@ -88,25 +107,21 @@ struct WorkflowHistoryStepRow: View {
             Text("Submission \(index + 1) · \(submission.statusLabel)").font(.caption).foregroundStyle(.secondary)
           }
           ForEach(submission.issues, id: \.self) { Text($0).foregroundStyle(.orange).lineLimit(3) }
-          WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
+          WorkflowHistoryDeliveryView(
+            delivery: submission.delivery, directory: directory, onOutput: onOutput, revision: revision)
         } else {
           DisclosureGroup("Submission \(index + 1) · \(submission.statusLabel)") {
             ForEach(submission.issues, id: \.self) { Text($0).foregroundStyle(.orange).lineLimit(3) }
-            WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
+            WorkflowHistoryDeliveryView(
+              delivery: submission.delivery, directory: directory, onOutput: onOutput, revision: revision)
           }.disclosureGroupStyle(.automatic)
         }
       }
     } else if let delivery = attempt.delivery, let directory {
-      WorkflowHistoryDeliveryView(delivery: delivery, directory: directory, onOutput: onOutput)
+      WorkflowHistoryDeliveryView(delivery: delivery, directory: directory, onOutput: onOutput, revision: revision)
     }
     if let outputs = attempt.outputs, !outputs.isEmpty {
       WorkflowHistoryJSONView(values: outputs, worktree: worktree, onOutput: onOutput)
-    }
-    if attempt.delivery == nil && (attempt.submissions ?? []).isEmpty && (attempt.outputs ?? [:]).isEmpty
-      && attempt.error == nil
-    {
-      Text(group.legacyDetailsUnavailable ? "No saved output" : "No output")
-        .foregroundStyle(.secondary)
     }
     if let directory, let diagnostics = WorkflowHistoryTiming.diagnosticDirectory(attempt, directory: directory) {
       Menu {

--- a/supacode/Features/Workflow/Views/WorkflowStepHistoryDetailView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStepHistoryDetailView.swift
@@ -14,7 +14,6 @@ struct WorkflowStepHistoryDetailView: View {
   @State private var confirmsControl = false
   @State private var groups: [WorkflowHistoryStepGroup] = []
   @State private var durations: [String: TimeInterval] = [:]
-  @ScaledMetric(relativeTo: .caption) private var agentIconSize = 13
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -30,6 +29,11 @@ struct WorkflowStepHistoryDetailView: View {
           ForEach(groups) { group in
             WorkflowHistoryStepRow(
               group: group, duration: durations[group.id], directory: directory, worktree: record.worktree.rootURL,
+              livePaneIDs: livePaneIDs, updatedAt: record.run.updatedAt,
+              onFocus: { surfaceID in
+                onInteraction()
+                onIntent(.focusPane(worktreeID: record.worktree.id, surfaceID: surfaceID))
+              },
               onOutput: onOutput, onInteraction: onInteraction)
           }
         }
@@ -97,29 +101,9 @@ struct WorkflowStepHistoryDetailView: View {
       HStack(spacing: 16) {
         ForEach(record.bindings.keys.sorted(), id: \.self) { role in
           if let binding = record.bindings[role] {
-            let presentation = WorkflowHistoryRole(role: role, binding: binding, livePaneIDs: livePaneIDs)
-            HStack(spacing: 5) {
-              Text("\(role):").foregroundStyle(.secondary)
-              if let agent = presentation.agent {
-                let token = DetectedAgent(rawValue: agent)?.iconLookupToken ?? agent
-                TabIconImage(
-                  rawName: (CommandIconMap.iconForFirstToken(token) ?? TabIconSource(systemSymbol: "terminal"))
-                    .storageString,
-                  pointSize: agentIconSize
-                )
-                .accessibilityLabel(agent)
-                .help(agent)
-              }
-              if let pane = presentation.livePane {
-                Button("@\(pane.handle)") {
-                  onInteraction()
-                  onIntent(.focusPane(worktreeID: record.worktree.id, surfaceID: pane.surfaceID))
-                }
-                .buttonStyle(.link)
-                .help("Focus \(role) in @\(pane.handle)")
-              } else if presentation.agent == nil {
-                Text("Not bound").foregroundStyle(.secondary)
-              }
+            WorkflowHistoryRoleView(role: role, binding: binding, livePaneIDs: livePaneIDs) { surfaceID in
+              onInteraction()
+              onIntent(.focusPane(worktreeID: record.worktree.id, surfaceID: surfaceID))
             }
           }
         }

--- a/supacode/Features/Workflow/Views/WorkflowStepHistoryDetailView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStepHistoryDetailView.swift
@@ -13,59 +13,46 @@ struct WorkflowStepHistoryDetailView: View {
   @State private var pendingControl: WorkflowAttentionControl?
   @State private var confirmsControl = false
   @State private var groups: [WorkflowHistoryStepGroup] = []
+  @State private var durations: [String: TimeInterval] = [:]
+  @ScaledMetric(relativeTo: .caption) private var agentIconSize = 13
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      VStack(alignment: .leading, spacing: 4) {
-        Text(record.run.workflowName).font(.headline)
-        Text(WorkflowHistoryStatus.label(record.run.status.state))
-          .font(.subheadline).foregroundStyle(.secondary)
-        Text(record.run.startedAt.formatted(date: .abbreviated, time: .shortened))
-          .font(.caption).foregroundStyle(.secondary)
-        if let finished = record.run.finishedAt {
-          Text(
-            "Finished \(finished.formatted(date: .omitted, time: .shortened)) · "
-              + "\(Int(max(0, finished.timeIntervalSince(record.run.startedAt))))s"
-          )
-          .font(.caption).foregroundStyle(.secondary)
-        }
-      }
-      ScrollView(.horizontal) {
-        HStack {
-          ForEach(record.bindings.keys.sorted(), id: \.self) { role in
-            let pane = record.bindings[role]?.pane
-            Button(role) {
-              onInteraction()
-              if let pane { onIntent(.focusPane(worktreeID: record.worktree.id, surfaceID: pane.surfaceID)) }
-            }
-            .disabled(pane.map { !livePaneIDs.contains($0.surfaceID) } ?? true)
-            .help(pane.map { "Focus \(role) in \($0.handle)" } ?? "This role has no pane")
-          }
-        }.controlSize(.small)
-      }.scrollIndicators(.never)
+      header
+      if !record.bindings.isEmpty { roles }
       if record.historyIsPartial == true {
         Text("Some control history was omitted after 10,000 records. Recorded outputs remain available.")
           .font(.caption).foregroundStyle(.secondary)
       }
       Divider()
       ScrollView {
-        LazyVStack(alignment: .leading, spacing: 12) {
+        LazyVStack(alignment: .leading, spacing: 2) {
           ForEach(groups) { group in
-            WorkflowHistoryStepRow(group: group, directory: directory, onOutput: onOutput, onInteraction: onInteraction)
+            WorkflowHistoryStepRow(
+              group: group, duration: durations[group.id], directory: directory, worktree: record.worktree.rootURL,
+              onOutput: onOutput, onInteraction: onInteraction)
           }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
       }
-      if let run = liveRun, run.status.attention != nil {
-        attentionControls(run)
-      }
+      if let run = liveRun, run.status.attention != nil { attentionControls(run) }
       Divider()
       footer
     }
     .task(id: HistoryProjectionKey(record: record)) {
       let snapshot = record
-      let result = await Task.detached(priority: .userInitiated) { WorkflowHistoryStepGroup.groups(snapshot) }.value
-      if !Task.isCancelled { groups = result }
+      let directory = directory
+      let storage = WorkflowHistoryStorage.configured
+      let result = await Task.detached(priority: .userInitiated) {
+        let groups = WorkflowHistoryStepGroup.groups(snapshot)
+        return (
+          groups, WorkflowHistoryTiming.durations(groups, record: snapshot, directory: directory, storage: storage)
+        )
+      }.value
+      if !Task.isCancelled {
+        groups = result.0
+        durations = result.1
+      }
     }
     .padding(16)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -77,6 +64,68 @@ struct WorkflowStepHistoryDetailView: View {
     } message: { control in
       Text(control.confirmationMessage ?? control.label)
     }
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .firstTextBaseline, spacing: 10) {
+        Text(record.run.workflowName).font(.headline).lineLimit(2)
+        Spacer(minLength: 0)
+        Text(WorkflowHistoryStatus.label(record.run.status.state))
+          .font(.subheadline).foregroundStyle(WorkflowHistoryStatus.tint(record.run.status.state))
+          .fixedSize()
+      }
+      if record.run.status.isTerminal {
+        timingLine(at: record.run.finishedAt ?? record.run.updatedAt)
+      } else {
+        TimelineView(.periodic(from: .now, by: 1)) { timingLine(at: $0.date) }
+      }
+    }
+  }
+
+  private func timingLine(at date: Date) -> some View {
+    let duration = WorkflowHistoryTiming.duration(date.timeIntervalSince(record.run.startedAt))
+    let elapsed = record.run.status.isTerminal ? "Finished in \(duration)" : "Running for \(duration)"
+    return Label("\(WorkflowHistoryTiming.timestamp(record.run.startedAt)) · \(elapsed)", systemImage: "clock")
+      .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+      .lineLimit(1)
+      .help("Started \(WorkflowHistoryTiming.timestamp(record.run.startedAt)) · \(elapsed)")
+  }
+
+  private var roles: some View {
+    ScrollView(.horizontal) {
+      HStack(spacing: 16) {
+        ForEach(record.bindings.keys.sorted(), id: \.self) { role in
+          if let binding = record.bindings[role] {
+            let presentation = WorkflowHistoryRole(role: role, binding: binding, livePaneIDs: livePaneIDs)
+            HStack(spacing: 5) {
+              Text("\(role):").foregroundStyle(.secondary)
+              if let agent = presentation.agent {
+                let token = DetectedAgent(rawValue: agent)?.iconLookupToken ?? agent
+                TabIconImage(
+                  rawName: (CommandIconMap.iconForFirstToken(token) ?? TabIconSource(systemSymbol: "terminal"))
+                    .storageString,
+                  pointSize: agentIconSize
+                )
+                .accessibilityLabel(agent)
+                .help(agent)
+              }
+              if let pane = presentation.livePane {
+                Button("@\(pane.handle)") {
+                  onInteraction()
+                  onIntent(.focusPane(worktreeID: record.worktree.id, surfaceID: pane.surfaceID))
+                }
+                .buttonStyle(.link)
+                .help("Focus \(role) in @\(pane.handle)")
+              } else if presentation.agent == nil {
+                Text("Not bound").foregroundStyle(.secondary)
+              }
+            }
+          }
+        }
+      }
+      .font(.caption)
+    }.scrollIndicators(.never)
   }
 
   private func attentionControls(_ run: WorkflowRun) -> some View {
@@ -125,10 +174,12 @@ struct WorkflowStepHistoryDetailView: View {
   private var footer: some View {
     HStack {
       if let directory {
-        Button("Run Folder", systemImage: "folder") { onIntent(.revealRunFolder(directory)) }
-          .help("Reveal this run in Finder")
-        Button("Log", systemImage: "doc.text") { onOutput(.openFile(directory.appending(path: "log.md"))) }
-          .help("Open the recorded workflow log")
+        WorkflowHistoryIconButton(label: "Reveal run in Finder", symbol: "folder") {
+          onIntent(.revealRunFolder(directory))
+        }
+        WorkflowHistoryIconButton(label: "Open workflow log", symbol: "doc.text") {
+          onOutput(.openFile(directory.appending(path: "log.md")))
+        }
         Spacer()
         Menu {
           Button("Keep Run") { onOutput(.keep(directory)) }.help("Protect this run from cleanup")
@@ -148,170 +199,12 @@ struct WorkflowStepHistoryDetailView: View {
         } label: {
           Image(systemName: "ellipsis").accessibilityLabel("More run actions")
         }
+        .menuIndicator(.hidden)
+        .menuStyle(.borderlessButton)
+        .fixedSize()
         .help("More run actions")
       }
     }.controlSize(.small)
-  }
-}
-
-private struct WorkflowHistoryStepRow: View {
-  let group: WorkflowHistoryStepGroup
-  let directory: URL?
-  let onOutput: (WorkflowHistoryOutputIntent) -> Void
-  let onInteraction: () -> Void
-  @State private var expanded: Bool
-
-  init(
-    group: WorkflowHistoryStepGroup, directory: URL?, onOutput: @escaping (WorkflowHistoryOutputIntent) -> Void,
-    onInteraction: @escaping () -> Void
-  ) {
-    self.onInteraction = onInteraction
-    self.group = group
-    self.directory = directory
-    self.onOutput = onOutput
-    _expanded = State(initialValue: group.state == "failed" || group.state == "needs_attention")
-  }
-
-  var body: some View {
-    DisclosureGroup(isExpanded: $expanded) {
-      VStack(alignment: .leading, spacing: 10) {
-        if group.attempts.isEmpty {
-          Text("No execution recorded.").foregroundStyle(.secondary)
-        }
-        ForEach(Array(group.attempts.enumerated()), id: \.offset) { index, attempt in
-          if group.attempts.count > 1 {
-            if index == group.attempts.count - 1 {
-              Text("Attempt \(index + 1) · \(WorkflowHistoryStatus.label(attempt.state.rawValue))")
-                .font(.caption).foregroundStyle(.secondary)
-              attemptContent(attempt)
-            } else {
-              DisclosureGroup("Attempt \(index + 1) · \(WorkflowHistoryStatus.label(attempt.state.rawValue))") {
-                attemptContent(attempt)
-              }
-            }
-          } else {
-            attemptContent(attempt)
-          }
-        }
-      }
-      .font(.callout)
-      .padding(.top, 6)
-    } label: {
-      HStack(alignment: .top, spacing: 8) {
-        Image(systemName: WorkflowHistoryStatus.symbol(group.state))
-          .foregroundStyle(group.state == "failed" || group.state == "needs_attention" ? .orange : .secondary)
-        VStack(alignment: .leading, spacing: 3) {
-          Text(group.title).font(.subheadline)
-          Text(group.subtitle).font(.caption).foregroundStyle(.secondary)
-        }
-        Spacer(minLength: 0)
-      }
-      .contentShape(.rect)
-    }
-    .accessibilityLabel("\(group.title), \(group.subtitle)")
-    .onChange(of: expanded) { _, _ in onInteraction() }
-  }
-
-  @ViewBuilder
-  private func attemptContent(_ attempt: WorkflowRunRecord.Step) -> some View {
-    if let error = attempt.error {
-      Text(attempt.state == .completed ? "Earlier issue" : "Error").font(.caption).foregroundStyle(.secondary)
-      Text(String(error.prefix(1000))).foregroundStyle(.orange).textSelection(.enabled).lineLimit(6)
-      Button("Open Full Error") { onOutput(.openText(error, "error.txt")) }
-        .help("Open the full recorded error in an external application")
-    }
-    if let submissions = attempt.submissions, !submissions.isEmpty, let directory {
-      ForEach(Array(submissions.enumerated()), id: \.offset) { index, submission in
-        if index == submissions.count - 1 {
-          Text("Submission \(index + 1) · \(submission.statusLabel)").font(.caption)
-          WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
-        } else {
-          DisclosureGroup("Submission \(index + 1) · \(submission.statusLabel)") {
-            ForEach(submission.issues, id: \.self) { Text($0).foregroundStyle(.orange).lineLimit(3) }
-            WorkflowHistoryDeliveryView(delivery: submission.delivery, directory: directory, onOutput: onOutput)
-          }
-        }
-      }
-    } else if let delivery = attempt.delivery, let directory {
-      WorkflowHistoryDeliveryView(delivery: delivery, directory: directory, onOutput: onOutput)
-    }
-    if let outputs = attempt.outputs, !outputs.isEmpty {
-      Text(WorkflowHistoryOutputPreview.json(outputs)).font(.caption.monospaced())
-        .textSelection(.enabled).lineLimit(8).frame(maxWidth: .infinity, alignment: .leading)
-      HStack {
-        Button("Open Full Output") { onOutput(.openJSON(outputs)) }
-          .help("Open the full JSON output in an external application")
-        Button("Copy Full Output") { onOutput(.copyJSON(outputs)) }
-          .help("Copy the complete JSON output")
-      }.controlSize(.small)
-      if case .string(let path) = outputs["output_path"] {
-        Button("Open Output File", systemImage: "doc") { onOutput(.openFile(URL(filePath: path))) }
-          .help("Open the action's recorded output file")
-      }
-    }
-    if attempt.delivery == nil && attempt.outputs == nil && attempt.error == nil {
-      Text(group.legacyDetailsUnavailable ? "Output details were not recorded." : "No output.").foregroundStyle(
-        .secondary)
-    }
-    if let execution = attempt.actionExecutionID, let directory {
-      HStack {
-        ForEach(["stdout.log", "stderr.log", "execution.json"], id: \.self) { name in
-          Button(name) { onOutput(.openFile(directory.appending(path: "actions/\(attempt.id)/\(execution)/\(name)"))) }
-            .help("Open the recorded action diagnostic; missing files are reported")
-        }
-      }.controlSize(.small)
-    }
-    DisclosureGroup("Execution Details") {
-      Text("Step: \(attempt.id)").textSelection(.enabled)
-      if let ordinal = attempt.ordinal { Text("Invocation: \(ordinal)") }
-      if let iteration = attempt.iteration { Text("Round: \(iteration)") }
-      if let path = attempt.iterationPath, !path.isEmpty {
-        Text("Iteration path: \(path.joined(separator: " / "))").textSelection(.enabled)
-      }
-    }.font(.caption).foregroundStyle(.secondary)
-  }
-}
-
-private struct WorkflowHistoryDeliveryView: View {
-  let delivery: WorkflowDeliveryRecord
-  let directory: URL
-  let onOutput: (WorkflowHistoryOutputIntent) -> Void
-  @State private var preview = "Loading output…"
-  @State private var available = false
-
-  private var url: URL {
-    if delivery.path.hasPrefix("/") { return URL(filePath: delivery.path) }
-    return directory.appending(path: delivery.path)
-  }
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text(delivery.name).font(.subheadline)
-      if let verdict = delivery.verdict { Text("Verdict: \(verdict)").font(.caption) }
-      Text(preview).textSelection(.enabled).lineLimit(8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-      HStack {
-        Button("Open Full Output") { onOutput(.openFile(url)) }
-          .help("Open the complete delivery in an external application")
-        Button("Copy Full Output") { onOutput(.copyFile(url)) }.help("Copy the complete delivery")
-        Button("Reveal", systemImage: "folder") { onOutput(.reveal(url)) }.help("Reveal this delivery in Finder")
-      }.controlSize(.small).disabled(!available)
-    }
-    .task(id: url) {
-      guard WorkflowSchema.isSlug(delivery.name), delivery.ordinal > 0 else {
-        preview = "Output reference is invalid."
-        return
-      }
-      let storage = WorkflowHistoryStorage.configured
-      let outputURL = url
-      let result = await Task.detached(priority: .utility) {
-        try? storage.readChunk(outputURL, offset: 0)
-      }.value
-      available = result != nil
-      preview =
-        result.map { WorkflowHistoryOutputPreview.text($0.data) ?? "Output preview is not valid UTF-8." }
-        ?? "Output is no longer available."
-    }
   }
 }
 

--- a/supacode/Features/Workflow/Views/WorkflowStepHistoryView.swift
+++ b/supacode/Features/Workflow/Views/WorkflowStepHistoryView.swift
@@ -42,7 +42,7 @@ struct WorkflowStepHistoryView: View {
           .id(detail.run.id)
         } else {
           ContentUnavailableView(
-            "No Run Selected", systemImage: "clock.arrow.circlepath",
+            "No Run Selected", systemImage: "checklist",
             description: Text("Select a run to inspect its steps and outputs.")
           )
           .frame(maxWidth: .infinity)
@@ -70,16 +70,10 @@ struct WorkflowStepHistoryView: View {
             onInteraction()
             store.send(.select(entry.id))
           } label: {
-            HStack(alignment: .top, spacing: 8) {
-              Image(systemName: WorkflowHistoryStatus.symbol(entry.state))
-                .accessibilityHidden(true)
-                .foregroundStyle(entry.state == "needs_attention" ? .orange : .secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+              WorkflowHistoryStatusIcon(state: entry.state)
               VStack(alignment: .leading, spacing: 3) {
                 Text(entry.name).lineLimit(2)
-                Text(WorkflowHistoryStatus.label(entry.state))
-                  .font(.caption).foregroundStyle(.secondary)
-                Text(entry.finishedAt ?? entry.startedAt, style: .relative)
-                  .font(.caption).foregroundStyle(.secondary)
                 if store.selectedScope == .all {
                   Text(URL(filePath: entry.root).lastPathComponent)
                     .font(.caption).foregroundStyle(.secondary).lineLimit(1)
@@ -90,6 +84,7 @@ struct WorkflowStepHistoryView: View {
               }
               Spacer(minLength: 0)
             }
+            .font(.body)
             .padding(8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(

--- a/supacodeTests/ToolbarPopoverCoordinatorTests.swift
+++ b/supacodeTests/ToolbarPopoverCoordinatorTests.swift
@@ -1,0 +1,57 @@
+import Clocks
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ToolbarPopoverCoordinatorTests {
+  @Test func historyToBellIgnoresOldPopoverCallbacksAndTimeout() async {
+    let clock = TestClock()
+    let popovers = ToolbarPopoverCoordinator(clock: clock)
+    popovers.hoverButton(.history, hovering: true)
+    popovers.hoverButton(.history, hovering: false)
+    popovers.hoverButton(.notifications, hovering: true)
+    popovers.hoverPopover(.history, hovering: false)
+    popovers.dismiss(.history)
+    await clock.advance(by: .seconds(1))
+    #expect(popovers.presented == .notifications)
+    popovers.hoverButton(.notifications, hovering: false)
+    await clock.advance(by: .seconds(1))
+    #expect(popovers.presented == nil)
+  }
+
+  @Test func enteringPanelCancelsCloseAndPinSurvivesHoverExit() async {
+    let clock = TestClock()
+    let popovers = ToolbarPopoverCoordinator(clock: clock)
+    popovers.hoverButton(.history, hovering: true)
+    popovers.hoverButton(.history, hovering: false)
+    popovers.hoverPopover(.history, hovering: true)
+    await clock.advance(by: .seconds(1))
+    #expect(popovers.presented == .history)
+    popovers.pin(.history)
+    popovers.hoverPopover(.history, hovering: false)
+    popovers.hoverButton(.notifications, hovering: true)
+    await clock.advance(by: .seconds(1))
+    #expect(popovers.presented == .history)
+    popovers.toggle(.notifications)
+    #expect(popovers.presented == .notifications)
+    popovers.dismiss(.history)
+    #expect(popovers.presented == .notifications)
+    popovers.toggle(.notifications)
+    #expect(popovers.presented == nil)
+  }
+
+  @Test func lateBellExitCannotClearHistoryHover() async {
+    let clock = TestClock()
+    let popovers = ToolbarPopoverCoordinator(clock: clock)
+    popovers.hoverButton(.notifications, hovering: true)
+    popovers.hoverButton(.history, hovering: true)
+    popovers.hoverButton(.notifications, hovering: false)
+    popovers.hoverPopover(.notifications, hovering: true)
+    popovers.dismiss(.notifications)
+    await clock.advance(by: .seconds(1))
+    #expect(popovers.presented == .history)
+    popovers.dismiss(.history)
+    #expect(popovers.presented == nil)
+  }
+}

--- a/supacodeTests/WorkflowCommandHandlerTests.swift
+++ b/supacodeTests/WorkflowCommandHandlerTests.swift
@@ -20,7 +20,7 @@ struct WorkflowCommandHandlerTests {
     steps:
       - id: ask
         message: author
-        text: "Say hello."
+        prompt: "Say hello."
     """
 
   private struct Fixture {

--- a/supacodeTests/WorkflowHistoryReviewTests.swift
+++ b/supacodeTests/WorkflowHistoryReviewTests.swift
@@ -238,17 +238,13 @@ struct WorkflowHistoryReviewTests {
     #expect(record.steps.last?.submissions?.first?.accepted == false)
   }
 
-  @Test func textPreviewKeepsMultibyteBoundariesAndRejectsInvalidData() {
-    for scalar in ["é", "中", "🐈"] {
-      for offset in 1..<scalar.utf8.count {
-        let prefix = String(repeating: "a", count: 4096 - offset)
-        let data = Data((prefix + scalar + "tail").utf8)
-        #expect(WorkflowHistoryOutputPreview.text(data) == prefix)
-      }
+  @Test func textPreviewKeepsMultibyteCharacterBoundaries() {
+    for character in ["é", "中", "🐈", "🐈‍⬛"] {
+      let prefix = String(repeating: "a", count: 199) + character
+      let preview = WorkflowHistoryTextPreview(prefix + "tail")
+      #expect(preview.text == prefix)
+      #expect(preview.remainingCharacters == 4)
     }
-    #expect(WorkflowHistoryOutputPreview.text(Data("hello".utf8)) == "hello")
-    #expect(WorkflowHistoryOutputPreview.text(Data([0xFF, 0x61])) == nil)
-    #expect(WorkflowHistoryOutputPreview.text(Data(repeating: 0x61, count: 4095) + Data([0xFF, 0x61])) == nil)
   }
 
   @Test func groupingKeepsTenThousandRoundsInNumericOrder() throws {
@@ -275,6 +271,6 @@ struct WorkflowHistoryReviewTests {
 
   @Test func longKeysCannotEscapeThePreviewBudget() {
     let key = String(repeating: "k", count: 1_000_000)
-    #expect(WorkflowHistoryOutputPreview.json(["output": .object([key: .string("value")])]).utf8.count <= 4096)
+    #expect(WorkflowHistoryOutputField(key: key, value: .string("value")).displayKey.count == 100)
   }
 }

--- a/supacodeTests/WorkflowHistoryReviewTests.swift
+++ b/supacodeTests/WorkflowHistoryReviewTests.swift
@@ -107,7 +107,7 @@ struct WorkflowHistoryReviewTests {
     #expect(work.allSatisfy { $0.subtitle.contains("outer") && $0.subtitle.contains("inner") })
   }
 
-  @Test func legacyActionOutputRequiresOneCompletedOccurrence() throws {
+  @Test func actionHistoryDoesNotReconstructMissingAttemptOutputs() throws {
     var machine = try start(
       """
       schema: prowl.workflow/v1
@@ -127,12 +127,11 @@ struct WorkflowHistoryReviewTests {
       JSONSerialization.jsonObject(
         with: WorkflowRunRecord.makeEncoder().encode(
           WorkflowRunRecord(run: machine.run))) as? [String: Any])
-    json.removeValue(forKey: "step_definitions")
     json["steps"] = [["id": "snapshot", "state": "completed"]]
     let single = try WorkflowRunRecord.makeDecoder().decode(
       WorkflowRunRecord.self,
       from: JSONSerialization.data(withJSONObject: json))
-    #expect(WorkflowHistoryStepGroup.groups(single).first?.attempts.first?.outputs == output)
+    #expect(WorkflowHistoryStepGroup.groups(single).first?.attempts.first?.outputs == nil)
     json["steps"] = [1, 2].map { ["id": "snapshot", "state": "completed", "iteration": $0] as [String: Any] }
     let repeated = try WorkflowRunRecord.makeDecoder().decode(
       WorkflowRunRecord.self,
@@ -152,7 +151,7 @@ struct WorkflowHistoryReviewTests {
       steps:
         - id: review
           message: author
-          instruction: Review
+          prompt: Review
           expect: {delivery: report, sections: ['## Findings']}
       """, roles: ["author": .current(pane)])
     _ = machine.apply(.roleIdle(ordinal: 1))
@@ -195,13 +194,9 @@ struct WorkflowHistoryReviewTests {
     #expect(try String(contentsOfFile: paths[0], encoding: .utf8).contains("First output"))
     #expect(try String(contentsOfFile: paths[1], encoding: .utf8).contains("Corrected output"))
 
-    var legacy = json
-    legacy.removeValue(forKey: "step_definitions")
-    legacy["steps"] = steps.map { $0.filter { ["id", "iteration", "state", "ordinal"].contains($0.key) } }
     let decoded = try WorkflowRunRecord.makeDecoder().decode(
-      WorkflowRunRecord.self,
-      from: JSONSerialization.data(withJSONObject: legacy))
-    #expect(WorkflowHistoryStepGroup.groups(decoded).flatMap(\.attempts).compactMap(\.delivery).count == 1)
+      WorkflowRunRecord.self, from: JSONSerialization.data(withJSONObject: json))
+    #expect(WorkflowHistoryStepGroup.groups(decoded).flatMap(\.attempts).flatMap { $0.submissions ?? [] }.count == 2)
   }
 
   @Test func cancelledSaveRetryKeepsTheSubmittedBody() throws {
@@ -215,7 +210,7 @@ struct WorkflowHistoryReviewTests {
       steps:
         - id: review
           message: author
-          instruction: Review
+          prompt: Review
           expect: {delivery: report, sections: ['## Findings']}
       """, roles: ["author": .current(pane)])
     _ = machine.apply(.roleIdle(ordinal: 1))

--- a/supacodeTests/WorkflowHistoryUIPresentationTests.swift
+++ b/supacodeTests/WorkflowHistoryUIPresentationTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import ProwlCLIShared
+import Testing
+
+@testable import supacode
+
+struct WorkflowHistoryUIPresentationTests {
+  @Test func durationUsesHoursMinutesAndSeconds() {
+    #expect(WorkflowHistoryTiming.duration(3661) == "1h 1m 1s")
+    #expect(WorkflowHistoryTiming.duration(139) == "2m 19s")
+    #expect(WorkflowHistoryTiming.duration(0.4) == "<1s")
+    #expect(WorkflowHistoryTiming.duration(-1) == "<1s")
+    #expect(WorkflowHistoryTiming.duration(60) == "1m 0s")
+  }
+
+  @Test func previewCountsCharactersRatherThanBytes() {
+    let body = String(repeating: "🐈‍⬛", count: 213)
+    let preview = WorkflowHistoryTextPreview(body)
+    #expect(preview.text == String(repeating: "🐈‍⬛", count: 200))
+    #expect(preview.remainingCharacters == 13)
+    #expect(WorkflowHistoryTextPreview("short").remainingCharacters == 0)
+  }
+
+  @Test func fieldsPreserveNestingAndOnlyRecognizeNamedAbsolutePaths() {
+    let fields = WorkflowHistoryOutputField.fields([
+      "output": .object(["path": .string("/tmp/context.md"), "branch": .string("main")]),
+      "output_path": .string("/tmp/result.json"),
+      "description": .string("/tmp/not-a-file"),
+      "relative_path": .string("../escape"),
+    ])
+    #expect(fields.map(\.key) == ["description", "output", "output_path", "relative_path"])
+    let output = fields.first { $0.key == "output" }
+    #expect(output?.children?.map(\.key) == ["branch", "path"])
+    #expect(output?.children?.last?.fileURL == URL(filePath: "/tmp/context.md"))
+    #expect(fields.first?.fileURL == nil)
+    #expect(fields.last?.fileURL == nil)
+  }
+
+  @Test func fieldTreesBoundWidthDepthAndText() {
+    let fields = WorkflowHistoryOutputField.fields(
+      Dictionary(
+        (0..<100).map { ("field-\($0)", WorkflowJSONValue.integer($0)) }, uniquingKeysWith: { first, _ in first }))
+    #expect(fields.count == 32)
+    var value = WorkflowJSONValue.string(String(repeating: "x", count: 100_000))
+    for _ in 0..<20 { value = .object(["child": value]) }
+    var node = WorkflowHistoryOutputField(key: "root", value: value)
+    for _ in 0..<5 { node = node.children?.first ?? node }
+    #expect(node.children == nil)
+    #expect(
+      WorkflowHistoryOutputField(key: "text", value: .string(String(repeating: "x", count: 100_000))).summary.count
+        <= 201)
+  }
+
+  @Test func closedPaneRetainsRecordedRuntimeButNoHandle() {
+    let pane = WorkflowPaneIdentity(surfaceID: UUID(), tabID: nil, handle: "p14", displayName: "Writer", agent: "pi")
+    let binding = WorkflowRunRecord.Binding(source: .current, profile: nil, pane: pane)
+    let closed = WorkflowHistoryRole(role: "author", binding: binding, livePaneIDs: [])
+    #expect(closed.agent == "pi")
+    #expect(closed.livePane == nil)
+    let live = WorkflowHistoryRole(role: "author", binding: binding, livePaneIDs: [pane.surfaceID])
+    #expect(live.livePane?.handle == "p14")
+  }
+
+  @Test func actionTimingRequiresBothValidTimestamps() throws {
+    let data = Data(#"{"started_at":"2026-09-09T12:00:00Z","finished_at":"2026-09-09T12:02:19Z"}"#.utf8)
+    #expect(WorkflowHistoryTiming.actionDuration(data) == 139)
+    #expect(WorkflowHistoryTiming.actionDuration(Data(#"{"started_at":"2026-09-09T12:00:00Z"}"#.utf8)) == nil)
+    #expect(
+      WorkflowHistoryTiming.actionDuration(
+        Data(#"{"started_at":"2026-09-09T12:00:00Z","finished_at":"2026-09-09T11:00:00Z"}"#.utf8)) == nil)
+  }
+
+  @Test func durationProjectionUsesExactInvocationsAndDoesNotGuessMissingTiming() throws {
+    let definition = WorkflowDefinition(id: "test", name: "Test", steps: [.init(id: "step", action: .notify("done"))])
+    let run = try WorkflowRunMachine.start(
+      .init(
+        definition: definition, runID: UUID(),
+        context: .init(
+          scope: .user, definitionPath: nil,
+          worktree: .init(id: "wt", name: "Test", branch: "main", path: "/tmp")), bindings: [:]),
+      now: { Date(timeIntervalSince1970: 100) }
+    ).machine.run
+    var json = try #require(
+      JSONSerialization.jsonObject(with: WorkflowRunRecord.makeEncoder().encode(WorkflowRunRecord(run: run)))
+        as? [String: Any])
+    json["steps"] = [["id": "step", "state": "completed", "ordinal": 7]]
+    json["invocations"] = [
+      [
+        "ordinal": 7, "step": "step", "role": "author", "kind": "message",
+        "started_at": "2026-09-09T12:00:00Z", "ended_at": "2026-09-09T12:00:30Z",
+      ]
+    ]
+    let record = try WorkflowRunRecord.makeDecoder().decode(
+      WorkflowRunRecord.self, from: JSONSerialization.data(withJSONObject: json))
+    let groups = WorkflowHistoryStepGroup.groups(record)
+    let timing = WorkflowHistoryTiming.durations(groups, record: record, directory: nil, storage: .configured)
+    #expect(timing[groups[0].id] == 30)
+    let untimed = WorkflowRunRecord(run: run)
+    #expect(
+      WorkflowHistoryTiming.durations(
+        WorkflowHistoryStepGroup.groups(untimed), record: untimed, directory: nil, storage: .configured
+      ).isEmpty)
+  }
+
+  @Test func fileActionsKeepHistoryAndHandoffContainment() throws {
+    let root = FileManager.default.temporaryDirectory.appending(path: "history-ui-\(UUID().uuidString)")
+    let handoff = root.appending(path: ".prowl/handoff")
+    try FileManager.default.createDirectory(at: handoff, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let file = handoff.appending(path: "current.md")
+    try Data("handoff".utf8).write(to: file)
+    let storage = WorkflowHistoryStorage(baseURL: root.appending(path: "history"))
+    #expect(throws: Never.self) {
+      try WorkflowHistoryArtifact.validate(file, worktree: root, storage: storage)
+      let canonicalRoot = WorkflowHistoryStorage.canonicalURL(root)
+      let canonicalFile = canonicalRoot.appending(path: ".prowl/handoff/current.md")
+      try WorkflowHistoryArtifact.validate(canonicalFile, worktree: canonicalRoot, storage: storage)
+      try WorkflowHistoryArtifact.validate(canonicalFile, worktree: root, storage: storage)
+    }
+    let outside = root.appending(path: "private.txt")
+    try Data().write(to: outside)
+    #expect(throws: (any Error).self) {
+      try WorkflowHistoryArtifact.validate(outside, worktree: root, storage: storage)
+    }
+    let link = handoff.appending(path: "linked.md")
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+    #expect(throws: (any Error).self) {
+      try WorkflowHistoryArtifact.validate(link, worktree: root, storage: storage)
+    }
+    let directoryLink = handoff.appending(path: "archive")
+    try FileManager.default.createSymbolicLink(at: directoryLink, withDestinationURL: root)
+    #expect(throws: (any Error).self) {
+      try WorkflowHistoryArtifact.validate(
+        directoryLink.appending(path: "private.txt"), worktree: root, storage: storage)
+    }
+  }
+}

--- a/supacodeTests/WorkflowLineRendererTests.swift
+++ b/supacodeTests/WorkflowLineRendererTests.swift
@@ -61,9 +61,9 @@ struct WorkflowLineRendererTests {
     #expect(block.contains("dispatch-complete"))
   }
 
-  @Test func instructionTrailerAndDeliveryRequiredMessageListTheMessageCommands() {
+  @Test func completionTrailerAndDeliveryRequiredMessageListTheMessageCommands() {
     let command = WorkflowCompletionCommand(token: token, verdicts: nil)
-    let trailer = command.instructionTrailer()
+    let trailer = command.completionTrailer()
     #expect(trailer.contains("PROWL_WORKFLOW_TOKEN=\(token) prowl workflow deliver -"))
     let message = command.deliveryRequiredMessage(runID: "RUN-1", stepID: "brief")
     #expect(message.contains("RUN-1"))
@@ -83,10 +83,16 @@ struct WorkflowLineRendererTests {
         == "[Prowl] Fix each item. — finish with: PROWL_WORKFLOW_TOKEN=\(token) prowl workflow deliver -")
   }
 
-  @Test func pointerLineNamesTheAbsolutePath() throws {
-    let line = try WorkflowTypedLine.pointer(
-      to: "/repo/.prowl/workflow-runs/R/instructions/brief.1.md", completion: nil)
-    #expect(line == "[Prowl] Read /repo/.prowl/workflow-runs/R/instructions/brief.1.md and follow it")
+  @Test func promptTransportUsesScopedReadForLongOrUnsafeLines() throws {
+    let root = URL(filePath: "/tmp/workflow-run")
+    for body in ["First\nSecond", "Tab\ttext", "Escape\u{1B}", String(repeating: "x", count: 4096)] {
+      let grant = WorkflowTaskContent.make(
+        text: body, task: (UUID(), 1), runDirectory: root, knownPaths: [], skill: nil)
+      #expect(try WorkflowTypedLine.prompt(grant, completion: nil) == "[Prowl] " + grant.guidance)
+    }
+    let grant = WorkflowTaskContent.make(
+      text: "Review.", task: (UUID(), 1), runDirectory: root, knownPaths: [], skill: nil)
+    #expect(try WorkflowTypedLine.prompt(grant, completion: nil) == "[Prowl] Review.")
   }
 
   @Test func renderedTextBoundaryRejectsTerminatorsAndControls() {

--- a/supacodeTests/WorkflowPromptHistoryTests.swift
+++ b/supacodeTests/WorkflowPromptHistoryTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import ProwlCLIShared
+import Testing
+
+@testable import supacode
+
+struct WorkflowPromptHistoryTests {
+  private let pane = WorkflowPaneIdentity(
+    surfaceID: UUID(), tabID: nil, handle: "p1", displayName: "Writer", agent: "pi")
+
+  @Test func savedPromptContainsOnlyTheRenderedTask() throws {
+    var machine = try start([
+      .init(id: "write", action: .message(role: "author", prompt: "# Task\nWrite a report.", expect: .init()))
+    ])
+    let effects = machine.apply(.roleIdle(ordinal: 1))
+    #expect(effects.contains(.materializePrompt(ordinal: 1, stepID: "write", text: "# Task\nWrite a report.")))
+    #expect(machine.run.invocations[0].promptPath?.hasSuffix("prompts/write.1.md") == true)
+    let encoded = try json(machine)
+    let invocations = try #require(encoded["invocations"] as? [[String: Any]])
+    #expect(invocations[0]["prompt_path"] != nil)
+    #expect(invocations[0]["instruction_path"] == nil)
+  }
+
+  @Test func controlAndNotifyKeepExecutionTimeTitlesAndSummaries() throws {
+    let machine = try start(
+      [
+        .init(
+          id: "choose", title: "Choose {{ state.count }}",
+          action: .control(
+            .conditional(
+              condition: "state.count == 1",
+              then: [
+                .init(id: "change", action: .control(.set(["count": "2"])))
+              ], else: []))),
+        .init(id: "sent", title: "Saved {{ state.count }}", action: .notify("Saved version {{ state.count }}")),
+      ], state: ["count": .init(type: "integer", initial: .integer(1))])
+    let steps = try #require(try json(machine)["steps"] as? [[String: Any]])
+    let choice = try #require(steps.first { $0["id"] as? String == "choose" })
+    #expect(choice["title"] as? String == "Choose 1")
+    #expect((choice["summary"] as? String)?.contains("true") == true)
+    let sent = try #require(steps.first { $0["id"] as? String == "sent" })
+    #expect(sent["title"] as? String == "Saved 2")
+    #expect(sent["summary"] as? String == "Saved version 2")
+  }
+
+  @Test func invocationKeepsItsTargetAfterRelaunch() throws {
+    let profile = WorkflowProfileBinding(id: UUID(), name: "Reviewer", agent: "pi")
+    var machine = try WorkflowRunMachine.start(
+      .init(
+        definition: .init(
+          id: "targets", name: "Targets",
+          roles: [
+            .init(name: "reviewer", source: .launch, launch: .init())
+          ],
+          steps: [
+            .init(id: "launch", action: .launch(role: "reviewer", prompt: "Review", skill: nil, expect: .init()))
+          ]),
+        runID: UUID(), context: context, bindings: ["reviewer": .launch(profile, pane: nil)]
+      ), now: { Date(timeIntervalSince1970: 100) }
+    ).machine
+    _ = machine.apply(.launched(ordinal: 1, pane: pane, dispatchID: "first"))
+    _ = machine.apply(.watchdog(ordinal: 1, .attention(.agentGone(.paneClosed))))
+    _ = machine.apply(.user(.relaunch))
+    let replacement = WorkflowPaneIdentity(
+      surfaceID: UUID(), tabID: nil, handle: "p2", displayName: "Reviewer", agent: "pi")
+    _ = machine.apply(.launched(ordinal: 2, pane: replacement, dispatchID: "second"))
+    let invocations = try #require(try json(machine)["invocations"] as? [[String: Any]])
+    #expect(invocations.count == 2)
+    let targets = invocations.compactMap { $0["target"] as? [String: Any] }
+    #expect(targets.count == 2)
+    #expect(targets.compactMap { ($0["pane"] as? [String: Any])?["handle"] as? String } == ["p1", "p2"])
+  }
+
+  @Test func loopRecordsEachCheckWithoutInventingRetryAttempts() throws {
+    let machine = try start(
+      [
+        .init(
+          id: "rounds", title: "Loop {{ state.count }}",
+          action: .control(
+            .loop(
+              condition: "state.count < 2", maximum: 3,
+              steps: [.init(id: "increment", action: .control(.set(["count": "state.count + 1"])))])
+          ))
+      ], state: ["count": .init(type: "integer", initial: .integer(0))])
+    let checks = machine.run.stepRecords.filter { $0.stepID == "rounds" }
+    #expect(checks.map(\.title) == ["Loop 0", "Loop 1", "Loop 2"])
+    #expect(checks.last?.summary?.contains("false") == true)
+    #expect(checks.allSatisfy { $0.iterationPath == [] && $0.iteration == nil })
+    let group = try #require(WorkflowHistoryStepGroup.groups(WorkflowRunRecord(run: machine.run)).first)
+    #expect(group.contextLabel == "3 checks")
+  }
+
+  @Test func failedControlKeepsItsRenderedTitle() throws {
+    let machine = try start(
+      [
+        .init(
+          id: "choose", title: "Choose {{ state.count }}",
+          action: .control(
+            .conditional(
+              condition: "state.count", then: [], else: [])))
+      ], state: ["count": .init(type: "integer", initial: .integer(1))])
+    #expect(machine.run.stepRecords.last?.title == "Choose 1")
+    #expect(machine.run.status.attention != nil)
+  }
+
+  @Test func promptPreviewReadsBeyondTheDeliveryLimitAndRejectsLinks() throws {
+    let root = WorkflowHistoryStorage.canonicalURL(FileManager.default.temporaryDirectory)
+      .appending(path: "prompt-preview-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let file = root.appending(path: "prompt.md")
+    let count = WorkflowSizeLimits.payload + 1
+    try Data(repeating: 120, count: count).write(to: file)
+    let storage = WorkflowHistoryStorage(baseURL: root)
+    let preview = try WorkflowHistoryTextPreview.read(file, storage: storage)
+    #expect(preview.text == String(repeating: "x", count: 200))
+    #expect(preview.remainingCharacters == count - 200)
+    let link = root.appending(path: "link.md")
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+    #expect(throws: (any Error).self) { try WorkflowHistoryTextPreview.read(link, storage: storage) }
+  }
+
+  @Test func fileLoadKeyChangesWhenAnAttemptFinishesOrPublishesAgain() {
+    let url = URL(filePath: "/tmp/request.json")
+    let active = WorkflowHistoryFileLoadKey(url: url, revision: .init(updatedAt: .distantPast, state: "active"))
+    #expect(active != WorkflowHistoryFileLoadKey(url: url, revision: .init(updatedAt: .distantFuture, state: "active")))
+    #expect(
+      active != WorkflowHistoryFileLoadKey(url: url, revision: .init(updatedAt: .distantPast, state: "completed")))
+  }
+
+  @Test func actionInputUsesOnlyTheSavedTypedInput() throws {
+    let request = Data(
+      #"{"input":{"enabled":true,"items":[1,"two"],"empty":null},"context":{"private":"not input"}}"#.utf8)
+    #expect(
+      try WorkflowHistoryExecution.actionInput(request) == [
+        "enabled": .boolean(true), "items": .array([.integer(1), .string("two")]), "empty": .null,
+      ])
+    #expect(throws: (any Error).self) {
+      try WorkflowHistoryExecution.actionInput(Data(#"{"context":{}}"#.utf8))
+    }
+  }
+
+  @Test func promptReferenceMustMatchItsRunStepAndInvocation() throws {
+    var machine = try start([.init(id: "write", action: .message(role: "author", prompt: "Write", expect: nil))])
+    _ = machine.apply(.roleIdle(ordinal: 1))
+    let directory = machine.run.runDirectory
+    var json = try json(machine)
+    let record = WorkflowRunRecord(run: machine.run)
+    #expect(
+      WorkflowHistoryExecution.promptURL(record.invocations[0], directory: directory)?.lastPathComponent == "write.1.md"
+    )
+    for path in ["/tmp/private.md", "prompts/write.2.md", "../other/prompts/write.1.md"] {
+      var invocations = try #require(json["invocations"] as? [[String: Any]])
+      invocations[0]["prompt_path"] = path
+      json["invocations"] = invocations
+      let changed = try WorkflowRunRecord.makeDecoder().decode(
+        WorkflowRunRecord.self, from: JSONSerialization.data(withJSONObject: json))
+      #expect(WorkflowHistoryExecution.promptURL(changed.invocations[0], directory: directory) == nil)
+    }
+  }
+
+  @Test func failedLaunchDoesNotClaimAnAgentStarted() throws {
+    let profile = WorkflowProfileBinding(id: UUID(), name: "Reviewer", agent: "pi")
+    var machine = try WorkflowRunMachine.start(
+      .init(
+        definition: .init(
+          id: "launch", name: "Launch", roles: [.init(name: "reviewer", source: .launch, launch: .init())],
+          steps: [
+            .init(id: "review", action: .launch(role: "reviewer", prompt: "Review", skill: nil, expect: .init()))
+          ]), runID: UUID(), context: context, bindings: ["reviewer": .launch(profile, pane: nil)]
+      ), now: { Date(timeIntervalSince1970: 100) })
+    #expect(machine.effects.contains(.materializePrompt(ordinal: 1, stepID: "review", text: "Review")))
+    _ = machine.machine.apply(.launchFailed(ordinal: 1, reason: "Unavailable"))
+    let invocation = try #require(WorkflowRunRecord(run: machine.machine.run).invocations.first)
+    #expect(WorkflowHistoryExecution.agentStatus(invocation) == "Agent has not started.")
+  }
+
+  private var context: WorkflowRunContext {
+    .init(scope: .user, definitionPath: nil, worktree: .init(id: "wt", name: "Test", branch: "main", path: "/tmp"))
+  }
+
+  private func start(_ steps: [WorkflowStepDefinition], state: [String: WorkflowStateDeclaration] = [:]) throws
+    -> WorkflowRunMachine
+  {
+    try WorkflowRunMachine.start(
+      .init(
+        definition: .init(
+          id: "history", name: "History", roles: [.init(name: "author", source: .current)], steps: steps, state: state),
+        runID: UUID(), context: context, bindings: ["author": .current(pane)]
+      ), now: { Date(timeIntervalSince1970: 100) }
+    ).machine
+  }
+
+  private func json(_ machine: WorkflowRunMachine) throws -> [String: Any] {
+    try #require(
+      JSONSerialization.jsonObject(
+        with: WorkflowRunRecord.makeEncoder().encode(WorkflowRunRecord(run: machine.run))) as? [String: Any])
+  }
+}

--- a/supacodeTests/WorkflowRunAdmissionTests.swift
+++ b/supacodeTests/WorkflowRunAdmissionTests.swift
@@ -30,7 +30,7 @@ struct WorkflowRunAdmissionTests {
     steps:
       - id: brief
         message: author
-        text: "Brief {{ inputs.rounds }}"
+        prompt: "Brief {{ inputs.rounds }}"
         expect: { delivery: brief }
       - id: launch
         launch: reviewer
@@ -38,7 +38,7 @@ struct WorkflowRunAdmissionTests {
         expect: { delivery: findings }
       - id: ping
         message: partner
-        text: "Findings: {{ deliveries.findings.path }}"
+        prompt: "Findings: {{ deliveries.findings.path }}"
     """
 
   private static let contextOnly = """

--- a/supacodeTests/WorkflowRunHarnessTests.swift
+++ b/supacodeTests/WorkflowRunHarnessTests.swift
@@ -109,8 +109,8 @@ final class WorkflowRunHarness {
       case .openActivation(_, let surfaceID, let ordinal):
         let dispatchID = bridge.openLaunchActivation(surfaceID: surfaceID)
         try await apply(.injectionSucceeded(ordinal: ordinal, dispatchID: dispatchID))
-      case .materializeInstruction(let ordinal, let stepID, let text):
-        try store.writeInstruction(runID: runID, stepID: stepID, ordinal: ordinal, text: text)
+      case .materializePrompt(let ordinal, let stepID, let text):
+        try store.writePrompt(runID: runID, stepID: stepID, ordinal: ordinal, text: text)
       case .materializeSkill(let id):
         let skill = BundledSkill(
           id: id, name: id, description: "d", audience: .workflow,
@@ -257,11 +257,9 @@ struct WorkflowRunHarnessTests {
     #expect(harness.typedLines[0].line.contains("PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow deliver -"))
     #expect(harness.bridge.opened.map(\.dispatchID) == ["dispatch-1"])
     #expect(harness.run.phase == .waitingForDelivery(ordinal: 1))
-    let instruction = try String(contentsOf: runDirectory.appending(path: "instructions/brief.1.md"), encoding: .utf8)
-    #expect(
-      instruction.hasPrefix(
-        "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n\n---\n"))
-    #expect(instruction.contains("PROWL_WORKFLOW_TOKEN=TOKEN-1 prowl workflow deliver -"))
+    let prompt = try String(contentsOf: runDirectory.appending(path: "prompts/brief.1.md"), encoding: .utf8)
+    #expect(prompt == "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n")
+    #expect(!prompt.contains("PROWL_WORKFLOW_TOKEN"))
 
     _ = try await harness.deliver(token: "TOKEN-1", body: "# Brief\n## Scope\nx\n## Claims\ny")
     #expect(harness.bridge.completed.map(\.dispatchID) == ["dispatch-1"])

--- a/supacodeTests/WorkflowRunMachineTests.swift
+++ b/supacodeTests/WorkflowRunMachineTests.swift
@@ -32,7 +32,7 @@ struct WorkflowRunMachineTests {
       - id: brief
         title: "Author writing the brief"
         message: author
-        instruction: |
+        prompt: |
           Write a short brief for an adversarial reviewer: ## Scope, ## Claims.
           Focus: {{ inputs.focus }}
         expect: { delivery: brief, sections: ["## Scope", "## Claims"], timeout: 10m }
@@ -53,12 +53,12 @@ struct WorkflowRunMachineTests {
           - id: fix
             title: "Round {{ context.step.iteration }}: author addressing findings"
             message: author
-            text: "Findings: {{ state.path }}. Fix or rebut each item."
+            prompt: "Findings: {{ state.path }}. Fix or rebut each item."
             expect: { delivery: disposition }
           - id: rereview
             title: "Round {{ context.step.iteration }}: reviewer re-checking"
             message: reviewer
-            text: "Disposition: {{ deliveries.disposition.path }}. Re-review."
+            prompt: "Disposition: {{ deliveries.disposition.path }}. Re-review."
             expect: { delivery: round_findings, verdicts: [clean, issues] }
           - id: retain
             set:
@@ -88,7 +88,7 @@ struct WorkflowRunMachineTests {
     steps:
       - id: brief
         message: source
-        instruction: |
+        prompt: |
           Write the handoff briefing.
         expect: { delivery: brief, sections: ["## Objective"] }
       - id: transition
@@ -225,17 +225,15 @@ struct WorkflowRunMachineTests {
     #expect(machine.run.inputs == ["max_rounds": "5", "focus": "", "mode": "strict"])
   }
 
-  @Test func roleIdleMaterializesTheInstructionAndInjectsThePointerLineWithTheToken() throws {
+  @Test func roleIdleSavesThePromptAndInjectsTheScopedReadLineWithTheToken() throws {
     var (machine, _) = try makeMachine(inputs: ["focus": "the parser"])
     let effects = machine.apply(.roleIdle(ordinal: 1))
-    let path = "\(runDir)/instructions/brief.1.md"
-    let command = WorkflowCompletionCommand(token: "TOKEN-1", verdicts: nil)
+    let path = "\(runDir)/prompts/brief.1.md"
     #expect(
       effects.contains(
-        .materializeInstruction(
+        .materializePrompt(
           ordinal: 1, stepID: "brief",
-          text: "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n"
-            + command.instructionTrailer())))
+          text: "Write a short brief for an adversarial reviewer: ## Scope, ## Claims.\nFocus: the parser\n")))
     #expect(
       effects.contains(
         .inject(
@@ -245,7 +243,7 @@ struct WorkflowRunMachineTests {
           opensActivation: true)))
     #expect(machine.run.phase == .injecting(ordinal: 1))
     #expect(machine.run.invocations[0].activation?.token == "TOKEN-1")
-    #expect(machine.run.invocations[0].instructionPath == path)
+    #expect(machine.run.invocations[0].promptPath == path)
   }
 
   @Test func injectionSuccessOpensTheActivationAndArmsTheWatchdog() throws {
@@ -740,11 +738,11 @@ struct WorkflowRunMachineTests {
       steps:
         - id: produce
           message: author
-          text: "Write it."
+          prompt: "Write it."
           expect: { delivery: draft }
         - id: consume
           message: author
-          text: "Polish {{ deliveries.draft.path }}."
+          prompt: "Polish {{ deliveries.draft.path }}."
           expect: { delivery: final }
         - id: done
           notify: "done"
@@ -1184,7 +1182,7 @@ struct WorkflowRunMachineTests {
           expect: { delivery: ready }
         - id: ping
           message: reviewer
-          text: "hello"
+          prompt: "hello"
           expect: { delivery: pong }
       """
     var (machine, _) = try makeMachine(yaml, skipped: ["launch"])

--- a/supacodeTests/WorkflowRunStoreTests.swift
+++ b/supacodeTests/WorkflowRunStoreTests.swift
@@ -73,7 +73,7 @@ struct WorkflowRunStoreTests {
     try store.ensureLayout(runID: runID)
     let runs = store.directory(for: runID).deletingLastPathComponent()
     #expect(!FileManager.default.fileExists(atPath: root.appending(path: ".prowl").path))
-    for name in ["instructions", "deliveries", "skills"] {
+    for name in ["prompts", "deliveries", "skills"] {
       var isDirectory: ObjCBool = false
       let path = runs.appending(path: runID.uuidString).appending(path: name).path(percentEncoded: false)
       #expect(FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue)
@@ -254,7 +254,7 @@ struct WorkflowRunStoreTests {
     let store = WorkflowRunStore(rootURL: root)
     let runID = UUID()
     try store.ensureLayout(runID: runID)
-    let instruction = try store.writeInstruction(runID: runID, stepID: "brief", ordinal: 1, text: "Do it.\n")
+    let instruction = try store.writePrompt(runID: runID, stepID: "brief", ordinal: 1, text: "Do it.\n")
     #expect(instruction.lastPathComponent == "brief.1.md")
     #expect(try String(contentsOf: instruction, encoding: .utf8) == "Do it.\n")
     try store.appendLog(runID: runID, line: "started", now: Self.now)
@@ -272,13 +272,13 @@ struct WorkflowRunStoreTests {
     let runID = UUID()
     try store.ensureLayout(runID: runID)
     #expect(throws: WorkflowRunStoreError.unsafePath("../escape")) {
-      try store.writeInstruction(runID: runID, stepID: "../escape", ordinal: 1, text: "x")
+      try store.writePrompt(runID: runID, stepID: "../escape", ordinal: 1, text: "x")
     }
     #expect(throws: WorkflowRunStoreError.unsafePath("Bad Name")) {
       try store.writeDelivery(runID: runID, name: "Bad Name", ordinal: 1, body: "x")
     }
     #expect(throws: WorkflowRunStoreError.unsafePath("brief")) {
-      try store.writeInstruction(runID: runID, stepID: "brief", ordinal: 0, text: "x")
+      try store.writePrompt(runID: runID, stepID: "brief", ordinal: 0, text: "x")
     }
   }
 

--- a/supacodeTests/WorkflowRunsFeatureTests.swift
+++ b/supacodeTests/WorkflowRunsFeatureTests.swift
@@ -38,7 +38,7 @@ struct WorkflowRunsFeatureTests {
     steps:
       - id: brief
         message: author
-        text: "Write the brief."
+        prompt: "Write the brief."
         expect: { delivery: brief }
       - id: launch
         launch: reviewer
@@ -48,7 +48,7 @@ struct WorkflowRunsFeatureTests {
         close: reviewer
       - id: summary
         message: author
-        text: "Findings: {{ deliveries.findings.path }}. Summarize."
+        prompt: "Findings: {{ deliveries.findings.path }}. Summarize."
         expect: { delivery: summary }
     """
 
@@ -500,7 +500,7 @@ struct WorkflowRunsFeatureTests {
     // The run directory's `instructions` leaf becomes a link, which the store refuses.
     try session.store.ensureLayout(runID: runID)
     let instructions = session.store.directory(for: runID).appending(
-      path: "instructions", directoryHint: .isDirectory)
+      path: "prompts", directoryHint: .isDirectory)
     try FileManager.default.removeItem(at: instructions)
     let elsewhere = fixture.root.appending(path: "elsewhere", directoryHint: .isDirectory)
     try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)

--- a/supacodeTests/WorkflowSettingsDetailFeatureTests.swift
+++ b/supacodeTests/WorkflowSettingsDetailFeatureTests.swift
@@ -18,7 +18,7 @@ struct WorkflowSettingsDetailFeatureTests {
     steps:
       - id: ask
         message: author
-        text: "Review this change."
+        prompt: "Review this change."
     """
 
   private func row(scope: WorkflowScope = .user) throws -> WorkflowSettingsRow {

--- a/supacodeTests/WorkflowStartContextTests.swift
+++ b/supacodeTests/WorkflowStartContextTests.swift
@@ -20,7 +20,7 @@ struct WorkflowStartContextTests {
     steps:
       - id: brief
         message: author
-        text: "Write about {{ inputs.focus }}."
+        prompt: "Write about {{ inputs.focus }}."
         expect: { delivery: brief }
       - id: launch
         launch: reviewer

--- a/supacodeTests/WorkflowStartFeatureTests.swift
+++ b/supacodeTests/WorkflowStartFeatureTests.swift
@@ -39,7 +39,7 @@ struct WorkflowStartFeatureTests {
     steps:
       - id: brief
         message: author
-        text: "Brief on {{ inputs.goal }}."
+        prompt: "Brief on {{ inputs.goal }}."
         expect: { delivery: brief }
       - id: launch
         launch: reviewer
@@ -59,7 +59,7 @@ struct WorkflowStartFeatureTests {
     steps:
       - id: note
         message: author
-        text: "Write a note."
+        prompt: "Write a note."
         expect: { delivery: note }
       - id: launch
         launch: runner

--- a/supacodeTests/WorkflowStatusCenterPresentationTests.swift
+++ b/supacodeTests/WorkflowStatusCenterPresentationTests.swift
@@ -219,7 +219,7 @@ struct WorkflowStatusCenterPresentationTests {
         role: "author",
         kind: .message,
         startedAt: Self.now,
-        instructionPath: nil,
+        promptPath: nil,
         activation: nil,
         endedAt: nil
       )
@@ -233,7 +233,7 @@ struct WorkflowStatusCenterPresentationTests {
       + "and address the findings in round 2."
 
     #expect(run.currentStepTitle == "Round 2: address findings")
-    #expect(run.currentInstruction == expectedInstruction)
+    #expect(run.currentPrompt == expectedInstruction)
     #expect(run.stepItems.count == 4)
     guard case .step(let brief) = run.stepItems[0] else {
       Issue.record("Expected the top-level brief step first")
@@ -282,7 +282,7 @@ struct WorkflowStatusCenterPresentationTests {
     #expect(run.roles.map(\.displayName) == ["Author", "Pi Reviewer"])
     #expect(run.roles.map(\.surfaceID) == [Self.authorPane.surfaceID, nil])
     #expect(run.currentStepTitle == "Finishing workflow")
-    #expect(run.currentInstruction == nil)
+    #expect(run.currentPrompt == nil)
     #expect(run.elapsedText == "1d 1h")
     #expect(run.elapsedText(at: session.run.startedAt.addingTimeInterval(-1)) == "0s")
   }
@@ -388,7 +388,7 @@ struct WorkflowStatusCenterPresentationTests {
       - id: brief
         title: "Write the brief"
         message: author
-        instruction: "Write a brief."
+        prompt: "Write a brief."
         expect: { delivery: brief }
       - id: rounds
         while: 'true'
@@ -397,13 +397,13 @@ struct WorkflowStatusCenterPresentationTests {
           - id: fix
             title: "Round {{ context.step.iteration }}: address findings"
             message: author
-            instruction: >-
+            prompt: >-
               Read {{ deliveries.brief.path }} and address the findings in round {{ context.step.iteration }}.
             expect: { delivery: disposition }
           - id: rereview
             title: "Round {{ context.step.iteration }}: re-review"
             message: author
-            text: "Review again."
+            prompt: "Review again."
             expect: { delivery: findings, verdicts: [clean, issues] }
       - id: finish
         notify: "Done"
@@ -419,7 +419,7 @@ struct WorkflowStatusCenterPresentationTests {
     steps:
       - id: note
         message: author
-        text: "Write an optional note."
+        prompt: "Write an optional note."
         expect: { delivery: note }
       - id: finish
         notify: "Done"
@@ -438,7 +438,7 @@ struct WorkflowStatusCenterPresentationTests {
     steps:
       - id: brief
         message: author
-        text: "Write a brief."
+        prompt: "Write a brief."
     """
 
   private func makeSession(

--- a/supacodeTests/WorkflowStepHistoryTests.swift
+++ b/supacodeTests/WorkflowStepHistoryTests.swift
@@ -93,7 +93,7 @@ struct WorkflowStepHistoryTests {
 
   @Test func outputPreviewBoundsLargeStringsAndDeepObjects() {
     let output: [String: WorkflowJSONValue] = ["result": .string(String(repeating: "a", count: 100_000))]
-    #expect(WorkflowHistoryOutputPreview.json(output).count < 400)
+    #expect(WorkflowHistoryOutputField.fields(output).first?.summary.count == 201)
   }
 
   @MainActor @Test func refreshDoesNotResurrectRemovedTerminalRuns() async throws {


### PR DESCRIPTION
## Summary

- Use only `prompt` for message and launch steps. Remove retired content fields and compatibility paths; update schemas, CLI payloads, bundles, templates, skills, and design references.
- Show execution-time titles, saved prompt previews, per-attempt target identity, action inputs, condition checks, and rendered notifications. Keep protocol commands out of saved prompt bodies.
- Keep compact history rows, nested JSON, full-content actions, and links only to live panes. Retain file containment checks and reload details after file publication.
- Coordinate History and Notifications hover previews and fix file actions across macOS temporary-directory aliases.

## Validation

- `make check`: formatting, lint, 153 script tests, and workflow naming checks passed.
- `make test`: 3,203 main tests and two process tests passed.
- CLI build and smoke checks, 297 unit tests, and 112 integration tests passed.
- `make build-app` passed.
- An isolated Debug workflow completed launch, multiline message, action, conditional, and notification steps. Verified Markdown previews, full prompt and input copies, external file opening, and closed-pane identity without stale links.
