### PR TITLE
Rename historyFlags to featureFlags in toolbar content

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -947,7 +947,7 @@ struct WorktreeDetailView: View {
   /// the trailing group that replaces the former branch item.
   struct AgentNotificationsToolbarContent: ToolbarContent {
     @Environment(StoreOf<WorkflowStepHistoryFeature>.self) private var historyStore
-    @Dependency(FeatureFlags.self) private var historyFlags
+    @Dependency(FeatureFlags.self) private var featureFlags
     let onHistoryIntent: (WorkflowRunPanelIntent) -> Void
 
     let agentsCapsule: AgentsCapsuleState?
@@ -996,7 +996,7 @@ struct WorktreeDetailView: View {
             onSelectNotification: onSelectNotification,
             onDismissAll: onDismissAllNotifications
           )
-          if historyFlags.workflowUI && !historyStore.entries.isEmpty {
+          if featureFlags.workflowUI && !historyStore.entries.isEmpty {
             WorkflowHistoryPopoverButton(store: historyStore, onIntent: onHistoryIntent)
           }
           if isUpdateAvailable {


### PR DESCRIPTION
## Summary

- Rename the `FeatureFlags` dependency in `AgentNotificationsToolbarContent` from `historyFlags` to `featureFlags`.
- Every other `@Dependency(FeatureFlags.self)` in the app already uses `featureFlags`; this was the single outlier introduced in 41ab2de8.
- The old name implied a history-specific flag set. The type is the app-wide `FeatureFlags`, and the field read is `workflowUI`.

No behavior change.

## Verification

- `make check` passed.
- `make build-app` passed.

https://claude.ai/code/session_01LMK5yuDQ9FLjueyQQu3WnD
