### PR TITLE
Record terminal log lifecycle feasibility spike

### DIFF
--- a/spikes/codex-log-events/README.md
+++ b/spikes/codex-log-events/README.md
@@ -1,0 +1,162 @@
+# Codex JSONL lifecycle spike
+
+Date: 2026-09-12. Base: `4a47564bdc622b53af9a3c91060e4928c2340ef8`.
+
+## Decision
+
+**Go for a guarded lifecycle supplement; no-go for replacing screen detection.**
+
+Codex 0.154.0 writes explicit start, completion, and cancellation records promptly in
+ordinary interactive TUI sessions, without hooks. File notification latency is not
+the main obstacle in these samples. Foreground session identity after `/new`,
+approval/input waits, and process death remain separate problems.
+
+Do not connect this directly to Working/Idle yet. No application behavior changes
+are included in this spike.
+
+## Environment and method
+
+- macOS 26.6.2, arm64; Python 3.14.7; `codex-cli 0.154.0`.
+- Three controlled PTY process runs, four session IDs, 13 model turns. The first
+  two TUI processes ran concurrently in the same directory and configuration home.
+- An isolated temporary `CODEX_HOME` used the existing login through an auth-file
+  symlink. Minimal configuration retained the user's model, disabled hooks, set
+  `notify = []`, and trusted only the temporary work directory. Launch arguments
+  also specified `--disable hooks -c notify=[] -s read-only -a on-request`.
+- The runtime selected `gpt-6-astra`; `/plan` selected medium effort itself. No
+  profile launcher, managed hooks, MCP setup, or existing user pane was involved.
+- `probe.py` recorded PTY input/output times, incremental JSONL visibility, and
+  the TUI PID's open rollout descriptors. JSONL polling used a nominal 20 ms loop,
+  discovery a 100 ms interval, and `lsof` a 1 s interval. Scheduling and synchronous
+  descriptor inspection can increase these intervals.
+- A separate `watch_file.py` run used macOS `kqueue` vnode notifications on an
+  already-bound file for two further turns within the 13-turn total.
+- `evidence.json` retains controls, file ownership transitions, lifecycle records,
+  event counts, exits, and vnode observations. Session history loaded before a
+  process started and files never owned by that process are excluded from latency
+  aggregation. The directory-wide probe reader is **not** a production binding rule.
+
+## Results
+
+| Case | Observed result | Consequence |
+| --- | --- | --- |
+| First prompt | No rollout descriptor before submission. `task_started` became readable 76.3 ms after Enter. | Startup needs an unresolved state and discovery retry. |
+| Same-session repeats | Distinct `turn_id` values, paired starts and completions. | State must be keyed by session and turn. |
+| Two TUIs, same cwd/home | Each initially held its own distinct writable rollout descriptor. | Descriptor ownership distinguishes these sessions; cwd cannot. |
+| Escape during `sleep 30` | A matching `turn_aborted` was recorded. | Cancellation has a usable explicit boundary in this case. |
+| Approval request | The TUI displayed the approval menu for `/usr/bin/true`. No standalone waiting event appeared; the log was unchanged for 36.8 s before Escape. Escape produced `turn_aborted`. | An open turn does not prove Working. The command was not approved. |
+| Plan-mode input question | The TUI displayed Red/Blue choices. No standalone waiting event appeared; the log was unchanged for 35.3 s before Escape. Escape produced `turn_aborted`. | Input waits still need screen evidence or another explicit channel. |
+| `/new` | Old and new rollouts remained open for writing in the **same** PID. | Ownership alone no longer identifies the foreground session. |
+| `/new`, without prior shell execution | The second TUI reproduced the two-writable-file state for at least 128 s, until normal exit. | This is not just the retained background terminal from the first run. |
+| Forced process exit during work | SIGKILL status 9; no completion or abort for that turn during the post-exit observation or later resume. | Process lifetime must invalidate the open turn. |
+| Explicit resume after that exit | A new PID held the original rollout. The TUI rendered an interruption notice; a new prompt produced a new paired turn. The old unmatched start remained in history. | Replaying all historical starts cannot establish current activity. |
+| Normal idle exit | Both remaining TUI processes exited with status 0 via Ctrl-D. | Probes were closed without touching user sessions. |
+
+During waits, a tool invocation was persisted (`custom_tool_call` for the approval
+probe, `function_call` for the question). This is not a general waiting-state event:
+the call alone does not prove whether execution is running, paused, denied, or
+already resolved but not yet flushed. The screen was inspected through captured
+PTY output, not through a native Prowl GUI interaction pass.
+
+### Timing
+
+The polling observer saw these record timestamp-to-read delays:
+
+| Event | Samples | Minimum | Median | Maximum |
+| --- | ---: | ---: | ---: | ---: |
+| `task_started` | 13 | 9.5 ms | 20.3 ms | 81.1 ms |
+| `task_complete` | 9 | 3.9 ms | 19.5 ms | 24.8 ms |
+| `turn_aborted` | 3 | 12.5 ms | 19.6 ms | 21.1 ms |
+
+Enter-to-visible-start ranged from 21.3 to 96.9 ms across the 13 turns. These
+measurements include observer overhead; they are not Prowl end-to-end latency.
+
+For the two vnode-notification turns, start record observation delays were 0.815
+and 0.231 ms; completion delays were 0.503 and 0.673 ms. Both produced real vnode
+notifications and readable appended records. Timestamps have millisecond precision,
+so these sub-millisecond values are indicative, not a precise storage benchmark.
+The vnode observer timestamp is sampled just before reading the notified file.
+This tests visibility to another process, **not fsync or power-loss durability**.
+
+## Existing Prowl integration points
+
+- `ProcessDetection.openFilePaths` already filters for writable descriptors using
+  `proc_pidinfo` / `proc_pidfdinfo`. The spike used `lsof` to independently inspect
+  that same OS property; it did not execute the Swift resolver in the GUI.
+- `AgentSessionResolver.resolveUncached` assigns exact confidence when writable
+  descriptors yield one unique session. Two sessions cannot take that branch.
+  The resolver can then fall back to other evidence; this spike did not establish
+  which fallback wins in a live Prowl pane after `/new`.
+- Resolved session results can be cached for 5 seconds. A lifecycle consumer must
+  not mistake cached identity for freshly verified foreground identity.
+- `AgentTranscriptResultReader` already parses `task_complete` and `turn_aborted`
+  for result extraction. That reader is not a live state machine, and must not be
+  treated as one: an older completed result can precede a new active turn.
+
+## Proposed boundary for a follow-up implementation
+
+1. Bind to a verified process identity `(pid, start time)` and a freshly established
+   foreground session. A unique writable descriptor is useful evidence; multiple
+   writable rollouts require additional foreground evidence. Never choose by mtime.
+2. Register a watcher before taking the initial read snapshot, then drain appended
+   complete lines with an offset and pending partial-line buffer. Handle truncation,
+   replacement, and duplicate wakes. Establish a history baseline without promoting
+   an old unmatched start into a fresh runtime event.
+3. Scope events to `(process epoch, session ID, turn ID)`. A matching completion or
+   abort closes that turn only. A stale completion must not end a newer turn.
+4. Treat an open turn as **in progress, possibly waiting**. Current confirmation or
+   input UI must take precedence over an inferred Working state.
+5. On process death or unresolved session transition, invalidate runtime evidence
+   and use the existing fallback. Do not manufacture successful completion.
+
+The first implementation gate is reliable foreground identity across `/new` and
+resume, not faster JSONL I/O. The measured event path is promising once that gate
+is satisfied. The documented app-server status channel is another research option,
+but attaching it to these existing TUI processes was not tested here:
+[official app-server status documentation](https://learn.chatgpt.com/docs/app-server#track-thread-status-changes).
+
+## Reproduce
+
+Create a private temporary root containing `home/` and `work/`. Put a minimal
+`config.toml` in `home/`, explicitly disabling hooks and notifications, and supply
+login access without committing credentials. The probe consumes model usage.
+
+```sh
+python3 spikes/codex-log-events/probe.py "$probe_root" first
+```
+
+In another terminal, append control records to `$probe_root/first/control.jsonl`.
+Send text and Enter separately to avoid the TUI's paste timing heuristic:
+
+```json
+{"action":"send","text":"Reply with exactly PROBE_OK. Do not use tools."}
+{"action":"send","text":"\r"}
+```
+
+Supported controls are `send`, `kill` (only the child TUI PID), and `stop`.
+`mark` records an observation without sending input. The probe has a 15-minute
+limit. `--resume SESSION_ID` starts an explicit resume run. Raw captures remain
+under the temporary root; only the content-free export belongs in the repository.
+
+```sh
+python3 spikes/codex-log-events/watch_file.py "$rollout_path" > "$probe_root/vnode.jsonl"
+python3 spikes/codex-log-events/summarize.py "$probe_root" > evidence.json
+```
+
+The summary expects runs named `first`, `second`, and `resumed`, matching this
+experiment. It is an evidence exporter, not a reusable product API.
+
+## Validation and limits
+
+The scripts were exercised against the real TUI and real files; all 13 starts,
+9 completions, 3 cancellations, and the unmatched crash turn are retained in the
+evidence. The temporary auth symlink was removed after all probes exited.
+Evidence consistency assertions passed, and all three Python scripts parsed.
+`make check` passed, including 153 script tests; `make build-app` passed with
+zero warnings and errors.
+
+No native GUI acceptance, production watcher, network-failure injection, shared
+daemon/remote TUI mode, file replacement/truncation injection, or supported-version
+matrix was tested. The JSONL format is treated as version-specific behavior, not
+a stable public contract. The sample is small and does not establish worst-case
+latency under system load.

--- a/spikes/codex-log-events/evidence.json
+++ b/spikes/codex-log-events/evidence.json
@@ -1,0 +1,928 @@
+{
+  "runs": {
+    "first": {
+      "pid": 91663,
+      "spawn_wall": 1789173993.788936,
+      "controls": [
+        {
+          "elapsed": 19.63190304208547,
+          "action": "send",
+          "text": "Reply with exactly PROBE_OK. Do not use tools."
+        },
+        {
+          "elapsed": 24.96753275010269,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 56.085126000107266,
+          "action": "send",
+          "text": "Reply with exactly PROBE_OK. Do not use tools."
+        },
+        {
+          "elapsed": 56.38313787500374,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 58.4809555420652,
+          "action": "send",
+          "text": "Reply with exactly PROBE_OK. Do not use tools."
+        },
+        {
+          "elapsed": 58.77988741709851,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 61.002979583106935,
+          "action": "send",
+          "text": "Run sleep 30 using the shell, then reply PROBE_DONE."
+        },
+        {
+          "elapsed": 61.30024462507572,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 78.85158054204658,
+          "action": "send",
+          "text": "\u001b"
+        },
+        {
+          "elapsed": 90.7381569170393,
+          "action": "send",
+          "text": "Use exec_command to run /usr/bin/true with sandbox_permissions=\"require_escalated\" and justification=\"Approval timing probe\". Request approval and wait for my decision. Do not substitute an unprivileged execution."
+        },
+        {
+          "elapsed": 91.0335631670896,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 120.41255425009876,
+          "action": "mark",
+          "case": "approval_visible",
+          "no_new_record_for_s": 25.711142778396606
+        },
+        {
+          "elapsed": 131.47390091710258,
+          "action": "send",
+          "text": "\u001b"
+        },
+        {
+          "elapsed": 152.8269262081012,
+          "action": "send",
+          "text": "/new"
+        },
+        {
+          "elapsed": 153.1262360420078,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 154.63479987508617,
+          "action": "send",
+          "text": "Reply with exactly NEW_OK. Do not use tools."
+        },
+        {
+          "elapsed": 154.94470125006046,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 194.9723697080044,
+          "action": "send",
+          "text": "Run sleep 30 using the shell, then reply CRASH_PROBE_DONE."
+        },
+        {
+          "elapsed": 195.331721458002,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 206.01190650009084,
+          "action": "kill"
+        }
+      ],
+      "open_rollouts": [
+        {
+          "elapsed": 0.02244054200127721,
+          "files": []
+        },
+        {
+          "elapsed": 25.381513875094242,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+              "mode": "u"
+            }
+          ]
+        },
+        {
+          "elapsed": 155.80786062509287,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+              "mode": "u"
+            },
+            {
+              "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+              "mode": "u"
+            }
+          ]
+        }
+      ],
+      "event_counts": {
+        "task_started": 7,
+        "item_completed": 15,
+        "token_count": 8,
+        "task_complete": 4,
+        "thread_settings_applied": 5,
+        "turn_aborted": 2
+      },
+      "lifecycle": [
+        {
+          "elapsed": 25.04382970801089,
+          "event": "task_started",
+          "turn_id": "01a09314-f2c1-7952-8774-9b89787d47e4",
+          "timestamp": "2026-09-12T00:46:58.763Z",
+          "visibility_lag_ms": 65.45376777648926,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+          "enter_to_visible_ms": 76.2932300567627
+        },
+        {
+          "elapsed": 27.498928958084434,
+          "event": "task_complete",
+          "turn_id": "01a09314-f2c1-7952-8774-9b89787d47e4",
+          "timestamp": "2026-09-12T00:47:01.264Z",
+          "visibility_lag_ms": 19.541025161743164,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl"
+        },
+        {
+          "elapsed": 56.40870170807466,
+          "event": "task_started",
+          "turn_id": "01a09315-6d76-75b1-b4cf-b5d218c22192",
+          "timestamp": "2026-09-12T00:47:30.171Z",
+          "visibility_lag_ms": 20.550012588500977,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+          "enter_to_visible_ms": 25.562763214111328
+        },
+        {
+          "elapsed": 58.37950320809614,
+          "event": "task_complete",
+          "turn_id": "01a09315-6d76-75b1-b4cf-b5d218c22192",
+          "timestamp": "2026-09-12T00:47:32.138Z",
+          "visibility_lag_ms": 24.321794509887695,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl"
+        },
+        {
+          "elapsed": 58.805954042007215,
+          "event": "task_started",
+          "turn_id": "01a09315-76d5-7cd3-8688-7f3e1e11a01d",
+          "timestamp": "2026-09-12T00:47:32.578Z",
+          "visibility_lag_ms": 10.570049285888672,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+          "enter_to_visible_ms": 26.06487274169922
+        },
+        {
+          "elapsed": 60.90478300000541,
+          "event": "task_complete",
+          "turn_id": "01a09315-76d5-7cd3-8688-7f3e1e11a01d",
+          "timestamp": "2026-09-12T00:47:34.666Z",
+          "visibility_lag_ms": 21.26932144165039,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl"
+        },
+        {
+          "elapsed": 61.32157083309721,
+          "event": "task_started",
+          "turn_id": "01a09315-80ac-7113-aee6-8f4a14b39b80",
+          "timestamp": "2026-09-12T00:47:35.092Z",
+          "visibility_lag_ms": 12.156963348388672,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+          "enter_to_visible_ms": 21.324872970581055
+        },
+        {
+          "elapsed": 78.8766386670759,
+          "event": "turn_aborted",
+          "turn_id": "01a09315-80ac-7113-aee6-8f4a14b39b80",
+          "timestamp": "2026-09-12T00:47:52.637Z",
+          "visibility_lag_ms": 21.138906478881836,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl"
+        },
+        {
+          "elapsed": 91.06061829207465,
+          "event": "task_started",
+          "turn_id": "01a09315-f4d2-7373-bf01-f436b9c008e7",
+          "timestamp": "2026-09-12T00:48:04.830Z",
+          "visibility_lag_ms": 11.039257049560547,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl",
+          "enter_to_visible_ms": 27.0540714263916
+        },
+        {
+          "elapsed": 131.4952173330821,
+          "event": "turn_aborted",
+          "turn_id": "01a09315-f4d2-7373-bf01-f436b9c008e7",
+          "timestamp": "2026-09-12T00:48:45.261Z",
+          "visibility_lag_ms": 12.542009353637695,
+          "file": "rollout-2026-09-12T09-46-34-01a09314-930a-7611-84f1-a28ce3f71844.jsonl"
+        },
+        {
+          "elapsed": 154.97066500002984,
+          "event": "task_started",
+          "turn_id": "01a09316-ee72-77f3-9ee5-208436cfb59d",
+          "timestamp": "2026-09-12T00:49:08.725Z",
+          "visibility_lag_ms": 22.536039352416992,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+          "enter_to_visible_ms": 25.96306800842285
+        },
+        {
+          "elapsed": 157.73099520802498,
+          "event": "task_complete",
+          "turn_id": "01a09316-ee72-77f3-9ee5-208436cfb59d",
+          "timestamp": "2026-09-12T00:49:11.497Z",
+          "visibility_lag_ms": 10.516881942749023,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl"
+        },
+        {
+          "elapsed": 195.35784104210325,
+          "event": "task_started",
+          "turn_id": "01a09317-8c34-74b0-8443-99eea459bb04",
+          "timestamp": "2026-09-12T00:49:49.112Z",
+          "visibility_lag_ms": 20.374059677124023,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+          "enter_to_visible_ms": 26.117801666259766
+        }
+      ],
+      "exit": [
+        {
+          "elapsed": 206.03590458305553,
+          "status": 9
+        }
+      ]
+    },
+    "second": {
+      "pid": 93822,
+      "spawn_wall": 1789174113.0569038,
+      "controls": [
+        {
+          "elapsed": 12.221348499995656,
+          "action": "send",
+          "text": "Reply with exactly SECOND_OK. Do not use tools."
+        },
+        {
+          "elapsed": 12.487369082984515,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 45.3371624579886,
+          "action": "send",
+          "text": "/plan"
+        },
+        {
+          "elapsed": 45.64723420795053,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 46.64994883304462,
+          "action": "send",
+          "text": "Use request_user_input to ask whether I prefer red or blue. Wait for my answer. Do not use other tools."
+        },
+        {
+          "elapsed": 46.95712875004392,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 75.6982951250393,
+          "action": "mark",
+          "case": "question_visible"
+        },
+        {
+          "elapsed": 86.73762716597412,
+          "action": "send",
+          "text": "\u001b"
+        },
+        {
+          "elapsed": 109.46828829101287,
+          "action": "send",
+          "text": "/new"
+        },
+        {
+          "elapsed": 109.78811191604473,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 110.97569774999283,
+          "action": "send",
+          "text": "Reply with exactly CLEAN_NEW_OK. Do not use tools."
+        },
+        {
+          "elapsed": 111.2933489580173,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 239.61706183303613,
+          "action": "send",
+          "text": "\u0004"
+        }
+      ],
+      "open_rollouts": [
+        {
+          "elapsed": 0.013135000015608966,
+          "files": []
+        },
+        {
+          "elapsed": 13.207460124976933,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl",
+              "mode": "u"
+            }
+          ]
+        },
+        {
+          "elapsed": 111.45471145794727,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl",
+              "mode": "u"
+            },
+            {
+              "file": "rollout-2026-09-12T09-50-22-01a09318-0ffb-7072-8088-c306c7716cfc.jsonl",
+              "mode": "u"
+            }
+          ]
+        },
+        {
+          "elapsed": 170.07946354104206,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-50-22-01a09318-0ffb-7072-8088-c306c7716cfc.jsonl",
+              "mode": "u"
+            }
+          ]
+        }
+      ],
+      "event_counts": {
+        "task_started": 3,
+        "item_completed": 5,
+        "token_count": 3,
+        "task_complete": 2,
+        "thread_settings_applied": 2,
+        "turn_aborted": 1
+      },
+      "lifecycle": [
+        {
+          "elapsed": 12.584226415958256,
+          "event": "task_started",
+          "turn_id": "01a09316-93e7-7af2-aa8e-302fef3dfdde",
+          "timestamp": "2026-09-12T00:48:45.557Z",
+          "visibility_lag_ms": 81.1300277709961,
+          "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl",
+          "enter_to_visible_ms": 96.85206413269043
+        },
+        {
+          "elapsed": 15.737619415973313,
+          "event": "task_complete",
+          "turn_id": "01a09316-93e7-7af2-aa8e-302fef3dfdde",
+          "timestamp": "2026-09-12T00:48:48.787Z",
+          "visibility_lag_ms": 3.948211669921875,
+          "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl"
+        },
+        {
+          "elapsed": 46.98138395801652,
+          "event": "task_started",
+          "turn_id": "01a09317-1a8a-7543-bce9-462afffd67d0",
+          "timestamp": "2026-09-12T00:49:20.013Z",
+          "visibility_lag_ms": 20.272016525268555,
+          "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl",
+          "enter_to_visible_ms": 24.25408363342285
+        },
+        {
+          "elapsed": 86.76206133305095,
+          "event": "turn_aborted",
+          "turn_id": "01a09317-1a8a-7543-bce9-462afffd67d0",
+          "timestamp": "2026-09-12T00:49:59.792Z",
+          "visibility_lag_ms": 19.591808319091797,
+          "file": "rollout-2026-09-12T09-48-33-01a09316-63c8-79a0-a1a7-934e98844f85.jsonl"
+        },
+        {
+          "elapsed": 111.31934920803178,
+          "event": "task_started",
+          "turn_id": "01a09318-15d6-7480-ac09-f5f3df05f402",
+          "timestamp": "2026-09-12T00:50:24.347Z",
+          "visibility_lag_ms": 20.33209800720215,
+          "file": "rollout-2026-09-12T09-50-22-01a09318-0ffb-7072-8088-c306c7716cfc.jsonl",
+          "enter_to_visible_ms": 25.999069213867188
+        },
+        {
+          "elapsed": 115.43923725001514,
+          "event": "task_complete",
+          "turn_id": "01a09318-15d6-7480-ac09-f5f3df05f402",
+          "timestamp": "2026-09-12T00:50:28.479Z",
+          "visibility_lag_ms": 7.881879806518555,
+          "file": "rollout-2026-09-12T09-50-22-01a09318-0ffb-7072-8088-c306c7716cfc.jsonl"
+        }
+      ],
+      "exit": [
+        {
+          "elapsed": 239.7621231660014,
+          "status": 0
+        }
+      ]
+    },
+    "resumed": {
+      "pid": 95913,
+      "spawn_wall": 1789174209.696857,
+      "controls": [
+        {
+          "elapsed": 12.530130582978018,
+          "action": "send",
+          "text": "Reply with exactly RESUMED_OK. Do not use tools."
+        },
+        {
+          "elapsed": 12.825821582926437,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 107.25671300000977,
+          "action": "send",
+          "text": "Reply with exactly VNODE_OK. Do not use tools."
+        },
+        {
+          "elapsed": 107.5227690829197,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 112.83265412494075,
+          "action": "send",
+          "text": "Reply with exactly VNODE_OK. Do not use tools."
+        },
+        {
+          "elapsed": 113.150218707975,
+          "action": "send",
+          "text": "\r"
+        },
+        {
+          "elapsed": 142.96492104197387,
+          "action": "send",
+          "text": "\u0004"
+        }
+      ],
+      "open_rollouts": [
+        {
+          "elapsed": 0.017255416954867542,
+          "files": []
+        },
+        {
+          "elapsed": 1.0597996669821441,
+          "files": [
+            {
+              "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+              "mode": "u"
+            }
+          ]
+        }
+      ],
+      "event_counts": {
+        "thread_settings_applied": 3,
+        "task_started": 3,
+        "item_completed": 6,
+        "token_count": 3,
+        "task_complete": 3
+      },
+      "lifecycle": [
+        {
+          "elapsed": 12.848923749988899,
+          "event": "task_started",
+          "turn_id": "01a09318-0eb8-70a1-864f-691f4ea2f316",
+          "timestamp": "2026-09-12T00:50:22.533Z",
+          "visibility_lag_ms": 9.521007537841797,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+          "enter_to_visible_ms": 23.100852966308594
+        },
+        {
+          "elapsed": 16.30445408297237,
+          "event": "task_complete",
+          "turn_id": "01a09318-0eb8-70a1-864f-691f4ea2f316",
+          "timestamp": "2026-09-12T00:50:25.988Z",
+          "visibility_lag_ms": 9.89389419555664,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl"
+        },
+        {
+          "elapsed": 107.5484433749225,
+          "event": "task_started",
+          "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+          "timestamp": "2026-09-12T00:51:57.217Z",
+          "visibility_lag_ms": 19.423961639404297,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+          "enter_to_visible_ms": 25.67291259765625
+        },
+        {
+          "elapsed": 109.9794922079891,
+          "event": "task_complete",
+          "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+          "timestamp": "2026-09-12T00:51:59.647Z",
+          "visibility_lag_ms": 20.342111587524414,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl"
+        },
+        {
+          "elapsed": 113.17547162494157,
+          "event": "task_started",
+          "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+          "timestamp": "2026-09-12T00:52:02.850Z",
+          "visibility_lag_ms": 13.007164001464844,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl",
+          "enter_to_visible_ms": 25.252103805541992
+        },
+        {
+          "elapsed": 115.96523404191248,
+          "event": "task_complete",
+          "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+          "timestamp": "2026-09-12T00:52:05.628Z",
+          "visibility_lag_ms": 24.815082550048828,
+          "file": "rollout-2026-09-12T09-49-06-01a09316-e76d-7393-8c03-d2a22959423e.jsonl"
+        }
+      ],
+      "exit": [
+        {
+          "elapsed": 143.11580862500705,
+          "status": 0
+        }
+      ]
+    }
+  },
+  "polling_visibility_ms": {
+    "task_started": {
+      "n": 13,
+      "minimum": 9.521007537841797,
+      "median": 20.272016525268555,
+      "maximum": 81.1300277709961
+    },
+    "task_complete": {
+      "n": 9,
+      "minimum": 3.948211669921875,
+      "median": 19.541025161743164,
+      "maximum": 24.815082550048828
+    },
+    "turn_aborted": {
+      "n": 3,
+      "minimum": 12.542009353637695,
+      "median": 19.591808319091797,
+      "maximum": 21.138906478881836
+    }
+  },
+  "vnode": [
+    {
+      "kind": "ready",
+      "wall": 1789174315.7305758
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174317.216115,
+      "bytes": 2050,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174317.216115,
+      "record_type": "event_msg",
+      "event": "thread_settings_applied",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:51:57.216Z",
+      "visibility_lag_ms": 0.11491775512695312
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174317.217815,
+      "bytes": 246,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174317.217815,
+      "record_type": "event_msg",
+      "event": "task_started",
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:57.217Z",
+      "visibility_lag_ms": 0.8149147033691406
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174317.22388,
+      "bytes": 2276,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174317.22388,
+      "record_type": "turn_context",
+      "event": null,
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:57.223Z",
+      "visibility_lag_ms": 0.8800029754638672
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174317.236862,
+      "bytes": 421,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174317.236862,
+      "record_type": "response_item",
+      "event": "message",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:51:57.236Z",
+      "visibility_lag_ms": 0.8618831634521484
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174317.237417,
+      "bytes": 499,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174317.237417,
+      "record_type": "event_msg",
+      "event": "item_completed",
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:57.237Z",
+      "visibility_lag_ms": 0.4169940948486328
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174319.577238,
+      "bytes": 433,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174319.577238,
+      "record_type": "event_msg",
+      "event": "item_completed",
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:59.577Z",
+      "visibility_lag_ms": 0.23818016052246094
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174319.579691,
+      "bytes": 424,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174319.579691,
+      "record_type": "response_item",
+      "event": "message",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:51:59.579Z",
+      "visibility_lag_ms": 0.6909370422363281
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174319.642944,
+      "bytes": 863,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174319.642944,
+      "record_type": "token_usage_record",
+      "event": null,
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:59.642Z",
+      "visibility_lag_ms": 0.9441375732421875
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174319.643669,
+      "bytes": 793,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174319.643669,
+      "record_type": "event_msg",
+      "event": "token_count",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:51:59.643Z",
+      "visibility_lag_ms": 0.6690025329589844
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174319.6475031,
+      "bytes": 288,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174319.6475031,
+      "record_type": "event_msg",
+      "event": "task_complete",
+      "turn_id": "01a09319-809c-7e21-9057-d3910846a25f",
+      "timestamp": "2026-09-12T00:51:59.647Z",
+      "visibility_lag_ms": 0.5030632019042969
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174322.846915,
+      "bytes": 2050,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174322.846915,
+      "record_type": "event_msg",
+      "event": "thread_settings_applied",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:52:02.846Z",
+      "visibility_lag_ms": 0.9150505065917969
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174322.850231,
+      "bytes": 246,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174322.850231,
+      "record_type": "event_msg",
+      "event": "task_started",
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:02.850Z",
+      "visibility_lag_ms": 0.23102760314941406
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174322.8592231,
+      "bytes": 2276,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174322.8592231,
+      "record_type": "turn_context",
+      "event": null,
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:02.859Z",
+      "visibility_lag_ms": 0.2231597900390625
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174322.8691452,
+      "bytes": 421,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174322.8691452,
+      "record_type": "response_item",
+      "event": "message",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:52:02.869Z",
+      "visibility_lag_ms": 0.14519691467285156
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174322.869649,
+      "bytes": 499,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174322.869649,
+      "record_type": "event_msg",
+      "event": "item_completed",
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:02.869Z",
+      "visibility_lag_ms": 0.6489753723144531
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174325.558617,
+      "bytes": 433,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174325.558617,
+      "record_type": "event_msg",
+      "event": "item_completed",
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:05.558Z",
+      "visibility_lag_ms": 0.6170272827148438
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174325.561111,
+      "bytes": 424,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174325.561111,
+      "record_type": "response_item",
+      "event": "message",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:52:05.561Z",
+      "visibility_lag_ms": 0.11086463928222656
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174325.626375,
+      "bytes": 863,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174325.626375,
+      "record_type": "token_usage_record",
+      "event": null,
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:05.626Z",
+      "visibility_lag_ms": 0.3750324249267578
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174325.626928,
+      "bytes": 793,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174325.626928,
+      "record_type": "event_msg",
+      "event": "token_count",
+      "turn_id": null,
+      "timestamp": "2026-09-12T00:52:05.626Z",
+      "visibility_lag_ms": 0.9281635284423828
+    },
+    {
+      "kind": "vnode",
+      "wall": 1789174325.628673,
+      "bytes": 288,
+      "flags": [
+        6
+      ]
+    },
+    {
+      "kind": "record",
+      "wall": 1789174325.628673,
+      "record_type": "event_msg",
+      "event": "task_complete",
+      "turn_id": "01a09319-9697-7a01-a47d-a0f02d8ba9c1",
+      "timestamp": "2026-09-12T00:52:05.628Z",
+      "visibility_lag_ms": 0.6730556488037109
+    }
+  ]
+}

