### PR TITLE
Fix false Idle state with animated composer backgrounds

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -49,6 +49,8 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    selection row such as `❯ 1. Yes`; a bare input prompt cuts off the preceding transcript.
    Codex uses exact bottom-of-screen `•`/`◦ Working (... esc to interrupt)` and
    `•`/`◦ Waiting for background terminal (... esc to interrupt)` footer fallbacks.
+   Braille-only starfield rows around the composer do not count toward that footer window;
+   animation alone does not indicate **Working**.
    Its confirmation detector requires a numbered selected row such as `› 1. Yes`
    paired with a live bottom footer or an explicit Yes/No choice structure. It also recognizes
    the current directory-trust, hook-review, and initial sign-in menus as **Blocked** from

--- a/supacode/Infrastructure/AgentDetection/CodexScreenProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/CodexScreenProfile.swift
@@ -219,8 +219,15 @@ private struct CodexScreenRegions: Sendable {
       .joined(separator: "\n")
       .trimmingCharacters(in: .newlines)
     // Background-terminal waits add a `└ command` detail row below the live
-    // footer, before the composer and status line.
-    self.workingFooter = agentDetectionRecentLines(snapshot.text, limit: 4)
+    // footer, before the composer and status line. The composer's starfield
+    // fills otherwise blank rows with braille; those rows must not consume
+    // the live-footer window. Keep every row that contains actual text.
+    let contentLines = snapshot.lines.filter { line in
+      !line.unicodeScalars.allSatisfy { scalar in
+        CharacterSet.whitespaces.contains(scalar) || (0x2800...0x28FF).contains(scalar.value)
+      }
+    }
+    self.workingFooter = contentLines.suffix(4).joined(separator: "\n")
   }
 
   nonisolated private static func makeSelectedChoice(from lines: [String]) -> SelectedChoice? {

--- a/supacodeTests/CodexScreenProfileTests.swift
+++ b/supacodeTests/CodexScreenProfileTests.swift
@@ -3,6 +3,46 @@ import Testing
 @testable import supacode
 
 struct CodexScreenProfileTests {
+  @Test func starfieldComposerKeepsLiveWorkingFooter() {
+    for marker in ["•", "◦"] {
+      for activity in ["Working", "Waiting for background terminal"] {
+        let detection = DetectedAgent.codex.detectScreen(
+          in: """
+            › hello
+            \(marker) \(activity) (1s • esc to interrupt)
+                ⠈                 ⠐       ⢀    ⠄ ⠄⠈   ⠠
+            ›⠁Ask Codex to do anything⡀    ⠈    ⠁ ⠁
+                    ⠠          ⢀      ⠠  ⠂  ⡀
+              gpt-6-astra medium · Context 5% used
+            """
+        )
+        #expect(detection.state == .working)
+        #expect(
+          detection.reason
+            == .matched(
+              activity == "Working"
+                ? CodexScreenProfile.RuleID.workingFooter : CodexScreenProfile.RuleID.backgroundTerminalFooter
+            )
+        )
+      }
+    }
+  }
+
+  @Test func starfieldDoesNotMakeIdleOrHistoricalOutputWorking() {
+    for output in ["", "• Working (1s • esc to interrupt)\n• Done\n  Result one\n  Result two"] {
+      let detection = DetectedAgent.codex.detectScreen(
+        in: """
+          \(output)
+              ⠈                 ⠐       ⢀    ⠄ ⠄⠈   ⠠
+          ›⠁Ask Codex to do anything⡀    ⠈    ⠁ ⠁
+                  ⠠          ⢀      ⠠  ⠂  ⡀
+            gpt-6-astra medium · Context 5% used
+          """
+      )
+      #expect(detection.state == .idle)
+    }
+  }
+
   @Test func ruleIDsAreUniqueAndRuntimePrefixed() {
     let ruleIDs = CodexScreenProfile.RuleID.all
 


### PR DESCRIPTION
Animated starfield rows fill otherwise blank lines below the live working footer. They consumed the four-line detection window and caused an active session to appear Idle.

Exclude whitespace and braille-only rows from that window while retaining text rows and the existing footer markers. Add regression coverage for active work, background terminal waits, idle animation, and historical output. Update the detection manual.

Validation: the new active-work regression failed before the fix. The screen detection test run passed 66 tests after the fix. `make check` passed, including 153 script tests. `make build-app` passed with no warnings or errors. GUI interaction has not been verified.