--- a/spikes/codex-log-events/probe.py
+++ b/spikes/codex-log-events/probe.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Observe an isolated Codex TUI and its JSONL writes. Not a production detector."""
+
+import argparse
+import datetime
+import fcntl
+import json
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import struct
+import subprocess
+import termios
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("run")
+    parser.add_argument("--resume")
+    args = parser.parse_args()
+    run = args.root / args.run
+    run.mkdir()
+    control = run / "control.jsonl"
+    control.touch()
+    events = (run / "observations.jsonl").open("w", buffering=1)
+    output = (run / "terminal.bin").open("wb", buffering=0)
+    started = time.monotonic()
+
+    def emit(kind, **fields):
+        events.write(json.dumps(dict(kind=kind, wall=time.time(), elapsed=time.monotonic() - started, **fields)) + "\n")
+
+    argv = ["codex", "--no-alt-screen", "--disable", "hooks", "-c", "notify=[]",
+            "-s", "read-only", "-a", "on-request", "-C", str(args.root / "work")]
+    if args.resume:
+        argv += ["resume", args.resume]
+    pid, master = pty.fork()
+    if pid == 0:
+        os.environ["CODEX_HOME"] = str(args.root / "home")
+        os.environ["TERM"] = "xterm-256color"
+        for key in list(os.environ):
+            if key.startswith("PROWL_") or key in {"CODEX_THREAD_ID", "CODEX_MANAGED_BY_NPM"}:
+                os.environ.pop(key)
+        os.execvp(argv[0], argv)
+    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 140, 0, 0))
+    (run / "pid").write_text(str(pid))
+    emit("spawn", pid=pid, argv=argv)
+    offsets = {}
+    pending = {}
+    control_offset = 0
+    last_scan = last_fd = 0
+    paths = []
+    last_fds = None
+    terminal_tail = b""
+    alive = True
+    end_at = started + 900
+    try:
+        while time.monotonic() < end_at:
+            now = time.monotonic()
+            if alive and select.select([master], [], [], 0)[0]:
+                try:
+                    data = os.read(master, 65536)
+                except OSError:
+                    data = b""
+                if data:
+                    output.write(data)
+                    terminal_tail = (terminal_tail + data)[-256:]
+                    for query, reply in [(b"\x1b[6n", b"\x1b[1;1R"), (b"\x1b[c", b"\x1b[?1;2c")]:
+                        if query in terminal_tail:
+                            os.write(master, reply)
+                            terminal_tail = terminal_tail.replace(query, b"")
+                    emit("terminal_bytes", count=len(data))
+            with control.open("rb") as stream:
+                stream.seek(control_offset)
+                for line in stream:
+                    if not line.endswith(b"\n"):
+                        break
+                    control_offset += len(line)
+                    command = json.loads(line)
+                    emit("control", command=command)
+                    if command["action"] == "send":
+                        os.write(master, command["text"].encode())
+                    elif command["action"] == "kill":
+                        os.kill(pid, signal.SIGKILL)
+                    elif command["action"] == "stop":
+                        end_at = now
+            if now - last_scan >= 0.1:
+                paths = list((args.root / "home" / "sessions").rglob("*.jsonl"))
+                last_scan = now
+            for path in paths:
+                key = str(path)
+                stat = path.stat()
+                previous = offsets.get(key, (stat.st_ino, 0))
+                if previous[0] != stat.st_ino or stat.st_size < previous[1]:
+                    emit("file_reset", path=key)
+                    previous = (stat.st_ino, 0)
+                    pending[key] = b""
+                with path.open("rb") as stream:
+                    stream.seek(previous[1])
+                    chunk = stream.read()
+                    offsets[key] = (stat.st_ino, stream.tell())
+                if not chunk:
+                    continue
+                seen_at = time.time()
+                lines = (pending.get(key, b"") + chunk).split(b"\n")
+                pending[key] = lines.pop()
+                for line in lines:
+                    record = json.loads(line)
+                    payload = record.get("payload", {})
+                    record_time = datetime.datetime.fromisoformat(record["timestamp"].replace("Z", "+00:00")).timestamp()
+                    fields = dict(path=key, record_type=record.get("type"), event=payload.get("type"),
+                                  turn_id=payload.get("turn_id"), timestamp=record["timestamp"],
+                                  visibility_lag_ms=(seen_at - record_time) * 1000)
+                    if record.get("type") == "session_meta":
+                        fields["session"] = {k: payload.get(k) for k in ["id", "cli_version", "source", "originator", "cwd"]}
+                    emit("record", **fields)
+            if alive and now - last_fd >= 1:
+                result = subprocess.run(["lsof", "-a", "-p", str(pid), "-Fnfa"], capture_output=True, text=True)
+                fd, mode = None, None
+                found = []
+                for line in result.stdout.splitlines():
+                    if line.startswith("f"):
+                        fd = line[1:]
+                    elif line.startswith("a"):
+                        mode = line[1:]
+                    elif line.startswith("n") and "/sessions/" in line and line.endswith(".jsonl"):
+                        found.append(dict(fd=fd, mode=mode, path=line[1:]))
+                if found != last_fds:
+                    emit("open_rollouts", pid=pid, files=found)
+                    last_fds = found
+                last_fd = now
+            if alive:
+                ended, status = os.waitpid(pid, os.WNOHANG)
+                if ended:
+                    alive = False
+                    emit("process_exit", status=status)
+                    end_at = min(end_at, now + 3)
+            time.sleep(0.02)
+    finally:
+        if alive:
+            os.kill(pid, signal.SIGTERM)
+            os.waitpid(pid, 0)
+        os.close(master)
+        emit("observer_stop")
+        output.close()
+        events.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/spikes/codex-log-events/summarize.py
+++ b/spikes/codex-log-events/summarize.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Export content-free evidence from probe.py observations."""
+
+import argparse
+from collections import Counter
+import datetime
+import json
+from pathlib import Path
+import statistics
+
+
+def summarize(root):
+    result = {"runs": {}}
+    for name in ["first", "second", "resumed"]:
+        rows = [json.loads(line) for line in (root / name / "observations.jsonl").read_text().splitlines()]
+        spawn = next(row for row in rows if row["kind"] == "spawn")
+        owners = [row for row in rows if row["kind"] == "open_rollouts"]
+        owned = {Path(file["path"]).name for row in owners for file in row["files"]}
+        live = [row for row in rows if row["kind"] == "record"
+                and Path(row["path"]).name in owned
+                and datetime.datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00")).timestamp() >= spawn["wall"]]
+        lifecycle = []
+        controls = [row for row in rows if row["kind"] == "control"]
+        for row in live:
+            if row.get("event") not in {"task_started", "task_complete", "turn_aborted"}:
+                continue
+            value = {key: row[key] for key in ["elapsed", "event", "turn_id", "timestamp", "visibility_lag_ms"]}
+            value["file"] = Path(row["path"]).name
+            enters = [item for item in controls if item["wall"] <= row["wall"]
+                      and item["command"].get("text") == "\r"]
+            if row["event"] == "task_started" and enters:
+                value["enter_to_visible_ms"] = (row["wall"] - enters[-1]["wall"]) * 1000
+            lifecycle.append(value)
+        result["runs"][name] = {
+            "pid": spawn["pid"],
+            "spawn_wall": spawn["wall"],
+            "controls": [{"elapsed": row["elapsed"], **row["command"]} for row in controls],
+            "open_rollouts": [{"elapsed": row["elapsed"], "files": [
+                {"file": Path(file["path"]).name, "mode": file["mode"]} for file in row["files"]
+            ]} for row in owners],
+            "event_counts": dict(Counter(row.get("event") for row in live if row["record_type"] == "event_msg")),
+            "lifecycle": lifecycle,
+            "exit": [{"elapsed": row["elapsed"], "status": row["status"]} for row in rows if row["kind"] == "process_exit"],
+        }
+    all_lifecycle = [row for run in result["runs"].values() for row in run["lifecycle"]]
+    result["polling_visibility_ms"] = {}
+    for event in ["task_started", "task_complete", "turn_aborted"]:
+        values = [row["visibility_lag_ms"] for row in all_lifecycle if row["event"] == event]
+        result["polling_visibility_ms"][event] = dict(n=len(values), minimum=min(values),
+                                                   median=statistics.median(values), maximum=max(values))
+    result["vnode"] = [json.loads(line) for line in (root / "vnode.jsonl").read_text().splitlines()]
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(summarize(args.root), indent=2))

--- a/spikes/codex-log-events/watch_file.py
+++ b/spikes/codex-log-events/watch_file.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Measure macOS vnode notifications for one already-bound rollout file."""
+
+import argparse
+from contextlib import closing
+import datetime
+import json
+import os
+import select
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path")
+    parser.add_argument("--seconds", type=float, default=30)
+    args = parser.parse_args()
+    with open(args.path, "rb") as stream, closing(select.kqueue()) as queue:
+        stream.seek(0, os.SEEK_END)
+        event = select.kevent(stream.fileno(), filter=select.KQ_FILTER_VNODE,
+                             flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
+                             fflags=select.KQ_NOTE_WRITE | select.KQ_NOTE_EXTEND
+                             | select.KQ_NOTE_RENAME | select.KQ_NOTE_DELETE)
+        queue.control([event], 0)
+        print(json.dumps({"kind": "ready", "wall": time.time()}), flush=True)
+        deadline = time.monotonic() + args.seconds
+        pending = b""
+        while time.monotonic() < deadline:
+            notifications = queue.control(None, 8, min(1, deadline - time.monotonic()))
+            if not notifications:
+                continue
+            seen = time.time()
+            chunk = stream.read()
+            print(json.dumps({"kind": "vnode", "wall": seen, "bytes": len(chunk),
+                              "flags": [item.fflags for item in notifications]}), flush=True)
+            lines = (pending + chunk).split(b"\n")
+            pending = lines.pop()
+            for line in lines:
+                record = json.loads(line)
+                payload = record.get("payload", {})
+                stamp = datetime.datetime.fromisoformat(record["timestamp"].replace("Z", "+00:00")).timestamp()
+                print(json.dumps({"kind": "record", "wall": seen,
+                                  "record_type": record["type"], "event": payload.get("type"),
+                                  "turn_id": payload.get("turn_id"), "timestamp": record["timestamp"],
+                                  "visibility_lag_ms": (seen - stamp) * 1000}), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Investigate whether interactive JSONL lifecycle events can supplement terminal state detection without hooks. Add a report, PTY and vnode probes, and content-free evidence from 13 turns across three process runs. Application behavior is unchanged.

Starts, completions, and cancellations became readable promptly. The important gaps are foreground identity after `/new` retains multiple writable logs, missing standalone approval/input-wait events, and an unmatched start after forced process exit. The report recommends guarded lifecycle evidence only after foreground identity is established.

Validation: real TUI probes, real macOS vnode notifications, evidence consistency assertions, `make check` (153 script tests), and `make build-app` passed. Native GUI acceptance and shared-daemon mode were not tested.
